### PR TITLE
Fix version for orbit-db-identity-provider to v0.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,7 +204,9 @@
         "orbit-db": "JoinColony/orbit-db#develop",
         "orbit-db-kvstore": "JoinColony/orbit-db-kvstore#develop",
         "orbit-db-store": "orbitdb/orbit-db-store#b5483fe3beec72fb8c98f993ea42b1345467ffd2",
-        "orbit-db-keystore": "orbitdb/orbit-db-keystore#fix/verification"
+        "orbit-db-keystore": "orbitdb/orbit-db-keystore#fix/verification",
+        "ipfs-log": "orbitdb/ipfs-log#2bdbe7a99d86570e0e05d28045da0379d2b9a879",
+        "orbit-db-identity-provider": "0.0.2"
     },
     "greenkeeper": {
         "ignore": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -7851,11 +7851,11 @@ ipfs-http-response@~0.2.0:
     promisify-es6 "^1.0.3"
     stream-to-blob "^1.0.1"
 
-"ipfs-log@github:orbitdb/ipfs-log":
+"ipfs-log@github:orbitdb/ipfs-log", ipfs-log@orbitdb/ipfs-log#2bdbe7a99d86570e0e05d28045da0379d2b9a879:
   version "4.2.0"
-  resolved "https://codeload.github.com/orbitdb/ipfs-log/tar.gz/febec397361594913fa6aad35f29de85cc526e28"
+  resolved "https://codeload.github.com/orbitdb/ipfs-log/tar.gz/2bdbe7a99d86570e0e05d28045da0379d2b9a879"
   dependencies:
-    orbit-db-identity-provider "^0.0.2"
+    orbit-db-identity-provider "github:orbitdb/orbit-db-identity-provider"
     p-map "^1.1.1"
     p-whilst "^1.0.0"
 
@@ -12275,9 +12275,10 @@ orbit-db-feedstore@~1.4.0:
   dependencies:
     orbit-db-eventstore "~1.4.0"
 
-orbit-db-identity-provider@^0.0.3, "orbit-db-identity-provider@github:orbitdb/orbit-db-identity-provider":
-  version "0.0.3"
-  resolved "https://codeload.github.com/orbitdb/orbit-db-identity-provider/tar.gz/db4bb11ddad8a2cea347782a011bec050827dcef"
+orbit-db-identity-provider@0.0.2, "orbit-db-identity-provider@github:orbitdb/orbit-db-identity-provider":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/orbit-db-identity-provider/-/orbit-db-identity-provider-0.0.2.tgz#f2e05ac05b2154667ab341e1da8402cea5d056f7"
+  integrity sha512-xE69h4FBIBU4im3KoirRxblHQyDeZesMKw12QqUtRYiIHVT7vhI4hx1QmsUDlZerBz8Pv4IJN4wVMijqCpc7xQ==
 
 orbit-db-keystore@^0.1.0, "orbit-db-keystore@github:orbitdb/orbit-db-keystore#fix/verification", orbit-db-keystore@orbitdb/orbit-db-keystore#fix/verification:
   version "0.1.0"


### PR DESCRIPTION
There was a `yarn` hiccup that should be resolved now.