### PR TITLE
Simplify and explain data types

### DIFF
--- a/src/data/service/commands/colony.js
+++ b/src/data/service/commands/colony.js
@@ -4,7 +4,7 @@ import type { Address, ENSName } from '~types';
 import type {
   ColonyClientContext,
   Command,
-  Context,
+  ContextWithMetadata,
   DDBContext,
   WalletContext,
 } from '../../types';
@@ -28,7 +28,7 @@ import {
   UpdateColonyProfileCommandArgsSchema,
 } from './schemas';
 
-export type ColonyContext = Context<
+export type ColonyContext = ContextWithMetadata<
   {|
     colonyENSName: string | ENSName,
     colonyAddress: Address,

--- a/src/data/service/commands/task.js
+++ b/src/data/service/commands/task.js
@@ -4,7 +4,7 @@ import type { Address, ENSName, OrbitDBAddress } from '~types';
 import type {
   ColonyClientContext,
   Command,
-  Context,
+  ContextWithMetadata,
   DDBContext,
   WalletContext,
 } from '../../types';
@@ -19,37 +19,37 @@ import {
 } from '../../stores';
 
 import {
-  createCommentStoreCreatedEvent,
-  createTaskStoreRegisteredEvent,
-  createTaskStoreUnregisteredEvent,
-  createTaskCreatedEvent,
-  createTaskUpdatedEvent,
-  createTaskDueDateSetEvent,
-  createTaskSkillSetEvent,
-  createWorkInviteSentEvent,
-  createWorkRequestCreatedEvent,
   createCommentPostedEvent,
+  createCommentStoreCreatedEvent,
   createTaskBountySetEvent,
-  createTaskFinalizedEvent,
   createTaskCancelledEvent,
   createTaskClosedEvent,
+  createTaskCreatedEvent,
+  createTaskDueDateSetEvent,
+  createTaskFinalizedEvent,
+  createTaskSkillSetEvent,
+  createTaskStoreRegisteredEvent,
+  createTaskStoreUnregisteredEvent,
+  createTaskUpdatedEvent,
   createWorkerAssignedEvent,
   createWorkerUnassignedEvent,
+  createWorkInviteSentEvent,
+  createWorkRequestCreatedEvent,
 } from '../events';
 
 import {
+  CancelTaskCommandArgsSchema,
   CreateTaskCommandArgsSchema,
-  UpdateTaskCommandArgsSchema,
+  FinalizeTaskCommandArgsSchema,
+  PostCommentCommandArgsSchema,
+  SendWorkInviteCommandArgsSchema,
+  SetTaskBountyCommandArgsSchema,
   SetTaskDueDateCommandArgsSchema,
   SetTaskSkillCommandArgsSchema,
-  SendWorkInviteCommandArgsSchema,
-  PostCommentCommandArgsSchema,
-  SetTaskBountyCommandArgsSchema,
-  FinalizeTaskCommandArgsSchema,
-  CancelTaskCommandArgsSchema,
+  UpdateTaskCommandArgsSchema,
 } from './schemas';
 
-export type TaskContext = Context<
+export type TaskContext = ContextWithMetadata<
   {|
     colonyENSName: string | ENSName,
     colonyAddress: Address,
@@ -58,7 +58,7 @@ export type TaskContext = Context<
   ColonyClientContext & WalletContext & DDBContext,
 >;
 
-export type CommentContext = Context<
+export type CommentContext = ContextWithMetadata<
   {|
     commentsStoreAddress: string | OrbitDBAddress,
   |},

--- a/src/data/service/commands/user.js
+++ b/src/data/service/commands/user.js
@@ -1,7 +1,12 @@
 /* @flow */
 
 import type { Address, OrbitDBAddress } from '~types';
-import type { Command, Context, IPFSContext, DDBContext } from '../../types';
+import type {
+  Command,
+  ContextWithMetadata,
+  IPFSContext,
+  DDBContext,
+} from '../../types';
 import type {
   EventStore,
   FeedStore,
@@ -29,14 +34,17 @@ type UserCommandMetadata = {|
   username?: string,
 |};
 
-export type UserCommandContext = Context<UserCommandMetadata, DDBContext>;
+export type UserCommandContext = ContextWithMetadata<
+  UserCommandMetadata,
+  DDBContext,
+>;
 
-export type UserAvatarCommandContext = Context<
+export type UserAvatarCommandContext = ContextWithMetadata<
   UserCommandMetadata,
   DDBContext & IPFSContext,
 >;
 
-export type UserMetadataCommandContext = Context<
+export type UserMetadataCommandContext = ContextWithMetadata<
   {|
     walletAddress: string,
     userMetadataStoreAddress: string | OrbitDBAddress,

--- a/src/data/service/queries/colonies.js
+++ b/src/data/service/queries/colonies.js
@@ -4,7 +4,7 @@ import type { Address, ENSName } from '~types';
 
 import type {
   ColonyClientContext,
-  Context,
+  ContextWithMetadata,
   DDBContext,
   Event,
   Query,
@@ -53,7 +53,7 @@ type ColonyMetadata = {|
   colonyAddress: Address,
 |};
 
-export type ColonyQueryContext = Context<
+export type ColonyQueryContext = ContextWithMetadata<
   ColonyMetadata,
   ColonyClientContext & DDBContext & WalletContext,
 >;
@@ -65,7 +65,7 @@ export type ColonyContractEventQuery<I: *, R: *> = Query<
 >;
 
 export type ColonyContractTransactionsEventQuery<I: *, R: *> = Query<
-  Context<ColonyMetadata, ColonyClientContext>,
+  ContextWithMetadata<ColonyMetadata, ColonyClientContext>,
   I,
   R,
 >;

--- a/src/data/service/queries/comments.js
+++ b/src/data/service/queries/comments.js
@@ -2,7 +2,7 @@
 
 import type { OrbitDBAddress } from '~types';
 
-import type { Context, DDBContext, Query } from '../../types';
+import type { ContextWithMetadata, DDBContext, Query } from '../../types';
 import type { CommentPostedEvent } from '../events';
 
 import { getCommentsStore } from '../../stores';
@@ -10,7 +10,7 @@ import { TASK_EVENT_TYPES } from '../../constants';
 
 const { COMMENT_POSTED } = TASK_EVENT_TYPES;
 
-export type CommentQueryContext = Context<
+export type CommentQueryContext = ContextWithMetadata<
   {|
     commentsStoreAddress: string | OrbitDBAddress,
   |},

--- a/src/data/service/queries/tasks.js
+++ b/src/data/service/queries/tasks.js
@@ -4,7 +4,7 @@ import type { Address, ENSName, OrbitDBAddress } from '~types';
 
 import type {
   ColonyClientContext,
-  Context,
+  ContextWithMetadata,
   DDBContext,
   Event,
   Query,
@@ -30,7 +30,7 @@ const {
   TASK_CANCELLED,
 } = TASK_EVENT_TYPES;
 
-export type TaskQueryContext = Context<
+export type TaskQueryContext = ContextWithMetadata<
   {|
     colonyENSName: string | ENSName,
     colonyAddress: Address,

--- a/src/data/service/queries/users.js
+++ b/src/data/service/queries/users.js
@@ -17,7 +17,7 @@ import {
 
 import type {
   ColonyClientContext,
-  Context,
+  ContextWithMetadata,
   DDBContext,
   ENSCacheContext,
   IPFSContext,
@@ -27,7 +27,7 @@ import type {
 
 import { getUserProfileStore } from '../../stores';
 
-type UserQueryContext = Context<
+type UserQueryContext = ContextWithMetadata<
   {|
     walletAddress: string,
     username?: string,
@@ -35,7 +35,7 @@ type UserQueryContext = Context<
   DDBContext,
 >;
 
-type UserAvatarQueryContext = Context<
+type UserAvatarQueryContext = ContextWithMetadata<
   {|
     walletAddress: string,
     username?: string,
@@ -43,24 +43,24 @@ type UserAvatarQueryContext = Context<
   DDBContext & IPFSContext,
 >;
 
-type UserBalanceQueryContext = Context<{}, NetworkClientContext>;
-type UserPermissionsQueryContext = Context<{}, ColonyClientContext>;
+type UserBalanceQueryContext = NetworkClientContext;
+type UserPermissionsQueryContext = ColonyClientContext;
 
-type UserColonyTransactionsQueryContext = Context<
+type UserColonyTransactionsQueryContext = ContextWithMetadata<
   {|
     walletAddress: string,
   |},
   ColonyClientContext,
 >;
 
-type UserTransactionIdsQueryContext = Context<
+type UserTransactionIdsQueryContext = ContextWithMetadata<
   {|
     walletAddress: string,
   |},
   ColonyClientContext,
 >;
 
-type UsernameQueryContext = Context<{}, ENSCacheContext & NetworkClientContext>;
+type UsernameQueryContext = {| ...ENSCacheContext, ...NetworkClientContext |};
 
 type UserQuery<I: *, R: *> = Query<UserQueryContext, I, R>;
 type UsernameQuery<I: *, R: *> = Query<UsernameQueryContext, I, R>;

--- a/src/data/types.js
+++ b/src/data/types.js
@@ -13,52 +13,90 @@ import type IPFSNodeType from '../lib/ipfs';
 import ENS from '../lib/ENS';
 
 /*
- * The specification for a store command.
+ * The specification for a data command.
  *
- * `I`: Object type indicating the arguments the command methods
+ * C: Optional object type indicating the context the command will
+ * be executed with.
+ *
+ * A: Optional object type for the arguments the execute function will
  * will be called with.
+ *
+ * R: Return type for the execute function.
  */
-export type Command<C: *, I: *, R: *> = C => {|
+export type Command<C: ?Object, A: ?Object, R> = C => {|
   /*
    * Script to execute the command for the given argument
    * (this usually performs a write of some kind).
    */
-  execute: (args: I) => Promise<R>,
+  execute: (args: A) => Promise<R>,
   schema?: SchemaType,
 |};
 
-export type Query<C: *, I: *, R: *> = C => {|
-  execute: (args: I) => Promise<R>,
+/*
+ * The specification for a data query.
+ *
+ * C: Optional object type indicating the context the query will
+ * be executed with.
+ *
+ * A: Optional type for the arguments the execute function will
+ * will be called with.
+ *
+ * R: Return type for the execute function.
+ */
+export type Query<C: ?Object, A, R> = C => {|
+  execute: (args: A) => Promise<R>,
 |};
 
 /*
- * M: metadata object
- * R: rest object (e.g. `DDBContext & IPFSContext`)
+ * Type that produces a context object with a `metadata` property
+ * and any other context properties
+ *
+ * M: Object type for the `metadata` property; this is usually data
+ * that is used to get a store, e.g. store address or colony address.
+ *
+ * R: Optional object for the rest of the context (e.g. `DDBContext & IPFSContext`).
  */
-export type Context<M: *, R: *> = {| metadata: M, ...R |};
+export type ContextWithMetadata<M: *, R: *> = {| metadata: M, ...R |};
 
+/*
+ * Individual context object types; these are not metadata, but are rather
+ * things that have some function needed for commands/queries.
+ */
 export type DDBContext = {| ddb: DDBType |};
-
 export type IPFSContext = {| ipfsNode: IPFSNodeType |};
-
 export type ColonyClientContext = {| colonyClient: ColonyClientType |};
-
 export type NetworkClientContext = {| networkClient: NetworkClientType |};
-
 export type WalletContext = {| wallet: WalletObjectType |};
-
 export type ENSCacheContext = {| ensCache: ENS |};
 
-export type EventPayload<I: *> = {|
+/*
+ * Object type representing the payload of an event; this includes
+ * various metadata properties and the actual payload properties.
+ *
+ * P: Object type representing the payload properties (technically optional).
+ */
+export type EventPayload<P: ?Object> = {|
   id: string,
   timestamp: number,
   version: number,
-  ...I,
+  ...P,
 |};
 
-export type Event<T: string, I: *> = {|
+/*
+ * Object type representing an event.
+ *
+ * T: String type for the event type, e.g. `DUE_DATE_SET`.
+ * P: Object type representing the payload properties (technically optional).
+ */
+export type Event<T: string, P: ?Object> = {|
   type: T,
-  payload: EventPayload<I>,
+  payload: EventPayload<P>,
 |};
 
-export type EventCreator<I: Object, O: Event<*, *>> = (args: I) => O;
+/*
+ * Function type representing an event creator.
+ *
+ * A: Object type for the function arguments (technically optional).
+ * E: Event type that will be created.
+ */
+export type EventCreator<A: ?Object, E: Event<*, *>> = (args: A) => E;

--- a/src/modules/core/sagas/setupUserContext.js
+++ b/src/modules/core/sagas/setupUserContext.js
@@ -105,7 +105,7 @@ export default function* setupUserContext(
      */
     const { networkClient } = colonyManager;
     const balance = yield* executeQuery(
-      { networkClient, metadata: {} },
+      { networkClient },
       getUserBalance,
       walletAddress,
     );

--- a/src/modules/users/sagas/setupUsersSagas.js
+++ b/src/modules/users/sagas/setupUsersSagas.js
@@ -126,7 +126,7 @@ function* usernameFetch({
   try {
     const { networkClient } = yield* getContext(CONTEXT.COLONY_MANAGER);
     const ensCache = yield* getContext(CONTEXT.ENS_INSTANCE);
-    const context = { ensCache, networkClient, metadata: {} };
+    const context = { ensCache, networkClient };
 
     const username = yield* executeQuery(context, getUsername, userAddress);
     yield put<Action<typeof ACTIONS.USERNAME_FETCH_SUCCESS>>({
@@ -144,7 +144,7 @@ function* currentUserGetBalance(
 ): Saga<void> {
   try {
     const { networkClient } = yield* getContext(CONTEXT.COLONY_MANAGER);
-    const context = { networkClient, metadata: {} };
+    const context = { networkClient };
     const walletAddress = yield select(currentUserAddressSelector);
 
     if (!walletAddress) {
@@ -246,7 +246,7 @@ function* usernameCheckAvailability({
 
     const { networkClient } = yield* getContext(CONTEXT.COLONY_MANAGER);
     const ensCache = yield* getContext(CONTEXT.ENS_INSTANCE);
-    const context = { ensCache, networkClient, metadata: {} };
+    const context = { ensCache, networkClient };
 
     // This will throw if the username is not available
     yield* executeQuery(context, checkUsernameIsAvailable, username);
@@ -321,7 +321,7 @@ function* userPermissionsFetch({
       throw new Error('Could not get wallet address for current user');
     }
 
-    const context = { colonyClient, metadata: {} };
+    const context = { colonyClient };
     const permissions = yield* executeQuery(
       context,
       getUserPermissions,


### PR DESCRIPTION
## Description

This PR simplifies the data types a little so it's easier to work with.

* Add comments explaining the data types
* Rename generics to match the variable/property names
* Avoid using `Context` for commands/queries with no metadata
* Remove empty `metadata` objects from context
* Rename `Context` type to `ContextWithMetadata`

## Other changes

* Sort some types/imports alphabetically so it reads better
