### PR TITLE
Claim profile dialog fix for `Get started with Colony` initial task

### DIFF
--- a/src/modules/dashboard/components/Dashboard/InitialTask.jsx
+++ b/src/modules/dashboard/components/Dashboard/InitialTask.jsx
@@ -38,7 +38,19 @@ const InitialTask = ({
             <button
               className={styles.taskDetailsTitle}
               type="button"
-              onClick={() => openDialog('CreateUsernameDialog')}
+              onClick={() =>
+                openDialog('UnfinishedProfileDialog')
+                  .afterClosed()
+                  .then(() =>
+                    openDialog('ClaimProfileDialog', { walletAddress })
+                      .afterClosed()
+                      .then(() => openDialog('ENSNameDialog'))
+                      .catch(err => {
+                        // eslint-disable-next-line no-console
+                        console.log(err);
+                      }),
+                  )
+              }
             >
               <FormattedMessage {...title} values={titleValues} />
             </button>


### PR DESCRIPTION

## Description

Bug fix. This PR simply uses the correct dialog for the `Get started with Colony` initial task in the dashboard (home) under `My Tasks`. The other places in the dApp were already using the correct dialog (user avatar dropdown, task comment input, request to work on a task), I think this one just got missed 🙂 

## Demos

### Broken (before this PR)
![get started](https://user-images.githubusercontent.com/3052635/51350208-35548600-1a6d-11e9-951e-8e464ebdfdb5.gif)

### Fixed (with this PR)
![fix get started dialog](https://user-images.githubusercontent.com/3052635/51350220-3ab1d080-1a6d-11e9-9220-ca6493ab1f41.gif)