### PR TITLE
Add eventlog store wrapper

### DIFF
--- a/src/lib/database/stores/EventStore.js
+++ b/src/lib/database/stores/EventStore.js
@@ -1,0 +1,33 @@
+/* @flow */
+
+import Store from './Store';
+
+import type { EventIteratorOptions, OrbitDBEventStore } from '../types';
+
+/**
+ * The wrapper Store class for orbit's eventlog store.
+ */
+class EventStore extends Store {
+  static orbitType = 'eventlog';
+
+  // https://github.com/babel/babel/issues/8417#issuecomment-415508558
+  +_orbitStore: OrbitDBEventStore = this._orbitStore;
+
+  async add(value: {}) {
+    return this._orbitStore.add(value);
+  }
+
+  get(hashOrOptions: string | EventIteratorOptions) {
+    return typeof hashOrOptions === 'string'
+      ? this._orbitStore.get(hashOrOptions)
+      : this.all(hashOrOptions);
+  }
+
+  all(options: EventIteratorOptions = { limit: -1 }) {
+    return this._orbitStore
+      .iterator(options)
+      .collect()
+      .map(item => item.payload.value);
+  }
+}
+export default EventStore;

--- a/src/lib/database/stores/__tests__/EventStore.test.js
+++ b/src/lib/database/stores/__tests__/EventStore.test.js
@@ -1,0 +1,38 @@
+import createSandbox from 'jest-sandbox';
+
+import createMockOrbitStore from './mockOrbitStore';
+import EventStore from '../EventStore';
+
+describe('EventStore', () => {
+  const sandbox = createSandbox();
+  const mockOrbitStore = createMockOrbitStore(sandbox);
+
+  const mockPinner = {
+    requestPinnedStore: sandbox.fn(() => ({ count: 5 })),
+  };
+
+  beforeEach(() => {
+    sandbox.clear();
+  });
+
+  const name = 'colony-store';
+  const type = 'eventlog';
+
+  test('It creates a EventStore', () => {
+    const store = new EventStore(mockOrbitStore, name, mockPinner);
+    expect(store._orbitStore).toBe(mockOrbitStore);
+    expect(store._name).toBe(name);
+    expect(store.constructor.orbitType).toBe(type);
+  });
+
+  test('It can append an event to the log', async () => {
+    const store = new EventStore(mockOrbitStore, name, mockPinner);
+    sandbox.spyOn(store, 'add');
+    const eventPayload = {
+      colonyName: 'Zombies',
+      user: 'jimmy',
+    };
+    await store.add(eventPayload);
+    expect(store.add).toHaveBeenCalledWith(eventPayload);
+  });
+});

--- a/src/lib/database/stores/__tests__/mockOrbitStore.js
+++ b/src/lib/database/stores/__tests__/mockOrbitStore.js
@@ -1,5 +1,6 @@
 const createMockOrbitStore = sandbox => ({
   _addOperation: sandbox.fn(),
+  add: sandbox.fn(),
   address: 'orbit store address',
   close: sandbox.fn(),
   drop: sandbox.fn(),

--- a/src/lib/database/stores/index.js
+++ b/src/lib/database/stores/index.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 export { default as DocStore } from './DocStore';
+export { default as EventStore } from './EventStore';
 export { default as FeedStore } from './FeedStore';
 export { default as KVStore } from './KVStore';
 export { default as Store } from './Store';

--- a/src/lib/database/types/OrbitDBEventStore.js
+++ b/src/lib/database/types/OrbitDBEventStore.js
@@ -1,0 +1,19 @@
+/* @flow */
+
+import type { OrbitDBStore } from './OrbitDBStore';
+
+// NOTE reverse option appears to have no effect
+export type EventIteratorOptions = {
+  gt?: string,
+  gte?: string,
+  lt?: string,
+  lte?: string,
+  limit?: number,
+  reverse?: boolean,
+};
+
+export interface OrbitDBEventStore extends OrbitDBStore {
+  add(value: any): Promise<string>;
+  get(key: string): Object;
+  iterator(options?: EventIteratorOptions): { collect: () => Array<Object> };
+}

--- a/src/lib/database/types/index.js
+++ b/src/lib/database/types/index.js
@@ -15,6 +15,10 @@ export type { OrbitDBStore } from './OrbitDBStore';
 export type { OrbitDBKVStore } from './OrbitDBKVStore';
 export type { OrbitDBDocStore, QueryFunction } from './OrbitDBDocStore';
 export type { FeedIteratorOptions, OrbitDBFeedStore } from './OrbitDBFeedStore';
+export type {
+  EventIteratorOptions,
+  OrbitDBEventStore,
+} from './OrbitDBEventStore';
 export type { ENSResolverType } from './ENSResolver';
 
 export type IPFSHash = string;


### PR DESCRIPTION
## Description

Adds a wrapper (EventStore) for orbit's eventlog store so we can use it for user metadata, colony and task stores 

Contributes to #264