### PR TITLE
Add our own orbit keystore

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
         "connected-react-router": "^4.4.1",
         "copy-to-clipboard": "^3.0.8",
         "core-js": "^2.5.7",
+        "elliptic": "^6.4.1",
         "es6-promisify": "^6.0.0",
         "ethers": "^3.0.27",
         "ethjs-unit": "^0.1.6",

--- a/src/lib/database/Keystore.js
+++ b/src/lib/database/Keystore.js
@@ -1,0 +1,40 @@
+/* @flow */
+
+import { ec as EC } from 'elliptic';
+
+import type { KeyPair } from './types';
+
+const ec = new EC('secp256k1');
+
+export default class Keystore {
+  static createKey(): KeyPair {
+    return ec.genKeyPair();
+  }
+
+  static sign(key: KeyPair, data: string): string {
+    if (!key) throw new Error('No signing key given');
+    if (!data) throw new Error('Given input data was undefined');
+    const sig = ec.sign(data, key);
+    return sig.toDER('hex');
+  }
+
+  static verify(signature: string, publicKey: string, data: string): boolean {
+    if (!signature) throw new Error('No signature given');
+    if (!publicKey) throw new Error('Given publicKey was undefined');
+    if (!data) throw new Error('Given input data was undefined');
+
+    let isValid = false;
+    const key = ec.keyPair({
+      pub: publicKey,
+      pubEnc: 'hex',
+    });
+
+    try {
+      isValid = ec.verify(data, signature, key);
+    } catch (e) {
+      // Catches 'Error: Signature without r or s'
+    }
+
+    return isValid;
+  }
+}

--- a/src/lib/database/PurserIdentity.js
+++ b/src/lib/database/PurserIdentity.js
@@ -4,9 +4,7 @@
  * orbit-db-identity-provider-purser (?)
  */
 
-import Keystore from 'orbit-db-keystore';
-
-import type { Identity } from './types';
+import type { Identity, KeyPair } from './types';
 
 import PurserIdentityProvider from './PurserIdentityProvider';
 
