### PR TITLE
Ignore orbit-db* updates for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,5 +186,13 @@
         "orbit-db-kvstore": "https://github.com/thiagodelgado111/orbit-db-kvstore#maintenance/new-ipfs-log",
         "orbit-db-store": "https://github.com/thiagodelgado111/orbit-db-store#fix/sync",
         "orbit-db-keystore": "https://github.com/orbitdb/orbit-db-keystore#fix/verification"
+    },
+    "greenkeeper": {
+        "ignore": [
+            "orbit-db",
+            "orbit-db-kvstore",
+            "orbit-db-store",
+            "orbit-db-keystore"
+        ]
     }
 }


### PR DESCRIPTION
This way it won't complain about new orbit release while we're still using our own fork