### PR TITLE
Add output publicPath to webpack config

### DIFF
--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -10,6 +10,7 @@ const config = {
   output: {
     filename: 'bundle.js',
     path: path.resolve(__dirname, 'dist'),
+    publicPath: "/",
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Description

Bug fix.

Add a publicPath to the webpack output setting. This will serve `bundle.js` from an absolute path (rather the current setting which serves from a relative path), fixing an issue where `bundle.js` can't resolve on nested routes.

Closes #136 