@@ -15,7 +13,7 @@ class PurserIdentity implements Identity {
 
   _idSignature: string;
 
-  _keystore: Keystore;
+  _orbitKey: KeyPair;
 
   _provider: PurserIdentityProvider;
 
@@ -37,6 +35,7 @@ class PurserIdentity implements Identity {
     pubKeyIdSignature: string,
     type: string,
     provider: PurserIdentityProvider,
+    orbitKey: KeyPair,
   ) {
     if (!id) {
       throw new Error('Identity id is required');
@@ -62,8 +61,12 @@ class PurserIdentity implements Identity {
       throw new Error('Identity provider is required');
     }
 
+    if (!orbitKey) {
+      throw new Error('Orbit key is required');
+    }
+
     this._id = id;
-    this._keystore = Keystore.create();
+    this._orbitKey = orbitKey;
     this._provider = provider;
     this._publicKey = publicKey;
     this._signatures = {
@@ -95,6 +98,10 @@ class PurserIdentity implements Identity {
 
   get provider() {
     return this._provider;
+  }
+
+  get orbitKey() {
+    return this._orbitKey;
   }
 
   toJSON() {

--- a/src/lib/database/PurserIdentityProvider.js
+++ b/src/lib/database/PurserIdentityProvider.js
@@ -1,25 +1,20 @@
 /* @flow */
+/* eslint-disable class-methods-use-this */
 
 import type { WalletObjectType } from '@colony/purser-core/flowtypes';
-
-import Keystore from 'orbit-db-keystore';
-
 import type { IdentityProvider } from './types';
 
+import Keystore from './Keystore';
 import PurserIdentity from './PurserIdentity';
 
-// TODO: Use actual type for common wallet interface
+// @TODO: Use actual type for common wallet interface
 type PurserWallet = WalletObjectType;
-
 type Options = {};
-
 type ProviderType = 'ETHEREUM_ACCOUNT';
 
 const PROVIDER_TYPE = 'ETHEREUM_ACCOUNT';
 
 class PurserIdentityProvider implements IdentityProvider {
-  _keystore: Keystore;
-
   _options: Options;
 
   _type: ProviderType;
@@ -27,12 +22,10 @@ class PurserIdentityProvider implements IdentityProvider {
   _purserWallet: PurserWallet;
 
   constructor(purserWallet: PurserWallet, options: Options = {}) {
-    // TODO: Assumption that creating a keystore like this is always OK
-    this._keystore = Keystore.create();
-    this._options = options;
-    // TOOD: Make sure wallet is unlocked when creating an identity
-    this._purserWallet = purserWallet;
     this._type = PROVIDER_TYPE;
+    // @TODO: Make sure wallet is unlocked when creating an identity
+    this._purserWallet = purserWallet;
+    this._options = options;
   }
 
   async createIdentity(): Promise<PurserIdentity> {
@@ -40,17 +33,14 @@ class PurserIdentityProvider implements IdentityProvider {
     if (!walletAddress) {
       throw new Error('Could not get wallet address. Is it unlocked?');
     }
-    // Get the key for id from the keystore or create one
-    // if it doesn't exist
-    const key =
-      (await this._keystore.getKey(walletAddress)) ||
-      (await this._keystore.createKey(walletAddress));
+    // Always create a key per "session"
+    const orbitKey = Keystore.createKey();
 
     // Sign the id with the signing key we're going to use
-    const idSignature = await this._keystore.sign(key, walletAddress);
+    const idSignature = Keystore.sign(orbitKey, walletAddress);
 
     // Get the hex string of the public key
-    const publicKey = key.getPublic('hex');
+    const publicKey = orbitKey.getPublic('hex');
 
     // Sign both the key and the signature created with that key
     const pubKeyIdSignature = await this._purserWallet.signMessage({
@@ -64,18 +54,18 @@ class PurserIdentityProvider implements IdentityProvider {
       pubKeyIdSignature,
       this._type,
       this,
+      orbitKey,
     );
   }
 
-  // TODO: It's this issue that we need to solve: https://flow.org/try/#0PQKgBAAgZgNg9gdzCYAoVBLAdgFwKYBOUAhgMZ5gCSAQmAN6pgCQUccAFMQFxUCCAlDwDOOAtgDmAblQBfdNnxEyFSr3qomAagD6AIx41pc1KRjEhQsGowBbAA4w8NvLkur1TPT2pH0p85a0tg5OLjhutAwsbJw8AupgiUkEeDgArgRYYADkrHDZ0klgcnJAA
+  // @TODO: It's this issue that we need to solve: https://flow.org/try/#0PQKgBAAgZgNg9gdzCYAoVBLAdgFwKYBOUAhgMZ5gCSAQmAN6pgCQUccAFMQFxUCCAlDwDOOAtgDmAblQBfdNnxEyFSr3qomAagD6AIx41pc1KRjEhQsGowBbAA4w8NvLkur1TPT2pH0p85a0tg5OLjhutAwsbJw8AupgiUkEeDgArgRYYADkrHDZ0klgcnJAA
   // $FlowFixMe
   async sign(identity: PurserIdentity, data: any): Promise<string> {
-    const signingKey = await this._keystore.getKey(identity.id);
-
+    const signingKey = identity.orbitKey;
     if (!signingKey)
       throw new Error(`Private signing key not found from Keystore`);
 
-    return this._keystore.sign(signingKey, data);
+    return Keystore.sign(signingKey, data);
   }
 
   async verify(
@@ -83,7 +73,7 @@ class PurserIdentityProvider implements IdentityProvider {
     publicKey: string,
     data: any,
   ): Promise<boolean> {
-    return this._keystore.verify(signature, publicKey, data);
+    return Keystore.verify(signature, publicKey, data);
   }
 }
 

--- a/src/lib/database/types/Identity.js
+++ b/src/lib/database/types/Identity.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import type { IdentityProvider } from './IdentityProvider';
+import type { KeyPair } from './KeyPair';
 
 type Signatures = {
   id: string,
@@ -17,6 +18,8 @@ export type IdentityObject = {
 export interface Identity {
   _id: string;
 
+  _orbitKey: KeyPair;
+
   +_provider: IdentityProvider;
 
   _publicKey: string;
@@ -26,6 +29,8 @@ export interface Identity {
   _type: string;
 
   get id(): string;
+
+  get orbitKey(): KeyPair;
 
   get provider(): IdentityProvider;
 

--- a/src/lib/database/types/IdentityProvider.js
+++ b/src/lib/database/types/IdentityProvider.js
@@ -1,12 +1,8 @@
 /* @flow */
 
-import Keystore from 'orbit-db-keystore';
-
 import type { Identity } from './Identity';
 
 export interface IdentityProvider {
-  _keystore: Keystore;
-
   +_type: string;
 
   createIdentity(): Promise<Identity>;

--- a/src/lib/database/types/KeyPair.js
+++ b/src/lib/database/types/KeyPair.js
@@ -1,0 +1,6 @@
+/* @flow */
+
+export type KeyPair = {
+  getPublic: (encoding?: string) => string,
+  getPrivate: (encoding?: string) => string,
+};

--- a/src/lib/database/types/index.js
+++ b/src/lib/database/types/index.js
@@ -3,6 +3,7 @@
 export type { AccessController, Entry } from './AccessController';
 export type { Identity, IdentityObject } from './Identity';
 export type { IdentityProvider } from './IdentityProvider';
+export type { KeyPair } from './KeyPair';
 export type { OrbitDBStore } from './OrbitDBStore';
 export type { OrbitDBKVStore } from './OrbitDBKVStore';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4409,7 +4409,7 @@ elliptic@=3.0.3:
     hash.js "^1.0.0"
     inherits "^2.0.1"
 
-elliptic@^6.0.0, elliptic@^6.2.3, elliptic@^6.4.0:
+elliptic@^6.0.0, elliptic@^6.2.3, elliptic@^6.4.0, elliptic@^6.4.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.1.tgz#c2d0b7776911b86722c632c3c06c60f2f819939a"
   integrity sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==


### PR DESCRIPTION
## Description

This PR adds a new keystore that doesn't store keys in `localStorage`. Instead, it creates a new key "per session".

## Other changes

- Changed/added types to accomodate the new Keystore

**New dependencies**:

- `elliptic` : This is a well-known library, that's what the original orbit-db-keystore used to u
   se to I had to install it :) We might wanna switch to something else in the future to optimize th    e bundle size, etc.

Closes #488