### PR TITLE
Clarify action types 

### DIFF
--- a/src/modules/admin/actionCreators/index.js
+++ b/src/modules/admin/actionCreators/index.js
@@ -7,17 +7,14 @@ import { ACTIONS } from '~redux';
 export const fetchColonyTransactions = (colonyENSName: ENSName) => ({
   type: ACTIONS.COLONY_FETCH_TRANSACTIONS,
   meta: { keyPath: [colonyENSName] },
-  payload: {},
 });
 
 export const fetchColonyUnclaimedTransactions = (colonyENSName: ENSName) => ({
   type: ACTIONS.COLONY_FETCH_UNCLAIMED_TRANSACTIONS,
   meta: { keyPath: [colonyENSName] },
-  payload: {},
 });
 
 export const claimColonyToken = (ensName: ENSName, tokenAddress: Address) => ({
   type: ACTIONS.COLONY_CLAIM_TOKEN,
-  meta: {},
   payload: { ensName, tokenAddress },
 });

--- a/src/modules/core/actionCreators/transactions.js
+++ b/src/modules/core/actionCreators/transactions.js
@@ -99,31 +99,22 @@ export const multisigTransactionRefreshed = (
 ) => ({
   type: ACTIONS.MULTISIG_TRANSACTION_REFRESHED,
   payload: { multisig },
-  meta: {
-    id,
-  },
+  meta: { id },
 });
 
 export const multisigTransactionSign = (id: string) => ({
   type: ACTIONS.MULTISIG_TRANSACTION_SIGN,
-  meta: {
-    id,
-  },
+  meta: { id },
 });
 
 export const multisigTransactionSigned = (id: string) => ({
   type: ACTIONS.MULTISIG_TRANSACTION_SIGNED,
-  payload: {},
-  meta: {
-    id,
-  },
+  meta: { id },
 });
 
 export const multisigTransactionReject = (id: string) => ({
   type: ACTIONS.MULTISIG_TRANSACTION_REJECT,
-  meta: {
-    id,
-  },
+  meta: { id },
 });
 
 export const transactionError = (id: string, error: TransactionError) => ({
@@ -135,7 +126,7 @@ export const transactionError = (id: string, error: TransactionError) => ({
 
 export const transactionReceiptReceived = <P: TransactionParams>(
   id: string,
-  payload: { receipt: TransactionReceipt, params: P },
+  payload: {| receipt: TransactionReceipt, params: P |},
 ) => ({
   type: ACTIONS.TRANSACTION_RECEIPT_RECEIVED,
   payload,
@@ -144,7 +135,7 @@ export const transactionReceiptReceived = <P: TransactionParams>(
 
 export const transactionSent = <P: TransactionParams>(
   id: string,
-  payload: { hash: string, params: P },
+  payload: {| hash: string, params: P |},
 ) => ({
   type: ACTIONS.TRANSACTION_SENT,
   payload,
@@ -156,7 +147,7 @@ export const transactionEventDataReceived = <
   E: TransactionEventData,
 >(
   id: string,
-  payload: { eventData: E, params: P },
+  payload: {| eventData: E, params: P |},
 ) => ({
   type: ACTIONS.TRANSACTION_SUCCEEDED,
   payload,

--- a/src/modules/dashboard/actionCreators/colony.js
+++ b/src/modules/dashboard/actionCreators/colony.js
@@ -7,17 +7,14 @@ import { ACTIONS } from '~redux';
 export const fetchColony = (ensName: ENSName) => ({
   type: ACTIONS.COLONY_FETCH,
   meta: { keyPath: [ensName] },
-  payload: {},
 });
 
 export const fetchColonyAvatar = (hash: string) => ({
   type: ACTIONS.COLONY_AVATAR_FETCH,
   meta: { keyPath: [hash] },
-  payload: {},
 });
 
 export const fetchColonyENSName = (colonyAddress: string) => ({
   type: ACTIONS.COLONY_ENS_NAME_FETCH,
   meta: { keyPath: [colonyAddress] },
-  payload: {},
 });

--- a/src/modules/dashboard/components/CreateColonyWizard/StepCreateColony.jsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepCreateColony.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { defineMessages } from 'react-intl';
 
 import type { WizardProps } from '~core/Wizard';
-import type { ActionType } from '~redux';
+import type { UniqueActionType } from '~redux';
 
 import Heading from '~core/Heading';
 import Button from '~core/Button';
@@ -81,7 +81,7 @@ const StepCreateColony = ({ nextStep, wizardForm, wizardValues }: Props) => (
     submit={ACTIONS.COLONY_CREATE}
     error={ACTIONS.COLONY_CREATE_ERROR}
     success={ACTIONS.COLONY_CREATE_SUCCESS}
-    setPayload={(action: ActionType<*, *, *>) => ({
+    setPayload={(action: UniqueActionType<*, *, *>) => ({
       ...action,
       payload: { tokenAddress: wizardValues.tokenAddress },
     })}

--- a/src/modules/dashboard/reducers/allTasks.js
+++ b/src/modules/dashboard/reducers/allTasks.js
@@ -16,8 +16,8 @@ const allTasksReducer: ReducerType<
     TASK_CREATE_SUCCESS: *,
     TASK_FETCH_SUCCESS: *,
     TASK_REMOVE_SUCCESS: *,
-    TASK_SET_DATE_SUCCESS: *,
-    TASK_SET_SKILL_SUCCESS: *,
+    // TASK_SET_DATE_SUCCESS: *,
+    // TASK_SET_SKILL_SUCCESS: *,
     TASK_UPDATE_SUCCESS: *,
   |},
 > = (state = new ImmutableMap(), action) => {
@@ -38,10 +38,11 @@ const allTasksReducer: ReducerType<
         : state.set(ensName, ImmutableMap({ [id]: data }));
     }
 
-    // Simple updates (where the payload can be set on the record directly)
-    case ACTIONS.TASK_UPDATE_SUCCESS:
-    case ACTIONS.TASK_SET_SKILL_SUCCESS:
-    case ACTIONS.TASK_SET_DATE_SUCCESS: {
+    // TODO handle these cases
+    // case ACTIONS.TASK_SET_SKILL_SUCCESS:
+    // case ACTIONS.TASK_SET_DATE_SUCCESS:
+    case ACTIONS.TASK_UPDATE_SUCCESS: {
+      // Simple update (where the payload can be set on the record directly)
       const {
         meta: { keyPath },
         payload,

--- a/src/modules/dashboard/sagas/colony.js
+++ b/src/modules/dashboard/sagas/colony.js
@@ -153,7 +153,7 @@ Action<'COLONY_CREATE_NEW'>): Saga<void> {
     yield put({
       type: ACTIONS.COLONY_CREATE_SUCCESS,
       meta,
-      payload: {},
+      payload: undefined,
     });
   } catch (error) {
     yield putError(ACTIONS.COLONY_CREATE_ERROR, error, meta);
@@ -240,7 +240,7 @@ function* colonyCreateLabel({
   // Dispatch and action to set the current colony in the app state (simulating fetching it)
   const fetchSuccessAction = {
     type: ACTIONS.COLONY_FETCH_SUCCESS,
-    meta: { ...meta, keyPath: [ensName] },
+    meta: { keyPath: [ensName] },
     payload: colonyStoreData,
   };
   yield put<Action<typeof ACTIONS.COLONY_FETCH_SUCCESS>>(fetchSuccessAction);
@@ -348,7 +348,7 @@ function* colonyDomainValidate({
   yield put<Action<typeof ACTIONS.COLONY_DOMAIN_VALIDATE_SUCCESS>>({
     type: ACTIONS.COLONY_DOMAIN_VALIDATE_SUCCESS,
     meta,
-    payload: {},
+    payload: undefined,
   });
 }
 
@@ -516,7 +516,7 @@ function* colonyAvatarRemove({
     yield put<Action<typeof ACTIONS.COLONY_AVATAR_REMOVE_SUCCESS>>({
       type: ACTIONS.COLONY_AVATAR_REMOVE_SUCCESS,
       meta,
-      payload: {},
+      payload: undefined,
     });
   } catch (error) {
     yield putError(ACTIONS.COLONY_AVATAR_REMOVE_ERROR, error, meta);

--- a/src/modules/dashboard/sagas/shared.js
+++ b/src/modules/dashboard/sagas/shared.js
@@ -74,8 +74,7 @@ export function* ensureColonyIsInState(colonyENSName: ENSName): Saga<*> {
   /*
    * Dispatch an action to fetch the given colony.
    */
-  const fetchAction = fetchColony(colonyENSName);
-  yield put<Action<typeof fetchAction.type>>(fetchAction);
+  yield put<Action<typeof ACTIONS.COLONY_FETCH>>(fetchColony(colonyENSName));
 
   /*
    * Wait for the successful fetch result (the colony should now be in state).

--- a/src/modules/dashboard/sagas/task.js
+++ b/src/modules/dashboard/sagas/task.js
@@ -130,7 +130,7 @@ function* taskRemove({
     yield put<Action<typeof ACTIONS.TASK_REMOVE_SUCCESS>>({
       type: ACTIONS.TASK_REMOVE_SUCCESS,
       meta,
-      payload: {},
+      payload: undefined,
     });
   } catch (error) {
     yield putError(ACTIONS.TASK_REMOVE_ERROR, error, meta);

--- a/src/modules/dashboard/sagas/token.js
+++ b/src/modules/dashboard/sagas/token.js
@@ -172,7 +172,6 @@ function* tokenIconFetch({
     yield put<Action<typeof ACTIONS.TOKEN_ICON_FETCH_SUCCESS>>({
       type: ACTIONS.TOKEN_ICON_FETCH_SUCCESS,
       payload: { hash, iconData },
-      meta: {},
     });
   } catch (error) {
     yield putError(ACTIONS.TOKEN_ICON_FETCH_ERROR, error);

--- a/src/modules/users/components/GasStation/TransactionCard/GroupedTransactionCard.jsx
+++ b/src/modules/users/components/GasStation/TransactionCard/GroupedTransactionCard.jsx
@@ -4,7 +4,7 @@ import React, { Component, Fragment } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
 import type { TransactionType } from '~immutable';
-import type { ActionType } from '~redux';
+import type { UniqueActionType } from '~redux';
 
 import { getMainClasses } from '~utils/css';
 
@@ -26,7 +26,7 @@ const MSG = defineMessages({
 });
 
 type Props = {|
-  cancelTransaction: (id: string) => ActionType<*, *, *>,
+  cancelTransaction: (id: string) => UniqueActionType<*, *, *>,
   idx: number,
   selected: boolean,
   transaction: TransactionType<*, *>,

--- a/src/modules/users/sagas/userSagas.js
+++ b/src/modules/users/sagas/userSagas.js
@@ -181,7 +181,6 @@ function* fetchUsername({
     yield put<Action<typeof ACTIONS.USERNAME_FETCH_SUCCESS>>({
       type: ACTIONS.USERNAME_FETCH_SUCCESS,
       payload: { key: userAddress, username },
-      meta: {},
     });
   } catch (error) {
     yield putError(ACTIONS.USERNAME_FETCH_ERROR, error, { key: userAddress });
@@ -250,7 +249,7 @@ function* validateUsername({
   yield put<Action<typeof ACTIONS.USERNAME_CHECK_AVAILABILITY_SUCCESS>>({
     type: ACTIONS.USERNAME_CHECK_AVAILABILITY_SUCCESS,
     meta,
-    payload: {},
+    payload: undefined,
   });
 }
 
@@ -312,7 +311,6 @@ function* fetchAvatar(
     yield put<Action<typeof ACTIONS.USER_AVATAR_FETCH_SUCCESS>>({
       type: ACTIONS.USER_AVATAR_FETCH_SUCCESS,
       payload: { hash, avatarData },
-      meta: {},
     });
   } catch (error) {
     yield putError(ACTIONS.USER_AVATAR_FETCH_ERROR, error);
@@ -434,7 +432,6 @@ function* fetchTokenTransfers(): Saga<void> {
     yield put<Action<typeof ACTIONS.USER_FETCH_TOKEN_TRANSFERS_SUCCESS>>({
       type: ACTIONS.USER_FETCH_TOKEN_TRANSFERS_SUCCESS,
       payload: { transactions },
-      meta: {},
     });
   } catch (error) {
     yield putError(ACTIONS.USER_FETCH_TOKEN_TRANSFERS_ERROR, error);
@@ -458,7 +455,6 @@ function* updateWalletBalance(): Saga<void> {
       payload: {
         balance: formatEther(walletBalance),
       },
-      meta: {},
     });
   } catch (error) {
     yield putError(ACTIONS.CURRENT_USER_GET_BALANCE_ERROR, error);

--- a/src/modules/users/sagas/walletSagas.js
+++ b/src/modules/users/sagas/walletSagas.js
@@ -36,7 +36,6 @@ function* fetchAccounts(
     yield put<Action<typeof ACTIONS.WALLET_FETCH_ACCOUNTS_SUCCESS>>({
       type: ACTIONS.WALLET_FETCH_ACCOUNTS_SUCCESS,
       payload: { allAddresses: wallet.otherAddresses },
-      meta: {},
     });
   } catch (err) {
     yield putError(ACTIONS.WALLET_FETCH_ACCOUNTS_ERROR, err);

--- a/src/redux/types/actions/colony.js
+++ b/src/redux/types/actions/colony.js
@@ -7,7 +7,12 @@ import type {
   DomainType,
   TransactionType,
 } from '~immutable';
-import type { ActionType, ErrorActionType, UniqueActionType } from '../index';
+import type {
+  ActionTypeWithMeta,
+  ActionTypeWithPayloadAndMeta,
+  ErrorActionType,
+  UniqueActionType,
+} from '../index';
 
 import { ACTIONS } from '../../index';
 
@@ -60,7 +65,7 @@ export type ColonyActionTypes = {|
   >,
   COLONY_AVATAR_FETCH: UniqueActionType<
     typeof ACTIONS.COLONY_AVATAR_FETCH,
-    *,
+    void,
     WithKeyPathDepth1,
   >,
   COLONY_AVATAR_FETCH_ERROR: ErrorActionType<
@@ -74,7 +79,7 @@ export type ColonyActionTypes = {|
   >,
   COLONY_AVATAR_REMOVE: UniqueActionType<
     typeof ACTIONS.COLONY_AVATAR_REMOVE,
-    *,
+    void,
     WithKeyPathDepth1,
   >,
   COLONY_AVATAR_REMOVE_ERROR: ErrorActionType<
@@ -83,7 +88,7 @@ export type ColonyActionTypes = {|
   >,
   COLONY_AVATAR_REMOVE_SUCCESS: UniqueActionType<
     typeof ACTIONS.COLONY_AVATAR_REMOVE_SUCCESS,
-    *,
+    void,
     WithKeyPathDepth1,
   >,
   COLONY_AVATAR_UPLOAD: UniqueActionType<
@@ -97,29 +102,29 @@ export type ColonyActionTypes = {|
   >,
   COLONY_AVATAR_UPLOAD_SUCCESS: UniqueActionType<
     typeof ACTIONS.COLONY_AVATAR_UPLOAD_SUCCESS,
-    *,
+    void,
     WithKeyPathDepth1,
   >,
   COLONY_CLAIM_TOKEN: UniqueActionType<
     typeof ACTIONS.COLONY_CLAIM_TOKEN,
     {| tokenAddress: string, ensName: string |},
-    *,
+    void,
   >,
   COLONY_CLAIM_TOKEN_ERROR: ErrorActionType<
     typeof ACTIONS.COLONY_CLAIM_TOKEN_ERROR,
-    *,
+    void,
   >,
   COLONY_CLAIM_TOKEN_SUCCESS: UniqueActionType<
     typeof ACTIONS.COLONY_CLAIM_TOKEN_SUCCESS,
     {| params: { token: string }, transaction: TransactionType<*, *> |},
-    *,
+    void,
   >,
   COLONY_CREATE: UniqueActionType<
     typeof ACTIONS.COLONY_CREATE,
     {|
       tokenAddress: string,
     |},
-    *,
+    void,
   >,
   COLONY_CREATE_ERROR: ErrorActionType<typeof ACTIONS.COLONY_CREATE_ERROR, *>,
   COLONY_CREATE_LABEL: UniqueActionType<
@@ -134,39 +139,39 @@ export type ColonyActionTypes = {|
       tokenSymbol: string,
       tokenIcon: string,
     |},
-    *,
+    void,
   >,
   COLONY_CREATE_LABEL_ERROR: ErrorActionType<
     typeof ACTIONS.COLONY_CREATE_LABEL_ERROR,
-    *,
+    void,
   >,
   COLONY_CREATE_LABEL_SUCCESS: UniqueActionType<
     typeof ACTIONS.COLONY_CREATE_LABEL_SUCCESS,
     TransactionType<{ colonyName: string }, *>,
-    *,
+    void,
   >,
   COLONY_CREATE_SUCCESS: UniqueActionType<
     typeof ACTIONS.COLONY_CREATE_SUCCESS,
-    *,
-    *,
+    void,
+    void,
   >,
   COLONY_DOMAIN_VALIDATE: UniqueActionType<
     typeof ACTIONS.COLONY_DOMAIN_VALIDATE,
     {| ensName: string |},
-    *,
+    void,
   >,
   COLONY_DOMAIN_VALIDATE_ERROR: ErrorActionType<
     typeof ACTIONS.COLONY_DOMAIN_VALIDATE_ERROR,
-    *,
+    void,
   >,
   COLONY_DOMAIN_VALIDATE_SUCCESS: UniqueActionType<
     typeof ACTIONS.COLONY_DOMAIN_VALIDATE_SUCCESS,
-    *,
-    *,
+    void,
+    void,
   >,
   COLONY_DOMAINS_FETCH: UniqueActionType<
     typeof ACTIONS.COLONY_DOMAINS_FETCH,
-    *,
+    void,
     WithKeyPathDepth1,
   >,
   COLONY_DOMAINS_FETCH_ERROR: ErrorActionType<
@@ -180,7 +185,7 @@ export type ColonyActionTypes = {|
   >,
   COLONY_ENS_NAME_FETCH: UniqueActionType<
     typeof ACTIONS.COLONY_ENS_NAME_FETCH,
-    *,
+    void,
     WithKeyPathDepth1,
   >,
   COLONY_ENS_NAME_FETCH_ERROR: ErrorActionType<
@@ -192,40 +197,41 @@ export type ColonyActionTypes = {|
     string,
     WithKeyPathDepth1,
   >,
-  COLONY_FETCH: ActionType<typeof ACTIONS.COLONY_FETCH, *, WithKeyPathDepth1>,
+  COLONY_FETCH: ActionTypeWithMeta<
+    typeof ACTIONS.COLONY_FETCH,
+    WithKeyPathDepth1,
+  >,
   COLONY_FETCH_ERROR: ErrorActionType<
     typeof ACTIONS.COLONY_FETCH_ERROR,
     WithKeyPathDepth1,
   >,
-  COLONY_FETCH_SUCCESS: ActionType<
+  COLONY_FETCH_SUCCESS: ActionTypeWithPayloadAndMeta<
     typeof ACTIONS.COLONY_FETCH_SUCCESS,
     ColonyType,
     WithKeyPathDepth1,
   >,
-  COLONY_FETCH_TRANSACTIONS: ActionType<
+  COLONY_FETCH_TRANSACTIONS: ActionTypeWithMeta<
     typeof ACTIONS.COLONY_FETCH_TRANSACTIONS,
-    *,
     WithKeyPathDepth1,
   >,
   COLONY_FETCH_TRANSACTIONS_ERROR: ErrorActionType<
     typeof ACTIONS.COLONY_FETCH_TRANSACTIONS_ERROR,
     WithKeyPathDepth1,
   >,
-  COLONY_FETCH_TRANSACTIONS_SUCCESS: ActionType<
+  COLONY_FETCH_TRANSACTIONS_SUCCESS: ActionTypeWithPayloadAndMeta<
     typeof ACTIONS.COLONY_FETCH_TRANSACTIONS_SUCCESS,
     ContractTransactionType[],
     WithKeyPathDepth1,
   >,
-  COLONY_FETCH_UNCLAIMED_TRANSACTIONS: ActionType<
+  COLONY_FETCH_UNCLAIMED_TRANSACTIONS: ActionTypeWithMeta<
     typeof ACTIONS.COLONY_FETCH_UNCLAIMED_TRANSACTIONS,
-    *,
     WithKeyPathDepth1,
   >,
   COLONY_FETCH_UNCLAIMED_TRANSACTIONS_ERROR: ErrorActionType<
     typeof ACTIONS.COLONY_FETCH_UNCLAIMED_TRANSACTIONS_ERROR,
     WithKeyPathDepth1,
   >,
-  COLONY_FETCH_UNCLAIMED_TRANSACTIONS_SUCCESS: ActionType<
+  COLONY_FETCH_UNCLAIMED_TRANSACTIONS_SUCCESS: ActionTypeWithPayloadAndMeta<
     typeof ACTIONS.COLONY_FETCH_UNCLAIMED_TRANSACTIONS_SUCCESS,
     ContractTransactionType[],
     WithKeyPathDepth1,
@@ -237,7 +243,7 @@ export type ColonyActionTypes = {|
   >,
   COLONY_PROFILE_UPDATE_ERROR: ErrorActionType<
     typeof ACTIONS.COLONY_PROFILE_UPDATE_ERROR,
-    *,
+    void,
   >,
   COLONY_PROFILE_UPDATE_SUCCESS: UniqueActionType<
     typeof ACTIONS.COLONY_PROFILE_UPDATE_SUCCESS,

--- a/src/redux/types/actions/currentUser.js
+++ b/src/redux/types/actions/currentUser.js
@@ -1,43 +1,43 @@
 /* @flow */
 
-import type { ActionType, ErrorActionType } from '../index';
+import type {
+  ActionType,
+  ActionTypeWithPayload,
+  ErrorActionType,
+  UniqueActionType,
+} from '../index';
 
 import { ACTIONS } from '../../index';
 
 export type CurrentUserActionTypes = {|
-  CURRENT_USER_CREATE: ActionType<
+  CURRENT_USER_CREATE: UniqueActionType<
     typeof ACTIONS.CURRENT_USER_CREATE,
     {|
       profileData: Object,
       walletAddress: string,
       balance: number,
     |},
-    *,
+    void,
   >,
   CURRENT_USER_CREATE_ERROR: ErrorActionType<
     typeof ACTIONS.CURRENT_USER_CREATE_ERROR,
-    *,
+    void,
   >,
-  CURRENT_USER_CREATE_SUCCESS: ActionType<
+  CURRENT_USER_CREATE_SUCCESS: UniqueActionType<
     typeof ACTIONS.CURRENT_USER_CREATE_SUCCESS,
-    *,
-    *,
+    void,
+    void,
   >,
-  CURRENT_USER_GET_BALANCE: ActionType<
-    typeof ACTIONS.CURRENT_USER_GET_BALANCE,
-    *,
-    *,
-  >,
+  CURRENT_USER_GET_BALANCE: ActionType<typeof ACTIONS.CURRENT_USER_GET_BALANCE>,
   CURRENT_USER_GET_BALANCE_ERROR: ErrorActionType<
     typeof ACTIONS.CURRENT_USER_GET_BALANCE_ERROR,
-    *,
+    void,
   >,
-  CURRENT_USER_GET_BALANCE_SUCCESS: ActionType<
+  CURRENT_USER_GET_BALANCE_SUCCESS: ActionTypeWithPayload<
     typeof ACTIONS.CURRENT_USER_GET_BALANCE_SUCCESS,
     {|
       // Apparently a string, maybe converted from BN?
       balance: string,
     |},
-    *,
   >,
 |};

--- a/src/redux/types/actions/domain.js
+++ b/src/redux/types/actions/domain.js
@@ -1,11 +1,17 @@
 /* @flow */
 
 import type { WithKeyPathDepth2 } from '~types';
+import type { DomainType } from '~immutable';
 
-import type { ActionType, ErrorActionType, UniqueActionType } from '../index';
+import type {
+  ActionType,
+  ErrorActionType,
+  UniqueActionType,
+  ActionTypeWithPayloadAndMeta,
+  ActionTypeWithMeta,
+} from '../index';
 
 import { ACTIONS } from '../../index';
-import type { DomainType } from '~immutable';
 
 export type DomainActionTypes = {|
   DOMAIN_CREATE: UniqueActionType<
@@ -19,29 +25,24 @@ export type DomainActionTypes = {|
   >,
   DOMAIN_CREATE_SUCCESS: UniqueActionType<
     typeof ACTIONS.DOMAIN_CREATE_SUCCESS,
-    *,
+    DomainType,
     WithKeyPathDepth2,
   >,
-  DOMAIN_CREATE_TX: ActionType<typeof ACTIONS.DOMAIN_CREATE_TX, *, *>,
+  DOMAIN_CREATE_TX: ActionType<typeof ACTIONS.DOMAIN_CREATE_TX>,
   DOMAIN_CREATE_TX_ERROR: ErrorActionType<
     typeof ACTIONS.DOMAIN_CREATE_TX_ERROR,
-    *,
+    void,
   >,
-  DOMAIN_CREATE_TX_SUCCESS: ActionType<
-    typeof ACTIONS.DOMAIN_CREATE_TX_SUCCESS,
-    *,
-    *,
-  >,
-  DOMAIN_FETCH: UniqueActionType<
+  DOMAIN_CREATE_TX_SUCCESS: ActionType<typeof ACTIONS.DOMAIN_CREATE_TX_SUCCESS>,
+  DOMAIN_FETCH: ActionTypeWithMeta<
     typeof ACTIONS.DOMAIN_FETCH,
-    *,
     WithKeyPathDepth2,
   >,
   DOMAIN_FETCH_ERROR: ErrorActionType<
     typeof ACTIONS.DOMAIN_FETCH_ERROR,
     WithKeyPathDepth2,
   >,
-  DOMAIN_FETCH_SUCCESS: UniqueActionType<
+  DOMAIN_FETCH_SUCCESS: ActionTypeWithPayloadAndMeta<
     typeof ACTIONS.DOMAIN_FETCH_SUCCESS,
     DomainType,
     WithKeyPathDepth2,

--- a/src/redux/types/actions/gasPrices.js
+++ b/src/redux/types/actions/gasPrices.js
@@ -1,10 +1,13 @@
 /* @flow */
 
-import type { ActionType } from '~redux';
+import type { ActionTypeWithPayload } from '~redux';
+import type { GasPricesProps } from '~immutable';
 
 import { ACTIONS } from '../../index';
 
 export type GasPricesActionTypes = {|
-  // TODO type this
-  GAS_PRICES_UPDATE: ActionType<typeof ACTIONS.GAS_PRICES_UPDATE, any, *>,
+  GAS_PRICES_UPDATE: ActionTypeWithPayload<
+    typeof ACTIONS.GAS_PRICES_UPDATE,
+    GasPricesProps,
+  >,
 |};

--- a/src/redux/types/actions/index.js
+++ b/src/redux/types/actions/index.js
@@ -20,26 +20,55 @@ import type { UsernameActionTypes } from './username';
 import type { WalletActionTypes } from './wallet';
 
 /*
- * Sealed object type that represents an action.
+ * Type that represents an action (bare minimum).
  *
  * T: the action type, e.g. `COLONY_CREATE`
+ */
+export type ActionType<T> = {|
+  type: T,
+|};
+
+/*
+ * Type that represents an action with a `payload` property.
+ *
  * P: the action payload, e.g. `{| tokenAddress: string |}`
  * M: any additional `meta` properties, e.g. `keyPath: [*]`
  */
-export type ActionType<T, P, M> = {|
-  type: T,
-  payload: P,
+export type ActionTypeWithPayload<T, P> = {| ...ActionType<T>, payload: P |};
+
+/*
+ * Type that represents an action with a `meta` property.
+ *
+ * M: any additional `meta` properties, e.g. `keyPath: [*]`
+ */
+export type ActionTypeWithMeta<T, M> = {| ...ActionType<T>, meta: M |};
+
+/*
+ * Type that represents an action with `payload` and `meta` properties.
+ *
+ * P: the action payload, e.g. `{| tokenAddress: string |}`
+ * M: any additional `meta` properties, e.g. `keyPath: [*]`
+ */
+export type ActionTypeWithPayloadAndMeta<T, P, M> = {|
+  ...ActionType<T>,
   meta: M,
+  payload: P,
 |};
 
-export type UniqueActionType<T, P, M> = ActionType<
+/*
+ * Type that represents a unique action (e.g. from `ActionForm`).
+ */
+export type UniqueActionType<T, P, M> = ActionTypeWithPayloadAndMeta<
   T,
   P,
   {| ...M, id: string |},
 >;
 
+/*
+ * Type that represents an error action.
+ */
 export type ErrorActionType<T, M> = {|
-  ...ActionType<T, Error, M>,
+  ...ActionTypeWithPayloadAndMeta<T, Error, M>,
   error: true,
 |};
 
@@ -71,7 +100,7 @@ export type Action<T: ActionTypeString> = $ElementType<ActionsType, T>;
 
 export type ActionCreator<T> = (...args: *) => Action<T>;
 
-export type TakeFilter = (action: ActionType<*, *, *>) => boolean;
+export type TakeFilter = (action: *) => boolean;
 
 /* eslint-disable */
 /*::

--- a/src/redux/types/actions/multisig.js
+++ b/src/redux/types/actions/multisig.js
@@ -1,34 +1,48 @@
 /* @flow */
 
-import type { UniqueActionType } from '~redux';
-import type { TransactionType } from '~immutable';
+import type { ActionTypeWithMeta, ActionTypeWithPayloadAndMeta } from '~redux';
+import type { TransactionMultisig, TransactionType } from '~immutable';
+import type { $Pick } from '~types';
 
 import { ACTIONS } from '../../index';
 
+type WithId = {| id: string |};
+
 export type MultisigActionTypes = {|
-  MULTISIG_TRANSACTION_CREATED: UniqueActionType<
+  MULTISIG_TRANSACTION_CREATED: ActionTypeWithPayloadAndMeta<
     typeof ACTIONS.MULTISIG_TRANSACTION_CREATED,
-    $Shape<TransactionType<*, *>>,
-    *,
+    $Pick<
+      TransactionType<*, *>,
+      {
+        context: *,
+        createdAt: *,
+        from: *,
+        group: *,
+        identifier: *,
+        methodName: *,
+        multisig: *,
+        options?: *,
+        params: *,
+        status: *,
+      },
+    >,
+    WithId,
   >,
-  MULTISIG_TRANSACTION_REFRESHED: UniqueActionType<
+  MULTISIG_TRANSACTION_REFRESHED: ActionTypeWithPayloadAndMeta<
     typeof ACTIONS.MULTISIG_TRANSACTION_REFRESHED,
-    $Shape<TransactionType<*, *>>,
-    *,
+    {| multisig: TransactionMultisig |},
+    WithId,
   >,
-  MULTISIG_TRANSACTION_REJECT: UniqueActionType<
+  MULTISIG_TRANSACTION_REJECT: ActionTypeWithMeta<
     typeof ACTIONS.MULTISIG_TRANSACTION_REJECT,
-    *,
-    *,
+    WithId,
   >,
-  MULTISIG_TRANSACTION_SIGN: UniqueActionType<
+  MULTISIG_TRANSACTION_SIGN: ActionTypeWithMeta<
     typeof ACTIONS.MULTISIG_TRANSACTION_SIGN,
-    *,
-    *,
+    WithId,
   >,
-  MULTISIG_TRANSACTION_SIGNED: UniqueActionType<
+  MULTISIG_TRANSACTION_SIGNED: ActionTypeWithMeta<
     typeof ACTIONS.MULTISIG_TRANSACTION_SIGNED,
-    *,
-    *,
+    WithId,
   >,
 |};

--- a/src/redux/types/actions/task.js
+++ b/src/redux/types/actions/task.js
@@ -1,6 +1,9 @@
 /* @flow */
 
+import type { ColonyClient as ColonyClientType } from '@colony/colony-js-client';
+
 import type { WithKeyPathDepth2 } from '~types';
+import type { TaskType } from '~immutable';
 
 import type { ErrorActionType, UniqueActionType } from '../index';
 
@@ -10,20 +13,20 @@ export type TaskActionTypes = {|
   TASK_COMMENT_ADD: UniqueActionType<
     typeof ACTIONS.TASK_COMMENT_ADD,
     {| draftId: string, commentData: * |},
-    *,
+    void,
   >,
   TASK_COMMENT_ADD_ERROR: UniqueActionType<
     typeof ACTIONS.TASK_COMMENT_ADD_ERROR,
-    *,
+    void,
   >,
   TASK_COMMENT_ADD_SUCCESS: UniqueActionType<
     typeof ACTIONS.TASK_COMMENT_ADD_SUCCESS,
     {| draftId: string, commentData: *, signature: string |},
-    *,
+    void,
   >,
   TASK_COMMENTS_GET: UniqueActionType<
     typeof ACTIONS.TASK_COMMENTS_GET,
-    *,
+    void,
     WithKeyPathDepth2,
   >,
   TASK_COMMENTS_GET_ERROR: ErrorActionType<
@@ -32,7 +35,7 @@ export type TaskActionTypes = {|
   >,
   TASK_COMMENTS_GET_SUCCESS: UniqueActionType<
     typeof ACTIONS.TASK_COMMENTS_GET_SUCCESS,
-    *,
+    void,
     WithKeyPathDepth2,
   >,
   TASK_CREATE: UniqueActionType<
@@ -55,13 +58,13 @@ export type TaskActionTypes = {|
   >,
   TASK_CREATE_SUCCESS: UniqueActionType<
     typeof ACTIONS.TASK_CREATE_SUCCESS,
-    *,
+    void,
     WithKeyPathDepth2,
   >,
   TASK_FETCH: UniqueActionType<typeof ACTIONS.TASK_FETCH, *, WithKeyPathDepth2>,
   TASK_FETCH_ALL: UniqueActionType<
     typeof ACTIONS.TASK_FETCH_ALL,
-    *,
+    void,
     WithKeyPathDepth2,
   >,
   TASK_FETCH_ERROR: ErrorActionType<
@@ -70,7 +73,7 @@ export type TaskActionTypes = {|
   >,
   TASK_FETCH_SUCCESS: UniqueActionType<
     typeof ACTIONS.TASK_FETCH_SUCCESS,
-    *,
+    void,
     WithKeyPathDepth2,
   >,
   TASK_FINALIZE: UniqueActionType<
@@ -87,12 +90,12 @@ export type TaskActionTypes = {|
   >,
   TASK_FINALIZE_SUCCESS: UniqueActionType<
     typeof ACTIONS.TASK_FINALIZE_SUCCESS,
-    *,
+    void,
     WithKeyPathDepth2,
   >,
   TASK_MANAGER_COMPLETE: UniqueActionType<
     typeof ACTIONS.TASK_MANAGER_COMPLETE,
-    *,
+    void,
     WithKeyPathDepth2,
   >,
   TASK_MANAGER_COMPLETE_ERROR: ErrorActionType<
@@ -101,7 +104,7 @@ export type TaskActionTypes = {|
   >,
   TASK_MANAGER_COMPLETE_SUCCESS: UniqueActionType<
     typeof ACTIONS.TASK_MANAGER_COMPLETE_SUCCESS,
-    *,
+    void,
     WithKeyPathDepth2,
   >,
   TASK_MANAGER_END: UniqueActionType<
@@ -119,7 +122,7 @@ export type TaskActionTypes = {|
   >,
   TASK_MANAGER_END_SUCCESS: UniqueActionType<
     typeof ACTIONS.TASK_MANAGER_END_SUCCESS,
-    *,
+    void,
     WithKeyPathDepth2,
   >,
   TASK_MANAGER_RATE_WORKER: UniqueActionType<
@@ -137,7 +140,7 @@ export type TaskActionTypes = {|
   >,
   TASK_MANAGER_RATE_WORKER_SUCCESS: UniqueActionType<
     typeof ACTIONS.TASK_MANAGER_RATE_WORKER_SUCCESS,
-    *,
+    void,
     WithKeyPathDepth2,
   >,
   TASK_MANAGER_REVEAL_WORKER_RATING: UniqueActionType<
@@ -154,7 +157,7 @@ export type TaskActionTypes = {|
   >,
   TASK_MANAGER_REVEAL_WORKER_RATING_SUCCESS: UniqueActionType<
     typeof ACTIONS.TASK_MANAGER_REVEAL_WORKER_RATING_SUCCESS,
-    *,
+    void,
     WithKeyPathDepth2,
   >,
   TASK_MODIFY_WORKER_PAYOUT: UniqueActionType<
@@ -174,12 +177,12 @@ export type TaskActionTypes = {|
   >,
   TASK_MODIFY_WORKER_PAYOUT_SUCCESS: UniqueActionType<
     typeof ACTIONS.TASK_MODIFY_WORKER_PAYOUT_SUCCESS,
-    *,
+    void,
     WithKeyPathDepth2,
   >,
   TASK_REMOVE: UniqueActionType<
     typeof ACTIONS.TASK_REMOVE,
-    *,
+    void,
     WithKeyPathDepth2,
   >,
   TASK_REMOVE_ERROR: ErrorActionType<
@@ -188,7 +191,7 @@ export type TaskActionTypes = {|
   >,
   TASK_REMOVE_SUCCESS: UniqueActionType<
     typeof ACTIONS.TASK_REMOVE_SUCCESS,
-    *,
+    void,
     WithKeyPathDepth2,
   >,
   TASK_SET_DATE: UniqueActionType<
@@ -206,7 +209,12 @@ export type TaskActionTypes = {|
   >,
   TASK_SET_DATE_SUCCESS: UniqueActionType<
     typeof ACTIONS.TASK_SET_DATE_SUCCESS,
-    *,
+    {
+      eventData: $PropertyType<
+        $PropertyType<ColonyClientType, 'events'>,
+        'TaskDueDateSet',
+      >,
+    },
     WithKeyPathDepth2,
   >,
   TASK_SET_SKILL: UniqueActionType<
@@ -223,7 +231,12 @@ export type TaskActionTypes = {|
   >,
   TASK_SET_SKILL_SUCCESS: UniqueActionType<
     typeof ACTIONS.TASK_SET_SKILL_SUCCESS,
-    *,
+    {
+      eventData: $PropertyType<
+        $PropertyType<ColonyClientType, 'events'>,
+        'TaskSkillSet',
+      >,
+    },
     WithKeyPathDepth2,
   >,
   TASK_SUBMIT_DELIVERABLE: UniqueActionType<
@@ -246,7 +259,7 @@ export type TaskActionTypes = {|
   >,
   TASK_UPDATE: UniqueActionType<
     typeof ACTIONS.TASK_UPDATE,
-    *,
+    void,
     WithKeyPathDepth2,
   >,
   TASK_UPDATE_ERROR: ErrorActionType<
@@ -255,7 +268,7 @@ export type TaskActionTypes = {|
   >,
   TASK_UPDATE_SUCCESS: UniqueActionType<
     typeof ACTIONS.TASK_UPDATE_SUCCESS,
-    *,
+    $Shape<TaskType>,
     WithKeyPathDepth2,
   >,
   TASK_WORKER_CLAIM_REWARD: UniqueActionType<
@@ -273,7 +286,12 @@ export type TaskActionTypes = {|
   >,
   TASK_WORKER_CLAIM_REWARD_SUCCESS: UniqueActionType<
     typeof ACTIONS.TASK_WORKER_CLAIM_REWARD_SUCCESS,
-    *,
+    {
+      eventData: $PropertyType<
+        $PropertyType<ColonyClientType, 'events'>,
+        'TaskPayoutClaimed',
+      >,
+    },
     WithKeyPathDepth2,
   >,
   TASK_WORKER_END: UniqueActionType<
@@ -292,7 +310,7 @@ export type TaskActionTypes = {|
   >,
   TASK_WORKER_END_SUCCESS: UniqueActionType<
     typeof ACTIONS.TASK_WORKER_END_SUCCESS,
-    *,
+    void,
     WithKeyPathDepth2,
   >,
   TASK_WORKER_RATE_MANAGER: UniqueActionType<
@@ -310,7 +328,7 @@ export type TaskActionTypes = {|
   >,
   TASK_WORKER_RATE_MANAGER_SUCCESS: UniqueActionType<
     typeof ACTIONS.TASK_WORKER_RATE_MANAGER_SUCCESS,
-    *,
+    void,
     WithKeyPathDepth2,
   >,
   TASK_WORKER_REVEAL_MANAGER_RATING: UniqueActionType<
@@ -327,7 +345,12 @@ export type TaskActionTypes = {|
   >,
   TASK_WORKER_REVEAL_MANAGER_RATING_SUCCESS: UniqueActionType<
     typeof ACTIONS.TASK_WORKER_REVEAL_MANAGER_RATING_SUCCESS,
-    *,
+    {
+      eventData: $PropertyType<
+        $PropertyType<ColonyClientType, 'events'>,
+        'TaskWorkRatingRevealed',
+      >,
+    },
     WithKeyPathDepth2,
   >,
 |};

--- a/src/redux/types/actions/token.js
+++ b/src/redux/types/actions/token.js
@@ -1,64 +1,71 @@
 /* @flow */
 
-import type { ActionType, ErrorActionType } from '../index';
+import type {
+  Action,
+  ActionTypeWithPayload,
+  ErrorActionType,
+  UniqueActionType,
+} from '../index';
 
 import { ACTIONS } from '../../index';
 
 export type TokenActionTypes = {|
-  TOKEN_CREATE: ActionType<
+  TOKEN_CREATE: UniqueActionType<
     typeof ACTIONS.TOKEN_CREATE,
     {|
       tokenName: string,
       tokenSymbol: string,
     |},
-    *,
+    void,
   >,
-  TOKEN_CREATE_ERROR: ErrorActionType<typeof ACTIONS.TOKEN_CREATE_ERROR, *>,
-  TOKEN_CREATE_SUCCESS: ActionType<typeof ACTIONS.TOKEN_CREATE_SUCCESS, *, *>,
-  TOKEN_ICON_FETCH: ActionType<
+  TOKEN_CREATE_ERROR: ErrorActionType<typeof ACTIONS.TOKEN_CREATE_ERROR, void>,
+  TOKEN_CREATE_SUCCESS: Action<typeof ACTIONS.TRANSACTION_RECEIPT_RECEIVED>,
+  TOKEN_ICON_FETCH: ActionTypeWithPayload<
     typeof ACTIONS.TOKEN_ICON_FETCH,
     {| hash: string |},
-    *,
   >,
   TOKEN_ICON_FETCH_ERROR: ErrorActionType<
     typeof ACTIONS.TOKEN_ICON_FETCH_ERROR,
-    *,
+    void,
   >,
-  TOKEN_ICON_FETCH_SUCCESS: ActionType<
+  TOKEN_ICON_FETCH_SUCCESS: ActionTypeWithPayload<
     typeof ACTIONS.TOKEN_ICON_FETCH_SUCCESS,
-    *,
-    *,
+    {| hash: string, iconData: string |},
   >,
-  TOKEN_ICON_UPLOAD: ActionType<
+  TOKEN_ICON_UPLOAD: UniqueActionType<
     typeof ACTIONS.TOKEN_ICON_UPLOAD,
     {|
       data: string,
     |},
-    *,
+    void,
   >,
   TOKEN_ICON_UPLOAD_ERROR: ErrorActionType<
     typeof ACTIONS.TOKEN_ICON_UPLOAD_ERROR,
-    *,
+    void,
   >,
-  TOKEN_ICON_UPLOAD_SUCCESS: ActionType<
+  TOKEN_ICON_UPLOAD_SUCCESS: UniqueActionType<
     typeof ACTIONS.TOKEN_ICON_UPLOAD_SUCCESS,
-    *,
-    *,
+    {| hash: string |},
+    void,
   >,
-  TOKEN_INFO_FETCH: ActionType<
+  TOKEN_INFO_FETCH: UniqueActionType<
     typeof ACTIONS.TOKEN_INFO_FETCH,
     {|
       tokenAddress: string,
     |},
-    *,
+    void,
   >,
   TOKEN_INFO_FETCH_ERROR: ErrorActionType<
     typeof ACTIONS.TOKEN_INFO_FETCH_ERROR,
-    *,
+    void,
   >,
-  TOKEN_INFO_FETCH_SUCCESS: ActionType<
+  TOKEN_INFO_FETCH_SUCCESS: UniqueActionType<
     typeof ACTIONS.TOKEN_INFO_FETCH_SUCCESS,
-    *,
-    *,
+    {|
+      decimals: number,
+      name: string,
+      symbols: string,
+    |},
+    void,
   >,
 |};

--- a/src/redux/types/actions/transaction.js
+++ b/src/redux/types/actions/transaction.js
@@ -1,68 +1,83 @@
 /* @flow */
 
-import type { UniqueActionType, ActionType } from '~redux';
+import type { ActionTypeWithPayloadAndMeta, ActionTypeWithMeta } from '~redux';
 import type { TransactionError, TransactionType } from '~immutable';
+import type { TransactionReceipt, $Pick } from '~types';
 
 import { ACTIONS } from '../../index';
+import BigNumber from 'bn.js';
+
+type WithId = {| id: string |};
 
 export type TransactionActionTypes = {|
-  TRANSACTION_ADD_IDENTIFIER: UniqueActionType<
+  TRANSACTION_ADD_IDENTIFIER: ActionTypeWithPayloadAndMeta<
     typeof ACTIONS.TRANSACTION_ADD_IDENTIFIER,
     {| identifier: string |},
-    void,
+    WithId,
   >,
-  TRANSACTION_ADD_PARAMS: UniqueActionType<
+  TRANSACTION_ADD_PARAMS: ActionTypeWithPayloadAndMeta<
     typeof ACTIONS.TRANSACTION_ADD_PARAMS,
     {| params: Object |},
-    void,
+    WithId,
   >,
-  TRANSACTION_READY: UniqueActionType<
+  TRANSACTION_READY: ActionTypeWithMeta<
     typeof ACTIONS.TRANSACTION_READY,
-    void,
-    void,
+    WithId,
   >,
-  TRANSACTION_CANCEL: UniqueActionType<
+  TRANSACTION_CANCEL: ActionTypeWithMeta<
     typeof ACTIONS.TRANSACTION_CANCEL,
-    $Shape<TransactionType<*, *>>,
-    *,
+    WithId,
   >,
-  TRANSACTION_CREATED: UniqueActionType<
+  TRANSACTION_CREATED: ActionTypeWithPayloadAndMeta<
     typeof ACTIONS.TRANSACTION_CREATED,
-    $Shape<TransactionType<*, *>>,
-    *,
+    $Pick<
+      TransactionType<*, *>,
+      {
+        context: *,
+        createdAt: *,
+        from: *,
+        group: *,
+        identifier: *,
+        methodName: *,
+        multisig: *,
+        options?: *,
+        params: *,
+        status: *,
+      },
+    >,
+    WithId,
   >,
   TRANSACTION_ERROR: {|
-    ...ActionType<
+    ...ActionTypeWithPayloadAndMeta<
       typeof ACTIONS.TRANSACTION_ERROR,
       TransactionError,
       { id: string },
     >,
     error: true,
   |},
-  TRANSACTION_ESTIMATE_GAS: UniqueActionType<
+  TRANSACTION_ESTIMATE_GAS: ActionTypeWithMeta<
     typeof ACTIONS.TRANSACTION_ESTIMATE_GAS,
-    $Shape<TransactionType<*, *>>,
-    *,
+    WithId,
   >,
-  TRANSACTION_GAS_UPDATE: UniqueActionType<
+  TRANSACTION_GAS_UPDATE: ActionTypeWithPayloadAndMeta<
     typeof ACTIONS.TRANSACTION_GAS_UPDATE,
-    $Shape<TransactionType<*, *>>,
-    *,
+    {| gasLimit: BigNumber, gasPrice: BigNumber |},
+    WithId,
   >,
-  TRANSACTION_RECEIPT_RECEIVED: UniqueActionType<
+  TRANSACTION_RECEIPT_RECEIVED: ActionTypeWithPayloadAndMeta<
     typeof ACTIONS.TRANSACTION_RECEIPT_RECEIVED,
-    $Shape<TransactionType<*, *>>,
-    *,
+    {| receipt: TransactionReceipt, params: Object |},
+    WithId,
   >,
-  TRANSACTION_SEND: UniqueActionType<typeof ACTIONS.TRANSACTION_SEND, *, *>,
-  TRANSACTION_SENT: UniqueActionType<
+  TRANSACTION_SEND: ActionTypeWithMeta<typeof ACTIONS.TRANSACTION_SEND, WithId>,
+  TRANSACTION_SENT: ActionTypeWithPayloadAndMeta<
     typeof ACTIONS.TRANSACTION_SENT,
-    $Shape<TransactionType<*, *>>,
-    *,
+    {| hash: string, params: Object |},
+    WithId,
   >,
-  TRANSACTION_SUCCEEDED: UniqueActionType<
+  TRANSACTION_SUCCEEDED: ActionTypeWithPayloadAndMeta<
     typeof ACTIONS.TRANSACTION_SUCCEEDED,
-    $Shape<TransactionType<*, *>>,
-    *,
+    {| eventData: Object, params: Object |},
+    WithId,
   >,
 |};

--- a/src/redux/types/actions/user.js
+++ b/src/redux/types/actions/user.js
@@ -3,92 +3,101 @@
 import type { WithKeyPathDepth1 } from '~types';
 import type { ContractTransactionType, UserProfileType } from '~immutable';
 
-import type { ActionType, UniqueActionType, ErrorActionType } from '../index';
+import type {
+  ActionType,
+  ActionTypeWithMeta,
+  ActionTypeWithPayload,
+  ActionTypeWithPayloadAndMeta,
+  ErrorActionType,
+  UniqueActionType,
+} from '../index';
 
 import { ACTIONS } from '../../index';
 
 export type UserActionTypes = {|
-  USER_AVATAR_FETCH: ActionType<
+  USER_AVATAR_FETCH: ActionTypeWithPayload<
     typeof ACTIONS.USER_AVATAR_FETCH,
     {| hash: string |},
-    *,
   >,
   USER_AVATAR_FETCH_ERROR: ErrorActionType<
     typeof ACTIONS.USER_AVATAR_FETCH_ERROR,
-    *,
+    void,
   >,
-  USER_AVATAR_FETCH_SUCCESS: ActionType<
+  USER_AVATAR_FETCH_SUCCESS: ActionTypeWithPayload<
     typeof ACTIONS.USER_AVATAR_FETCH_SUCCESS,
     {|
       avatarData: string,
       hash: string,
     |},
-    *,
   >,
   USER_FETCH_TOKEN_TRANSFERS: ActionType<
     typeof ACTIONS.USER_FETCH_TOKEN_TRANSFERS,
-    *,
-    *,
   >,
   USER_FETCH_TOKEN_TRANSFERS_ERROR: ErrorActionType<
     typeof ACTIONS.USER_FETCH_TOKEN_TRANSFERS_ERROR,
-    *,
+    void,
   >,
-  USER_FETCH_TOKEN_TRANSFERS_SUCCESS: ActionType<
+  USER_FETCH_TOKEN_TRANSFERS_SUCCESS: ActionTypeWithPayload<
     typeof ACTIONS.USER_FETCH_TOKEN_TRANSFERS_SUCCESS,
     {|
       transactions: ContractTransactionType[],
     |},
-    *,
   >,
-  USER_PROFILE_FETCH: UniqueActionType<
+  USER_PROFILE_FETCH: ActionTypeWithMeta<
     typeof ACTIONS.USER_PROFILE_FETCH,
-    *,
     WithKeyPathDepth1,
   >,
   USER_PROFILE_FETCH_ERROR: ErrorActionType<
     typeof ACTIONS.USER_PROFILE_FETCH_ERROR,
     WithKeyPathDepth1,
   >,
-  USER_PROFILE_FETCH_SUCCESS: UniqueActionType<
+  USER_PROFILE_FETCH_SUCCESS: ActionTypeWithPayloadAndMeta<
     typeof ACTIONS.USER_PROFILE_FETCH_SUCCESS,
     UserProfileType,
     WithKeyPathDepth1,
   >,
-  USER_PROFILE_UPDATE: ActionType<typeof ACTIONS.USER_PROFILE_UPDATE, *, *>,
+  USER_PROFILE_UPDATE: UniqueActionType<
+    typeof ACTIONS.USER_PROFILE_UPDATE,
+    UserProfileType,
+    void,
+  >,
   USER_PROFILE_UPDATE_ERROR: ErrorActionType<
     typeof ACTIONS.USER_PROFILE_UPDATE_ERROR,
-    *,
+    void,
   >,
-  USER_PROFILE_UPDATE_SUCCESS: ActionType<
+  USER_PROFILE_UPDATE_SUCCESS: UniqueActionType<
     typeof ACTIONS.USER_PROFILE_UPDATE_SUCCESS,
     UserProfileType,
-    *,
+    void,
   >,
-  USER_REMOVE_AVATAR: ActionType<typeof ACTIONS.USER_REMOVE_AVATAR, *, *>,
+  USER_REMOVE_AVATAR: UniqueActionType<
+    typeof ACTIONS.USER_REMOVE_AVATAR,
+    void,
+    void,
+  >,
   USER_REMOVE_AVATAR_ERROR: ErrorActionType<
     typeof ACTIONS.USER_REMOVE_AVATAR_ERROR,
-    *,
+    void,
   >,
-  USER_REMOVE_AVATAR_SUCCESS: ActionType<
+  USER_REMOVE_AVATAR_SUCCESS: UniqueActionType<
     typeof ACTIONS.USER_REMOVE_AVATAR_SUCCESS,
-    *,
-    *,
+    {| user: UserProfileType |}, // TODO this probably shouldn't be here
+    void,
   >,
-  USER_UPLOAD_AVATAR: ActionType<
+  USER_UPLOAD_AVATAR: UniqueActionType<
     typeof ACTIONS.USER_UPLOAD_AVATAR,
     {| data: string |},
-    *,
+    void,
   >,
   USER_UPLOAD_AVATAR_ERROR: ErrorActionType<
     typeof ACTIONS.USER_UPLOAD_AVATAR_ERROR,
-    *,
+    void,
   >,
-  USER_UPLOAD_AVATAR_SUCCESS: ActionType<
+  USER_UPLOAD_AVATAR_SUCCESS: UniqueActionType<
     typeof ACTIONS.USER_UPLOAD_AVATAR_SUCCESS,
     {|
       hash: string,
     |},
-    *,
+    void,
   >,
 |};

--- a/src/redux/types/actions/username.js
+++ b/src/redux/types/actions/username.js
@@ -1,6 +1,10 @@
 /* @flow */
 
-import type { ActionType, ErrorActionType, UniqueActionType } from '../index';
+import type {
+  ActionTypeWithPayload,
+  ErrorActionType,
+  UniqueActionType,
+} from '../index';
 
 import { ACTIONS } from '../../index';
 
@@ -10,25 +14,25 @@ export type UsernameActionTypes = {|
     {|
       username: string,
     |},
-    *,
+    void,
   >,
   USERNAME_CHECK_AVAILABILITY_ERROR: ErrorActionType<
     typeof ACTIONS.USERNAME_CHECK_AVAILABILITY_ERROR,
-    *,
+    void,
   >,
   USERNAME_CHECK_AVAILABILITY_SUCCESS: UniqueActionType<
     typeof ACTIONS.USERNAME_CHECK_AVAILABILITY_SUCCESS,
-    *,
-    *,
+    void,
+    void,
   >,
   USERNAME_CREATE: UniqueActionType<
     typeof ACTIONS.USERNAME_CREATE,
     {| username: string |},
-    *,
+    void,
   >,
   USERNAME_CREATE_ERROR: ErrorActionType<
     typeof ACTIONS.USERNAME_CREATE_ERROR,
-    *,
+    void,
   >,
   USERNAME_CREATE_SUCCESS: UniqueActionType<
     typeof ACTIONS.USERNAME_CREATE_SUCCESS,
@@ -37,17 +41,15 @@ export type UsernameActionTypes = {|
         username: string,
       },
     |},
-    *,
+    void,
   >,
-  USERNAME_FETCH: ActionType<
+  USERNAME_FETCH: ActionTypeWithPayload<
     typeof ACTIONS.USERNAME_FETCH,
     {| userAddress: string |},
-    *,
   >,
   USERNAME_FETCH_ERROR: ErrorActionType<typeof ACTIONS.USERNAME_FETCH_ERROR, *>,
-  USERNAME_FETCH_SUCCESS: ActionType<
+  USERNAME_FETCH_SUCCESS: ActionTypeWithPayload<
     typeof ACTIONS.USERNAME_FETCH_SUCCESS,
     {| key: string, username: string |},
-    *,
   >,
 |};

--- a/src/redux/types/actions/wallet.js
+++ b/src/redux/types/actions/wallet.js
@@ -1,11 +1,15 @@
 /* @flow */
 
-import type { ActionType, ErrorActionType } from '../index';
+import type {
+  ActionTypeWithPayload,
+  ErrorActionType,
+  UniqueActionType,
+} from '../index';
 
 import { ACTIONS } from '../../index';
 
 export type WalletActionTypes = {|
-  WALLET_CREATE: ActionType<
+  WALLET_CREATE: UniqueActionType<
     typeof ACTIONS.WALLET_CREATE,
     {|
       accountIndex?: number,
@@ -16,25 +20,26 @@ export type WalletActionTypes = {|
       mnemonic?: *,
       password?: *,
     |},
-    *,
+    void,
   >,
-  WALLET_CREATE_ERROR: ErrorActionType<typeof ACTIONS.WALLET_CREATE_ERROR, *>,
-  WALLET_FETCH_ACCOUNTS: ActionType<
+  WALLET_CREATE_ERROR: ErrorActionType<
+    typeof ACTIONS.WALLET_CREATE_ERROR,
+    void,
+  >,
+  WALLET_FETCH_ACCOUNTS: ActionTypeWithPayload<
     typeof ACTIONS.WALLET_FETCH_ACCOUNTS,
     {|
       walletType: string,
     |},
-    *,
   >,
   WALLET_FETCH_ACCOUNTS_ERROR: ErrorActionType<
     typeof ACTIONS.WALLET_FETCH_ACCOUNTS_ERROR,
-    *,
+    void,
   >,
-  WALLET_FETCH_ACCOUNTS_SUCCESS: ActionType<
+  WALLET_FETCH_ACCOUNTS_SUCCESS: ActionTypeWithPayload<
     typeof ACTIONS.WALLET_FETCH_ACCOUNTS_SUCCESS,
     {|
       allAddresses: string[],
     |},
-    *,
   >,
 |};

--- a/src/utils/reducers/__tests__/withDataReducer.test.js
+++ b/src/utils/reducers/__tests__/withDataReducer.test.js
@@ -64,7 +64,7 @@ describe('reducers - withDataReducer', () => {
       error: true,
       meta: { keyPath: ['myKey'] },
       payload: {
-        error: { message: 'fetch error' },
+        message: 'fetch error',
       },
     };
 

--- a/src/utils/reducers/withDataReducer.js
+++ b/src/utils/reducers/withDataReducer.js
@@ -5,15 +5,12 @@ import type { Map as ImmutableMapType } from 'immutable';
 import { Map as ImmutableMap, fromJS } from 'immutable';
 
 import type { KeyPath } from '~types';
-import type { ActionType } from '~redux';
 
 import { DataRecord } from '../../immutable';
 import type { DataRecordType } from '../../immutable';
+import type { ActionTypeString } from '~redux/types/actions';
 
-export type DataReducer<S: ImmutableMapType<*, *>> = (
-  state: S,
-  action: ActionType<*, *, *>,
-) => S;
+export type DataReducer<S: ImmutableMapType<*, *>> = (state: S, action: *) => S;
 
 const getNextState = <S: ImmutableMapType<*, *>, V: *>(
   state: S,
@@ -33,10 +30,7 @@ const getNextState = <S: ImmutableMapType<*, *>, V: *>(
     : state.set(keyPath[0], data);
 };
 
-const handleFetch = <S: ImmutableMapType<*, *>, V: *>(
-  state: S,
-  action: ActionType<*, *, *>,
-) => {
+const handleFetch = <S: ImmutableMapType<*, *>, V: *>(state: S, action: *) => {
   const {
     meta: { keyPath },
   } = action;
@@ -45,7 +39,7 @@ const handleFetch = <S: ImmutableMapType<*, *>, V: *>(
 
 const handleSuccess = <S: ImmutableMapType<*, *>, V: *>(
   state: S,
-  action: ActionType<*, *, *>,
+  action: *,
 ) => {
   const {
     meta: { keyPath },
@@ -58,7 +52,7 @@ const handleSuccess = <S: ImmutableMapType<*, *>, V: *>(
 
 const handleError = <S: ImmutableMapType<*, *>, V: *>(
   state: S,
-  { meta: { keyPath }, payload: { error } }: ActionType<*, *, *>,
+  { meta: { keyPath }, payload: error }: *,
 ) =>
   getNextState<S, V>(state, keyPath, {
     isFetching: false,
@@ -92,7 +86,7 @@ const handleError = <S: ImmutableMapType<*, *>, V: *>(
  * {V} The value wrapped in the data record, e.g. `ColonyRecord` or `ListType<TransationRecord>`
  */
 const withDataReducer = <S: ImmutableMapType<*, *>, V: *>(
-  actionTypes: string | Set<string>,
+  actionTypes: ActionTypeString | Set<ActionTypeString>,
   initialState: S,
 ) => (wrappedReducer: DataReducer<S>) => {
   // Set up fetch/success/error types according to the usual pattern
@@ -106,7 +100,7 @@ const withDataReducer = <S: ImmutableMapType<*, *>, V: *>(
   );
 
   // Return a wrapped reducer.
-  return (state: S = initialState, action: ActionType<*, *, *>) => {
+  return (state: S = initialState, action: *) => {
     // Pass the state to the wrapped reducer as the first step.
     const nextState = wrappedReducer(state, action);
 


### PR DESCRIPTION
## Description

Not in the sprint, but I'd already mostly finished it, so here it is:

This PR makes some changes to the action types (and where they're created/dispatched) in order to make sure we're always specifying what the `payload`/`meta` is. 

* Increase specificity of action types
  * Split up `ActionType` into separate types that cover any kind of redux standard action (e.g. just type, type and error, type and meta, etc)
  * Specify missing `payload`/`meta` types for all actions (particularly transactions)
  * Remove inferred payload/meta
  * Allow `withDataReducer` to have inferred action types (it's just too much to handle otherwise)
* Remove empty `meta`/`payload` from action creators/`put` actions
* Misc fixes
  * Disable `TASK_SET_SKILL_SUCCESS`/`TASK_SET_DATE_SUCCESS` from the task reducer (these were not being used, and we need to decide what to do with the event data)
  * Set a default `status` for created transactions (`created`)

