### PR TITLE
Update textarea to use new asField helper

### DIFF
--- a/src/modules/core/components/Fields/Textarea/Textarea.jsx
+++ b/src/modules/core/components/Fields/Textarea/Textarea.jsx
@@ -60,7 +60,7 @@ class Textarea extends Component<Props> {
   };
 
   renderTextarea = inputProps => {
-    const { innerRef, ...props } = inputProps;
+    const { innerRef, formatIntl, setError, ...props } = inputProps;
     return <textarea ref={innerRef} {...props} />;
   };
 
@@ -107,4 +107,4 @@ class Textarea extends Component<Props> {
   }
 }
 
-export default asField(Textarea);
+export default asField()(Textarea);

--- a/src/modules/core/components/Fields/Textarea/Textarea.md
+++ b/src/modules/core/components/Fields/Textarea/Textarea.md
@@ -150,7 +150,7 @@ Uses the background color of its background (same for text). This should also wo
 const { Formik } = require('formik');
 <Formik
   initialValues={{
-    textarea: 'Hello let me write some text',
+    textarea1: 'Hello let me write some text',
   }}
   onSubmit={values => console.log(values)}
   render={

--- a/yarn.lock
+++ b/yarn.lock
@@ -13479,6 +13479,13 @@ style-loader@^0.21.0:
     loader-utils "^1.1.0"
     schema-utils "^0.4.5"
 
+style-loader@^0.22.0:
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.22.0.tgz#2044d96156f454cc37b61f98eb49980239f4b8eb"
+  dependencies:
+    loader-utils "^1.1.0"
+    schema-utils "^0.4.5"
+
 style-search@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"


### PR DESCRIPTION
## Description

Bug fix. Update the textarea component to use the updated `asField` helper. 

Also updated a styleguide example so `initialValues` key matches a textarea name.

Closes #219 
