### PR TITLE
Fix Gas Station insufficient funds Alert

### DIFF
--- a/src/modules/users/components/GasStation/GasStationPrice/GasStationPrice.jsx
+++ b/src/modules/users/components/GasStation/GasStationPrice/GasStationPrice.jsx
@@ -179,13 +179,11 @@ class GasStationPrice extends Component<Props, State> {
 
   render() {
     const {
-      isNetworkCongested,
       gasPrices,
       updateGas,
       transaction: { id, gasLimit },
-      walletNeedsAction,
     } = this.props;
-    const { isSpeedMenuOpen, speedMenuId, insufficientFunds } = this.state;
+    const { isSpeedMenuOpen, speedMenuId } = this.state;
     const initialFormValues: FormValues = {
       id,
       transactionSpeed: transactionSpeedOptions[0].value,
@@ -305,9 +303,7 @@ class GasStationPrice extends Component<Props, State> {
             );
           }}
         </ActionForm>
-        {(isNetworkCongested || walletNeedsAction || insufficientFunds) && (
-          <div>{this.showAlert()}</div>
-        )}
+        <div>{this.showAlert()}</div>
       </div>
     );
   }


### PR DESCRIPTION
This PR fixes the available funds logic compare of the Gas Station Price Component. 

Based on this logic, the Gas Station Price component determines if it should show the insufficient funds alert.

Changed:
- [x] Fixed `GasStationPrice` `showAlert()` values compare logic
- [x] Removed `GasStationPrice` redundant `showAlert()` logic

Demo:
_With less funds then necessary:_
![Screenshot from 2019-03-24 23-27-03](https://user-images.githubusercontent.com/1193222/54886113-e1ab5200-4e8c-11e9-9c04-450b46aa5de8.png)

_With more funds then necessary:_
![Screenshot from 2019-03-24 23-27-22](https://user-images.githubusercontent.com/1193222/54886123-f2f45e80-4e8c-11e9-8b59-0bb52accd5d6.png)


Resolves #989 