### PR TITLE
CircleCI nightly job build dApp fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
           path: reports
       - run:
           name: "Building library"
-          command: yarn build
+          command: yarn webpack:build
   integration-testing:
     docker:
       - image: circleci/node:10.12


### PR DESCRIPTION
As it says in the title, this PR just changes the `yarn` script that runs within the circle `nightly-job`, to test building the dApp at the end of it's run.

This isn't a problem with the Circle job per se, it's just that we forgot to change it after we renamed the `package.json` scripts: e629bd4096b861676543a2408029d935a3e1f383