### PR TITLE
Remove provision postinstall step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,9 @@ jobs:
             yarn global add lerna
       - run:
           name: "Installing modules"
-          command: yarn install
+          command: |
+            yarn install
+            yarn provision
       - save_cache:
           paths:
             - node_modules
@@ -71,7 +73,9 @@ jobs:
           command: yarn global add lerna
       - run:
           name: "Installing modules"
-          command: yarn install
+          command: |
+            yarn install
+            yarn provision
       - save_cache:
           paths:
             - node_modules
@@ -118,7 +122,9 @@ jobs:
           command: yarn global add lerna
       - run:
           name: "Installing modules"
-          command: yarn install
+          command: |
+            yarn install
+            yarn provision
       - save_cache:
           paths:
             - node_modules

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "test:integration:debug": "DEBUG=true yarn test:integration --color | tee integration-testing-output.log",
     "test:integration:ci": "jest --clearCache && NODE_ENV=test jest --ci --bail --verbose --runInBand --config=jest-integration.conf.json --reporters='jest-junit'",
     "test:ci": "jest --clearCache && NODE_ENV=test jest --ci --coverage --verbose=true --config=jest.conf.json --reporters='jest-junit'",
-    "postinstall": "yarn provision",
     "styleguide": "styleguidist server",
     "build:styleguide": "styleguidist build",
     "deploy:styleguide": "gh-pages -d styleguide -r git@github.com:JoinColony/colonyUI.git"


### PR DESCRIPTION
This removes the `provision` postinstall hook in the `package.json`. I added it back to the CI steps where it's needed.