### PR TITLE
Wait for replication when loading KVStores

### DIFF
--- a/src/lib/database/stores/KVStore.js
+++ b/src/lib/database/stores/KVStore.js
@@ -64,6 +64,31 @@ class KVStore extends Store {
       return promise.then(next);
     }, Promise.resolve(true));
   }
+
+  /*
+    Wait for the store to be fully replicated.
+    NOTE: The current usage of this KVStore is for a specific set of keys
+    (rather than an unlimited number of keys); if this restriction is removed,
+    then this should be moved to another function.
+   */
+  async load() {
+    const replicatedPromise = new Promise(resolve => {
+      this._orbitStore.events.once('replicated', resolve);
+    });
+    const timeoutPromise = new Promise((resolve, reject) => {
+      setTimeout(() => {
+        reject(
+          new Error(
+            `Timeout while waiting on replication for store "${this._name}"`,
+          ),
+        );
+      }, 15 * 1000); // 15 seconds
+    });
+
+    await super.load();
+
+    return Promise.race([replicatedPromise, timeoutPromise]);
+  }
 }
 
 export default KVStore;

--- a/src/lib/database/stores/Store.js
+++ b/src/lib/database/stores/Store.js
@@ -28,6 +28,9 @@ class Store {
     return this._orbitStore.address;
   }
 
+  /*
+    NOTE: `load` is an async function, so this function returns a promise.
+   */
   load() {
     return this._orbitStore.load();
   }


### PR DESCRIPTION
## Description

Given that KVStores are currently used with fixed keys (rather than any number of arbitrary keys like IDs), loading the store should load all of these values; to do this, we have to wait for replication to complete.
