### PR TITLE
Fix colonyResolver unit test (and actually test stuff!)

### DIFF
--- a/src/lib/database/resolvers/__tests__/ColonyResolver.test.js
+++ b/src/lib/database/resolvers/__tests__/ColonyResolver.test.js
@@ -1,16 +1,20 @@
 import ENSResolver from '../ENSResolver';
 import ColonyResolver from '../ColonyResolver';
 
-let colonyResolver;
-
 describe('Colony Resolver', () => {
   test('Colony resolver inherits from ENSResolver', () => {
-    colonyResolver = new ColonyResolver({});
+    const colonyResolver = new ColonyResolver({});
 
     expect(colonyResolver instanceof ENSResolver).toBeTruthy();
   });
   test('Colony resolver implemented', async () => {
-    // TODO this test could be better 🙃
-    expect(colonyResolver.resolve).not.toThrow();
+    const colonyResolver = new ColonyResolver({
+      getProfileDBAddress: {
+        call: () =>
+          Promise.resolve({ orbitDBAddress: '/orbitdb/someAddresss' }),
+      },
+    });
+    const resolved = await colonyResolver.resolve('foo');
+    expect(resolved).toBe('/orbitdb/someAddresss');
   });
 });


### PR DESCRIPTION
## Issue
The test was just wrong. I actually added a proper test to test the `resolve` function here.

Sadly it is not possible to make the tests fail on these uncaught exceptions. The problem is that the tests might not even run long enough to spit out this error (it is suppressed when the runner process exits): https://github.com/facebook/jest/issues/3251