### PR TITLE
Implement seen/unseen UI behaviour for inbox items

### DIFF
--- a/src/modules/dashboard/components/Inbox/Inbox.css
+++ b/src/modules/dashboard/components/Inbox/Inbox.css
@@ -9,3 +9,9 @@
   display: flex;
   flex-direction: column;
 }
+
+.inboxHeading {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}

--- a/src/modules/dashboard/components/Inbox/Inbox.jsx
+++ b/src/modules/dashboard/components/Inbox/Inbox.jsx
@@ -1,10 +1,11 @@
 /* @flow */
 
-import React from 'react';
+import React, { Component } from 'react';
 import { defineMessages } from 'react-intl';
 
 import { Table, TableBody } from '~core/Table';
 import Heading from '~core/Heading';
+import Button from '~core/Button';
 
 import InboxItem from './InboxItem.jsx';
 
@@ -14,27 +15,48 @@ import mockInbox from './__datamocks__/mockInbox';
 
 import styles from './Inbox.css';
 
+import type { InboxElement } from './types';
+
 const MSG = defineMessages({
   title: {
     id: 'dashboard.Inbox.Inbox.title',
     defaultMessage: 'Inbox',
   },
+  markAllRead: {
+    id: 'dashboard.Inbox.Inbox.markAllRead',
+    defaultMessage: 'Mark all as read',
+  },
 });
 
 const displayName = 'dashboard.Inbox';
 
