### PR TITLE
Refactor callCaller

### DIFF
--- a/src/modules/dashboard/sagas/colony.js
+++ b/src/modules/dashboard/sagas/colony.js
@@ -17,6 +17,8 @@ import type { Action, ENSName } from '~types';
 import { putError, callCaller } from '~utils/saga/effects';
 import { getHashedENSDomainString } from '~utils/web3/ens';
 
+import { NETWORK_CONTEXT } from '../../../lib/ColonyManager/constants';
+
 import { getNetworkMethod } from '../../core/sagas/utils';
 import { getAll } from '../../../lib/database/commands';
 
@@ -267,6 +269,7 @@ function* fetchColonyENSName({
 }: Action): Saga<void> {
   try {
     const { domain } = yield callCaller({
+      context: NETWORK_CONTEXT,
       methodName: 'lookupRegisteredENSDomain',
       params: { ensAddress: colonyAddress },
     });

--- a/src/modules/dashboard/sagas/task.js
+++ b/src/modules/dashboard/sagas/task.js
@@ -8,6 +8,8 @@ import type { Action, ENSName } from '~types';
 
 import { putError, raceError, callCaller } from '~utils/saga/effects';
 
+import { COLONY_CONTEXT } from '../../../lib/ColonyManager/constants';
+
 import {
   TASK_SET_SKILL,
   TASK_WORKER_END,
@@ -45,7 +47,8 @@ import {
 function* generateRatingSalt(colonyENSName: ENSName, taskId: number) {
   const wallet = yield getContext('wallet');
   const { specificationHash } = yield callCaller({
-    colonyENSName,
+    context: COLONY_CONTEXT,
+    identifier: colonyENSName,
     methodName: 'getTask',
     params: { taskId },
   });
@@ -62,7 +65,8 @@ function* generateRatingSecret(
   rating: number,
 ) {
   return yield callCaller({
-    colonyENSName,
+    context: COLONY_CONTEXT,
+    identifier: colonyENSName,
     methodName: 'generateSecret',
     params: { salt, rating },
   });
@@ -88,7 +92,8 @@ function* guessRating(
   salt: string,
 ) {
   const publishedSecret = yield callCaller({
-    colonyENSName,
+    context: COLONY_CONTEXT,
+    identifier: colonyENSName,
     methodName: 'getTaskWorkRatingSecret',
     params: { taskId, role },
   });

--- a/src/modules/users/sagas/userSagas.js
+++ b/src/modules/users/sagas/userSagas.js
@@ -26,6 +26,7 @@ import {
 
 import { DDB } from '../../../lib/database';
 import { FeedStore, ValidatedKVStore } from '../../../lib/database/stores';
+import { NETWORK_CONTEXT } from '../../../lib/ColonyManager/constants';
 import { getAll } from '../../../lib/database/commands';
 import { getNetworkMethod } from '../../core/sagas/utils';
 import { joinedColonyEvent } from '../../dashboard/components/UserActivities';
@@ -241,6 +242,7 @@ function* fetchUsername(action: Action): Saga<void> {
 
   try {
     const { domain } = yield callCaller({
+      context: NETWORK_CONTEXT,
       methodName: 'lookupRegisteredENSDomain',
       params: { ensAddress: userAddress },
     });
@@ -268,6 +270,7 @@ function* fetchProfile({
   // TODO: do we want to cache these in redux?
   const nameHash = yield call(getHashedENSDomainString, username, 'user');
   const { ensAddress: walletAddress } = yield callCaller({
+    context: NETWORK_CONTEXT,
     methodName: 'getAddressForENSHash',
     params: { nameHash },
   });

--- a/src/utils/saga/effects.js
+++ b/src/utils/saga/effects.js
@@ -9,11 +9,6 @@ import type { ENSName, TakeFilter } from '~types';
 
 import { isDev, log } from '~utils/debug';
 
-import {
-  COLONY_CONTEXT,
-  NETWORK_CONTEXT,
-} from '../../lib/ColonyManager/constants';
-
 /*
  * Effect to create a new class instance of Class (use instead of "new Class")
  */
@@ -68,22 +63,23 @@ export const raceError = (
  * parameters. If no colonyENSName, network context is assumed.
  */
 export const callCaller = ({
-  params = {},
-  colonyENSName,
+  context,
+  identifier,
   methodName,
+  params = {},
 }: {
-  params?: Object,
-  colonyENSName?: ENSName,
+  context: 'colony' | 'network',
+  identifier?: ENSName,
   methodName: string,
+  params?: Object,
 }) => {
   function* callCallerGenerator(): Saga<Object> {
     const colonyManager = yield getContext('colonyManager');
     const caller = yield call(
-      // $FlowFixMe why are you unhappy with this valid syntax?!
       [colonyManager, colonyManager.getMethod],
-      colonyENSName ? COLONY_CONTEXT : NETWORK_CONTEXT,
+      context,
       methodName,
-      colonyENSName,
+      identifier,
     );
     return yield call([caller, caller.call], params);
   }


### PR DESCRIPTION
This PR is supposed to make `callCaller` a bit more explicit and bring its API in line with the new transaction action creators