### PR TITLE
Improve username validation

### DIFF
--- a/flow-typed/npm/yup_v0.26.x.js
+++ b/flow-typed/npm/yup_v0.26.x.js
@@ -19,6 +19,7 @@ declare module 'yup' {
 
   declare export interface Schema {
     isValid: IsValid;
+    isValidSync: IsValid;
     validate: Validate;
     shape(props?: Object): *;
   }

--- a/src/modules/users/components/ENSNameDialog/ENSNameDialog.jsx
+++ b/src/modules/users/components/ENSNameDialog/ENSNameDialog.jsx
@@ -69,6 +69,10 @@ const MSG = defineMessages({
     id: 'users.ENSNameDialog.errorDomainTaken',
     defaultMessage: 'This colony domain name is already taken',
   },
+  errorIllegalCharacters: {
+    id: 'users.ENSNameDialog.errorIllegalCharacters',
+    defaultMessage: 'This colony domain name includes illegal characters',
+  },
 });
 
 type FormValues = {
@@ -105,19 +109,21 @@ class ENSNameDialog extends Component<Props, State> {
 
   validateDomain = async (values: FormValues) => {
     // 1. Validate with schema
-    await validationSchema.validate(values).catch(err =>
-      // eslint-disable-next-line no-console
-      console.log(err),
-    );
-
-    // 2. Validate with saga
-    try {
-      await this.checkDomainTaken.asyncFunction(values);
-    } catch (e) {
+    if (!validationSchema.isValidSync(values)) {
       const error = {
-        username: MSG.errorDomainTaken,
+        username: MSG.errorIllegalCharacters,
       };
       throw error;
+    } else {
+      // 2. Validate with saga
+      try {
+        await this.checkDomainTaken.asyncFunction(values);
+      } catch (e) {
+        const error = {
+          username: MSG.errorDomainTaken,
+        };
+        throw error;
+      }
     }
   };
 


### PR DESCRIPTION
## Description 

The username validation was a causing a bug since both two validations were called at the same time.  

Normally we just pass in the ValidationSchema for synchronous validations to Formik, but we can also manually validate using the schema. 

Now we are calling them both on after another. On blur, 
1. we do a synchronous that checks i.e. for incorrect characters
2. we do a asynchronous that checks if the username is taken. 

Closes #662
