### PR TITLE
Rename hint prop to extra on InputLabel

### DIFF
--- a/src/modules/core/components/Fields/Input/Input.jsx
+++ b/src/modules/core/components/Fields/Input/Input.jsx
@@ -30,6 +30,8 @@ type Props = {
   connect?: boolean,
   /** Just render the `<input>` element without label */
   elementOnly?: boolean,
+  /** Extra node to render on the top right in the label */
+  extra?: Node,
   /** Options for cleave.js formatting (see [this list](https://github.com/nosir/cleave.js/blob/master/doc/options.md)) */
   formattingOptions?: CleaveOptions,
   /** Input field name (form variable) */
@@ -38,8 +40,6 @@ type Props = {
   help?: string | MessageDescriptor,
   /** Values for help text (react-intl interpolation) */
   helpValues?: { [string]: string },
-  /** Hint (will appear on the top right in the label) */
-  hint?: Node,
   /** Pass a ref to the `<input>` element */
   innerRef?: (ref: ?HTMLElement) => void,
   /** Label text */
@@ -77,7 +77,7 @@ const Input = ({
   formattingOptions,
   formatIntl,
   help,
-  hint,
+  extra,
   $id,
   innerRef,
   label,
@@ -115,7 +115,7 @@ const Input = ({
         label={label}
         error={$error}
         help={help}
-        hint={hint}
+        extra={extra}
       />
       <InputComponent {...inputProps} />
       <InputStatus appearance={appearance} status={status} error={$error} />

--- a/src/modules/core/components/Fields/Input/Input.md
+++ b/src/modules/core/components/Fields/Input/Input.md
@@ -70,14 +70,14 @@
 />
 ```
 
-### Input text with label and hint
+### Input text with label and extra node
 
 ```js
 <Input
-  name="inputlabelhint"
-  placeholder="I have a hint!"
+  name="inputlabelextra"
+  placeholder="I have an extra node!"
   label="Look right ->"
-  hint={<a href="#">I'm a hint!</a>}
+  extra={<a href="#">I'm an extra node!</a>}
   connect={false}
 />
 ```

--- a/src/modules/core/components/Fields/InputLabel/InputLabel.css
+++ b/src/modules/core/components/Fields/InputLabel/InputLabel.css
@@ -52,7 +52,7 @@
   color: var(--text);
 }
 
-.hint {
+.extra {
   position: absolute;
   top: 0;
   right: 0;

--- a/src/modules/core/components/Fields/InputLabel/InputLabel.jsx
+++ b/src/modules/core/components/Fields/InputLabel/InputLabel.jsx
@@ -22,12 +22,12 @@ type Appearance = {
 type Props = {
   /** Appearance object */
   appearance?: Appearance,
+  /** Extra node to render on the top right in the label */
+  extra?: Node,
   /** Help text (will appear next to label text) */
   help?: string | MessageDescriptor,
   /** Values for help text (react-intl interpolation) */
   helpValues?: { [string]: string },
-  /** Hint (will appear on the top right in the label) */
-  hint?: Node,
   /** `id` attribute value of accompanied input field */
   inputId?: string,
   /** Label text */
@@ -42,7 +42,7 @@ const InputLabel = ({
   appearance = {},
   help,
   helpValues,
-  hint,
+  extra,
   inputId = '',
   intl: { formatMessage },
   label: inputLabel,
@@ -62,7 +62,7 @@ const InputLabel = ({
     >
       <span className={styles.labelText}>{labelText}</span>
       {helpText && <span className={styles.help}>({helpText})</span>}
-      {hint && <span className={styles.hint}>{hint}</span>}
+      {extra && <span className={styles.extra}>{extra}</span>}
     </label>
   );
 };

--- a/src/modules/core/components/Fields/Textarea/Textarea.jsx
+++ b/src/modules/core/components/Fields/Textarea/Textarea.jsx
@@ -30,14 +30,14 @@ type Props = {
   connect?: boolean,
   /** Just render the `<textarea>` element without label */
   elementOnly?: boolean,
+  /** Extra node to render on the top right in the label */
+  extra?: Node,
   /** Textarea field name (form variable) */
   name: string,
   /** Help text (will appear next to label text) */
   help?: string | MessageDescriptor,
   /** Values for help text (react-intl interpolation) */
   helpValues?: { [string]: string },
-  /** Hint (will appear on the top right in the label) */
-  hint?: Node,
   /** Pass a ref to the `<textarea>` element */
   innerRef?: (ref: ?HTMLElement) => void,
   /** Label text */
@@ -111,7 +111,7 @@ class Textarea extends Component<Props> {
       formatIntl,
       isSubmitting,
       help,
-      hint,
+      extra,
       label,
       maxLength = null,
       name,
@@ -143,7 +143,7 @@ class Textarea extends Component<Props> {
           label={label}
           error={$error}
           help={help}
-          hint={hint}
+          extra={extra}
         />
         {this.renderTextarea(inputProps)}
         <InputStatus appearance={appearance} status={status} error={$error} />

--- a/src/modules/core/components/Fields/Textarea/Textarea.md
+++ b/src/modules/core/components/Fields/Textarea/Textarea.md
@@ -101,14 +101,14 @@
 />
 ```
 
-### Textarea text with label and hint
+### Textarea text with label and extra node
 
 ```js
 <Textarea
   name="textareastatus"
-  placeholder="I have a hint!"
+  placeholder="I have an extra!"
   label="Look right ->"
-  hint={<a href="#">I'm a hint!</a>}
+  extra={<a href="#">I'm an extra node!</a>}
   connect={false}
 />
 ```

--- a/src/modules/core/components/FileUpload/FileUpload.jsx
+++ b/src/modules/core/components/FileUpload/FileUpload.jsx
@@ -91,8 +91,8 @@ type Props = {
   help?: string | MessageDescriptor,
   /** Values for help text (react-intl interpolation) */
   helpValues?: { [string]: string },
-  /** Hint (will appear on the top right in the label) */
-  hint?: Node,
+  /** Extra node to render on the top right in the label */
+  extra?: Node,
   /** Label text */
   label?: string | MessageDescriptor,
   /** Values for label text (react-intl interpolation) */
@@ -183,7 +183,7 @@ class FileUpload extends Component<Props> {
       dropzoneRef,
       form: { values, isValid, dirty, resetForm },
       help,
-      hint,
+      extra,
       helpValues,
       itemComponent: FileUploaderItem,
       id,
@@ -212,7 +212,7 @@ class FileUpload extends Component<Props> {
               help={help}
               labelValues={labelValues}
               helpValues={helpValues}
-              hint={hint}
+              extra={extra}
             />
           )}
         <Dropzone

--- a/src/modules/core/components/FileUpload/FileUpload.md
+++ b/src/modules/core/components/FileUpload/FileUpload.md
@@ -19,7 +19,7 @@ const { Formik } = require('formik');
 />
 ```
 
-### FileUpload with Hint
+### FileUpload with `extra` node
 
 ```js
 const { Formik } = require('formik');
@@ -32,7 +32,7 @@ const { Formik } = require('formik');
           accept={['application/json',]}
           label="File upload"
           name="fileUpload"
-          hint="<span>Wink! Wink!</span>"
+          extra={<span>Wink! Wink!</span>}
         />
         <Button appearance={{ theme: 'primary' }} disabled={!isValid} type="submit">Upload everything!</Button>
       </form>

--- a/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.jsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.jsx
@@ -101,7 +101,7 @@ const StepCreateToken = ({ previousStep, handleSubmit, isValid }: Props) => (
           name="tokenName"
           appearance={{ theme: 'fat' }}
           label={MSG.labelTokenName}
-          hint={<FormattedMessage {...MSG.helpTokenName} />}
+          extra={<FormattedMessage {...MSG.helpTokenName} />}
         />
       </div>
       <div className={styles.inputFieldWrapper}>
@@ -109,7 +109,7 @@ const StepCreateToken = ({ previousStep, handleSubmit, isValid }: Props) => (
           name="tokenSymbol"
           appearance={{ theme: 'fat' }}
           label={MSG.labelTokenSymbol}
-          hint={<FormattedMessage {...MSG.helpTokenSymbol} />}
+          extra={<FormattedMessage {...MSG.helpTokenSymbol} />}
         />
       </div>
       <div className={styles.inputFieldWrapper}>
@@ -118,7 +118,7 @@ const StepCreateToken = ({ previousStep, handleSubmit, isValid }: Props) => (
           maxFileSize={ACCEPTED_MAX_FILE_SIZE}
           name="tokenIcon"
           label={MSG.labelTokenIcon}
-          hint={<FormattedMessage {...MSG.helpTokenIcon} />}
+          extra={<FormattedMessage {...MSG.helpTokenIcon} />}
         />
       </div>
     </div>

--- a/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.jsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.jsx
@@ -166,7 +166,7 @@ class StepSelectToken extends Component<Props, State> {
             <Input
               name="tokenAddress"
               label={MSG.label}
-              hint={
+              extra={
                 <Button text={MSG.learnMore} appearance={{ theme: 'blue' }} />
               }
               status={tokenData ? MSG.preview : MSG.hint}


### PR DESCRIPTION
This renames the `hint` property on the `InputLabel` to `extra` (to be in line with what we do in `TablList`). There was a bit of a confusion with `help` vs. `hint`, hence this rename.

There was no issue created for this.