### PR TITLE
Use `DDB.storeExists` to determine whether stores exist at a given address before attempting to get them

### DIFF
--- a/src/immutable/UserProfile.js
+++ b/src/immutable/UserProfile.js
@@ -20,9 +20,6 @@ export type UserProfileProps = {
 
 export type UserProfileRecord = RecordOf<UserProfileProps>;
 
-// TODO: Ideally, we should be able to validate the required properties
-// (`walletAddress`, `profileStore`) before creating a record, rather than using
-// empty strings.
 const defaultProps: $Shape<UserProfileProps> = {
   activitiesStore: undefined,
   avatar: undefined,

--- a/src/modules/dashboard/sagas/domains.js
+++ b/src/modules/dashboard/sagas/domains.js
@@ -83,12 +83,18 @@ function* getOrCreateDomainsIndexStore(colonyENSName: ENSName) {
    * Get the store if the `domainsIndex` address was found.
    */
   if (domainsIndexAddress) {
-    // TODO no access controller is available yet
-    store = yield call(
-      [ddb, ddb.getStore],
-      domainsIndexStoreBlueprint,
+    const domainsIndexStoreExists = yield call(
+      [ddb, ddb.storeExists],
       domainsIndexAddress,
     );
+    if (domainsIndexStoreExists) {
+      // TODO: No access controller available yet
+      store = yield call(
+        [ddb, ddb.getStore],
+        domainsIndexStoreBlueprint,
+        domainsIndexAddress,
+      );
+    }
     if (store) {
       /*
        * Load the store if it was found (it may have been cached).

--- a/src/modules/users/reducers/currentUserReducer.js
+++ b/src/modules/users/reducers/currentUserReducer.js
@@ -40,8 +40,17 @@ const currentUserReducer = (state: State = INITIAL_STATE, action: Action) => {
         ? state.set('activities', fromJS(activities))
         : state;
     }
-    case USER_PROFILE_UPDATE_SUCCESS:
-      return state ? state.merge(fromJS(action.payload)) : state;
+    case USER_PROFILE_UPDATE_SUCCESS: {
+      const {
+        activitiesStoreAddress,
+        inboxStoreAddress,
+        metadataStoreAddress,
+        username,
+        walletAddress,
+        ...profile
+      } = action.payload;
+      return state ? state.mergeDeepIn(['profile'], fromJS(profile)) : state;
+    }
     case USERNAME_CREATE_SUCCESS: {
       const {
         params: { username },

--- a/src/modules/users/sagas/userSagas.js
+++ b/src/modules/users/sagas/userSagas.js
@@ -168,7 +168,6 @@ export function* addUserActivity({ payload }: Action): Saga<void> {
 
 function* updateProfile({
   payload: {
-    profileStore,
     walletAddress: removedWalletAddress,
     username,
     // TODO: We want to disallow the easy update of certain fields here. There might be a better way to do this
@@ -177,9 +176,11 @@ function* updateProfile({
   meta,
 }: UniqueAction): Saga<void> {
   try {
+    const walletAddress = yield select(walletAddressSelector);
+    const userStore = yield call(getOrCreateUserStore, walletAddress);
     // if user is not allowed to write to store, this should throw an error
-    yield call([profileStore, profileStore.set], update);
-    const user = yield call(getAll, profileStore);
+    yield call([userStore, userStore.set], update);
+    const user = yield call(getAll, userStore);
     yield put({
       type: USER_PROFILE_UPDATE_SUCCESS,
       payload: user,


### PR DESCRIPTION
## Description

* Use the `DDB.storeExists` method in sagas to make sure that the store exists before attempting to get it.
* Remove `profileStore` from the `updateProfile` action payload
* Fix `updateProfile` saga

✅Tested usual workflows locally (create/fetch user/colony/domain, update colony/user).
