### PR TITLE
Fix annoying base58 bug in store creation

### DIFF
--- a/src/lib/database/DDB.js
+++ b/src/lib/database/DDB.js
@@ -17,8 +17,10 @@ import IPFSNode from '../ipfs';
 import { setMeta } from './commands';
 import { PermissiveAccessController } from './accessControllers';
 
-const base58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
-const generateId = () => generate(base58, 21);
+// We'll skip the Q here because every id that contains a `Qm` is not allowed
+const ipfsCompatibleBase57 =
+  '123456789ABCDEFGHJKLMNPRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+const generateId = () => generate(ipfsCompatibleBase57, 21);
 
 type StoreIdentifier = string | OrbitDBAddress;
 


### PR DESCRIPTION
Turns out the `multihash` verifier of orbit-db doesn't like the phrase `Qm` in there. So I excluded the Q from the dictionary which generates the id.

Resolves #822 