### PR TITLE
Set `from` field when estimating gas

### DIFF
--- a/src/lib/EthersWrappedWallet/index.js
+++ b/src/lib/EthersWrappedWallet/index.js
@@ -68,7 +68,10 @@ export default class EthersWrappedWallet {
    * our BN format.
    */
   async estimateGas(tx: TransactionRequest): Promise<BigNumber> {
-    const estimate = await this.provider.estimateGas(tx);
+    // We need to properly send `from`, so that `msg.sender` will have the correct value when estimating
+    const from = await this.getAddress();
+    const transformedTx = { ...tx, from };
+    const estimate = await this.provider.estimateGas(transformedTx);
     return new BigNumber(estimate.toString());
   }
 


### PR DESCRIPTION
OK, here's what I know now:

1) We need to have a `from` field in our transactions to be able to estimate gas properly (because of the "dry-run" the estimation does)
2) The default `msg.sender` in ganache’s gas estimation equals to the first account in the list it's set up with
3) The issue was that our `EthersWrappedWallet` would not set the `from` field to the according address.

The actual issue here was that it didn't happen when sending a transaction but when estimating gas. So when we used the first account (0) to create a user label it would set that properly. But when doing it the second time with no `from` set, gas estimation would fail as the `from`/`msg.sender` defaults to the first account address.

This is fixed by setting the `from` field when estimating.

Closes #679.