### PR TITLE
Pass through meta (id) in ALL relevant sagas

### DIFF
--- a/src/modules/admin/sagas/index.js
+++ b/src/modules/admin/sagas/index.js
@@ -4,7 +4,13 @@ import type { Saga } from 'redux-saga';
 
 import { call, getContext, put, takeEvery, all } from 'redux-saga/effects';
 
-import type { Action, Address, ENSName, UniqueActionWithKeyPath } from '~types';
+import type {
+  Action,
+  Address,
+  ENSName,
+  UniqueAction,
+  UniqueActionWithKeyPath,
+} from '~types';
 import type { ContractTransactionProps } from '~immutable';
 
 import { putError, raceError } from '~utils/saga/effects';
@@ -173,7 +179,7 @@ const filterClaimSuccess = (token: Address, colonyENSName: ENSName) => ({
 function* claimColonyToken({
   payload: { ensName, tokenAddress: token },
   meta,
-}: Action): Saga<void> {
+}: UniqueAction): Saga<void> {
   try {
     yield put(
       claimColonyTokenTransaction({
@@ -189,7 +195,7 @@ function* claimColonyToken({
     yield put(fetchColonyTransactions(ensName));
     yield put(fetchColonyUnclaimedTransactions(ensName));
   } catch (error) {
-    yield putError(COLONY_CLAIM_TOKEN_ERROR, error);
+    yield putError(COLONY_CLAIM_TOKEN_ERROR, error, meta);
   }
 }
 

--- a/src/modules/core/sagas/setupUserContext.js
+++ b/src/modules/core/sagas/setupUserContext.js
@@ -6,7 +6,7 @@ import { setContext, call, all, put, fork } from 'redux-saga/effects';
 
 import { create, putError } from '~utils/saga/effects';
 
-import type { Action } from '~types';
+import type { UniqueAction } from '~types';
 import type { UserProfileProps } from '~immutable';
 
 import setupAdminSagas from '../../admin/sagas';
@@ -41,7 +41,8 @@ function* setupContextSagas(): any {
  * context that depends on it (the wallet itself, the DDB, the ColonyManager),
  * and then any other context that depends on that.
  */
-export default function* setupUserContext(action: Action): Saga<void> {
+export default function* setupUserContext(action: UniqueAction): Saga<void> {
+  const { meta } = action;
   try {
     const wallet = yield call(getWallet, action);
     yield setContext({ wallet });
@@ -87,8 +88,9 @@ export default function* setupUserContext(action: Action): Saga<void> {
         profileData,
         walletAddress: wallet.address,
       },
+      meta,
     });
   } catch (err) {
-    yield putError(WALLET_CREATE_ERROR, err);
+    yield putError(WALLET_CREATE_ERROR, err, meta);
   }
 }

--- a/src/modules/core/sagas/transactions/onTransactionSent.js
+++ b/src/modules/core/sagas/transactions/onTransactionSent.js
@@ -155,7 +155,7 @@ function* sendTransaction<P: TransactionParams, E: TransactionEventData>(
 export default function* onTransactionSent<
   P: TransactionParams,
   E: TransactionEventData,
->({ meta: { id } }: SendTransactionAction): Saga<void> {
+>({ meta: { id }, meta }: SendTransactionAction): Saga<void> {
   let tx;
 
   try {
@@ -181,10 +181,10 @@ export default function* onTransactionSent<
     // Unexpected errors `put` the given error action...
     const { lifecycle: { error: errorType } = {} } = tx || {};
     if (errorType) {
-      yield putError(errorType, caughtError);
+      yield putError(errorType, caughtError, meta);
     } else {
       // We still dispatch this error as a general TRANASACTION_ERROR
-      yield putError(TRANSACTION_ERROR, caughtError);
+      yield putError(TRANSACTION_ERROR, caughtError, meta);
     }
   }
 }

--- a/src/modules/dashboard/sagas/colony.js
+++ b/src/modules/dashboard/sagas/colony.js
@@ -12,7 +12,12 @@ import {
 } from 'redux-saga/effects';
 import { replace } from 'connected-react-router';
 
-import type { Action, ENSName, UniqueActionWithKeyPath } from '~types';
+import type {
+  Action,
+  ENSName,
+  UniqueAction,
+  UniqueActionWithKeyPath,
+} from '~types';
 
 import { putError, callCaller } from '~utils/saga/effects';
 import { getHashedENSDomainString } from '~utils/web3/ens';
@@ -80,7 +85,10 @@ function* getOrCreateColonyStore(colonyENSName: ENSName) {
 /*
  * Simply forward on the form params to create a transaction.
  */
-function* createColonySaga({ payload: params, meta }: Action): Saga<void> {
+function* createColonySaga({
+  payload: params,
+  meta,
+}: UniqueAction): Saga<void> {
   yield put(
     createColony({
       meta,
@@ -105,7 +113,7 @@ function* createColonyLabelSaga({
     tokenIcon,
   },
   meta,
-}: Action): Saga<void> {
+}: UniqueAction): Saga<void> {
   const colonyStoreData = {
     address: colonyAddress,
     ensName,
@@ -175,8 +183,10 @@ function* createColonyLabelSaga({
   );
 }
 
-function* validateColonyDomain(action: Action): Saga<void> {
-  const { ensName } = action.payload;
+function* validateColonyDomain({
+  payload: { ensName },
+  meta,
+}: UniqueAction): Saga<void> {
   yield delay(300);
 
   const nameHash = yield call(getHashedENSDomainString, ensName, 'colony');
@@ -194,15 +204,17 @@ function* validateColonyDomain(action: Action): Saga<void> {
     yield putError(
       COLONY_DOMAIN_VALIDATE_ERROR,
       new Error('ENS address already exists'),
+      meta,
     );
     return;
   }
-  yield put({ type: COLONY_DOMAIN_VALIDATE_SUCCESS });
+  yield put({ type: COLONY_DOMAIN_VALIDATE_SUCCESS, meta });
 }
 
 /*
  * Redirect to the colony home for the given (newly-registered) label
  */
+// TODO: we have cases where we do something like that with the raceError effect (custom take)
 function* createColonyLabelSuccessSaga({
   payload: {
     params: { colonyName },

--- a/src/modules/dashboard/sagas/task.js
+++ b/src/modules/dashboard/sagas/task.js
@@ -4,7 +4,7 @@ import type { Saga } from 'redux-saga';
 
 import { all, put, takeEvery, call, getContext } from 'redux-saga/effects';
 
-import type { Action, ENSName } from '~types';
+import type { ENSName, UniqueAction } from '~types';
 
 import { putError, raceError, callCaller } from '~utils/saga/effects';
 
@@ -119,7 +119,7 @@ function* guessRating(
 function* taskSetSkillSaga({
   payload: { taskId, skillId, colonyENSName },
   meta,
-}: Action): Saga<void> {
+}: UniqueAction): Saga<void> {
   yield put(
     taskSetSkill({
       identifier: colonyENSName,
@@ -129,7 +129,7 @@ function* taskSetSkillSaga({
   );
 }
 
-function* taskSetDueDateSaga(action: Action): Saga<void> {
+function* taskSetDueDateSaga(action: UniqueAction): Saga<void> {
   const {
     payload: { taskId, dueDate, colonyENSName },
     meta,
@@ -147,7 +147,7 @@ function* taskSetDueDateSaga(action: Action): Saga<void> {
 function* taskWorkerEndSaga({
   payload: { colonyENSName, taskId, workDescription, rating },
   meta,
-}: Action): Saga<void> {
+}: UniqueAction): Saga<void> {
   const ipfsNode = yield getContext('ipfsNode');
   try {
     const deliverableHash = yield call(
@@ -168,14 +168,14 @@ function* taskWorkerEndSaga({
       }),
     );
   } catch (error) {
-    yield putError(TASK_WORKER_END_ERROR, error);
+    yield putError(TASK_WORKER_END_ERROR, error, meta);
   }
 }
 
 function* taskManagerEndSaga({
   payload: { colonyENSName, taskId, rating },
   meta,
-}: Action): Saga<void> {
+}: UniqueAction): Saga<void> {
   try {
     // complete task past due date
     yield put(
@@ -209,16 +209,16 @@ function* taskManagerEndSaga({
     );
 
     // if we got this far without a throw, success!
-    yield put({ type: TASK_MANAGER_END_SUCCESS });
+    yield put({ type: TASK_MANAGER_END_SUCCESS, meta });
   } catch (error) {
-    yield putError(TASK_MANAGER_END_ERROR, error);
+    yield putError(TASK_MANAGER_END_ERROR, error, meta);
   }
 }
 
 function* taskWorkerRateManagerSaga({
   payload: { colonyENSName, taskId, rating },
   meta,
-}: Action): Saga<void> {
+}: UniqueAction): Saga<void> {
   try {
     // generate secret
     const secret = yield call(
@@ -237,14 +237,14 @@ function* taskWorkerRateManagerSaga({
       }),
     );
   } catch (error) {
-    yield putError(TASK_WORKER_RATE_MANAGER_ERROR, error);
+    yield putError(TASK_WORKER_RATE_MANAGER_ERROR, error, meta);
   }
 }
 
 function* taskManagerRateWorkerSaga({
   payload: { colonyENSName, taskId, rating },
   meta,
-}: Action): Saga<void> {
+}: UniqueAction): Saga<void> {
   try {
     // generate secret
     const secret = yield call(
@@ -263,14 +263,14 @@ function* taskManagerRateWorkerSaga({
       }),
     );
   } catch (error) {
-    yield putError(TASK_MANAGER_RATE_WORKER_ERROR, error);
+    yield putError(TASK_MANAGER_RATE_WORKER_ERROR, error, meta);
   }
 }
 
 function* taskWorkerRevealRatingSaga({
   payload: { colonyENSName, taskId },
   meta,
-}: Action): Saga<void> {
+}: UniqueAction): Saga<void> {
   try {
     const salt = yield call(generateRatingSalt, colonyENSName, taskId);
     const rating = yield call(
@@ -293,14 +293,14 @@ function* taskWorkerRevealRatingSaga({
       }),
     );
   } catch (error) {
-    yield putError(TASK_WORKER_REVEAL_MANAGER_RATING_ERROR, error);
+    yield putError(TASK_WORKER_REVEAL_MANAGER_RATING_ERROR, error, meta);
   }
 }
 
 function* taskManagerRevealRatingSaga({
   payload: { colonyENSName, taskId },
   meta,
-}: Action): Saga<void> {
+}: UniqueAction): Saga<void> {
   try {
     const salt = yield call(generateRatingSalt, colonyENSName, taskId);
     const rating = yield call(
@@ -323,14 +323,14 @@ function* taskManagerRevealRatingSaga({
       }),
     );
   } catch (error) {
-    yield putError(TASK_MANAGER_REVEAL_WORKER_RATING_ERROR, error);
+    yield putError(TASK_MANAGER_REVEAL_WORKER_RATING_ERROR, error, meta);
   }
 }
 
 function* taskWorkerClaimRewardSaga({
   payload: { colonyENSName, taskId, tokenAddresses },
   meta,
-}: Action): Saga<void> {
+}: UniqueAction): Saga<void> {
   yield all(
     tokenAddresses.map(token =>
       put(
@@ -351,7 +351,7 @@ function* taskWorkerClaimRewardSaga({
 function* taskFinalizeSaga({
   payload: { taskId, colonyENSName },
   meta,
-}: Action): Saga<void> {
+}: UniqueAction): Saga<void> {
   yield put(
     taskFinalize({ identifier: colonyENSName, params: { taskId }, meta }),
   );

--- a/src/modules/dashboard/sagas/token.js
+++ b/src/modules/dashboard/sagas/token.js
@@ -14,7 +14,7 @@ import {
   takeLatest,
 } from 'redux-saga/effects';
 
-import type { Action } from '~types';
+import type { Action, UniqueAction } from '~types';
 
 import { putError } from '~utils/saga/effects';
 
@@ -77,7 +77,7 @@ async function getTokenClientInfo(
 /**
  * Get the token info for a given `tokenAddress`.
  */
-function* getTokenInfo({ payload: { tokenAddress } }): Saga<void> {
+function* getTokenInfo({ payload: { tokenAddress } }: Action): Saga<void> {
   // Debounce with 1000ms, since this is intended to run directly following
   // user keyboard input.
 
@@ -101,15 +101,17 @@ function* getTokenInfo({ payload: { tokenAddress } }): Saga<void> {
 function* createTokenSaga({
   payload: { tokenName: name, tokenSymbol: symbol },
   meta,
-}: *): Saga<void> {
+}: UniqueAction): Saga<void> {
   yield put(createToken({ params: { name, symbol }, meta }));
 }
 
 /**
  * Upload a token icon to IPFS.
  */
-function* uploadTokenIcon(action: Action): Saga<void> {
-  const { data } = action.payload;
+function* uploadTokenIcon({
+  payload: { data },
+  meta,
+}: UniqueAction): Saga<void> {
   const ipfsNode = yield getContext('ipfsNode');
 
   try {
@@ -118,9 +120,10 @@ function* uploadTokenIcon(action: Action): Saga<void> {
     yield put({
       type: TOKEN_ICON_UPLOAD_SUCCESS,
       payload: { hash },
+      meta,
     });
   } catch (error) {
-    yield putError(TOKEN_ICON_UPLOAD_ERROR, error);
+    yield putError(TOKEN_ICON_UPLOAD_ERROR, error, meta);
   }
 }
 

--- a/src/modules/users/sagas/userSagas.js
+++ b/src/modules/users/sagas/userSagas.js
@@ -13,7 +13,12 @@ import {
   takeEvery,
 } from 'redux-saga/effects';
 
-import type { Action, Address, UniqueActionWithKeyPath } from '~types';
+import type {
+  Action,
+  Address,
+  UniqueAction,
+  UniqueActionWithKeyPath,
+} from '~types';
 import type { UserProfileProps, ContractTransactionProps } from '~immutable';
 
 import { putError, callCaller } from '~utils/saga/effects';
@@ -203,7 +208,16 @@ export function* addUserActivity({ payload }: Action): Saga<void> {
   }
 }
 
-function* updateProfile(action: Action): Saga<void> {
+function* updateProfile({
+  payload: {
+    profileStore,
+    walletAddress: removedWalletAddress,
+    username,
+    // TODO: We want to disallow the easy update of certain fields here. There might be a better way to do this
+    ...update
+  },
+  meta,
+}: UniqueAction): Saga<void> {
   try {
     const walletAddress = yield select(walletAddressSelector);
 
@@ -219,21 +233,15 @@ function* updateProfile(action: Action): Saga<void> {
     );
 
     // if user is not allowed to write to store, this should throw an error
-    // TODO: We want to disallow the easy update of certain fields here. There might be a better way to do this
-    const {
-      profileStore,
-      walletAddress: removedWalletAddress,
-      username,
-      ...update
-    } = action.payload;
     yield call([store, store.set], update);
     const user = yield call(getAll, store);
     yield put({
       type: USER_PROFILE_UPDATE_SUCCESS,
       payload: user,
+      meta,
     });
   } catch (error) {
-    yield putError(USER_PROFILE_UPDATE_ERROR, error);
+    yield putError(USER_PROFILE_UPDATE_ERROR, error, meta);
   }
 }
 
@@ -299,8 +307,10 @@ function* fetchProfile({
   }
 }
 
-function* validateUsername(action: Action): Saga<void> {
-  const { username } = action.payload;
+function* validateUsername({
+  payload: { username },
+  meta,
+}: UniqueActionWithKeyPath): Saga<void> {
   yield delay(300);
 
   const nameHash = yield call(getHashedENSDomainString, username, 'user');
@@ -318,13 +328,17 @@ function* validateUsername(action: Action): Saga<void> {
     yield putError(
       USERNAME_CHECK_AVAILABILITY_ERROR,
       new Error('ENS address already exists'),
+      meta,
     );
     return;
   }
-  yield put({ type: USERNAME_CHECK_AVAILABILITY_SUCCESS });
+  yield put({ type: USERNAME_CHECK_AVAILABILITY_SUCCESS, meta });
 }
 
-function* createUsername({ payload: { username }, meta }: Action): Saga<void> {
+function* createUsername({
+  payload: { username },
+  meta,
+}: UniqueAction): Saga<void> {
   const ddb: DDB = yield getContext('ddb');
   const userProfileStoreAddress = yield select(userProfileStoreAddressSelector);
   const walletAddress = yield select(walletAddressSelector);
@@ -367,9 +381,7 @@ function* fetchAvatar(action: Action): Saga<void> {
   }
 }
 
-function* uploadAvatar(action: Action): Saga<void> {
-  const { data } = action.payload;
-
+function* uploadAvatar({ payload: { data }, meta }: UniqueAction): Saga<void> {
   const ipfsNode = yield getContext('ipfsNode');
   const ddb: DDB = yield getContext('ddb');
 
@@ -394,13 +406,14 @@ function* uploadAvatar(action: Action): Saga<void> {
     yield put({
       type: USER_UPLOAD_AVATAR_SUCCESS,
       payload: { hash },
+      meta,
     });
   } catch (error) {
-    yield putError(USER_UPLOAD_AVATAR_ERROR, error);
+    yield putError(USER_UPLOAD_AVATAR_ERROR, error, meta);
   }
 }
 
-function* removeAvatar(): Saga<void> {
+function* removeAvatar({ meta }: UniqueAction): Saga<void> {
   const ddb: DDB = yield getContext('ddb');
 
   const userProfileStoreAddress = yield select(userProfileStoreAddressSelector);
@@ -421,9 +434,10 @@ function* removeAvatar(): Saga<void> {
     yield put({
       type: USER_REMOVE_AVATAR_SUCCESS,
       payload: { user },
+      meta,
     });
   } catch (error) {
-    yield putError(USER_REMOVE_AVATAR_ERROR, error);
+    yield putError(USER_REMOVE_AVATAR_ERROR, error, meta);
   }
 }
 

--- a/src/utils/saga/effects.js
+++ b/src/utils/saga/effects.js
@@ -1,7 +1,6 @@
 /* @flow */
 
 import type { Saga } from 'redux-saga';
-import type { MessageDescriptor } from 'react-intl';
 
 import { call, put, race, take, getContext } from 'redux-saga/effects';
 
@@ -18,19 +17,14 @@ export const create = (Class: Function, ...args: any[]) =>
 /*
  * Effect to put a consistent error action
  */
-export const putError = (
-  type: string,
-  error: Error,
-  meta?: Object = {},
-  msg?: MessageDescriptor | string,
-) => {
+export const putError = (type: string, error: Error, meta?: Object = {}) => {
   const action = {
     type,
-    error: true,
-    meta,
     payload: {
-      error: msg || { id: `sagaError.${type}` },
+      error,
     },
+    meta,
+    error: true,
   };
   if (isDev) {
     log(error);


### PR DESCRIPTION
This PR is continuing the work which was started in #765. Here we add the id to all relevant places (i.e. all sagas that are used in conjunction with the redux-promise-listener). The `meta` property is passed through to the subsequent `success` and `error` actions.

I also used the `UniqueAction` type in all relevant sagas to indicate that these actions will always have an id assigned.

Furthermore this changes the `putError` handler which will break things for the data-reducer. ~James is already working on a PR, so I'll put this on-hold to be able to rebase on top of it later~ This is now done 🙂 . The `putError` handler is now compliant to the FSA (flux-standard-action) convention.