### PR TITLE
Add wallet-based access controller

### DIFF
--- a/src/data/orbit.js
+++ b/src/data/orbit.js
@@ -1,8 +1,10 @@
 /* @flow */
+
 import OrbitDB from 'orbit-db';
 import type { ColonyIPFSNode, ColonyOrbitOptions, OrbitOptions } from './types';
 
 const DEFAULT_DB_PATH = 'colonyOrbitdb';
+const ETHEREUM_PROVIDER_TYPE = 'ETHEREUM';
 
 type WrappedOptions = { path: ?string, options: OrbitOptions };
 
@@ -16,4 +18,34 @@ export async function getOrbitDB(
   { path, options }: WrappedOptions = { path: DEFAULT_DB_PATH, options: {} },
 ) {
   return new OrbitDB(ipfs, path, options);
+}
+
+// @TODO: apply flow
+export class EthereumWalletAccessController {
+  constructor(wallet) {
+    if (!wallet) throw new Error('Wallet is required');
+    this._wallet = wallet;
+  }
+
+  async canAppend(entry, provider) {
+    const {
+      identity: {
+        id: walletAddress,
+        publicKey: orbitPublicKey,
+        signatures,
+        type,
+      },
+    } = entry;
+
+    if (type !== ETHEREUM_PROVIDER_TYPE) return false;
+
+    // Current wallet is the only one that can write to this store so we use the current wallet to check the signature
+    const isWalletSignatureValid = await this._wallet.verifyMessage({
+      message: orbitPublicKey + signatures.id,
+      signature: signatures.publicKey,
+    });
+    if (!isWalletSignatureValid) return false;
+
+    return provider.verify(signatures.id, orbitPublicKey, walletAddress);
+  }
 }


### PR DESCRIPTION
## Description

This PR was based on #371. It adds an access controller that can be connected to an Ethereum wallet

## TODO
- [x] Add wallet-based access controller 
- [ ] Integrate with purser
- [ ] Identity creation method on our side
- [ ] Check out and make sure we can use orbit's default identity provider
- [ ] Verify message by any ethereum account (optional)

Closes #318
