### PR TITLE
Fix Popover to call render function outside of Popper function

### DIFF
--- a/src/modules/core/components/Popover/Popover.jsx
+++ b/src/modules/core/components/Popover/Popover.jsx
@@ -268,6 +268,7 @@ class Popover extends Component<Props, State> {
       showArrow,
     } = this.props;
     const { isOpen } = this.state;
+    const content = this.renderContent();
     return (
       <Manager>
         <Reference innerRef={this.registerRefNode}>
@@ -290,7 +291,7 @@ class Popover extends Component<Props, State> {
                 onFocus={this.handleWrapperFocus}
                 retainRefFocus={retainRefFocus}
               >
-                {this.renderContent()}
+                {content}
               </PopoverWrapper>
             )}
           </Popper>


### PR DESCRIPTION
## Description

The `Popover` `renderContent` function was being called within the `Popper` function, which was causing the Popover to rerender whenever a change occurred in Popper. This potentially included scrolling and window resize.

The `renderContent` function is now called outside of this but still within the `Popover` `render`, so that changes in props can still be taken into account.

Closes #654 
