### PR TITLE
Reset directory before provisioning modules

### DIFF
--- a/scripts/provision_submodules.sh
+++ b/scripts/provision_submodules.sh
@@ -34,7 +34,7 @@ log() {
 
 log "Generating ssl certificate"
 if [ ! -f ssl/localhost+2.pem ]; then
-  cd ssl && mkcert localhost 127.0.0.1 ::1
+  cd ssl && mkcert localhost 127.0.0.1 ::1 && cd ${ROOT_PATH}
 else
   echo "Certificate already exists"
 fi


### PR DESCRIPTION
## Description


This PR adjusts the `provision` script so that it resets the directory to the root path after generating a certificate in the `ssl` directory.
