### PR TITLE
Separate store validation / Add `ValidatedKVStore`

### DIFF
--- a/integration-testing/ValidatedKVStore.test.js
+++ b/integration-testing/ValidatedKVStore.test.js
@@ -2,7 +2,7 @@ import test from 'ava';
 import * as yup from 'yup';
 import { create as createWallet } from '@colony/purser-software';
 import PurserIdentityProvider from '../src/lib/database/PurserIdentityProvider';
-import { KVStore } from '../src/lib/database/stores';
+import { ValidatedKVStore } from '../src/lib/database/stores';
 import '../src/modules/validations';
 import { DDB } from '../src/lib/database';
 
@@ -17,7 +17,7 @@ const kvBlueprint = {
     username: yup.string().required(),
     bio: yup.string().required(),
   }),
-  type: KVStore,
+  type: ValidatedKVStore,
 };
 
 test.before(async t => {

--- a/src/lib/database/DDB.js
+++ b/src/lib/database/DDB.js
@@ -56,14 +56,11 @@ class DDB {
     orbitStore: OrbitDBStore,
     { name, schema, type: StoreClass }: StoreBlueprint,
   ): Store {
-    if (!schema) {
-      throw new Error(`Schema for store ${name} not found. Did you define it?`);
-    }
     const store = new StoreClass(
       orbitStore,
       name,
-      schema,
       this._ipfsNode.pinner,
+      schema,
     );
     const { root, path } = store.address;
     this._stores.set(`${root}/${path}`, store);

--- a/src/lib/database/commands.js
+++ b/src/lib/database/commands.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { Store, KVStore } from './stores';
+import { Store, KVStore, ValidatedKVStore } from './stores';
 
 // This file is in preparation to handle multiple store types with one command
 // and to add more complex functionality
@@ -8,5 +8,5 @@ import { Store, KVStore } from './stores';
 export const get = (store: Store | KVStore, key: string) =>
   typeof store.get === 'function' ? store.get(key) : null;
 
-export const getAll = (store: Store | KVStore) =>
+export const getAll = (store: Store | ValidatedKVStore) =>
   typeof store.all === 'function' ? store.all() : null;

--- a/src/lib/database/stores/FeedStore.js
+++ b/src/lib/database/stores/FeedStore.js
@@ -1,9 +1,15 @@
 /* @flow */
 
-import type { ValidateOptions } from 'yup';
+import type { ValidateOptions, ObjectSchema } from 'yup';
 
-import type { FeedIteratorOptions, OrbitDBFeedStore } from '../types/index';
+import PinnerConnector from '../../ipfs/PinnerConnector';
 import Store from './Store';
+
+import type {
+  FeedIteratorOptions,
+  OrbitDBFeedStore,
+  OrbitDBStore,
+} from '../types';
 
 /**
  * The wrapper Store class for orbit's feed stores.
@@ -12,7 +18,20 @@ import Store from './Store';
 class FeedStore extends Store {
   static orbitType = 'feed';
 
+  // https://github.com/babel/babel/issues/8417#issuecomment-415508558
   +_orbitStore: OrbitDBFeedStore = this._orbitStore;
+
+  _schema: ObjectSchema;
+
+  constructor(
+    orbitStore: OrbitDBStore,
+    name: string,
+    pinner: PinnerConnector,
+    schema: ObjectSchema,
+  ) {
+    super(orbitStore, name, pinner);
+    this._schema = schema;
+  }
 
   async validate(value?: any, options?: ValidateOptions = { strict: true }) {
     return this._schema.validate(value, options);

--- a/src/lib/database/stores/KVStore.js
+++ b/src/lib/database/stores/KVStore.js
@@ -1,6 +1,5 @@
 /* @flow */
 
-import type { ValidateOptions } from 'yup';
 import promiseSeries from 'p-series';
 
 import type { OrbitDBKVStore } from '../types';
@@ -8,7 +7,7 @@ import Store from './Store';
 
 /**
  * The wrapper Store class for orbit's key-value stores. Includes functions to
- * set and get entire objects and schema validation
+ * set and get entire objects
  */
 class KVStore extends Store {
   static orbitType = 'keyvalue';
@@ -16,47 +15,20 @@ class KVStore extends Store {
   // https://github.com/babel/babel/issues/8417#issuecomment-415508558
   +_orbitStore: OrbitDBKVStore = this._orbitStore;
 
-  async validate(
-    keyOrObject: string | {},
-    value?: any,
-    options?: ValidateOptions = { strict: true },
-  ) {
-    if (typeof keyOrObject === 'string') {
-      const schema = this._schema.fields[keyOrObject];
-      if (!schema) throw new Error(`Key "${keyOrObject}" not found on schema`);
-      return { [keyOrObject]: await schema.validate(value, options) };
-    }
-
-    return this._schema.validate(keyOrObject, options);
-  }
-
   async set(keyOrObject: string | {}, value?: any) {
-    const validated = await this.validate(keyOrObject, value);
-    this.pin();
-    return this._setObject(validated);
+    this.pin(); // XXX this promise is ignored
+    return typeof keyOrObject === 'string'
+      ? this._orbitStore.put(keyOrObject, value)
+      : this._setObject(keyOrObject);
   }
 
   async append(key: string, value?: any) {
-    const validated = await this.validate(key, [value]);
     const existing = this._orbitStore.get(key) || [];
-    return this._orbitStore.put(key, existing.concat(validated));
+    return this._orbitStore.put(key, existing.concat(value));
   }
 
   get(key: string) {
     return this._orbitStore.get(key);
-  }
-
-  all() {
-    return Object.keys(this._schema.fields).reduce((data, key) => {
-      const value = this._orbitStore.get(key);
-      // XXX We could `.cast()` the values from the schema instead of removing
-      // undefined values, but that could potentially throw errors.
-      if (typeof value !== 'undefined') {
-        // eslint-disable-next-line no-param-reassign
-        data[key] = value;
-      }
-      return data;
-    }, {});
   }
 
   async _setObject(obj: {}) {

--- a/src/lib/database/stores/Store.js
+++ b/src/lib/database/stores/Store.js
@@ -1,7 +1,5 @@
 /* @flow */
 
-import type { ObjectSchema } from 'yup';
-
 import { raceAgainstTimeout } from '../../../utils/async';
 
 import type { OrbitDBStore } from '../types';
@@ -9,8 +7,8 @@ import type { OrbitDBStore } from '../types';
 import PinnerConnector from '../../ipfs/PinnerConnector';
 
 /**
- * A parent class for a wrapper around an orbit store that can hold its schema
- * and perform certain validations based on the store type.
+ * A parent class for a wrapper around an orbit store that can load
+ * data in the store and pin the store.
  */
 class Store {
   static orbitType: string;
@@ -19,20 +17,17 @@ class Store {
 
   _name: string;
 
-  _schema: ObjectSchema;
-
   _pinner: PinnerConnector;
 
   constructor(
     orbitStore: OrbitDBStore,
     name: string,
-    schema: ObjectSchema,
     pinner: PinnerConnector,
+    ...args: * // eslint-disable-line no-unused-vars
   ) {
     this._orbitStore = orbitStore;
     this._name = name;
     this._pinner = pinner;
-    this._schema = schema;
   }
 
   get address() {

--- a/src/lib/database/stores/ValidatedKVStore.js
+++ b/src/lib/database/stores/ValidatedKVStore.js
@@ -1,0 +1,67 @@
+/* @flow */
+
+import type { ObjectSchema, ValidateOptions } from 'yup';
+
+import KVStore from './KVStore';
+import PinnerConnector from '../../ipfs/PinnerConnector';
+
+import type { OrbitDBKVStore } from '../types';
+
+/**
+ * The wrapper Store class for orbit's key-value stores. Includes functions to
+ * set and get entire objects and schema validation
+ */
+class ValidatedKVStore extends KVStore {
+  _schema: ObjectSchema;
+
+  constructor(
+    orbitStore: OrbitDBKVStore,
+    name: string,
+    pinner: PinnerConnector,
+    schema: ObjectSchema,
+  ) {
+    super(orbitStore, name, pinner);
+    this._schema = schema;
+  }
+
+  async validate(
+    keyOrObject: string | {},
+    value?: any,
+    options?: ValidateOptions = { strict: true },
+  ) {
+    if (typeof keyOrObject === 'string') {
+      const schema = this._schema.fields[keyOrObject];
+      if (!schema) throw new Error(`Key "${keyOrObject}" not found on schema`);
+      return schema.validate(value, options);
+    }
+
+    return this._schema.validate(keyOrObject, options);
+  }
+
+  async set(keyOrObject: string | {}, value?: any) {
+    const validated = await this.validate(keyOrObject, value);
+    return typeof keyOrObject === 'string'
+      ? super.set(keyOrObject, validated)
+      : super.set(validated);
+  }
+
+  async append(key: string, value?: any) {
+    const validated = await this.validate(key, [value]);
+    return super.append(validated);
+  }
+
+  all() {
+    return Object.keys(this._schema.fields).reduce((data, key) => {
+      const value = this._orbitStore.get(key);
+      // XXX We could `.cast()` the values from the schema instead of removing
+      // undefined values, but that could potentially throw errors.
+      if (typeof value !== 'undefined') {
+        // eslint-disable-next-line no-param-reassign
+        data[key] = value;
+      }
+      return data;
+    }, {});
+  }
+}
+
+export default ValidatedKVStore;

--- a/src/lib/database/stores/__tests__/FeedStore.test.js
+++ b/src/lib/database/stores/__tests__/FeedStore.test.js
@@ -11,6 +11,10 @@ const schema = yup.object({
 describe('FeedStore', () => {
   const sandbox = createSandbox();
 
+  const mockPinner = {
+    requestPinnedStore: sandbox.fn(() => ({ count: 5 })),
+  };
+
   beforeEach(() => {
     sandbox.clear();
   });
@@ -20,13 +24,13 @@ describe('FeedStore', () => {
   const name = 'UserActivity';
 
   test('It creates a FeedStore', () => {
-    const store = new FeedStore(mockOrbitStore, name, schema);
+    const store = new FeedStore(mockOrbitStore, name, mockPinner, schema);
     expect(store._orbitStore).toBe(mockOrbitStore);
     expect(store._name).toBe(name);
     expect(store._schema).toBe(schema);
   });
   test('It validates an activity event against the schema', async () => {
-    const store = new FeedStore(mockOrbitStore, name, schema);
+    const store = new FeedStore(mockOrbitStore, name, mockPinner, schema);
     sandbox.spyOn(store._schema, 'validate');
     const validProps = {
       colonyName: 'Zombies',

--- a/src/lib/database/stores/__tests__/KVStore.test.js
+++ b/src/lib/database/stores/__tests__/KVStore.test.js
@@ -1,15 +1,9 @@
 import createSandbox from 'jest-sandbox';
-import * as yup from 'yup';
 
 import createMockOrbitStore from './mockOrbitStore';
 import KVStore from '../KVStore';
 
-const schema = yup.object({
-  requiredProp: yup.string().required(),
-  optionalProp: yup.string(),
-});
-
-const name = 'kvStoreSchemaId';
+const name = 'kvStore';
 
 describe('KVStore', () => {
   const sandbox = createSandbox();
@@ -23,69 +17,9 @@ describe('KVStore', () => {
   test('It creates a KVStore', () => {
     mockOrbitStore.put.mockResolvedValueOnce(null);
 
-    const store = new KVStore(mockOrbitStore, name, schema);
+    const store = new KVStore(mockOrbitStore, name);
     expect(store._orbitStore).toBe(mockOrbitStore);
     expect(store._name).toBe(name);
-    expect(store._schema).toBe(schema);
-  });
-
-  test('It validates objects against the schema', async () => {
-    mockOrbitStore.put.mockResolvedValueOnce(null);
-
-    const store = new KVStore(mockOrbitStore, name, schema);
-
-    sandbox.spyOn(store._schema, 'validate');
-
-    const validProps = { requiredProp: 'foo', optionalProp: 'bar' };
-    const validated = await store.validate(validProps);
-    expect(validated).toEqual(validProps);
-    expect(store._schema.validate).toHaveBeenCalledWith(
-      validProps,
-      expect.any(Object),
-    );
-
-    // Missing `requiredProp`
-    const invalidProps = { optionalProp: 'bar' };
-    try {
-      await store.validate(invalidProps);
-      expect(false).toBe(true); // unreachable
-    } catch (error) {
-      expect(store._schema.validate).toHaveBeenCalledWith(
-        invalidProps,
-        expect.any(Object),
-      );
-      expect(error.toString()).toMatch('requiredProp is a required field');
-    }
-  });
-
-  test('It validates a key/value pair against the schema', async () => {
-    mockOrbitStore.put.mockResolvedValueOnce(null);
-
-    const store = new KVStore(mockOrbitStore, name, schema);
-
-    const key = 'requiredProp';
-    const value = 'foo';
-
-    sandbox.spyOn(store._schema.fields[key], 'validate');
-
-    const validated = await store.validate(key, value);
-    expect(validated).toEqual({ [key]: value });
-    expect(store._schema.fields[key].validate).toHaveBeenCalledWith(
-      value,
-      expect.any(Object),
-    );
-
-    // Missing a value
-    try {
-      await store.validate(key);
-      expect(false).toBe(true); // unreachable
-    } catch (error) {
-      expect(store._schema.fields[key].validate).toHaveBeenCalledWith(
-        undefined,
-        expect.any(Object),
-      );
-      expect(error.toString()).toMatch('this is a required field');
-    }
   });
 
   // TODO test: all(), get(), append(), set(), _setObject()

--- a/src/lib/database/stores/__tests__/Store.test.js
+++ b/src/lib/database/stores/__tests__/Store.test.js
@@ -1,17 +1,11 @@
 import createSandbox from 'jest-sandbox';
-import * as yup from 'yup';
 
 import createMockOrbitStore from './mockOrbitStore';
 import KVStore from '../KVStore';
 
-const schema = yup.object({
-  requiredProp: yup.string().required(),
-  optionalProp: yup.string(),
-});
+const name = 'storeId';
 
-const name = 'storeSchemaId';
-
-describe('KVStore', () => {
+describe('Store (KVStore)', () => {
   const sandbox = createSandbox();
 
   const mockOrbitStore = createMockOrbitStore(sandbox);
@@ -25,7 +19,7 @@ describe('KVStore', () => {
   });
 
   test('It waits for replication when loading', async () => {
-    const store = new KVStore(mockOrbitStore, name, schema, mockPinner);
+    const store = new KVStore(mockOrbitStore, name, mockPinner);
 
     sandbox
       .spyOn(store._orbitStore, 'load')

--- a/src/lib/database/stores/__tests__/ValidatedKVStore.test.js
+++ b/src/lib/database/stores/__tests__/ValidatedKVStore.test.js
@@ -1,0 +1,112 @@
+import createSandbox from 'jest-sandbox';
+import * as yup from 'yup';
+
+import createMockOrbitStore from './mockOrbitStore';
+import ValidatedKVStore from '../ValidatedKVStore';
+
+const schema = yup.object({
+  requiredProp: yup.string().required(),
+  optionalProp: yup.string(),
+});
+
+const name = 'kvStoreSchemaId';
+
+describe('ValidatedKVStore', () => {
+  const sandbox = createSandbox();
+
+  const mockOrbitStore = createMockOrbitStore(sandbox);
+
+  const mockPinner = {
+    requestPinnedStore: sandbox.fn(() => ({ count: 5 })),
+  };
+
+  beforeEach(() => {
+    sandbox.clear();
+  });
+
+  test('It creates a ValidatedKVStore', () => {
+    mockOrbitStore.put.mockResolvedValueOnce(null);
+
+    const store = new ValidatedKVStore(
+      mockOrbitStore,
+      name,
+      mockPinner,
+      schema,
+    );
+    expect(store._orbitStore).toBe(mockOrbitStore);
+    expect(store._name).toBe(name);
+    expect(store._pinner).toBe(mockPinner);
+    expect(store._schema).toBe(schema);
+  });
+
+  test('It validates objects against the schema', async () => {
+    mockOrbitStore.put.mockResolvedValueOnce(null);
+
+    const store = new ValidatedKVStore(
+      mockOrbitStore,
+      name,
+      mockPinner,
+      schema,
+    );
+
+    sandbox.spyOn(store._schema, 'validate');
+
+    const validProps = { requiredProp: 'foo', optionalProp: 'bar' };
+    const validated = await store.validate(validProps);
+    expect(validated).toEqual(validProps);
+    expect(store._schema.validate).toHaveBeenCalledWith(
+      validProps,
+      expect.any(Object),
+    );
+
+    // Missing `requiredProp`
+    const invalidProps = { optionalProp: 'bar' };
+    try {
+      await store.validate(invalidProps);
+      expect(false).toBe(true); // unreachable
+    } catch (error) {
+      expect(store._schema.validate).toHaveBeenCalledWith(
+        invalidProps,
+        expect.any(Object),
+      );
+      expect(error.toString()).toMatch('requiredProp is a required field');
+    }
+  });
+
+  test('It validates a key/value pair against the schema', async () => {
+    mockOrbitStore.put.mockResolvedValueOnce(null);
+
+    const store = new ValidatedKVStore(
+      mockOrbitStore,
+      name,
+      mockPinner,
+      schema,
+    );
+
+    const key = 'requiredProp';
+    const value = 'foo';
+
+    sandbox.spyOn(store._schema.fields[key], 'validate');
+
+    const validated = await store.validate(key, value);
+    expect(validated).toEqual(value);
+    expect(store._schema.fields[key].validate).toHaveBeenCalledWith(
+      value,
+      expect.any(Object),
+    );
+
+    // Missing a value
+    try {
+      await store.validate(key);
+      expect(false).toBe(true); // unreachable
+    } catch (error) {
+      expect(store._schema.fields[key].validate).toHaveBeenCalledWith(
+        undefined,
+        expect.any(Object),
+      );
+      expect(error.toString()).toMatch('this is a required field');
+    }
+  });
+
+  // TODO test: all(), append(), set()
+});

--- a/src/lib/database/stores/index.js
+++ b/src/lib/database/stores/index.js
@@ -1,7 +1,6 @@
 /* @flow */
 
-import FeedStore from './FeedStore';
-import KVStore from './KVStore';
-import Store from './Store';
-
-export { FeedStore, KVStore, Store };
+export { default as FeedStore } from './FeedStore';
+export { default as KVStore } from './KVStore';
+export { default as Store } from './Store';
+export { default as ValidatedKVStore } from './ValidatedKVStore';

--- a/src/lib/database/types/index.js
+++ b/src/lib/database/types/index.js
@@ -41,7 +41,7 @@ export type OrbitStoreOpenOpts = {
 
 export type StoreBlueprint = {
   name: string,
-  schema: ObjectSchema,
+  schema?: ObjectSchema,
   getAccessController?: (
     storeProps?: Object,
   ) => AccessController<PurserIdentity, PurserIdentityProvider<PurserIdentity>>,

--- a/src/modules/dashboard/stores/colonyStore.js
+++ b/src/modules/dashboard/stores/colonyStore.js
@@ -2,7 +2,7 @@
 
 import * as yup from 'yup';
 
-import { KVStore } from '../../../lib/database/stores';
+import { ValidatedKVStore } from '../../../lib/database/stores';
 
 import type { StoreBlueprint } from '~types';
 
@@ -40,7 +40,7 @@ const colonyStore: StoreBlueprint = {
       symbol: yup.string(),
     }),
   }),
-  type: KVStore,
+  type: ValidatedKVStore,
 };
 
 export default colonyStore;

--- a/src/modules/users/sagas/userSagas.js
+++ b/src/modules/users/sagas/userSagas.js
@@ -19,7 +19,7 @@ import { putError } from '~utils/saga/effects';
 import { getHashedENSDomainString } from '~utils/ens';
 
 import { DDB } from '../../../lib/database';
-import { FeedStore, KVStore } from '../../../lib/database/stores';
+import { FeedStore, ValidatedKVStore } from '../../../lib/database/stores';
 import { getAll } from '../../../lib/database/commands';
 import { getNetworkMethod } from '../../core/sagas/utils';
 import { joinedColonyEvent } from '../../dashboard/components/UserActivities';
@@ -64,7 +64,9 @@ import {
 } from '../actionTypes';
 import { registerUserLabel } from '../actionCreators';
 
-export function* getOrCreateUserStore(walletAddress: Address): Saga<KVStore> {
+export function* getOrCreateUserStore(
+  walletAddress: Address,
+): Saga<ValidatedKVStore> {
   const ddb: DDB = yield getContext('ddb');
 
   try {
@@ -134,7 +136,9 @@ export function* getUserActivitiesStore(
   );
 }
 
-export function* getUserProfileData(store: KVStore): Saga<UserProfileProps> {
+export function* getUserProfileData(
+  store: ValidatedKVStore,
+): Saga<UserProfileProps> {
   return yield call(getAll, store);
 }
 

--- a/src/modules/users/stores/userProfileStore.js
+++ b/src/modules/users/stores/userProfileStore.js
@@ -4,7 +4,7 @@ import * as yup from 'yup';
 
 import type { StoreBlueprint } from '~types';
 
-import { KVStore } from '../../../lib/database/stores';
+import { ValidatedKVStore } from '../../../lib/database/stores';
 import { EthereumWalletAccessController } from '../../../lib/database/accessControllers';
 
 type StoreProps = {
@@ -32,7 +32,7 @@ const userProfileStore: StoreBlueprint = {
     activitiesStore: yup.string(),
     inboxStore: yup.string(),
   }),
-  type: KVStore,
+  type: ValidatedKVStore,
 };
 
 export default userProfileStore;


### PR DESCRIPTION
## Description

This PR moves the store validation away from the base `Store` class, so that we can use `KVStore`s (or any kind of store, in theory) without strict validation. One use-case for this could be storing IDs as keys in a `KVStore`. 

`FeedStore` and `ValidatedKVStore` use schema validation as before.

## Changes

* Remove schema/validation from `Store` and `KVStore`.
* Add `ValidatedKVStore` (extends `KVStore`).
* Move store schema/validation to `FeedStore` and `ValidatedKVStore`.
* Change the order of arguments to `Store` classes, so that the pinner is the 3rd argument (instead of 4th).
* Fix an issue where `ValidatedKVStore.append()` was validating the value as a key/value object as opposed to a single value.
* Use `ValidatedKVStore` for user and colony stores.


Contributes to #576 
