### PR TITLE
Add `withDataRecord` reducer wrapper

### DIFF
--- a/src/immutable/Data.js
+++ b/src/immutable/Data.js
@@ -4,15 +4,15 @@ import type { RecordOf, RecordFactory } from 'immutable';
 
 import { Record } from 'immutable';
 
-type Shared<R: any> = {|
+type Shared<R> = {|
   record: ?R,
   error: ?string,
   isFetching: boolean,
 |};
 
-export type DataType<R: any> = $ReadOnly<Shared<R>>;
+export type DataType<R> = $ReadOnly<Shared<R>>;
 
-export type DataRecordType<R: any> = RecordOf<Shared<R>>;
+export type DataRecordType<R> = RecordOf<Shared<R>>;
 
 const defaultValues: $Shape<Shared<*>> = {
   record: undefined,

--- a/src/modules/admin/reducers/transactions.js
+++ b/src/modules/admin/reducers/transactions.js
@@ -5,7 +5,7 @@ import type { List as ListType } from 'immutable';
 import { Map as ImmutableMap, List } from 'immutable';
 
 import { ContractTransactionRecord, DataRecord } from '~immutable';
-import { withDataReducer } from '~utils/reducers';
+import { withDataRecordMap } from '~utils/reducers';
 import { ACTIONS } from '~redux';
 
 import type {
@@ -38,7 +38,7 @@ const adminTransactionsReducer: ReducerType<
   }
 };
 
-export default withDataReducer<
+export default withDataRecordMap<
   AdminTransactionsState,
   ContractTransactionRecordType,
 >(ACTIONS.COLONY_FETCH_TRANSACTIONS, ImmutableMap())(adminTransactionsReducer);

--- a/src/modules/admin/reducers/unclaimedTransactions.js
+++ b/src/modules/admin/reducers/unclaimedTransactions.js
@@ -5,7 +5,7 @@ import type { List as ListType } from 'immutable';
 import { Map as ImmutableMap, List } from 'immutable';
 
 import { ContractTransactionRecord, DataRecord } from '~immutable';
-import { withDataReducer } from '~utils/reducers';
+import { withDataRecordMap } from '~utils/reducers';
 import { ACTIONS } from '~redux';
 
 import type {
@@ -38,7 +38,7 @@ const colonyUnclaimedTransactionsReducer: ReducerType<
   }
 };
 
-export default withDataReducer<
+export default withDataRecordMap<
   AdminUnclaimedTransactionsState,
   ContractTransactionRecordType,
 >(ACTIONS.COLONY_FETCH_UNCLAIMED_TRANSACTIONS, ImmutableMap())(

--- a/src/modules/dashboard/reducers/allDomains.js
+++ b/src/modules/dashboard/reducers/allDomains.js
@@ -3,7 +3,7 @@
 import { Map as ImmutableMap } from 'immutable';
 
 import { DomainRecord, DataRecord } from '~immutable';
-import { withDataReducer } from '~utils/reducers';
+import { withDataRecordMap } from '~utils/reducers';
 import { ACTIONS } from '~redux';
 
 import type { AllDomainsMap, DomainRecordType } from '~immutable';
@@ -60,7 +60,7 @@ const allDomainsReducer: ReducerType<
   }
 };
 
-export default withDataReducer<AllDomainsMap, DomainRecordType>(
+export default withDataRecordMap<AllDomainsMap, DomainRecordType>(
   ACTIONS.DOMAIN_FETCH,
   ImmutableMap(),
 )(allDomainsReducer);

--- a/src/modules/dashboard/reducers/allTasks.js
+++ b/src/modules/dashboard/reducers/allTasks.js
@@ -5,7 +5,7 @@ import { Map as ImmutableMap } from 'immutable';
 import { ACTIONS } from '~redux';
 
 import { TaskRecord, DataRecord } from '~immutable';
-import { withDataReducer } from '~utils/reducers';
+import { withDataRecordMap } from '~utils/reducers';
 
 import type { AllTasksMap, TaskRecordType } from '~immutable';
 import type { ReducerType } from '~redux/types';
@@ -59,7 +59,7 @@ const allTasksReducer: ReducerType<
   }
 };
 
