### PR TITLE
Improve saga context typing

### DIFF
--- a/src/context/constants.js
+++ b/src/context/constants.js
@@ -1,0 +1,10 @@
+/* @flow */
+
+// eslint-disable-next-line import/prefer-default-export
+export const CONTEXT = Object.freeze({
+  COLONY_MANAGER: 'colonyManager',
+  DDB_INSTANCE: 'ddb',
+  DDB_CLASS: 'DDB',
+  IPFS_NODE: 'ipfsNode',
+  WALLET: 'wallet',
+});

--- a/src/context/index.js
+++ b/src/context/index.js
@@ -1,19 +1,23 @@
 /* @flow */
 
-import { DDB } from '../lib/database';
-import IPFSNode from '../lib/ipfs';
+import type { Saga } from 'redux-saga';
 
-import ipfsNodeContext from './ipfsNodeContext';
-import DDBContext from './DDBContext';
+import { getContext as getContextOriginal } from 'redux-saga/effects';
 
-type RootContext = {
-  ipfsNode: IPFSNode,
-  DDB: typeof DDB,
-};
+import rootContext from './rootContext';
 
-const rootContext: RootContext = {
-  ipfsNode: ipfsNodeContext,
-  DDB: DDBContext,
-};
+import type { RootContext } from './rootContext';
+import type { UserContext } from './userContext';
+
+type ContextType = $Exact<RootContext & UserContext>;
+type ContextName = $Keys<ContextType>;
+
+export * from './constants';
+
+export function* getContext<C: ContextName>(
+  contextName: C,
+): Saga<$ElementType<ContextType, C>> {
+  return yield getContextOriginal(contextName);
+}
 
 export default rootContext;

--- a/src/context/rootContext.js
+++ b/src/context/rootContext.js
@@ -1,0 +1,20 @@
+/* @flow */
+
+import { DDB } from '../lib/database';
+import IPFSNode from '../lib/ipfs';
+
+import ipfsNodeContext from './ipfsNodeContext';
+import DDBContext from './DDBContext';
+import { CONTEXT } from './constants';
+
+export type RootContext = {|
+  ipfsNode: IPFSNode,
+  DDB: typeof DDB,
+|};
+
+const rootContext: RootContext = {
+  [CONTEXT.IPFS_NODE]: ipfsNodeContext,
+  [CONTEXT.DDB_CLASS]: DDBContext,
+};
+
+export default rootContext;

--- a/src/context/userContext.js
+++ b/src/context/userContext.js
@@ -1,0 +1,12 @@
+/* @flow */
+
+import type { WalletObjectType } from '@colony/purser-core';
+import type { DDB } from '../lib/database';
+
+import ColonyManager from '../lib/ColonyManager';
+
+export type UserContext = {|
+  colonyManager: ColonyManager,
+  ddb: DDB,
+  wallet: WalletObjectType,
+|};

--- a/src/modules/admin/sagas/index.js
+++ b/src/modules/admin/sagas/index.js
@@ -2,7 +2,7 @@
 
 import type { Saga } from 'redux-saga';
 
