### PR TITLE
Avatar Dropdown disable choices when User has not claimed the Profile

### DIFF
--- a/src/modules/users/components/AvatarDropdown/AvatarDropdownPopover.jsx
+++ b/src/modules/users/components/AvatarDropdown/AvatarDropdownPopover.jsx
@@ -63,15 +63,17 @@ class AvatarDropdownPopover extends Component<Props> {
     } = this.props;
     return (
       <DropdownMenuSection separator>
-        <DropdownMenuItem>
-          <DialogLink to="CreateUsernameDialog">
-            {({ open }) => (
-              <button type="button" onClick={open}>
-                <FormattedMessage {...MSG.buttonGetStarted} />
-              </button>
-            )}
-          </DialogLink>
-        </DropdownMenuItem>
+        {!username && (
+          <DropdownMenuItem>
+            <DialogLink to="CreateUsernameDialog">
+              {({ open }) => (
+                <button type="button" onClick={open}>
+                  <FormattedMessage {...MSG.buttonGetStarted} />
+                </button>
+              )}
+            </DialogLink>
+          </DropdownMenuItem>
+        )}
         {username && (
           <DropdownMenuItem>
             <NavLink to={`/user/${username}`} text={MSG.myProfile} />


### PR DESCRIPTION
This PR disables the choices for: _My Profile_, _Settings_ and _Create Colony_ from the Avatar Dropdown menu, in the case where the user has not claimed the profile, and replaces them with a _Get Started_ link which redirects to the _Claim Profile_ workflow.

A big note here, that most of this was implemented by @chmanie as part of #582, so in essence I just disabled two extra links in this PR: _Create Colony_ and the _Get Started_ if there already is an username

Changed:
- [x] Disable the _Create Colony_ link in `AvatarDropdown` if there's no `username` value
- [x] Disable the _Get Started_ link in `AvatarDropdown` if there is a `username` value

Screenshots:

Profile claimed:
![screenshot from 2018-11-21 17-26-34](https://user-images.githubusercontent.com/1193222/48851638-41490200-edb4-11e8-8552-951e490f2e4f.png)

Profile is not claimed:
![screenshot from 2018-11-21 17-33-51](https://user-images.githubusercontent.com/1193222/48851651-46a64c80-edb4-11e8-96d1-985e1afd1132.png)

Resoves #549 