### PR TITLE
Fix ColonyGrid list props

### DIFF
--- a/src/modules/core/components/ColonyGrid/ColonyGrid.jsx
+++ b/src/modules/core/components/ColonyGrid/ColonyGrid.jsx
@@ -3,11 +3,11 @@
 import React from 'react';
 import { defineMessages } from 'react-intl';
 import { compose } from 'recompose';
+import withImmutablePropsToJS from 'with-immutable-props-to-js';
 
 import { withColonies } from '../../../dashboard/hocs';
 
 import Heading from '../Heading';
-import { SpinnerLoader } from '../Preloaders';
 
 import ColonyGridItem from './ColonyGridItem.jsx';
 
@@ -25,38 +25,33 @@ const MSG = defineMessages({
 type Props = {|
   /** List of colonies to display */
   colonies: Array<ColonyType>,
-  /** Indicates that the data is loading */
-  loading?: boolean,
 |};
 
 const displayName = 'ColonyGrid';
 
-const ColonyGrid = ({ colonies = [], loading }: Props) => (
+const ColonyGrid = ({ colonies = [] }: Props) => (
   <div className={styles.main}>
     <div className={styles.sectionTitle}>
       <Heading text={MSG.title} appearance={{ size: 'medium' }} />
     </div>
-    {loading ? (
-      <div className={styles.loader}>
-        <SpinnerLoader appearance={{ size: 'large' }} />
-      </div>
-    ) : (
-      <div className={styles.colonyGrid}>
-        {colonies.map(({ ensName, address, name, avatar }) => (
-          <div className={styles.colonyGridItem} key={address}>
-            <ColonyGridItem
-              address={address}
-              avatar={avatar}
-              ensName={ensName}
-              name={name}
-            />
-          </div>
-        ))}
-      </div>
-    )}
+    <div className={styles.colonyGrid}>
+      {colonies.map(({ ensName, address, name, avatar }) => (
+        <div className={styles.colonyGridItem} key={address}>
+          <ColonyGridItem
+            address={address}
+            avatar={avatar}
+            ensName={ensName}
+            name={name}
+          />
+        </div>
+      ))}
+    </div>
   </div>
 );
 
 ColonyGrid.displayName = displayName;
 
-export default compose(withColonies)(ColonyGrid);
+export default compose(
+  withColonies,
+  withImmutablePropsToJS,
+)(ColonyGrid);

--- a/src/modules/dashboard/hocs/withColonies.js
+++ b/src/modules/dashboard/hocs/withColonies.js
@@ -4,10 +4,10 @@ import { connect } from 'react-redux';
 
 import type { RootStateRecord } from '~immutable';
 
-import { coloniesSelector } from '../selectors';
+import { coloniesListSelector } from '../selectors';
 
 const withColonies = connect((state: RootStateRecord) => ({
-  colonies: coloniesSelector(state),
+  colonies: coloniesListSelector(state),
 }));
 
 export default withColonies;

--- a/src/modules/dashboard/selectors/colony.js
+++ b/src/modules/dashboard/selectors/colony.js
@@ -25,6 +25,9 @@ export const allColoniesSelector = (state: RootStateRecord) =>
 export const coloniesSelector = (state: RootStateRecord) =>
   state.getIn([ns, DASHBOARD_ALL_COLONIES, DASHBOARD_COLONIES], ImmutableMap());
 
+export const coloniesListSelector = (state: RootStateRecord) =>
+  coloniesSelector(state).toList();
+
 export const colonyAvatarsSelector = (state: RootStateRecord) =>
   state.getIn([ns, DASHBOARD_ALL_COLONIES, DASHBOARD_AVATARS], ImmutableMap());
 


### PR DESCRIPTION
## Description

Fixes an issue where the `ColonyGrid` received incorrect props.

* Use a selector of colonies as a `List` rather than a `Map`
* Use `withImmutablePropsToJS` to convert the list to an array

(I should have noticed this when reviewing it, sorry...)