### PR TITLE
Bring the validations in line with their translations

### DIFF
--- a/src/i18n/en-validation.json
+++ b/src/i18n/en-validation.json
@@ -1,10 +1,13 @@
 {
     "mixed": {
-        "equalTo": "${path} must be the same as ${reference}"
+        "equalTo": "${path} must be the same as ${reference}",
+        "lessThanPot": "Not enough funds in the pot"
     },
     "string": {
         "address": "This is not a valid address",
-        "ensAddress": "This is not a valid ENS address",
-        "username": "This is not a valid username"
+        "ensAddress": "This is not a valid ENS address"
+    },
+    "array": {
+        "includes": "The values should include ${searchVal}"
     }
 }

--- a/src/modules/validations.js
+++ b/src/modules/validations.js
@@ -29,7 +29,7 @@ function equalTo(ref, msg) {
 function lessThanPot(availableTokens, msg) {
   return this.test({
     name: 'lessThanPot',
-    message: msg,
+    message: msg || en.mixed.lessThanPot,
     test(value) {
       // $FlowFixMe `yup.ref` not recognised
       const tokenIndex = this.resolve(yup.ref('token'));
@@ -69,7 +69,10 @@ function ensAddress(msg) {
 function includes(searchVal, msg) {
   return this.test({
     name: 'includes',
-    message: msg || en.mixed.required,
+    message: msg || en.array.includes,
+    params: {
+      searchVal,
+    },
     test(value) {
       return value.includes(searchVal);
     },


### PR DESCRIPTION
This PR doesn't introduce any new features or fixes bugs. It's just there for good measure, providing fallbacks for validation messages if not given and picking the proper `yup` types.