### PR TITLE
Wire worker submit work button on Task

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "dependencies": {
         "@babel/runtime": "^7.0.0",
         "@colony/colony-js-adapter-ethers": "^1.7.0",
-        "@colony/colony-js-client": "^1.7.4",
+        "@colony/colony-js-client": "^1.7.5",
         "@colony/colony-js-contract-loader-http": "^1.6.2",
         "@colony/colony-js-contract-loader-network": "^1.6.2",
         "@colony/purser-core": "^2.0.0",

--- a/src/modules/dashboard/actionCreators/index.js
+++ b/src/modules/dashboard/actionCreators/index.js
@@ -2,7 +2,10 @@
 
 import type { SendOptions } from '@colony/colony-js-client';
 
-import { createNetworkTransaction } from '../../core/actionCreators';
+import {
+  createNetworkTransaction,
+  createColonyTransaction,
+} from '../../core/actionCreators';
 
 import {
   COLONY_CREATE_ERROR,
@@ -11,6 +14,8 @@ import {
   COLONY_CREATE_LABEL_SUCCESS,
   TOKEN_CREATE_ERROR,
   TOKEN_CREATE_SUCCESS,
+  TASK_SUBMIT_WORK_ERROR,
+  TASK_SUBMIT_WORK_SUCCESS,
 } from '../actionTypes';
 
 export const createColony = (
@@ -55,5 +60,25 @@ export const createColonyLabel = (
     lifecycle: {
       error: COLONY_CREATE_LABEL_ERROR,
       success: COLONY_CREATE_LABEL_SUCCESS,
+    },
+  });
+
+export const taskSubmitWork = (
+  identifier: string,
+  params: {
+    taskId: string,
+    deliverableHash: string,
+    secret: string,
+  },
+  options?: SendOptions,
+) =>
+  createColonyTransaction({
+    params,
+    options,
+    methodName: 'submitTaskDeliverableAndRating',
+    identifier,
+    lifecycle: {
+      error: TASK_SUBMIT_WORK_ERROR,
+      success: TASK_SUBMIT_WORK_SUCCESS,
     },
   });

--- a/src/modules/dashboard/actionTypes/index.js
+++ b/src/modules/dashboard/actionTypes/index.js
@@ -1,3 +1,4 @@
 /* @flow */
 
 export * from './colony';
+export * from './task';

--- a/src/modules/dashboard/actionTypes/task.js
+++ b/src/modules/dashboard/actionTypes/task.js
@@ -1,0 +1,8 @@
+/* @flow */
+/* eslint-disable max-len */
+
+import ns from '../namespace';
+
+export const TASK_SUBMIT_WORK = `${ns}/TASK_SUBMIT_WORK`;
+export const TASK_SUBMIT_WORK_ERROR = `${ns}/TASK_SUBMIT_WORK_ERROR`;
+export const TASK_SUBMIT_WORK_SUCCESS = `${ns}/TASK_SUBMIT_WORK_SUCCESS`;

--- a/src/modules/dashboard/components/Task/DialogActionButton.jsx
+++ b/src/modules/dashboard/components/Task/DialogActionButton.jsx
@@ -1,0 +1,58 @@
+/* @flow */
+
+import React from 'react';
+
+import type { MessageDescriptor } from 'react-intl';
+
+import withDialog from '~core/Dialog/withDialog';
+import { ActionForm } from '~core/Fields';
+import Button from '~core/Button';
+
+import type { OpenDialog } from '~core/Dialog/types';
+import type { Action } from '~types/';
+
+type Props = {
+  openDialog: OpenDialog,
+  dialog: string,
+  options: Object,
+  submit: string,
+  success: string,
+  error: string,
+  text: MessageDescriptor | string,
+  setPayload?: (action: Action, values: Object) => Action,
+};
+
+const DialogActionButton = ({
+  openDialog,
+  dialog,
+  options,
+  submit,
+  success,
+  error,
+  text,
+  setPayload,
+}: Props) => (
+  <ActionForm
+    submit={submit}
+    success={success}
+    error={error}
+    setPayload={setPayload}
+  >
+    {({ isSubmitting, setValues, submitForm }) => (
+      <Button
+        text={text}
+        onClick={() =>
+          openDialog(dialog, options)
+            .afterClosed()
+            .then(values => {
+              setValues(values);
+              submitForm();
+            })
+        }
+        loading={isSubmitting}
+      />
+    )}
+  </ActionForm>
+);
+
+export default withDialog()(DialogActionButton);

--- a/src/modules/dashboard/components/Task/Task.jsx
+++ b/src/modules/dashboard/components/Task/Task.jsx
@@ -24,6 +24,13 @@ import TaskComments from '~dashboard/TaskComments';
 import TaskFeed from '~dashboard/TaskFeed';
 import TaskClaimReward from '~dashboard/TaskClaimReward';
 import TaskSkills from '~dashboard/TaskSkills';
+import DialogActionButton from './DialogActionButton.jsx';
+
+import {
+  TASK_SUBMIT_WORK,
+  TASK_SUBMIT_WORK_ERROR,
+  TASK_SUBMIT_WORK_SUCCESS,
+} from '../../actionTypes';
 
 import taskMock from './__datamocks__/mockTask';
 import userMocks from './__datamocks__/mockUsers';
@@ -45,6 +52,10 @@ const MSG = defineMessages({
   completed: {
     id: 'dashboard.Task.completed',
     defaultMessage: 'Task completed',
+  },
+  submitWork: {
+    id: 'dashboard.Task.submitWork',
+    defaultMessage: 'Submit Work',
   },
 });
 
@@ -182,12 +193,26 @@ class Task extends Component<Props> {
                     })
                   }
                 />
