### PR TITLE
Wire current user address in Wallet

### DIFF
--- a/src/modules/dashboard/components/Wallet/Wallet.js
+++ b/src/modules/dashboard/components/Wallet/Wallet.js
@@ -1,10 +1,12 @@
 /* @flow */
 
+import { connect } from 'react-redux';
 import { compose, withProps } from 'recompose';
 
 import withDialog from '~core/Dialog/withDialog';
 
 import Wallet from './Wallet.jsx';
+import { currentUserAddressSelector } from '../../../users/selectors';
 
 import mockTokens from '../../../../__mocks__/mockTokens';
 
@@ -12,6 +14,9 @@ const enhance = compose(
   withDialog(),
   withProps(() => ({
     tokens: mockTokens,
+  })),
+  connect(state => ({
+    walletAddress: currentUserAddressSelector(state),
   })),
 );
 

--- a/src/modules/dashboard/components/Wallet/Wallet.jsx
+++ b/src/modules/dashboard/components/Wallet/Wallet.jsx
@@ -6,6 +6,7 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 
 import type { DialogType } from '~core/Dialog';
 import type { TokenRecord } from '~immutable';
+import type { Address } from '~types';
 
 import { Tab, Tabs, TabList, TabPanel } from '~core/Tabs';
 import CopyableAddress from '~core/CopyableAddress';
@@ -18,7 +19,6 @@ import TokenList from '~admin/Tokens/TokenList.jsx';
 
 import styles from './Wallet.css';
 
-import mockUser from './__datamocks__/mockUser';
 import mockTransactions from './__datamocks__/mockTransactions';
 
 const MSG = defineMessages({
@@ -49,6 +49,7 @@ const displayName = 'dashboard.Wallet';
 type Props = {
   openDialog: (dialogName: string, dialogProps?: Object) => DialogType,
   tokens: List<TokenRecord>,
+  walletAddress: Address,
 };
 
 class Wallet extends Component<Props> {
@@ -71,19 +72,19 @@ class Wallet extends Component<Props> {
   };
 
   render() {
-    const { tokens } = this.props;
+    const { tokens, walletAddress } = this.props;
     return (
       <div className={styles.layoutMain}>
         <main className={styles.content}>
           <div className={styles.walletDetails}>
-            <QRCode address={mockUser.profile.walletAddress} width={55} />
+            <QRCode address={walletAddress} width={55} />
             <div className={styles.address}>
               <Heading
                 text={MSG.titleWallet}
                 appearance={{ size: 'medium', margin: 'small' }}
               />
               <CopyableAddress appearance={{ theme: 'big' }} full>
-                {mockUser.profile.walletAddress}
+                {walletAddress}
               </CopyableAddress>
             </div>
           </div>
@@ -102,7 +103,7 @@ class Wallet extends Component<Props> {
             <TabPanel>
               <WalletTransactions
                 transactions={mockTransactions}
-                userAddress={mockUser.profile.walletAddress}
+                userAddress={walletAddress}
               />
             </TabPanel>
           </Tabs>

--- a/src/modules/users/selectors/users.js
+++ b/src/modules/users/selectors/users.js
@@ -53,6 +53,10 @@ export const userSelector: UserProfileSelector = createSelector(
   usernameFromProps,
   (users, username) => users.get(username),
 );
+export const currentUserAddressSelector = createSelector(
+  currentUser,
+  user => user.profile.walletAddress,
+);
 export const avatarSelector: UserAvatarSelector = createSelector(
   avatarsSelector,
   (state, { user }) => user && user.getIn(['record', 'profile', 'avatar']),


### PR DESCRIPTION
## Description

This PR makes it so that the wallet address displayed on the user wallet is for the current user. It also adds the `currentUserAddressSelector`.

Closes #595 
