### PR TITLE
Wire colony grid

### DIFF
--- a/src/modules/core/components/ColonyGrid/ColonyGrid.jsx
+++ b/src/modules/core/components/ColonyGrid/ColonyGrid.jsx
@@ -2,6 +2,9 @@
 
 import React from 'react';
 import { defineMessages } from 'react-intl';
+import { compose } from 'recompose';
+
+import { withColonies } from '../../../dashboard/hocs';
 
 import Heading from '../Heading';
 import { SpinnerLoader } from '../Preloaders';
@@ -56,4 +59,4 @@ const ColonyGrid = ({ colonies = [], loading }: Props) => (
 
 ColonyGrid.displayName = displayName;
 
-export default ColonyGrid;
+export default compose(withColonies)(ColonyGrid);

--- a/src/modules/dashboard/hocs/index.js
+++ b/src/modules/dashboard/hocs/index.js
@@ -2,6 +2,7 @@
 
 // Add additional ad-hoc hocs here.
 export { default as withColony } from './withColony';
+export { default as withColonies } from './withColonies';
 export { default as withColonyAvatar } from './withColonyAvatar';
 export { default as withColonyENSName } from './withColonyENSName';
 export { default as withColonyFromRoute } from './withColonyFromRoute';

--- a/src/modules/dashboard/hocs/withColonies.js
+++ b/src/modules/dashboard/hocs/withColonies.js
@@ -1,0 +1,13 @@
+/* @flow */
+
+import { connect } from 'react-redux';
+
+import type { RootStateRecord } from '~immutable';
+
+import { coloniesSelector } from '../selectors';
+
+const withColonies = connect((state: RootStateRecord) => ({
+  colonies: coloniesSelector(state),
+}));
+
+export default withColonies;


### PR DESCRIPTION
## Description 

The colony grid UI element has to be wired since it's still using mock data. 

Below is the colony grid the way it was before: ( using mock data )
<img width="535" alt="screen shot 2019-02-13 at 13 07 10" src="https://user-images.githubusercontent.com/6294044/52725287-32d44600-2fb1-11e9-9693-9c9ea21c7a4b.png">

There's a couple of occurrences all over the app, as Pat commented on the issue for this, the colony grid on the dashboard will be killed for launch:  https://app.zenhub.com/workspaces/colony-dev-sprints-5a03ce25d83fbd6b606fe397/issues/joincolony/colonydapp/686 

The only one that remains right now is the colony grid in the user profile.
This one will be showing all the colonies that a user is active in since other occurrences of the colony grid have been redesigned.  
The redux store still has to be populated with the correct values but the basic wiring is done with this issue.
 

 

Closes #686