-                <Button
-                  text="Rate Manager (Work Submitted)"
-                  onClick={() =>
-                    openDialog('ManagerRatingDialog', { workSubmitted: true })
-                  }
-                />
+                {!task.workSubmitted && (
+                  <DialogActionButton
+                    dialog="ManagerRatingDialog"
+                    options={{
+                      workSubmitted: true,
+                    }}
+                    text={MSG.submitWork}
+                    submit={TASK_SUBMIT_WORK}
+                    success={TASK_SUBMIT_WORK_SUCCESS}
+                    error={TASK_SUBMIT_WORK_ERROR}
+                    setPayload={(action, values) => ({
+                      ...action,
+                      payload: {
+                        ...values,
+                        colonyIdentifier: task.colonyAddress,
+                        taskId: task.id,
+                      },
+                    })}
+                  />
+                )}
                 <Button
                   text="Rate Worker"
                   onClick={() =>

--- a/src/modules/dashboard/components/Task/__datamocks__/mockTask.js
+++ b/src/modules/dashboard/components/Task/__datamocks__/mockTask.js
@@ -21,6 +21,7 @@ export const mockTaskReward = {
 export const mockTask = {
   id: 1,
   title: 'Develop Github integration',
+  colonyAddress: '0xdd90e005D1Cebb6621B673d3116b5E2CF6f1B902',
   reputation: 19.5,
   payouts: [
     { symbol: 'ETH', amount: 21545, isEth: true },

--- a/src/modules/dashboard/components/TaskRatingDialogs/ManagerRatingDialog.jsx
+++ b/src/modules/dashboard/components/TaskRatingDialogs/ManagerRatingDialog.jsx
@@ -100,15 +100,14 @@ const validationSchemaExtended = validationSchema.shape({
   workDescription: yup.string().required(MSG.workDescriptionError),
 });
 
-const ManagerRatingDialog = ({ cancel, workSubmitted }: Props) => (
+const ManagerRatingDialog = ({ close, cancel, workSubmitted }: Props) => (
   <Dialog cancel={cancel} className={styles.main}>
     <Form
       initialValues={{
         rating: '',
         workDescription: '',
       }}
-      /* eslint-disable-next-line no-console */
-      onSubmit={(values: FormValues) => console.log(`[${displayName}]`, values)}
+      onSubmit={close}
       validationSchema={
         workSubmitted ? validationSchemaExtended : validationSchema
       }

--- a/src/modules/dashboard/sagas/index.js
+++ b/src/modules/dashboard/sagas/index.js
@@ -3,7 +3,8 @@
 import { all } from 'redux-saga/effects';
 
 import colonySagas from './colony';
+import taskSagas from './task';
 
 export default function* dashboardSagas(): any {
-  yield all([colonySagas()]);
+  yield all([colonySagas(), taskSagas()]);
 }

--- a/src/modules/dashboard/sagas/task.js
+++ b/src/modules/dashboard/sagas/task.js
@@ -1,0 +1,60 @@
+/* @flow */
+
+import type { Saga } from 'redux-saga';
+
+import { put, takeEvery, call, getContext } from 'redux-saga/effects';
+
+import type { Action } from '~types/index';
+
+import { putError } from '~utils/saga/effects';
+import { COLONY_CONTEXT } from '../../../lib/ColonyManager/constants';
+
+import { TASK_SUBMIT_WORK, TASK_SUBMIT_WORK_ERROR } from '../actionTypes';
+
+import { taskSubmitWork } from '../actionCreators';
+
+function* taskSubmitWorkSaga(action: Action): Saga<void> {
+  const {
+    payload: { colonyIdentifier, taskId, workDescription, rating },
+  } = action;
+  const colonyManager = yield getContext('colonyManager');
+  const wallet = yield getContext('wallet');
+  const ipfsNode = yield getContext('ipfsNode');
+  try {
+    const deliverableHash = yield call(
+      [ipfsNode, ipfsNode.addString],
+      workDescription,
+    );
+    const getTask = yield call(
+      [colonyManager, colonyManager.getMethod],
+      COLONY_CONTEXT,
+      'getTask',
+      colonyIdentifier,
+    );
+    const generateSecret = yield call(
+      [colonyManager, colonyManager.getMethod],
+      COLONY_CONTEXT,
+      'generateSecret',
+      colonyIdentifier,
+    );
+    const { specificationHash } = yield call([getTask, getTask.call], {
+      taskId,
+    });
+    const salt = yield call([wallet, wallet.signMessage], {
+      message: specificationHash,
+    });
+    const secret = yield call([generateSecret, generateSecret.call], {
+      salt,
+      rating,
+    });
+    yield put(
+      taskSubmitWork(colonyIdentifier, { taskId, deliverableHash, secret }),
+    );
+  } catch (error) {
+    yield putError(TASK_SUBMIT_WORK_ERROR, error);
+  }
+}
+
+export default function* taskSagas(): any {
+  yield takeEvery(TASK_SUBMIT_WORK, taskSubmitWorkSaga);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -951,13 +951,13 @@
     "@colony/colony-js-contract-loader" "^1.6.2"
     bn.js "^4.11.6"
 
-"@colony/colony-js-client@^1.7.4":
-  version "1.7.4"
-  resolved "https://registry.yarnpkg.com/@colony/colony-js-client/-/colony-js-client-1.7.4.tgz#7fa3eb9130ecba1bdfd6be4b37669f7acea3ecf2"
-  integrity sha512-mBF7ddw4IRqQFEvr0CBGJ5VwXS9FN0yGdtlVyHXyxMAdjUQEBxvhxK8nc07ZWRw0E5YqGQcweN20kt33SPEPVA==
+"@colony/colony-js-client@^1.7.5":
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/@colony/colony-js-client/-/colony-js-client-1.7.5.tgz#60a8fa75c12c2ac849c3cd708e7ab9195d7ade02"
+  integrity sha512-vw6Mdod2PbB5h6XHX7p5DaLin0ICfDWg2EPlSvlS+IPKutLdtMvF/5370rmioI9Eag7iySOh8lpALtT1D9mSlw==
   dependencies:
     "@colony/colony-js-adapter" "^1.7.0"
-    "@colony/colony-js-contract-client" "^1.7.3"
+    "@colony/colony-js-contract-client" "^1.7.5"
     "@colony/colony-js-contract-loader" "^1.6.2"
     "@colony/colony-js-utils" "^1.5.4"
     assert "^1.4.1"
@@ -966,10 +966,10 @@
     isomorphic-fetch "^2.2.1"
     web3-utils "^1.0.0-beta.34"
 
-"@colony/colony-js-contract-client@^1.7.3":
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/@colony/colony-js-contract-client/-/colony-js-contract-client-1.7.3.tgz#921671c3fa56b54c417552c03767f654a3f7b7d0"
-  integrity sha512-l7soEl+3FyxLV/d77srPccXK9ezZIXy5JnIM1+0IHC+C0PwvGNBK2KwPgPm/Xf5W+YELbpWKesguVWsmgFFE+Q==
+"@colony/colony-js-contract-client@^1.7.5":
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/@colony/colony-js-contract-client/-/colony-js-contract-client-1.7.5.tgz#3e6a5b5fcfa958078cfc937172f0846b8e7de064"
+  integrity sha512-ZL3G5mmxQ/J7a3B2gq2vl1WmwLB7pHkC3QeWM14PNTSUpIbfov8XGZht4kjy97sqFAAZaKH00DHSK80mkQjaNA==
   dependencies:
     "@colony/colony-js-adapter" "^1.7.0"
     "@colony/colony-js-contract-loader" "^1.6.2"


### PR DESCRIPTION
## Description

The submit work button and dialog are now **_wired_**. Sagas handle the actions to compute the `secret` to be submitted (`generateSecret` with `salt` as result of `signMessage` on `specificationHash`) and store the submission on IPFS, finally submitting the transaction to call the `submitTaskDeliverableAndRating ` contract method.

Additionally created the `DialogActionButton` - opens dialog and submits values with `ActionForm` on close. This can be used for all buttons which open a dialog, then spin while waiting for a transaction to complete.

## NB: Scott did an oops

A while after opening this and embarking on #632 I realise I'd actually only done half the job and not completed the entire workflow set out in the issue. So this issue actually only deals with the worker submitting the work, and the counter-party rating is handled in #632 (manager rates the worker after work has been submitted). The rebase would not have been worth...

**May be worth just reviewing the whole thing in #632**

## Deps

**New dependencies**:

- `@colony/colony-js-client` : upgraded to `^1.7.4`

Closes #461 
