### PR TITLE
Add missing props to task bounty event and work request creation

### DIFF
--- a/src/data/service/commands/task.js
+++ b/src/data/service/commands/task.js
@@ -92,6 +92,7 @@ type SetTaskDueDateCommandArgs = {|
 
 type SetTaskBountyCommandArgs = {|
   amount: string,
+  token?: ?string,
 |};
 
 type AssignWorkerCommandArgs = {|
@@ -113,7 +114,11 @@ type FinalizeTaskCommandArgs = {|
 |};
 
 type SetTaskSkillCommandArgs = {|
-  skillId: string,
+  skillId: number,
+|};
+
+type CreateWorkRequestCommandArgs = {|
+  worker: string,
 |};
 
 type SendWorkInviteCommandArgs = {|
@@ -215,17 +220,15 @@ export const setTaskSkill: TaskCommand<SetTaskSkillCommandArgs, EventStore> = ({
   },
 });
 
-export const createWorkRequest: TaskCommand<void, EventStore> = ({
-  ddb,
-  colonyClient,
-  wallet,
-  metadata,
-}) => ({
-  async execute() {
+export const createWorkRequest: TaskCommand<
+  CreateWorkRequestCommandArgs,
+  EventStore,
+> = ({ ddb, colonyClient, wallet, metadata }) => ({
+  async execute({ worker }) {
     const taskStore = await getTaskStore(colonyClient, ddb, wallet)(metadata);
     await taskStore.append(
       createWorkRequestCreatedEvent({
-        worker: wallet.address,
+        worker,
       }),
     );
 

--- a/src/data/service/events/schemas.js
+++ b/src/data/service/events/schemas.js
@@ -119,6 +119,7 @@ export const TaskStatusChangeEventSchema = yup.object({
 
 export const CreateBountySetEventSchema = yup.object({
   amount: yup.string().required(),
+  token: yup.string(),
 });
 
 export const CreateTaskFinalizedEventSchema = yup.object({

--- a/src/data/service/events/tasks.js
+++ b/src/data/service/events/tasks.js
@@ -53,7 +53,7 @@ export type DueDateSetEvent = Event<
 >;
 
 export type SkillSetEventArgs = {|
-  skillId: string,
+  skillId: number,
 |};
 export type SkillSetEventPayload = SkillSetEventArgs;
 export type SkillSetEvent = Event<typeof SKILL_SET, SkillSetEventPayload>;
@@ -164,6 +164,7 @@ export type WorkerUnassignedEvent = Event<
 
 export type BountySetEventArgs = {|
   amount: string,
+  token?: ?string,
 |};
 export type BountySetEventPayload = BountySetEventArgs;
 export type BountySetEvent = Event<typeof BOUNTY_SET, BountySetEventPayload>;


### PR DESCRIPTION
## Description (Required)
This PR adds missing `token` and creates a command args type for work request creation event

Contributes to #878