### PR TITLE
Add transaction to every tx lifecycle payload

### DIFF
--- a/src/modules/core/sagas/transactions/sendMethodTransaction.js
+++ b/src/modules/core/sagas/transactions/sendMethodTransaction.js
@@ -20,7 +20,7 @@ import {
   TRANSACTION_EVENT_DATA_RECEIVED,
   TRANSACTION_RECEIPT_RECEIVED,
   TRANSACTION_SENT,
-} from '../../actionTypes/index';
+} from '../../actionTypes';
 import {
   transactionEventDataError,
   transactionEventDataReceived,
@@ -29,7 +29,8 @@ import {
   transactionSendError,
   transactionSent,
   transactionUnsuccessfulError,
-} from '../../actionCreators/index';
+} from '../../actionCreators';
+import { oneTransaction } from '../../selectors';
 
 /*
  * Given a promise for sending a transaction, send the transaction and
@@ -197,11 +198,22 @@ function* sendTransaction<P: TransactionParams, E: TransactionEventData>(
     while (true) {
       const action = yield take(channel);
 
-      // Put the action to the store as-is
-      yield put(action);
+      // Get the current transaction state from the store
+      const transaction = yield select(oneTransaction, id);
+
+      // Add the transaction to the payload
+      const payload = {
+        ...action.payload,
+        transaction,
+      };
+
+      // Put the action to the store
+      yield put({
+        ...action,
+        payload,
+      });
 
       // Handle lifecycle action types
-      const { payload } = action;
       switch (action.type) {
         case TRANSACTION_ERROR:
           if (errorType) yield put({ type: errorType, payload });

--- a/src/modules/core/selectors/transactions.js
+++ b/src/modules/core/selectors/transactions.js
@@ -11,8 +11,11 @@ import type { TransactionRecord } from '~types/TransactionRecord';
 type State = { [typeof ns]: { transactions: TransactionsState } };
 
 type TransactionSelector = (tx: TransactionRecord<*, *>) => boolean;
-
 type TransactionsSelector = (state: State) => TransactionsState;
+type OneTransactionSelector = (
+  state: State,
+  id: string,
+) => ?TransactionRecord<*, *>;
 
 /**
  * Individual transaction selectors
@@ -44,6 +47,8 @@ const createdAtDesc = (
  */
 export const allTransactions: TransactionsSelector = state =>
   state[ns].transactions;
+export const oneTransaction: OneTransactionSelector = (state, id) =>
+  state[ns].transactions.get(id);
 export const pendingTransactions: TransactionsSelector = createSelector(
   allTransactions,
   transactions => transactions.filter(isPending).sort(createdAtDesc),


### PR DESCRIPTION
This adds a `transaction` object to the payload of every dispatched transaction lifecycle action via getting the current state from the store before attaching it.

Closes #629.