### PR TITLE
Fix BYOT Colony creation step

### DIFF
--- a/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.jsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.jsx
@@ -85,7 +85,6 @@ export const validationSchema = yup.object({
   tokenName: yup.string(),
 });
 
-// TODO in #453 - show inputs for minimal ERC20 contracts
 class StepSelectToken extends Component<Props, State> {
   static displayName = 'dashboard.CreateColonyWizard.StepSelectToken';
 


### PR DESCRIPTION
## Description

The function `getTokenClientInfo` now uses the current provider and wallet, rather than Etherscan/dummy wallet. There was also an error with the instantiation of the TokenClient, meaning that data was never returned for tokens which exist.

Closes #453 
