### PR TITLE
Closing task being wired in task component 

### DIFF
--- a/src/modules/dashboard/components/Task/Task.js
+++ b/src/modules/dashboard/components/Task/Task.js
@@ -1,16 +1,28 @@
 /* @flow */
 
-import { compose, withProps } from 'recompose';
+import { compose, withProps, lifecycle } from 'recompose';
+import { connect } from 'react-redux';
 
 import withDialog from '~core/Dialog/withDialog';
 
 import Task from './Task.jsx';
+
+import promiseListener from '../../../../createPromiseListener';
 
 import userMock from '~users/AvatarDropdown/__datamocks__/mockUser';
 import { mockTask } from './__datamocks__/mockTask';
 
 const enhance = compose(
   withDialog(),
+  lifecycle({
+    componentDidMount() {
+      this.asyncFunc = promiseListener.createAsyncFunction({
+        start: 'TASK_FETCH_DETAILS',
+        resolve: 'TASK_FETCH_DETAILS_SUCCESS',
+        reject: 'TASK_FETCH_DETAILS_ERROR',
+      });
+    },
+  }),
   withProps(() => {
     const task = mockTask;
     const user = userMock;
@@ -22,9 +34,17 @@ const enhance = compose(
       user,
       isTaskCreator,
       preventEdit:
-        !!task && !task.currentState === 'finalized' && isTaskCreator,
+        !!task &&
+        !task.currentState === 'TASK_STATE.FINALIZED' &&
+        isTaskCreator,
     };
   }),
+  connect(
+    state => ({
+      task: state.task,
+    }),
+    {},
+  ),
 );
 
 export default enhance(Task);


### PR DESCRIPTION
## Description

_
We do not have a way to fetch taskDetails into the task component yet. 
Use recompose's lifecycle method to provide them based on the taskId.

The taskDetails will include a currentState property, and once there is task data it can be wired up  properly ( without mockData ) to hide and show functionality to the user based on the task status. 
_

Closes #573 
