### PR TITLE
Add copy for GasStationCard 

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -29,7 +29,7 @@
     "label.password": "Password",
     "placeholder.email": "handle@domain.com",
     "placeholder.password": "Password",
-    "transaction.debug.description": "DEBUG: {debug}",
+    "transaction.debug.description": "DEBUG: context: {context} methodName: {methodName}",
     "transaction.network.createTask.description": "Create Task",
     "transaction.network.moveFundsBetweenPots.description": "Move Funds",
     "transaction.network.setTaskWorkerRole.description": "Assign Worker",
@@ -41,7 +41,7 @@
     "transaction.network.setTaskDueDatedescription": "Modify Due Date",
     "transaction.network.submitTaskDeliverable.description": "Submit Work",
     "transaction.network.endTask.description": "End Task",
-    "transaction.network.submitTaskDeliverableAndRating..description": "Rate Manager",
+    "transaction.network.submitTaskDeliverableAndRating.description": "Rate Manager",
     "transaction.network.submitTaskWorkRating.description": "Rate Worker",
     "transaction.network.revealTaskWorkRating.description": "Reveal Rating",
     "transaction.network.finalizeTask.description": "Finalize Task",
@@ -88,7 +88,7 @@
     "transaction.colony.enterRecoveryMode.title": "Enter Recovery Mode",
     "transaction.colony.mintTokens.title": "Mint New Tokens",
     "transaction.colony.claimColonyFunds.title": "Claim Pending Transactions",
-    "transaction.colony.setAdminRole.title": "Add Admin {username}",
-    "transaction.colony.removeAdminRole.title": "Remove Admin {username}",
-    "transaction.colony.addDomain.title": "Create Domain {domain}"
+    "transaction.colony.setAdminRole.title": "Add Admin",
+    "transaction.colony.removeAdminRole.title": "Remove Admin",
+    "transaction.colony.addDomain.title": "Create Domain"
   }

--- a/src/modules/users/components/GasStationPopover/GasStationCard/GasStationCard.jsx
+++ b/src/modules/users/components/GasStationPopover/GasStationCard/GasStationCard.jsx
@@ -47,7 +47,7 @@ const MSG = defineMessages({
   },
   failedAction: {
     id: 'users.GasStationPopover.GasStationCard.failedAction',
-    defaultMessage: 'Failed transaction. Try again.',
+    defaultMessage: `Failed transaction. Try again.`,
   },
   transactionTitle: {
     id: 'users.GasStationPopover.GasStationCard.transactionTitle',
@@ -55,10 +55,6 @@ const MSG = defineMessages({
       registerUserLabel {Claim your profile}
       other {Generic Transaction}
     }`,
-  },
-  transactionDescription: {
-    id: 'users.GasStationPopover.GasStationCard.transactionDescription',
-    defaultMessage: `DEBUG: context: {context} methodName: {methodName}`,
   },
   /*
    * @NOTE Below this line are just temporary message descriptors as the actual
@@ -188,13 +184,16 @@ class GasStationCard extends Component<Props, State> {
         <div className={styles.description}>
           <Heading
             appearance={{ theme: 'dark', size: 'normal', margin: 'none' }}
-            text={MSG.transactionTitle}
-            textValues={{ methodName }}
-          />
+          >
+            {context && methodName && (
+              <FormattedMessage
+                id={`transaction.${context}.${methodName}.title`}
+                values={{ context, methodName }}
+              />
+            )}
+          </Heading>
           <Link
             className={styles.transactionLink}
-            text={MSG.transactionDescription}
-            textValues={{ methodName, context }}
             /*
              * @TODO Either change this by removing the link, or point
              * it in a relevant direction
@@ -206,7 +205,18 @@ class GasStationCard extends Component<Props, State> {
              * another place, so there's no reason to change the state prior to that
              */
             onClick={(event: SyntheticEvent<>) => event.stopPropagation()}
-          />
+          >
+            {context && methodName && (
+              <FormattedMessage
+                id={
+                  process.env.DEBUG
+                    ? `transaction.debug.description`
+                    : `transaction.${context}.${methodName}.description`
+                }
+                values={{ context, methodName }}
+              />
+            )}
+          </Link>
         </div>
         {status && (
           <div className={styles.status}>


### PR DESCRIPTION
## Description

To add the correct copy for title and descriptions for transactions in the gas station we need to add the copy to `en.json` according to the method being called on the contracts. Currently they are sorted like in the doc https://docs.google.com/spreadsheets/d/1KSolf0uOM5bhdomwwEnw6rUGfSBiNvsV4_Pk98il27Q/edit#gid=748772830 to make reviewing easier, I'll sort them alphabetically before merging. 

There's a title and a description entry separately. 

The format is the following:
`transaction.[context].[methodName].description`

In addition to that we show the `process.env.DEBUG variable for the debugging purposes.

## Additional Info:
Keep in mind that some sequential transactions share the same title but need their own copy key
i.e. "Move Funds", "Set Payout" are both under the title "Create task".

## Example copy
<img width="467" alt="screen shot 2019-01-21 at 15 48 00" src="https://user-images.githubusercontent.com/6294044/51481413-1bc87c80-1d94-11e9-91d8-70c24f071ffb.png">



Closes  #769
