### PR TITLE
Remove hidden Help button

### DIFF
--- a/src/modules/pages/components/LoadingTemplate/LoadingTemplate.css
+++ b/src/modules/pages/components/LoadingTemplate/LoadingTemplate.css
@@ -6,12 +6,6 @@
   background: var(--gradient-default);
 }
 
-.header {
-  display: flex;
-  justify-content: flex-end;
-  padding: 20px;
-}
-
 .mainContent {
   margin-top: 160px;
   padding-bottom: var(--pad-large);

--- a/src/modules/pages/components/LoadingTemplate/LoadingTemplate.jsx
+++ b/src/modules/pages/components/LoadingTemplate/LoadingTemplate.jsx
@@ -3,19 +3,10 @@ import type { Node } from 'react';
 import type { MessageDescriptor } from 'react-intl';
 
 import React from 'react';
-import { defineMessages } from 'react-intl';
 
 import { SpinnerLoader } from '~core/Preloaders';
-import Button from '~core/Button';
 
 import styles from './LoadingTemplate.css';
-
-const MSG = defineMessages({
-  helpLinkText: {
-    id: 'LoadingTemplate.helpLinkText',
-    defaultMessage: 'Help',
-  },
-});
 
 type Props = {|
   children?: Node,
@@ -24,9 +15,6 @@ type Props = {|
 
 const LoadingTemplate = ({ children, loadingText }: Props) => (
   <div className={styles.main}>
-    <header className={styles.header}>
-      <Button to="/" text={MSG.helpLinkText} appearance={{ theme: 'blue' }} />
-    </header>
     <main className={styles.mainContent}>
       <div>
         <div className={styles.loaderContainer}>


### PR DESCRIPTION
## Description

When viewing the user profile, there's some blue copy showing behind the avatar in the menu, that shouldn't be there: ( see below )
![screen shot 2019-02-15 at 17 37 49](https://user-images.githubusercontent.com/6294044/52870626-8e850780-3148-11e9-86a1-7f5e290379e9.png)

Steps to reproduce:

1. Create Username by clicking on "Get Started"
2. Go to "My Profile" and find the above situation.

Closes #842