-const Inbox = () => (
+const Inbox = ({
+  inboxItems,
+  markAsRead,
+  markAllRead,
+}: {
+  inboxItems: Array<InboxElement>,
+  markAsRead: (id: number) => void,
+  markAllRead: () => void,
+}) => (
   <CenteredTemplate appearance={{ theme: 'alt' }}>
     <div className={styles.contentContainer}>
-      <Heading
-        appearance={{ size: 'medium', margin: 'small' }}
-        text={MSG.title}
-      />
+      <div className={styles.inboxHeading}>
+        <Heading
+          appearance={{ size: 'medium', margin: 'small' }}
+          text={MSG.title}
+        />
+        <Button
+          appearance={{ theme: 'blue' }}
+          text={MSG.markAllRead}
+          onClick={markAllRead}
+        />
+      </div>
       <div className={styles.inboxContainer}>
         <Table scrollable appearance={{ separators: 'borders' }}>
           <TableBody>
-            {mockInbox.map(item => (
-              <InboxItem key={item.id} item={item} />
+            {inboxItems.map(item => (
+              <InboxItem key={item.id} item={item} markAsRead={markAsRead} />
             ))}
           </TableBody>
         </Table>
@@ -45,4 +67,38 @@ const Inbox = () => (
 
 Inbox.displayName = displayName;
 
-export default Inbox;
+// To be replaced with e.g. react-redux connect()
+class MockInbox extends Component<{}, { inboxItems: Array<InboxElement> }> {
+  state = {
+    inboxItems: mockInbox,
+  };
+
+  markAsRead = (id: number) =>
+    this.setState(prev => {
+      const { inboxItems } = prev;
+      inboxItems[id - 1].unread = false;
+      return { inboxItems };
+    });
+
+  markAllRead = () =>
+    this.setState(prev => {
+      const { inboxItems } = prev;
+      return {
+        inboxItems: inboxItems.map(item => ({ ...item, unread: false })),
+      };
+    });
+
+  render() {
+    const { inboxItems } = this.state;
+    const { markAsRead, markAllRead } = this;
+    return (
+      <Inbox
+        inboxItems={inboxItems}
+        markAsRead={markAsRead}
+        markAllRead={markAllRead}
+      />
+    );
+  }
+}
+
+export default MockInbox;

--- a/src/modules/dashboard/components/Inbox/InboxItem.css
+++ b/src/modules/dashboard/components/Inbox/InboxItem.css
@@ -1,9 +1,13 @@
-td.inboxDetails {
+.inboxRowCell {
+  width: 100%;
+}
+
+.inboxDetails {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   padding: 24px 20px;
-  width: 100%;
+  position: relative;
   font-weight: var(--weight-semi);
 }
 
@@ -49,4 +53,19 @@ td.inboxDetails {
 
 .inboxDomain {
   display: block;
+}
+
+.inboxUnread {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+}
+
+.inboxUnreadAction {
+  border-left: 2px solid var(--pink);
+}
+
+.inboxUnreadNotification {
+  border-left: 2px solid var(--sky-blue);
 }

--- a/src/modules/dashboard/components/Inbox/InboxItem.jsx
+++ b/src/modules/dashboard/components/Inbox/InboxItem.jsx
@@ -10,7 +10,7 @@ import UserAvatar from '~core/UserAvatar';
 
 import styles from './InboxItem.css';
 
-import type { InboxElement, InboxAction } from './types';
+import type { InboxElement, InboxAction, ActionType } from './types';
 
 const MSG = defineMessages({
   actionAddedSkillTag: {
@@ -43,53 +43,71 @@ const displayName = 'dashboard.Inbox.InboxItem';
 
 type Props = {
   item: InboxElement,
+  markAsRead: (id: number) => void,
 };
 
 const getEventActionKey = (actionType: InboxAction) =>
   camelcase(`action-${actionType}`);
 
-const InboxItem = ({
-  item: { user, action, task, domain, colonyName, createdAt },
-}: Props) => (
-  <TableRow className={styles.inboxRow}>
-    <TableCell className={styles.inboxDetails}>
-      <UserAvatar
-        size="xxs"
-        walletAddress={user.walletAddress}
-        username={user.username}
-        className={styles.UserAvatar}
-      />
-      <FormattedMessage
-        className={styles.inboxAction}
-        {...MSG[getEventActionKey(action)]}
-        values={{
-          user: (
-            <span className={styles.inboxDetail} title={user.username}>
-              {user.username}
-            </span>
-          ),
-          task: (
-            <span className={styles.inboxDetail} title={user.username}>
-              {task}
-            </span>
-          ),
-        }}
-      />
+const UnreadIndicator = ({ type }: { type: ActionType }) => (
+  <div
+    className={`${styles.inboxUnread} ${
+      type === 'action'
+        ? styles.inboxUnreadAction
+        : styles.inboxUnreadNotification
+    }`}
+  />
+);
 
-      <span className={styles.additionalDetails}>
+const InboxItem = ({
+  item: { id, user, action, task, domain, colonyName, createdAt, unread, type },
+  markAsRead,
+}: Props) => (
+  <TableRow
+    className={styles.inboxRow}
+    onClick={() => unread && markAsRead(id)}
+  >
+    <TableCell className={styles.inboxRowCell}>
+      <div className={styles.inboxDetails}>
+        {unread && <UnreadIndicator type={type} />}
+        <UserAvatar
+          size="xxs"
+          walletAddress={user.walletAddress}
+          username={user.username}
+          className={styles.UserAvatar}
+        />
         <FormattedMessage
-          {...MSG.inboxMeta}
+          className={styles.inboxAction}
+          {...MSG[getEventActionKey(action)]}
           values={{
-            colonyName,
-            domain,
+            user: (
+              <span className={styles.inboxDetail} title={user.username}>
+                {user.username}
+              </span>
+            ),
+            task: (
+              <span className={styles.inboxDetail} title={user.username}>
+                {task}
+              </span>
+            ),
           }}
         />
 
-        <span className={styles.pipe}>|</span>
-        <span className={styles.time}>
-          <TimeRelative value={createdAt} />
+        <span className={styles.additionalDetails}>
+          <FormattedMessage
+            {...MSG.inboxMeta}
+            values={{
+              colonyName,
+              domain,
+            }}
+          />
+
+          <span className={styles.pipe}>|</span>
+          <span className={styles.time}>
+            <TimeRelative value={createdAt} />
+          </span>
         </span>
-      </span>
+      </div>
     </TableCell>
   </TableRow>
 );

--- a/src/modules/dashboard/components/Inbox/__datamocks__/mockInbox.js
+++ b/src/modules/dashboard/components/Inbox/__datamocks__/mockInbox.js
@@ -12,6 +12,8 @@ const mockInbox = [
       walletAddress: '0xdeadbeef',
       username: 'Brad Pitt',
     },
+    unread: false,
+    type: 'notification',
   },
   {
     id: 2,
@@ -24,6 +26,8 @@ const mockInbox = [
       walletAddress: '0xbeefdead',
       username: 'Ragnar Lothbrok',
     },
+    unread: true,
+    type: 'notification',
   },
   {
     id: 3,
@@ -36,6 +40,8 @@ const mockInbox = [
       walletAddress: '0xbeefdwad',
       username: 'Cornelia Bodenbaum',
     },
+    unread: true,
+    type: 'action',
   },
   {
     id: 4,
@@ -48,6 +54,8 @@ const mockInbox = [
       walletAddress: '0xbeefdeid',
       username: 'Stefan Zweig',
     },
+    unread: false,
+    type: 'notification',
   },
   {
     id: 5,
@@ -60,6 +68,8 @@ const mockInbox = [
       walletAddress: '0xbeefdeid',
       username: 'Carlos Martinez',
     },
+    unread: true,
+    type: 'notification',
   },
   {
     id: 6,
@@ -72,6 +82,8 @@ const mockInbox = [
       walletAddress: '0xbeefdeid',
       username: 'Ludwig Kartoffelstampfer',
     },
+    unread: false,
+    type: 'notification',
   },
   {
     id: 7,
@@ -84,6 +96,8 @@ const mockInbox = [
       walletAddress: '0xbeefdeid',
       username: 'Axel Mäusezahn',
     },
+    unread: false,
+    type: 'notification',
   },
 ];
 

--- a/src/modules/dashboard/components/Inbox/types.js
+++ b/src/modules/dashboard/components/Inbox/types.js
@@ -6,6 +6,8 @@ export type InboxAction =
   | 'addedSkillTag'
   | 'assignedUser';
 
+export type ActionType = 'action' | 'notification';
+
 export type InboxElement = {
   id: number,
   action: InboxAction,
@@ -17,4 +19,6 @@ export type InboxElement = {
     walletAddress: string,
     username: string,
   },
+  unread: boolean,
+  type: ActionType,
 };


### PR DESCRIPTION
## Description

Adds `unseen` and `type` properties to the inbox items schema, displays unseen items with a coloured border to the left according to their type, and will mark items as seen when clicked on.

![image](https://user-images.githubusercontent.com/7497084/47029469-e7796a80-d16b-11e8-8480-e827e247f2ba.png)

## Other changes

- Add "mark all as read" button to inbox

## TODO

- [x] Currently based on #430 - merge that before this

Resolves #166
