### PR TITLE
Fix `StepSelectToken` form

### DIFF
--- a/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.jsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.jsx
@@ -121,11 +121,11 @@ class StepSelectToken extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = { isLoading: false, tokenData: null };
-    this.getToken = promiseListener.generateAsyncFunction(
-      TOKEN_INFO_FETCH,
-      TOKEN_INFO_FETCH_SUCCESS,
-      TOKEN_INFO_FETCH_ERROR,
-    );
+    this.getToken = promiseListener.createAsyncFunction({
+      start: TOKEN_INFO_FETCH,
+      resolve: TOKEN_INFO_FETCH_SUCCESS,
+      reject: TOKEN_INFO_FETCH_ERROR,
+    });
   }
 
   componentDidUpdate({ values: { tokenAddress: prevTokenAddress } }: Props) {
@@ -154,9 +154,9 @@ class StepSelectToken extends Component<Props, State> {
 
     // Get the token address and handle success/error
     this.getToken
-      .asyncFunction(tokenAddress)
-      .then(this.handleGetTokenSuccess)
-      .catch(this.handleGetTokenError);
+      .asyncFunction({ tokenAddress })
+      .then((...args) => this.handleGetTokenSuccess(...args))
+      .catch(error => this.handleGetTokenError(error));
   }
 
   componentWillUnmount() {
@@ -192,7 +192,6 @@ class StepSelectToken extends Component<Props, State> {
 
   render() {
     const {
-      handleTokenAddressChange,
       isValid,
       previousStep,
       values: { tokenAddress },
@@ -213,7 +212,6 @@ class StepSelectToken extends Component<Props, State> {
                 <Button text={MSG.learnMore} appearance={{ theme: 'blue' }} />
               }
               status={tokenData ? MSG.preview : MSG.hint}
-              onChange={handleTokenAddressChange}
               statusValues={
                 tokenData
                   ? { tokenName: tokenData.name, tokenSymbol: tokenData.symbol }


### PR DESCRIPTION
## Description

Some recent changes were made to the `StepSelectToken` form without being checked thoroughly enough, sadly. Most of the issues were related to us trusting the `redux-promise-listener` documentation, but others were our own issues.

This PR fixes the issues:

* Use `createAsyncFunction` from `redux-promise-listener`, unlike the suggestion in its README
* Supply the async function `start/resolve/reject` properties in an object (again, unlike what the README suggests)
* Supply the payload object (`{ tokenAddress }`) to the async function (this one is on us)
* Fix `then/catch` scopes for calling the async function
* Remove unnecessary `onChange` handler for `tokenAddress` field
