### PR TITLE
Fix flow issues

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -24,5 +24,7 @@ module.name_mapper='^\~users\/\(.*\)$' -> '<PROJECT_ROOT>/src/modules/users/comp
 module.name_mapper='^\~wallet\/\(.*\)$' -> '<PROJECT_ROOT>/src/modules/wallet/components/\1'
 module.name_mapper='^\~utils\/\(.*\)$' -> '<PROJECT_ROOT>/src/utils/\1'
 module.name_mapper='^\~styles\/\(.*\)$' -> '<PROJECT_ROOT>/src/styles/shared/\1'
+module.name_mapper='^\~routes\/\(.*\)$' -> '<PROJECT_ROOT>/src/routes/\1'
+module.name_mapper='^\~routes' -> '<PROJECT_ROOT>/src/routes'
 
 [strict]

--- a/src/createReduxStore.js
+++ b/src/createReduxStore.js
@@ -21,8 +21,9 @@ function* rootSaga(): any {
 
 const sagaMiddleware = createSagaMiddleware();
 
-// eslint-disable-next-line no-underscore-dangle
-const composeEnhancer = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+const composeEnhancer: Function =
+  // eslint-disable-next-line no-underscore-dangle
+  window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
 const store = createStore(
   connectRouter(history)(rootReducer),

--- a/src/index.js
+++ b/src/index.js
@@ -18,4 +18,5 @@ ReactModal.setAppElement(rootNode);
 
 if (rootNode) render(createElement(App, { store, context, history }), rootNode);
 
+// $FlowFixMe
 if (module.hot) module.hot.accept();

--- a/src/routes/ConnectedOnlyRoute.jsx
+++ b/src/routes/ConnectedOnlyRoute.jsx
@@ -2,8 +2,7 @@
 
 import React from 'react';
 import { Route, Redirect } from 'react-router-dom';
-
-import type { Component as ReactComponent } from 'react';
+import type { ComponentType } from 'react';
 
 import { START_ROUTE } from './routeConstants';
 
@@ -12,7 +11,7 @@ const ConnectedOnlyRoute = ({
   isConnected,
   ...rest
 }: {
-  component: ReactComponent,
+  component: ComponentType<*>,
   isConnected?: boolean,
 }) => (
   <Route

--- a/src/routes/DisconnectedOnlyRoute.jsx
+++ b/src/routes/DisconnectedOnlyRoute.jsx
@@ -2,8 +2,7 @@
 
 import React from 'react';
 import { Route, Redirect } from 'react-router-dom';
-
-import type { Component as ReactComponent } from 'react';
+import type { ComponentType } from 'react';
 
 import { DASHBOARD_ROUTE } from './routeConstants';
 
@@ -12,7 +11,7 @@ const DisconnectedOnlyRoute = ({
   isConnected,
   ...rest
 }: {
-  component: ReactComponent,
+  component: ComponentType<*>,
   isConnected?: boolean,
 }) => (
   <Route

--- a/src/utils/colonyNetwork/index.js
+++ b/src/utils/colonyNetwork/index.js
@@ -19,7 +19,7 @@ const adapter = new EthersAdapter({
 
 let instance;
 const loadNetwork = async () => {
-  const networkClient = new ColonyNetworkClient({ adapter });
+  const networkClient = new ColonyNetworkClient({ adapter, query: {} });
   await networkClient.init();
   instance = networkClient;
   return instance;


### PR DESCRIPTION
## Description

Fix some issues that appear to have been introduced with flow 0.81 (but may have been around for longer, silently breaking).

* Add `~routes` paths to flowconfig
* Use `ComponentType` for route components
* Pass empty `query` to `ColonyNetworkClient`
* Add type to `compose` function for store
* Ignore `module.hot` type