-export default withDataReducer<AllTasksMap, TaskRecordType>(
+export default withDataRecordMap<AllTasksMap, TaskRecordType>(
   ACTIONS.TASK_FETCH,
   new ImmutableMap(),
 )(allTasksReducer);

--- a/src/modules/dashboard/reducers/coloniesReducer.js
+++ b/src/modules/dashboard/reducers/coloniesReducer.js
@@ -3,7 +3,7 @@
 import { Map as ImmutableMap, fromJS } from 'immutable';
 
 import { ColonyRecord, DataRecord, TokenRecord } from '~immutable';
-import { withDataReducer } from '~utils/reducers';
+import { withDataRecordMap } from '~utils/reducers';
 import { ACTIONS } from '~redux';
 
 import type { AllColoniesMap, ColonyRecordType } from '~immutable';
@@ -116,7 +116,7 @@ const coloniesReducer: ReducerType<
   }
 };
 
-export default withDataReducer<AllColoniesMap, ColonyRecordType>(
+export default withDataRecordMap<AllColoniesMap, ColonyRecordType>(
   ACTIONS.COLONY_FETCH,
   ImmutableMap(),
 )(coloniesReducer);

--- a/src/modules/users/reducers/currentUser/permissions.js
+++ b/src/modules/users/reducers/currentUser/permissions.js
@@ -7,7 +7,7 @@ import type {
   UserPermissionsRecordType,
 } from '~immutable';
 import { UserPermissionsRecord, DataRecord } from '~immutable';
-import { withDataReducer } from '~utils/reducers';
+import { withDataRecordMap } from '~utils/reducers';
 import { ACTIONS } from '~redux';
 
 import type { ReducerType } from '~redux';
@@ -33,7 +33,7 @@ const userPermissionsReducer: ReducerType<
   }
 };
 
-export default withDataReducer<
+export default withDataRecordMap<
   CurrentUserPermissionsType,
   UserPermissionsRecordType,
 >(ACTIONS.USER_PERMISSIONS_FETCH, ImmutableMap())(userPermissionsReducer);

--- a/src/modules/users/reducers/currentUser/transactions.js
+++ b/src/modules/users/reducers/currentUser/transactions.js
@@ -2,38 +2,37 @@
 
 import { List } from 'immutable';
 
-import { ContractTransactionRecord, DataRecord } from '~immutable';
-import { ACTIONS } from '~redux';
-
 import type { CurrentUserTransactionsType } from '~immutable';
 import type { ReducerType } from '~redux';
 
+import { ContractTransactionRecord, DataRecord } from '~immutable';
+import { ACTIONS } from '~redux';
+import { withDataRecord } from '~utils/reducers';
+
+type CurrentUserTransactionsActions = {
+  USER_TOKEN_TRANSFERS_FETCH: *,
+  USER_TOKEN_TRANSFERS_FETCH_ERROR: *,
+  USER_TOKEN_TRANSFERS_FETCH_SUCCESS: *,
+};
+
 const currentUserTransactionsReducer: ReducerType<
   CurrentUserTransactionsType,
-  {|
-    USER_TOKEN_TRANSFERS_FETCH: *,
-    USER_TOKEN_TRANSFERS_FETCH_ERROR: *,
-    USER_TOKEN_TRANSFERS_FETCH_SUCCESS: *,
-  |},
+  CurrentUserTransactionsActions,
 > = (state = DataRecord(), action) => {
   switch (action.type) {
-    case ACTIONS.USER_TOKEN_TRANSFERS_FETCH: {
-      return state.set('isFetching', true);
-    }
-    case ACTIONS.USER_TOKEN_TRANSFERS_FETCH_ERROR: {
-      const { message: error } = action.payload;
-      return state.merge({ error, isFetching: false });
-    }
     case ACTIONS.USER_TOKEN_TRANSFERS_FETCH_SUCCESS: {
       const { transactions } = action.payload;
-      const record = List(
-        transactions.map(tx => ContractTransactionRecord(tx)),
+      return state.set(
+        'record',
+        List(transactions.map(tx => ContractTransactionRecord(tx))),
       );
-      return state.merge({ record, isFetching: false });
     }
     default:
       return state;
   }
 };
 
-export default currentUserTransactionsReducer;
+export default withDataRecord<
+  CurrentUserTransactionsType,
+  CurrentUserTransactionsActions,
+>(ACTIONS.USER_TOKEN_TRANSFERS_FETCH)(currentUserTransactionsReducer);

--- a/src/modules/users/reducers/userProfilesReducer.js
+++ b/src/modules/users/reducers/userProfilesReducer.js
@@ -2,7 +2,7 @@
 
 import { List, Map as ImmutableMap } from 'immutable';
 
-import { withDataReducer } from '~utils/reducers';
+import { withDataRecordMap } from '~utils/reducers';
 import { UserRecord, UserProfileRecord, UserActivityRecord } from '~immutable';
 import { ACTIONS } from '~redux';
 
@@ -50,7 +50,7 @@ const userProfilesReducer: ReducerType<
   }
 };
 
