### PR TITLE
Add `from` field to every transaction

### DIFF
--- a/src/immutable/Transaction.js
+++ b/src/immutable/Transaction.js
@@ -39,6 +39,7 @@ type Shared<P: TransactionParams, E: TransactionEventData> = {|
   context: ColonyContext,
   createdAt: Date,
   eventData?: E,
+  from: string,
   gasLimit?: BigNumber,
   gasPrice?: BigNumber,
   group?: {
@@ -81,6 +82,7 @@ const defaultValues: $Shape<TransactionRecordProps<*, *>> = {
   createdAt: new Date(),
   errors: new List(),
   eventData: undefined,
+  from: undefined,
   gasLimit: undefined,
   gasPrice: undefined,
   group: undefined,

--- a/src/modules/core/reducers/transactions.js
+++ b/src/modules/core/reducers/transactions.js
@@ -49,6 +49,7 @@ const coreTransactionsReducer = (
       const {
         context,
         createdAt,
+        from,
         identifier,
         lifecycle,
         methodName,
@@ -61,6 +62,7 @@ const coreTransactionsReducer = (
       const tx = TransactionRecord({
         context,
         createdAt,
+        from,
         id,
         identifier,
         lifecycle,


### PR DESCRIPTION
This PR adds a `from` field to every transaction on creation (when created with the new flow introduced in #853). This is required for #797.

Closes #857.