### PR TITLE
Improve debuggability of unexpected transaction errors

### DIFF
--- a/src/modules/core/sagas/transactions/sendMethodTransaction.js
+++ b/src/modules/core/sagas/transactions/sendMethodTransaction.js
@@ -11,6 +11,9 @@ import type {
   TransactionParams,
   TransactionEventData,
 } from '~types/index';
+
+import { putError } from '~utils/saga/effects';
+
 import type { Sender, SendTransactionAction } from '../../types';
 
 import { getMethod } from '../utils';
@@ -285,10 +288,10 @@ export default function* sendMethodTransaction<
     // Unexpected errors `put` the given error action...
     const { lifecycle: { error: errorType } = {} } = tx || {};
     if (errorType) {
-      yield put({ type: errorType, payload: caughtError });
+      yield putError(errorType, caughtError);
     } else {
-      // ...or re-throw if the error type was not found.
-      throw caughtError;
+      // We still dispatch this error as a general TRANASACTION_ERROR
+      yield putError(TRANSACTION_ERROR, caughtError);
     }
   }
 }


### PR DESCRIPTION
This PR will improve the debug process related to TX sagas. When errors are thrown that weren't really expected we now get them in the console, too (when in dev mode). Also just using an `Error` object as a payload for an action doesn't really work (it's not being picked up by the redux debugger at least). Anyways, we're using the custom `putError` effect now, which can be adjusted to our needs later as well.

Closes #620.