### PR TITLE
Allow passing of more custom tx lifecycle actions to methodSagaFactory

### DIFF
--- a/src/modules/core/actionCreators/transactions.js
+++ b/src/modules/core/actionCreators/transactions.js
@@ -12,14 +12,15 @@ import {
 
 export function startTransaction(
   id: string,
-  actionType: string,
+  transactionActionType: string,
   params: Object,
   options: SendOptions,
+  actionType?: string,
 ) {
   return {
-    type: TRANSACTION_STARTED,
+    type: actionType || TRANSACTION_STARTED,
     payload: {
-      actionType,
+      actionType: transactionActionType,
       createdAt: new Date(),
       id,
       options,
@@ -28,37 +29,53 @@ export function startTransaction(
   };
 }
 
-export function transactionSendError(id: string, message: string) {
+export function transactionSendError(
+  id: string,
+  message: string,
+  actionType?: string,
+) {
   return {
-    type: TRANSACTION_ERROR,
+    type: actionType || TRANSACTION_ERROR,
     payload: { id, error: { type: 'send', message } },
   };
 }
 
-export function transactionEventDataError(id: string, message: string) {
+export function transactionEventDataError(
+  id: string,
+  message: string,
+  actionType?: string,
+) {
   return {
-    type: TRANSACTION_ERROR,
+    type: actionType || TRANSACTION_ERROR,
     payload: { id, error: { type: 'eventData', message } },
   };
 }
 
-export function transactionReceiptError(id: string, message: string) {
+export function transactionReceiptError(
+  id: string,
+  message: string,
+  actionType?: string,
+) {
   return {
-    type: TRANSACTION_ERROR,
+    type: actionType || TRANSACTION_ERROR,
     payload: { id, error: { type: 'receipt', message } },
   };
 }
 
-export function transactionReceiptReceived(id: string, receipt: Object) {
+export function transactionReceiptReceived(
+  id: string,
+  receipt: Object,
+  actionType?: string,
+) {
   return {
-    type: TRANSACTION_RECEIPT_RECEIVED,
+    type: actionType || TRANSACTION_RECEIPT_RECEIVED,
     payload: { id, receipt },
   };
 }
 
-export function sendTransaction(id: string, hash: string) {
+export function sendTransaction(id: string, hash: string, actionType?: string) {
   return {
-    type: TRANSACTION_SENT,
+    type: actionType || TRANSACTION_SENT,
     payload: { id, hash },
   };
 }
@@ -66,9 +83,10 @@ export function sendTransaction(id: string, hash: string) {
 export function transactionEventDataReceived<EventData>(
   id: string,
   eventData: EventData,
+  actionType?: string,
 ) {
   return {
-    type: TRANSACTION_EVENT_DATA_RECEIVED,
+    type: actionType || TRANSACTION_EVENT_DATA_RECEIVED,
     payload: { id, eventData },
   };
 }

--- a/src/modules/core/sagas/utils/sendMethodTransaction.js
+++ b/src/modules/core/sagas/utils/sendMethodTransaction.js
@@ -4,7 +4,11 @@ import type { Saga } from 'redux-saga';
 
 import { cancel, call, fork } from 'redux-saga/effects';
 
-import type { Sender, TransactionAction } from '../../types';
+import type {
+  Sender,
+  TransactionAction,
+  LifecycleActionTypes,
+} from '../../types';
 
 import { getTransactionResponse, sendTransaction } from './sendTransaction';
 
@@ -32,6 +36,7 @@ export default function* sendMethodTransaction<
 >(
   method: Sender<Params, EventData>,
   action: TransactionAction<Params>,
+  lifecycleActionTypes: LifecycleActionTypes,
 ): Saga<{ error?: Error, receipt?: Object, eventData?: EventData }> {
   let response;
   let task;
@@ -40,7 +45,7 @@ export default function* sendMethodTransaction<
     const txPromise = getMethodTxPromise(method, action);
 
     // Create a task to send the transaction for the given action.
-    task = yield fork(sendTransaction, txPromise, action);
+    task = yield fork(sendTransaction, txPromise, action, lifecycleActionTypes);
 
     // Get the successful/erroneous transaction response.
     response = yield call(getTransactionResponse);

--- a/src/modules/core/types.js
+++ b/src/modules/core/types.js
@@ -33,3 +33,12 @@ export type TransactionAction<Params: Object> = {
 };
 
 export type TransactionsState = ImmutableMap<TransactionId, TransactionRecord>;
+
+export type LifecycleActionTypes = {
+  started?: string,
+  sent?: string,
+  error?: string,
+  eventDataReceived?: string,
+  receiptReceived?: string,
+  success?: string,
+};


### PR DESCRIPTION
## Description

Removes the `successType` and `errorType` action type arguments from `methodSagaFactory` in favour of an object. This allows specifying custom (additional) lifecycle hooks in more granular detail for transactions.

It now supports the following action types (strings):

```js
{
  started,
  sent,
  error,
  eventDataReceived,
  receiptReceived,
  success,
}
```

## TODO

- [x] Fix tests

Closes #483 