-export default withDataReducer<UsersMap, UserRecordType>(
+export default withDataRecordMap<UsersMap, UserRecordType>(
   new Set([ACTIONS.USER_PROFILE_FETCH, ACTIONS.USER_ACTIVITIES_FETCH]),
   ImmutableMap(),
 )(userProfilesReducer);

--- a/src/redux/types/reducer.js
+++ b/src/redux/types/reducer.js
@@ -8,12 +8,12 @@ import type { ActionsType } from './actions';
  * This type, when assigned to a reducer, ensures that the actions specified
  * exist in `ActionsType`, and that the action objects are fully typed.
  *
- * S: State for the reducer, e.g. ImmutableMapType<>
+ * T: State for the reducer, e.g. ImmutableMapType<>
  *
- * T: Object of action types with passthrough values, e.g.
+ * U: Object of action types with passthrough values, e.g.
  * ReducerType<State, {| COLONY_CREATE: *, COLONY_CREATE_ERROR: * |}>
  */
-export type ReducerType<S, T: { [actionType: $Keys<ActionsType>]: * }> = (
-  state: S,
-  action: $Values<$Pick<ActionsType, T>>,
-) => S;
+export type ReducerType<T, U: { [actionType: $Keys<ActionsType>]: * }> = (
+  state: T,
+  action: $Values<$Pick<ActionsType, U>>,
+) => T;

--- a/src/utils/reducers/__tests__/withDataRecordMap.test.js
+++ b/src/utils/reducers/__tests__/withDataRecordMap.test.js
@@ -1,9 +1,9 @@
 import { Map as ImmutableMap, Record } from 'immutable';
 import createSandbox from 'jest-sandbox';
 
-import withDataReducer from '../withDataReducer';
+import withDataRecordMap from '../withDataRecordMap';
 
-describe('reducers - withDataReducer', () => {
+describe('reducers - withDataRecordMap', () => {
   const sandbox = createSandbox();
 
   beforeEach(() => {
@@ -48,7 +48,7 @@ describe('reducers - withDataReducer', () => {
       }
     });
 
-    const myWrappedReducer = withDataReducer(MY_FETCH, ImmutableMap())(
+    const myWrappedReducer = withDataRecordMap(MY_FETCH, ImmutableMap())(
       myReducer,
     );
 

--- a/src/utils/reducers/index.js
+++ b/src/utils/reducers/index.js
@@ -1,4 +1,5 @@
 /* @flow */
 
-export * from './withDataReducer';
-export { default as withDataReducer } from './withDataReducer';
+export * from './withDataRecordMap';
+export { default as withDataRecordMap } from './withDataRecordMap';
+export { default as withDataRecord } from './withDataRecord';

--- a/src/utils/reducers/utils.js
+++ b/src/utils/reducers/utils.js
@@ -1,0 +1,18 @@
+/* @flow */
+
+import type { ActionTypeString } from '~redux/types/actions';
+
+// eslint-disable-next-line import/prefer-default-export
+export const getActionTypes = (
+  actionTypes: ActionTypeString | Set<ActionTypeString>,
+) => {
+  const fetchTypes =
+    typeof actionTypes === 'string' ? new Set<*>([actionTypes]) : actionTypes;
+  const successTypes = new Set<*>(
+    [...fetchTypes.values()].map(type => `${type}_SUCCESS`),
+  );
+  const errorTypes = new Set<*>(
+    [...fetchTypes.values()].map(type => `${type}_ERROR`),
+  );
+  return { fetchTypes, successTypes, errorTypes };
+};

--- a/src/utils/reducers/withDataRecord.js
+++ b/src/utils/reducers/withDataRecord.js
@@ -1,0 +1,48 @@
+/* @flow */
+
+import type { DataRecordType } from '../../immutable';
+import type { ActionsType, ActionTypeString } from '~redux/types/actions';
+import type { ReducerType } from '~redux/types';
+
+import { getActionTypes } from './utils';
+
+const handleFetch = <T: DataRecordType<*>>(state: T) =>
+  state.set('isFetching', true);
+
+const handleSuccess = <T: DataRecordType<*>>(state: T) =>
+  state.merge({
+    error: undefined,
+    isFetching: false,
+  });
+
+const handleError = <T: DataRecordType<*>>(state: T, { payload: error }: *) =>
+  state.merge({
+    isFetching: false,
+    error: error.message || error.toString(),
+  });
+
+const withDataRecord = <
+  T: DataRecordType<*>,
+  U: { [actionType: $Keys<ActionsType>]: * },
+>(
+  actionTypes: ActionTypeString | Set<ActionTypeString>,
+) => (wrappedReducer: ReducerType<T, U>) => {
+  // Set up fetch/success/error types according to the usual pattern
+  const { fetchTypes, successTypes, errorTypes } = getActionTypes(actionTypes);
+
+  // Return a wrapped reducer.
+  return (state: *, action: *) => {
+    // Pass the state to the wrapped reducer as the first step.
+    const nextState = wrappedReducer(state, action);
+
+    // If the action matches a fetch/success/error type, set the next state again.
+    const { type } = action;
+    if (fetchTypes.has(type)) return handleFetch<T>(nextState);
+    if (successTypes.has(type)) return handleSuccess<T>(nextState);
+    if (errorTypes.has(type)) return handleError<T>(nextState, action);
+
+    return nextState;
+  };
+};
+
+export default withDataRecord;

--- a/src/utils/reducers/withDataRecordMap.js
+++ b/src/utils/reducers/withDataRecordMap.js
@@ -9,6 +9,7 @@ import type { KeyPath } from '~types';
 import { DataRecord } from '../../immutable';
 import type { DataRecordType } from '../../immutable';
 import type { ActionTypeString } from '~redux/types/actions';
+import { getActionTypes } from './utils';
 
 export type DataReducer<S: ImmutableMapType<*, *>> = (state: S, action: *) => S;
 
@@ -85,19 +86,11 @@ const handleError = <S: ImmutableMapType<*, *>, V: *>(
  *
  * {V} The value wrapped in the data record, e.g. `ColonyRecord` or `ListType<TransationRecord>`
  */
-const withDataReducer = <S: ImmutableMapType<*, *>, V: *>(
+const withDataRecordMap = <S: ImmutableMapType<*, *>, V: *>(
   actionTypes: ActionTypeString | Set<ActionTypeString>,
-  initialState: S,
+  initialState: S, // TODO see if this can be removed
 ) => (wrappedReducer: DataReducer<S>) => {
-  // Set up fetch/success/error types according to the usual pattern
-  const fetchTypes =
-    typeof actionTypes === 'string' ? new Set([actionTypes]) : actionTypes;
-  const successTypes = new Set(
-    [...fetchTypes.values()].map(type => `${type}_SUCCESS`),
-  );
-  const errorTypes = new Set(
-    [...fetchTypes.values()].map(type => `${type}_ERROR`),
-  );
+  const { fetchTypes, successTypes, errorTypes } = getActionTypes(actionTypes);
 
   // Return a wrapped reducer.
   return (state: S = initialState, action: *) => {
@@ -114,4 +107,4 @@ const withDataReducer = <S: ImmutableMapType<*, *>, V: *>(
   };
 };
 
-export default withDataReducer;
+export default withDataRecordMap;


### PR DESCRIPTION
## Description

As requested by @chmanie 

* Add a `withDataRecord` wrapper for reducers that use a single `DataRecord` at the top level
* Rename `withDataReducer` to `withDataRecordMap` to clarify intent
* Use `withDataRecord` for `currentUserTransactionsReducer`

## Other changes

Move around some generics here and there, nothing major.

Resolves #931 
