### PR TITLE
Upgrade husky to next rc version

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,5 +1,5 @@
 {
   "hooks": {
-      "pre-commit": "yarn flow && lint-staged"
+      "pre-commit": "lint-staged"
   }
 }

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
         "flow-bin": "^0.81.0",
         "gh-pages": "^1.2.0",
         "html-webpack-plugin": "^3.2.0",
-        "husky": "^1.0.0-rc.12",
+        "husky": "^1.0.0-rc.14",
         "jest": "^23.3.0",
         "jest-enzyme": "^6.0.2",
         "jest-junit": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3545,6 +3545,10 @@ ci-info@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.2.tgz#03561259db48d0474c8bdc90f5b47b068b6bbfb4"
 
+ci-info@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.5.1.tgz#17e8eb5de6f8b2b6038f0cbb714d410bfa9f3030"
+
 cids@0.5.3, cids@^0.5.2, cids@^0.5.3, cids@~0.5.1, cids@~0.5.2, cids@~0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/cids/-/cids-0.5.3.tgz#9a25b697eb76faf807afcec35c4ab936edfbd0a4"
@@ -4048,6 +4052,14 @@ cosmiconfig@^4.0.0:
 cosmiconfig@^5.0.0, cosmiconfig@^5.0.2, cosmiconfig@^5.0.5:
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.5.tgz#a809e3c2306891ce17ab70359dc8bdf661fe2cd0"
+  dependencies:
+    is-directory "^0.3.1"
+    js-yaml "^3.9.0"
+    parse-json "^4.0.0"
+
+cosmiconfig@^5.0.6:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.6.tgz#dca6cf680a0bd03589aff684700858c81abeeb39"
   dependencies:
     is-directory "^0.3.1"
     js-yaml "^3.9.0"
@@ -6851,15 +6863,15 @@ humanize-url@^1.0.0:
     normalize-url "^1.0.0"
     strip-url-auth "^1.0.0"
 
-husky@^1.0.0-rc.12:
-  version "1.0.0-rc.13"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-1.0.0-rc.13.tgz#49c3cc210bfeac24d4ad272f770b7505c9091828"
+husky@^1.0.0-rc.14:
+  version "1.0.0-rc.14"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-1.0.0-rc.14.tgz#e1380575fe4cf17e1ca98791395c1baafa8064c7"
   dependencies:
-    cosmiconfig "^5.0.2"
+    cosmiconfig "^5.0.6"
     execa "^0.9.0"
     find-up "^3.0.0"
     get-stdin "^6.0.0"
-    is-ci "^1.1.0"
+    is-ci "^1.2.1"
     pkg-dir "^3.0.0"
     please-upgrade-node "^3.1.1"
     read-pkg "^4.0.1"
@@ -7595,11 +7607,17 @@ is-callable@^1.1.1, is-callable@^1.1.3, is-callable@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
 
-is-ci@^1.0.10, is-ci@^1.1.0:
+is-ci@^1.0.10:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.1.0.tgz#247e4162e7860cebbdaf30b774d6b0ac7dcfe7a5"
   dependencies:
     ci-info "^1.0.0"
+
+is-ci@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.2.1.tgz#e3779c8ee17fccf428488f6e281187f2e632841c"
+  dependencies:
+    ci-info "^1.5.0"
 
 is-circular@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This PR upgrades husky to the next rc version. This should repair your pre-commit hooks.

## Manual to repair your pre-commit hooks

1) Check out this branch - or - check out master after this branch was merged

2) Remove all existing hooks (don't worry, husky will re-add them all)
```
rm -rf .git/hooks/*.* && rm -rf .git/hooks/*
```

3) For extra safety remove your `node_modules` folder and clean your yarn cache (optional)

4) Do a `yarn`

5) 🤞

This also removes the flow check from pre-commit hook. See here: https://github.com/JoinColony/colonyDapp/issues/312#issuecomment-422969144

Closes #321.