### PR TITLE
Click `cancel` to exit colony wizard

### DIFF
--- a/src/modules/dashboard/components/CreateColonyWizard/StepColonyName.jsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepColonyName.jsx
@@ -1,7 +1,9 @@
 /* @flow */
+import type { ContextRouter } from 'react-router-dom';
 
 import React from 'react';
 import { defineMessages } from 'react-intl';
+import { withRouter } from 'react-router-dom';
 import * as yup from 'yup';
 
 import type { WizardProps } from '~core/Wizard';
@@ -47,11 +49,15 @@ type FormValues = {
   colonyName: string,
 };
 
-type Props = WizardProps<FormValues>;
+type Props = WizardProps<FormValues> & ContextRouter;
 
 const displayName = 'dashboard.CreateColonyWizard.StepColonyName';
 
-const StepColonyName = ({ nextStep, wizardForm }: Props) => (
+const StepColonyName = ({
+  nextStep,
+  wizardForm,
+  history: { goBack },
+}: Props) => (
   <Form onSubmit={nextStep} validationSchema={validationSchema} {...wizardForm}>
     {({ isValid }) => (
       <section className={styles.main}>
@@ -71,6 +77,7 @@ const StepColonyName = ({ nextStep, wizardForm }: Props) => (
               <Button
                 appearance={{ theme: 'secondary', size: 'large' }}
                 text={MSG.cancel}
+                onClick={goBack}
               />
               <Button
                 appearance={{ theme: 'primary', size: 'large' }}
@@ -88,4 +95,4 @@ const StepColonyName = ({ nextStep, wizardForm }: Props) => (
 
 StepColonyName.displayName = displayName;
 
-export default StepColonyName;
+export default withRouter(StepColonyName);


### PR DESCRIPTION
## Description

Bug fix. This PR allows a user to click `cancel` on the first step of the `Create Colony Wizard` to go back to the previous route.

Prior to this fix, the `cancel` button was not not assigned an `onClick` handler or URL.

### Prior to Fix:
![cancel colony wizard broken](https://user-images.githubusercontent.com/3052635/51050630-1058a280-1597-11e9-8149-cc7ccb81e5c7.gif)

### Solution:
![cancel colony wizard](https://user-images.githubusercontent.com/3052635/51050635-18184700-1597-11e9-85f5-b53672c2abe7.gif)
