### PR TITLE
Fix top margin on wallet connect wizard steps

### DIFF
--- a/src/modules/users/components/ConnectWalletWizard/StepHardware/StepHardware.css
+++ b/src/modules/users/components/ConnectWalletWizard/StepHardware/StepHardware.css
@@ -2,6 +2,7 @@
 
 .content {
   composes: marginBottomMedium from '~styles/layout.css';
+  margin-top: 180px;
   min-width: 700px;
   background-color: var(--grey-blue-1);
 }

--- a/src/modules/users/components/ConnectWalletWizard/StepJSONUpload/StepJSONUpload.css
+++ b/src/modules/users/components/ConnectWalletWizard/StepJSONUpload/StepJSONUpload.css
@@ -1,5 +1,6 @@
 .content {
   composes: marginBottomMedium from '~styles/layout.css';
+  margin-top: 180px;
 }
 
 .actions {

--- a/src/modules/users/components/ConnectWalletWizard/StepMetaMask/StepMetaMask.css
+++ b/src/modules/users/components/ConnectWalletWizard/StepMetaMask/StepMetaMask.css
@@ -1,6 +1,7 @@
 .content {
   composes: alignCenter from '~styles/text.css';
   composes: marginBottomMedium from '~styles/layout.css';
+  margin-top: 180px;
   padding: 50px;
   background-color: var(--grey-blue-1);
 }

--- a/src/modules/users/components/ConnectWalletWizard/StepMnemonic/StepMnemonic.css
+++ b/src/modules/users/components/ConnectWalletWizard/StepMnemonic/StepMnemonic.css
@@ -1,5 +1,6 @@
 .content {
   composes: marginBottomMedium from '~styles/layout.css';
+  margin-top: 180px;
 }
 
 .actions {


### PR DESCRIPTION
## Description

Adds a margin of `180px` (the original amount) to each step of the `ConnectWalletWizard` after it was [accidentally removed](https://github.com/JoinColony/colonyDapp/pull/383#discussion_r225059171).

Resolves #420 
