### PR TITLE
Fix IPFSNode to call correct files.cat

### DIFF
--- a/src/lib/ipfs/IPFSNode.js
+++ b/src/lib/ipfs/IPFSNode.js
@@ -122,7 +122,7 @@ class IPFSNode {
   /** Return a file from IPFS as text */
   async getString(hash: string): Promise<string> {
     await this.ready;
-    const result = await this._ipfs.cat(hash);
+    const result = await this._ipfs.files.cat(hash);
     if (!result) throw new Error('No such file');
     return result.toString();
   }


### PR DESCRIPTION
## Description

IPFSNode was using a newer API than the version of IPFS we depend on, which prevented fetching files from IPFS (thus why avatars were not being displayed).

See [our version](https://github.com/ipfs/js-ipfs/tree/v0.33.1#files) (`ipfs.files.cat`) vs [newer version](https://github.com/ipfs/js-ipfs/tree/v0.34.0-rc.0#files) (`ipfs.cat`).

Closes #723 
