### PR TITLE
Remove transaction reducer persistence and rehydration

### DIFF
--- a/src/modules/core/reducers/transactions.js
+++ b/src/modules/core/reducers/transactions.js
@@ -1,22 +1,15 @@
 /* @flow */
 
-import { fromJS, Map as ImmutableMap } from 'immutable';
+import { fromJS } from 'immutable';
 import getObjectFromPath from 'lodash/get';
-import BigNumber from 'bn.js';
 
 import type { CoreTransactionsRecord, TransactionRecordType } from '~immutable';
 
 import { TransactionRecord, CoreTransactions } from '~immutable';
 import { ACTIONS } from '~redux';
-import { persistReducer } from '~redux/persist';
 
 import { CORE_TRANSACTIONS_LIST } from '../constants';
 import type { ReducerType } from '~redux';
-
-const persistConfig = {
-  key: 'transactions',
-  version: 1,
-};
 
 /*
  * Helpers for transaction transformations
@@ -199,24 +192,9 @@ const coreTransactionsReducer: ReducerType<
       }
       return state.deleteIn([CORE_TRANSACTIONS_LIST, id]);
     }
-    case ACTIONS.REHYDRATED: {
-      const { key, value } = action.payload;
-      if (key !== persistConfig.key) {
-        return state;
-      }
-      return CoreTransactions({
-        [CORE_TRANSACTIONS_LIST]: ImmutableMap(
-          value[CORE_TRANSACTIONS_LIST],
-        ).map(tx =>
-          TransactionRecord(tx)
-            .set('gasLimit', new BigNumber(tx.gasLimit))
-            .set('gasPrice', new BigNumber(tx.gasPrice)),
-        ),
-      });
-    }
     default:
       return state;
   }
 };
 
-export default persistReducer(persistConfig, coreTransactionsReducer);
+export default coreTransactionsReducer;

--- a/src/modules/core/sagas/setupUserContext.js
+++ b/src/modules/core/sagas/setupUserContext.js
@@ -12,7 +12,6 @@ import type { DDB as DDBType } from '../../../lib/database';
 import { create, executeQuery, putError } from '~utils/saga/effects';
 import { CONTEXT } from '~context';
 import { ACTIONS } from '~redux';
-import { rehydrate } from '~redux/persist';
 
 import * as resolvers from '../../../lib/database/resolvers';
 import { getUserBalance, getUserProfile } from '../../../data/service/queries';
@@ -118,8 +117,6 @@ export default function* setupUserContext(
     });
 
     yield call(setupOnBeforeUnload);
-
-    yield put(rehydrate('transactions'));
   } catch (error) {
     yield putError(ACTIONS.WALLET_CREATE_ERROR, error, meta);
   }


### PR DESCRIPTION
This PR removes the persistence of transactions because of the reasons mentioned in #798 and #894.

However it doesn't remove the persistence tools itself as we might want to use those in the future.

Closes #894.