-import { call, getContext, put, takeEvery, all } from 'redux-saga/effects';
+import { call, put, takeEvery, all } from 'redux-saga/effects';
 
 import type {
   Action,
@@ -14,6 +14,7 @@ import type {
 import type { ContractTransactionProps } from '~immutable';
 
 import { putError, raceError } from '~utils/saga/effects';
+import { CONTEXT, getContext } from '~context';
 
 import {
   parseColonyFundsClaimedEvent,
@@ -55,7 +56,7 @@ function* fetchColonyTransactionsSaga({
   meta,
 }: UniqueActionWithKeyPath): Saga<void> {
   try {
-    const colonyManager = yield getContext('colonyManager');
+    const colonyManager = yield* getContext(CONTEXT.COLONY_MANAGER);
 
     const colonyClient = yield call(
       [colonyManager, colonyManager.getColonyClient],
@@ -105,7 +106,7 @@ function* fetchColonyUnclaimedTransactionsSaga({
   meta,
 }: UniqueActionWithKeyPath): Saga<void> {
   try {
-    const colonyManager = yield getContext('colonyManager');
+    const colonyManager = yield* getContext(CONTEXT.COLONY_MANAGER);
     const colonyClient = yield call(
       [colonyManager, colonyManager.getColonyClient],
       colonyENSName,

--- a/src/modules/core/sagas/setupUserContext.js
+++ b/src/modules/core/sagas/setupUserContext.js
@@ -5,6 +5,7 @@ import type { Saga } from 'redux-saga';
 import { setContext, call, all, put, fork } from 'redux-saga/effects';
 
 import { create, putError } from '~utils/saga/effects';
+import { CONTEXT } from '~context';
 
 import type { UniqueAction } from '~types';
 import type { UserProfileProps } from '~immutable';
@@ -45,7 +46,7 @@ export default function* setupUserContext(action: UniqueAction): Saga<void> {
   const { meta } = action;
   try {
     const wallet = yield call(getWallet, action);
-    yield setContext({ wallet });
+    yield setContext({ [CONTEXT.WALLET]: wallet });
     const [ddb, colonyManager] = yield all([
       call(getDDB),
       call(getColonyManager),
@@ -65,7 +66,10 @@ export default function* setupUserContext(action: UniqueAction): Saga<void> {
     );
     yield call([ddb, ddb.addResolver], 'colony', colonyResolver);
 
-    yield setContext({ ddb, colonyManager });
+    yield setContext({
+      [CONTEXT.COLONY_MANAGER]: colonyManager,
+      [CONTEXT.DDB_INSTANCE]: ddb,
+    });
 
     const userStore = yield call(getOrCreateUserStore, wallet.address);
 

--- a/src/modules/core/sagas/utils/getDDB.js
+++ b/src/modules/core/sagas/utils/getDDB.js
@@ -1,16 +1,19 @@
 /* @flow */
 
-import { call, getContext } from 'redux-saga/effects';
+import type { Saga } from 'redux-saga';
+
+import { call } from 'redux-saga/effects';
 
 import { create } from '~utils/saga/effects';
+import { CONTEXT, getContext } from '~context';
 
 import { DDB as DDBClass } from '../../../../lib/database/index';
 import PurserIdentityProvider from '../../../../lib/database/PurserIdentityProvider';
 
-export default function* getDDB(): Generator<*, DDBClass, *> {
-  const wallet = yield getContext('wallet');
-  const DDB: typeof DDBClass = yield getContext('DDB');
-  const ipfsNode = yield getContext('ipfsNode');
+export default function* getDDB(): Saga<DDBClass> {
+  const wallet = yield* getContext(CONTEXT.WALLET);
+  const DDB = yield* getContext(CONTEXT.DDB_CLASS);
+  const ipfsNode = yield* getContext(CONTEXT.IPFS_NODE);
 
   if (!wallet || !DDB || !ipfsNode) {
     throw new Error('Required context for ddb instantiation not found');

--- a/src/modules/core/sagas/utils/getGasPrices.js
+++ b/src/modules/core/sagas/utils/getGasPrices.js
@@ -3,10 +3,11 @@
 import type { Saga } from 'redux-saga';
 import BigNumber from 'bn.js';
 
-import { call, getContext, put, select } from 'redux-saga/effects';
+import { call, put, select } from 'redux-saga/effects';
 
 import type { GasPricesProps } from '~immutable';
 
+import { CONTEXT, getContext } from '~context';
 import { gasPrices as gasPricesSelector } from '../../selectors';
 import { updateGasPrices } from '../../actionCreators';
 
@@ -28,7 +29,7 @@ const ETH_GAS_STATION_ENDPOINT =
   'https://ethgasstation.info/json/ethgasAPI.json';
 
 export default function* getGasPrices(): Saga<GasPricesProps> {
-  const colonyManager = yield getContext('colonyManager');
+  const colonyManager = yield* getContext(CONTEXT.COLONY_MANAGER);
 
   const cachedPrices = yield select(gasPricesSelector);
 

--- a/src/modules/core/sagas/utils/getMethod.js
+++ b/src/modules/core/sagas/utils/getMethod.js
@@ -1,6 +1,10 @@
 /* @flow */
 
-import { call, getContext } from 'redux-saga/effects';
+import type { Saga } from 'redux-saga';
+
+import { call } from 'redux-saga/effects';
+
+import { CONTEXT, getContext } from '~context';
 
 import type {
   AddressOrENSName,
@@ -11,8 +15,8 @@ export default function* getMethod(
   context: ColonyContext,
   methodName: string,
   identifier?: AddressOrENSName,
-): Generator<*, *, *> {
-  const colonyManager = yield getContext('colonyManager');
+): Saga<*> {
+  const colonyManager = yield* getContext(CONTEXT.COLONY_MANAGER);
   return yield call(
     [colonyManager, colonyManager.getMethod],
     context,

--- a/src/modules/core/sagas/utils/getNetworkClient.js
+++ b/src/modules/core/sagas/utils/getNetworkClient.js
@@ -2,7 +2,7 @@
 
 import type { Saga } from 'redux-saga';
 
-import { call, getContext } from 'redux-saga/effects';
+import { call } from 'redux-saga/effects';
 import { providers } from 'ethers';
 import EthersAdapter from '@colony/colony-js-adapter-ethers';
 import { TrufflepigLoader } from '@colony/colony-js-contract-loader-http';
@@ -10,6 +10,7 @@ import ColonyNetworkClient from '@colony/colony-js-client';
 import NetworkLoader from '@colony/colony-js-contract-loader-network';
 
 import { create } from '~utils/saga/effects';
+import { CONTEXT, getContext } from '~context';
 import EthersWrappedWallet from '../../../../lib/EthersWrappedWallet/index';
 
 /*
@@ -21,7 +22,7 @@ export default function* getNetworkClient(): Saga<ColonyNetworkClient> {
     network === 'local'
       ? yield create(providers.JsonRpcProvider)
       : yield call(providers.getDefaultProvider, network);
-  const wallet = yield getContext('wallet');
+  const wallet = yield* getContext(CONTEXT.WALLET);
 
   let loader;
   switch (process.env.LOADER) {

--- a/src/modules/dashboard/sagas/colony.js
+++ b/src/modules/dashboard/sagas/colony.js
@@ -2,14 +2,7 @@
 
 import type { Saga } from 'redux-saga';
 
-import {
-  call,
-  delay,
-  getContext,
-  put,
-  takeEvery,
-  takeLatest,
-} from 'redux-saga/effects';
+import { call, delay, put, takeEvery, takeLatest } from 'redux-saga/effects';
 import { replace } from 'connected-react-router';
 
 import type {
@@ -21,6 +14,7 @@ import type {
 
 import { putError, callCaller } from '~utils/saga/effects';
 import { getHashedENSDomainString } from '~utils/web3/ens';
+import { CONTEXT, getContext } from '~context';
 
 import { NETWORK_CONTEXT } from '../../../lib/ColonyManager/constants';
 
@@ -71,7 +65,7 @@ function* getOrCreateColonyStore(colonyENSName: ENSName) {
    */
   // TODO: No access controller available yet
   if (!store) {
-    const ddb = yield getContext('ddb');
+    const ddb = yield* getContext(CONTEXT.DDB_INSTANCE);
     store = yield call([ddb, ddb.createStore], colonyStoreBlueprint);
   }
 
@@ -306,7 +300,7 @@ function* uploadColonyAvatar({
 }: UniqueActionWithKeyPath): Saga<void> {
   try {
     // first attempt upload to IPFS
-    const ipfsNode = yield getContext('ipfsNode');
+    const ipfsNode = yield* getContext(CONTEXT.IPFS_NODE);
     const hash = yield call([ipfsNode, ipfsNode.addString], data);
 
     /*
@@ -342,7 +336,7 @@ function* fetchColonyAvatar({
     /*
      * Get the base64 avatar image from ipfs
      */
-    const ipfsNode = yield getContext('ipfsNode');
+    const ipfsNode = yield* getContext(CONTEXT.IPFS_NODE);
     const avatarData = yield call([ipfsNode, ipfsNode.getString], hash);
     /*
      * Put the base64 value in the redux state so we can show it

--- a/src/modules/dashboard/sagas/comments.js
+++ b/src/modules/dashboard/sagas/comments.js
@@ -2,11 +2,12 @@
 
 import type { Saga } from 'redux-saga';
 
-import { call, put, takeEvery, getContext } from 'redux-saga/effects';
+import { call, put, takeEvery } from 'redux-saga/effects';
 
 import type { Action } from '~types';
 
 import { putError } from '~utils/saga/effects';
+import { CONTEXT, getContext } from '~context';
 
 import { createCommentsStore } from './shared';
 
@@ -24,7 +25,7 @@ function* addNewComment({
     /*
      * @TODO Wire message signing to the Gas Station, once it's available
      */
-    const wallet = yield getContext('wallet');
+    const wallet = yield* getContext(CONTEXT.WALLET);
     const commentSignature = yield call([wallet, wallet.signMessage], {
       message: JSON.stringify(commentData),
     });

--- a/src/modules/dashboard/sagas/domains.js
+++ b/src/modules/dashboard/sagas/domains.js
@@ -2,14 +2,7 @@
 
 import type { Saga } from 'redux-saga';
 
-import {
-  call,
-  getContext,
-  put,
-  select,
-  take,
-  takeEvery,
-} from 'redux-saga/effects';
+import { call, put, select, take, takeEvery } from 'redux-saga/effects';
 
 import type {
   AddressOrENSName,
@@ -18,6 +11,7 @@ import type {
 } from '~types';
 
 import { putError } from '~utils/saga/effects';
+import { CONTEXT, getContext } from '~context';
 
 import { set, get, getAll } from '../../../lib/database/commands';
 import { getColonyMethod } from '../../core/sagas/utils';
@@ -77,7 +71,7 @@ function* createDomainTransaction(
  * (via the colony state).
  */
 function* getOrCreateDomainsIndexStore(colonyENSName: ENSName) {
-  const ddb = yield getContext('ddb');
+  const ddb = yield* getContext(CONTEXT.DDB_INSTANCE);
   let store;
 
   /*

--- a/src/modules/dashboard/sagas/shared.js
+++ b/src/modules/dashboard/sagas/shared.js
@@ -1,7 +1,7 @@
 /* @flow */
 import type { Saga } from 'redux-saga';
 
-import { call, getContext, select, put } from 'redux-saga/effects';
+import { call, select, put } from 'redux-saga/effects';
 
 import type { ENSName } from '~types';
 import type {
@@ -12,8 +12,8 @@ import type {
 
 import { getENSDomainString } from '~utils/web3/ens';
 import { raceError } from '~utils/saga/effects';
+import { CONTEXT, getContext } from '~context';
 
-import { DDB } from '../../../lib/database';
 import { walletAddressSelector } from '../../users/selectors';
 import {
   colonyStoreBlueprint,
@@ -31,7 +31,7 @@ import { domainsIndexSelector, singleColonySelector } from '../selectors';
 export function* fetchColonyStore(
   colonyENSName: ENSName,
 ): Saga<?ValidatedKVStore> {
-  const ddb: DDB = yield getContext('ddb');
+  const ddb = yield* getContext(CONTEXT.DDB_INSTANCE);
   const walletAddress = yield select(walletAddressSelector);
 
   /*
@@ -93,7 +93,7 @@ export function* getDomainsIndexStore(colonyENSName: ENSName): Saga<?DocStore> {
   /*
    * Get the store for the `domainsIndex` address.
    */
-  const ddb = yield getContext('ddb');
+  const ddb = yield* getContext(CONTEXT.DDB_INSTANCE);
   // TODO: No access controller available yet
   return yield call(
     [ddb, ddb.getStore],
@@ -108,7 +108,7 @@ export function* getDomainsIndexStore(colonyENSName: ENSName): Saga<?DocStore> {
 export function* createDomainsIndexStore(
   colonyENSName: ENSName,
 ): Saga<DocStore> {
-  const ddb: DDB = yield getContext('ddb');
+  const ddb = yield* getContext(CONTEXT.DDB_INSTANCE);
 
   // TODO: No access controller available yet
   return yield call([ddb, ddb.createStore], domainsIndexStoreBlueprint, {
@@ -141,7 +141,7 @@ export function* getOrCreateDomainsIndexStore(
  * Create a tasks index store for a colony.
  */
 export function* createTasksIndexStore(colonyENSName: ENSName): Saga<DocStore> {
-  const ddb: DDB = yield getContext('ddb');
+  const ddb = yield* getContext(CONTEXT.DDB_INSTANCE);
 
   // TODO: No access controller available yet
   return yield call([ddb, ddb.createStore], tasksIndexStoreBlueprint, {
@@ -153,7 +153,7 @@ export function* createTasksIndexStore(colonyENSName: ENSName): Saga<DocStore> {
  * Create the comments store for a given task.
  */
 export function* createCommentsStore(taskId: string): Saga<FeedStore> {
-  const ddb: DDB = yield getContext('ddb');
+  const ddb = yield* getContext(CONTEXT.DDB_INSTANCE);
 
   return yield call([ddb, ddb.createStore], commentsBlueprint, {
     taskId,
@@ -182,7 +182,7 @@ export function* getCommentsStore(taskId: string): Saga<?FeedStore> {
    * Get the comments store, fro the returned address
    */
   // TODO no access controller available yet
-  const ddb = yield getContext('ddb');
+  const ddb = yield* getContext(CONTEXT.DDB_INSTANCE);
   return yield call(
     [ddb, ddb.getStore],
     commentsBlueprint,

--- a/src/modules/dashboard/sagas/task.js
+++ b/src/modules/dashboard/sagas/task.js
@@ -2,18 +2,12 @@
 
 import type { Saga } from 'redux-saga';
 
-import {
-  all,
-  call,
-  getContext,
-  put,
-  select,
-  takeEvery,
-} from 'redux-saga/effects';
+import { all, call, put, select, takeEvery } from 'redux-saga/effects';
 
 import type { ENSName, UniqueActionWithKeyPath } from '~types';
 
 import { putError, raceError, callCaller } from '~utils/saga/effects';
+import { CONTEXT, getContext } from '~context';
 
 import { COLONY_CONTEXT } from '../../../lib/ColonyManager/constants';
 import {
@@ -207,7 +201,7 @@ function* taskRemoveSaga({
 }
 
 function* generateRatingSalt(colonyENSName: ENSName, taskId: number) {
-  const wallet = yield getContext('wallet');
+  const wallet = yield* getContext(CONTEXT.WALLET);
   const { specificationHash } = yield callCaller({
     context: COLONY_CONTEXT,
     identifier: colonyENSName,
@@ -308,7 +302,7 @@ function* taskWorkerEndSaga({
   payload: { colonyENSName, taskId, workDescription, rating },
   meta,
 }: UniqueActionWithKeyPath): Saga<void> {
-  const ipfsNode = yield getContext('ipfsNode');
+  const ipfsNode = yield* getContext(CONTEXT.IPFS_NODE);
   try {
     const deliverableHash = yield call(
       [ipfsNode, ipfsNode.addString],

--- a/src/modules/dashboard/sagas/token.js
+++ b/src/modules/dashboard/sagas/token.js
@@ -5,18 +5,12 @@ import type { Saga } from 'redux-saga';
 import ColonyNetworkClient from '@colony/colony-js-client';
 import TokenClient from '@colony/colony-js-client/lib/TokenClient';
 import EthersAdapter from '@colony/colony-js-adapter-ethers';
-import {
-  call,
-  delay,
-  getContext,
-  put,
-  takeEvery,
-  takeLatest,
-} from 'redux-saga/effects';
+import { call, delay, put, takeEvery, takeLatest } from 'redux-saga/effects';
 
 import type { Action, UniqueAction } from '~types';
 
 import { putError } from '~utils/saga/effects';
+import { CONTEXT, getContext } from '~context';
 
 import {
   TOKEN_CREATE,
@@ -86,7 +80,7 @@ function* getTokenInfo({ payload: { tokenAddress } }: Action): Saga<void> {
   let info;
   try {
     // Attempt to get the token info from a new `TokenClient` instance.
-    const { networkClient } = yield getContext('colonyManager');
+    const { networkClient } = yield* getContext(CONTEXT.COLONY_MANAGER);
     info = yield call(getTokenClientInfo, tokenAddress, networkClient);
   } catch (error) {
     yield putError(TOKEN_INFO_FETCH_ERROR, error);
@@ -122,7 +116,7 @@ function* uploadTokenIcon({
   payload: { data },
   meta,
 }: UniqueAction): Saga<void> {
-  const ipfsNode = yield getContext('ipfsNode');
+  const ipfsNode = yield* getContext(CONTEXT.IPFS_NODE);
 
   try {
     const hash = yield call([ipfsNode, ipfsNode.addString], data);
@@ -142,7 +136,7 @@ function* uploadTokenIcon({
  */
 function* getTokenIcon(action: Action): Saga<void> {
   const { hash } = action.payload;
-  const ipfsNode = yield getContext('ipfsNode');
+  const ipfsNode = yield* getContext(CONTEXT.IPFS_NODE);
 
   try {
     const iconData = yield call([ipfsNode, ipfsNode.getString], hash);

--- a/src/modules/users/sagas/userSagas.js
+++ b/src/modules/users/sagas/userSagas.js
@@ -8,7 +8,6 @@ import {
   delay,
   put,
   select,
-  getContext,
   takeLatest,
   takeEvery,
 } from 'redux-saga/effects';
@@ -22,6 +21,7 @@ import type {
 import type { UserProfileProps, ContractTransactionProps } from '~immutable';
 
 import { putError, callCaller } from '~utils/saga/effects';
+import { CONTEXT, getContext } from '~context';
 
 // @TODO This would go into queries
 import { getHashedENSDomainString } from '~utils/web3/ens';
@@ -31,7 +31,6 @@ import {
   parseUserTransferEvent,
 } from '~utils/web3/eventLogs';
 
-import { DDB } from '../../../lib/database';
 import {
   getUserProfileStoreIdentifier,
   getUserProfileStore,
@@ -89,7 +88,7 @@ import { registerUserLabel } from '../actionCreators';
 export function* getOrCreateUserStore(
   walletAddress: Address,
 ): Saga<ValidatedKVStore> {
-  const ddb: DDB = yield getContext('ddb');
+  const ddb = yield* getContext(CONTEXT.DDB_INSTANCE);
 
   try {
     // @TODO We have two try-catches here because this isn't suppose to go together!
@@ -125,7 +124,7 @@ export function* fetchUserActivities(action: Action): Saga<void> {
   );
 
   try {
-    const ddb: DDB = yield getContext('ddb');
+    const ddb = yield* getContext(CONTEXT.DDB_INSTANCE);
     const activitiesStore = yield call(
       getUserActivityStore(ddb),
       activitiesStoreAddress,
@@ -148,7 +147,7 @@ export function* addUserActivity({ payload }: Action): Saga<void> {
   );
 
   try {
-    const ddb: DDB = yield getContext('ddb');
+    const ddb = yield* getContext(CONTEXT.DDB_INSTANCE);
     const activitiesStore = yield call(
       getUserActivityStore(ddb),
       activitiesStoreAddress,
@@ -229,7 +228,7 @@ function* fetchProfile({
     params: { nameHash },
   });
 
-  const ddb: DDB = yield getContext('ddb');
+  const ddb = yield* getContext(CONTEXT.DDB_INSTANCE);
 
   // should throw an error if username is not registered
   try {
@@ -282,7 +281,7 @@ function* createUsername({
   payload: { username },
   meta,
 }: UniqueAction): Saga<void> {
-  const ddb: DDB = yield getContext('ddb');
+  const ddb = yield* getContext(CONTEXT.DDB_INSTANCE);
   const walletAddress = yield select(walletAddressSelector);
   const { profileStore, activityStore } = yield call(
     createUserProfileStore(ddb),
@@ -306,7 +305,7 @@ function* createUsername({
 
 function* fetchAvatar(action: Action): Saga<void> {
   const { hash } = action.payload;
-  const ipfsNode = yield getContext('ipfsNode');
+  const ipfsNode = yield* getContext(CONTEXT.IPFS_NODE);
 
   try {
     const avatarData = yield call([ipfsNode, ipfsNode.getString], hash);
@@ -320,8 +319,8 @@ function* fetchAvatar(action: Action): Saga<void> {
 }
 
 function* uploadAvatar({ payload: { data }, meta }: UniqueAction): Saga<void> {
-  const ipfsNode = yield getContext('ipfsNode');
-  const ddb: DDB = yield getContext('ddb');
+  const ipfsNode = yield* getContext(CONTEXT.IPFS_NODE);
+  const ddb = yield* getContext(CONTEXT.DDB_INSTANCE);
 
   const walletAddress = yield select(walletAddressSelector);
 
@@ -344,7 +343,7 @@ function* uploadAvatar({ payload: { data }, meta }: UniqueAction): Saga<void> {
 }
 
 function* removeAvatar({ meta }: UniqueAction): Saga<void> {
-  const ddb: DDB = yield getContext('ddb');
+  const ddb = yield* getContext(CONTEXT.DDB_INSTANCE);
   const walletAddress = yield select(walletAddressSelector);
 
   try {
@@ -367,7 +366,7 @@ function* removeAvatar({ meta }: UniqueAction): Saga<void> {
  * ContractTransactionProps objects.
  */
 function* fetchTokenTransfers(): Saga<void> {
-  const colonyManager = yield getContext('colonyManager');
+  const colonyManager = yield* getContext(CONTEXT.COLONY_MANAGER);
   const userAddress = yield select(currentUserAddressSelector);
 
   try {

--- a/src/utils/saga/effects.js
+++ b/src/utils/saga/effects.js
@@ -7,6 +7,7 @@ import { call, put, race, take, getContext } from 'redux-saga/effects';
 import type { ENSName, TakeFilter } from '~types';
 
 import { isDev, log } from '~utils/debug';
+import { CONTEXT } from '~context';
 
 /*
  * Effect to create a new class instance of Class (use instead of "new Class")
@@ -71,7 +72,7 @@ export const callCaller = ({
   params?: Object,
 }) => {
   function* callCallerGenerator(): Saga<Object> {
-    const colonyManager = yield getContext('colonyManager');
+    const colonyManager = yield getContext(CONTEXT.COLONY_MANAGER);
     const caller = yield call(
       [colonyManager, colonyManager.getMethod],
       context,


### PR DESCRIPTION
## Description

This PR makes some changes to the sagas and context such that `getContext` can be called with known types (i.e. both the argument and resulting value now have types).

## Changes

* Define constants/types for the root and user saga context objects
* Add a wrapper generator for the `getContext` effect that we can call with `yield*` and get reliable types for
* Use the `CONSTANT_NAMES` constant to get context in sagas
* Use the custom `getContext` effect with `yield*` in sagas

## Implications for developers

* `getContext` should now be imported from `~context`.
* A constant (`CONTEXT`) is available from `~context` with context names, which can be passed to `getContext` or `setContext`.
* `getContext` should use a delegated yield, i.e. `const ipfs = yield* getContext(CONTEXT.IPFS_NODE);`
* There is no need to define explicit types for variables defined with `getContext`.