### PR TITLE
Clean up selectors

### DIFF
--- a/src/modules/admin/hocs/withColonyTransactions.js
+++ b/src/modules/admin/hocs/withColonyTransactions.js
@@ -6,7 +6,10 @@ import { connect } from 'react-redux';
 import type { ENSName } from '~types';
 import type { RootStateRecord } from '~immutable';
 
-import { colonyTransactions, colonyUnclaimedTransactions } from '../selectors';
+import {
+  colonyTransactionsSelector,
+  colonyUnclaimedTransactionsSelector,
+} from '../selectors';
 import {
   fetchColonyTransactions,
   fetchColonyUnclaimedTransactions,
@@ -16,8 +19,11 @@ import fetchMissingColonyTransactions from './fetchMissingColonyTransactions';
 const withColonyTransactions = compose(
   connect(
     (state: RootStateRecord, { ensName }: { ensName: ENSName }) => ({
-      transactions: colonyTransactions(state, ensName),
-      unclaimedTransactions: colonyUnclaimedTransactions(state, ensName),
+      transactions: colonyTransactionsSelector(state, ensName),
+      unclaimedTransactions: colonyUnclaimedTransactionsSelector(
+        state,
+        ensName,
+      ),
     }),
     {
       fetchColonyTransactions,

--- a/src/modules/admin/selectors/index.js
+++ b/src/modules/admin/selectors/index.js
@@ -9,10 +9,15 @@ import {
   ADMIN_UNCLAIMED_TRANSACTIONS,
 } from '../constants';
 
-export const colonyTransactions = (state: RootStateRecord, ensName: ENSName) =>
-  state.getIn([ns, ADMIN_TRANSACTIONS, ensName]);
+/*
+ * Input selectors
+ */
+export const colonyTransactionsSelector = (
+  state: RootStateRecord,
+  ensName: ENSName,
+) => state.getIn([ns, ADMIN_TRANSACTIONS, ensName]);
 
-export const colonyUnclaimedTransactions = (
+export const colonyUnclaimedTransactionsSelector = (
   state: RootStateRecord,
   ensName: ENSName,
 ) => state.getIn([ns, ADMIN_UNCLAIMED_TRANSACTIONS, ensName]);

--- a/src/modules/core/fetchers.js
+++ b/src/modules/core/fetchers.js
@@ -1,10 +1,10 @@
 /* @flow */
 /* eslint-disable import/prefer-default-export */
 
-import { getNetwork } from './selectors';
+import { networkSelector } from './selectors';
 import { fetchNetworkVersion } from './actionCreators';
 
 export const networkVersionFetcher = {
-  select: getNetwork,
+  select: networkSelector,
   fetch: fetchNetworkVersion,
 };

--- a/src/modules/core/selectors/network.js
+++ b/src/modules/core/selectors/network.js
@@ -4,8 +4,11 @@ import type { RootStateRecord } from '~immutable';
 
 import { CORE_NAMESPACE as ns, CORE_NETWORK } from '../constants';
 
-export const getNetwork = (state: RootStateRecord) =>
+/*
+ * Input selectors
+ */
+export const networkSelector = (state: RootStateRecord) =>
   state.getIn([ns, CORE_NETWORK]);
 
-export const getNetworkVersion = (state: RootStateRecord) =>
+export const networkVersionSelector = (state: RootStateRecord) =>
   state.getIn([ns, CORE_NETWORK, 'record', 'version']);

--- a/src/modules/dashboard/fetchers.js
+++ b/src/modules/dashboard/fetchers.js
@@ -3,12 +3,12 @@
 import {
   colonyAdminsSelector,
   colonyDomainsSelector,
-  singleColonySelector,
+  colonySelector,
 } from './selectors';
 import { fetchAdmins, fetchColony, fetchDomains } from './actionCreators';
 
 export const colonyFetcher = {
-  select: singleColonySelector,
+  select: colonySelector,
   fetch: fetchColony,
   ttl: 1000 * 60, // 1 minute
 };

--- a/src/modules/dashboard/hocs/withColony.js
+++ b/src/modules/dashboard/hocs/withColony.js
@@ -3,7 +3,7 @@
 import { connect } from 'react-redux';
 import compose from 'recompose/compose';
 
-import { singleColonySelector } from '../selectors';
+import { colonySelector } from '../selectors';
 import { fetchColony } from '../actionCreators';
 import fetchMissingColony from './fetchMissingColony';
 
@@ -12,7 +12,7 @@ import type { ENSName } from '~types';
 const withColony = compose(
   connect(
     (state, { ensName }: { ensName: ENSName }) => ({
-      colony: singleColonySelector(state, ensName),
+      colony: colonySelector(state, ensName),
     }),
     {
       fetchColony,

--- a/src/modules/dashboard/hooks/useToken.js
+++ b/src/modules/dashboard/hooks/useToken.js
@@ -18,7 +18,7 @@ const useToken = (tokenAddress: Address) => {
   );
   const mapState = useCallback(
     state => ({
-      token: tokenWithIconSelector(state, { tokenAddress }),
+      token: tokenWithIconSelector(state, tokenAddress),
     }),
     [tokenAddress],
   );

--- a/src/modules/dashboard/sagas/colony.js
+++ b/src/modules/dashboard/sagas/colony.js
@@ -50,7 +50,7 @@ import { createTransaction, getTxChannel } from '../../core/sagas';
 import { COLONY_CONTEXT } from '../../core/constants';
 
 import { colonyAvatarHashSelector } from '../selectors';
-import { getNetworkVersion } from '../../core/selectors';
+import { networkVersionSelector } from '../../core/selectors';
 
 import { getColonyContext } from './shared';
 
@@ -501,7 +501,7 @@ function* colonyAvatarRemove({
 }: Action<typeof ACTIONS.COLONY_AVATAR_REMOVE>): Saga<void> {
   try {
     const context = yield* getColonyContext(ensName);
-    const ipfsHash = yield select(colonyAvatarHashSelector, { ensName });
+    const ipfsHash = yield select(colonyAvatarHashSelector, ensName);
     /*
      * Remove colony avatar
      */
@@ -556,7 +556,7 @@ function* colonyUpgradeContract({
 }: Action<typeof ACTIONS.COLONY_VERSION_UPGRADE>) {
   const txChannel = yield call(getTxChannel, meta.id);
 
-  const newVersion = yield select(getNetworkVersion);
+  const newVersion = yield select(networkVersionSelector);
 
   try {
     yield fork(createTransaction, meta.id, {

--- a/src/modules/dashboard/sagas/task.js
+++ b/src/modules/dashboard/sagas/task.js
@@ -11,7 +11,7 @@ import { putError, executeCommand, executeQuery } from '~utils/saga/effects';
 import { ACTIONS } from '~redux';
 
 import {
-  allColonyENSNames,
+  allColonyENSNamesSelector,
   taskSelector,
   taskStorePropsSelector,
 } from '../selectors';
@@ -248,7 +248,7 @@ function* taskFetchAllForColony({
  * colonies (in parallel).
  */
 function* taskFetchAll(): Saga<void> {
-  const colonyENSNames = yield select(allColonyENSNames);
+  const colonyENSNames = yield select(allColonyENSNamesSelector);
   yield all(
     colonyENSNames.map(colonyENSName =>
       put<Action<typeof ACTIONS.TASK_FETCH_ALL_FOR_COLONY>>({

--- a/src/modules/dashboard/selectors/admins.js
+++ b/src/modules/dashboard/selectors/admins.js
@@ -1,21 +1,12 @@
 /* @flow */
-import { createSelector } from 'reselect';
 
 import type { RootStateRecord } from '~immutable';
 
 import { DASHBOARD_NAMESPACE as ns, DASHBOARD_ALL_ADMINS } from '../constants';
 
 /*
- * Getters
- */
-const getColonyAdmins = (state: RootStateRecord, ensName: string) =>
-  state.getIn([ns, DASHBOARD_ALL_ADMINS, ensName]);
-
-/*
- * Selectors
+ * Input selectors
  */
 // eslint-disable-next-line import/prefer-default-export
-export const colonyAdminsSelector = createSelector(
-  getColonyAdmins,
-  admins => admins,
-);
+export const colonyAdminsSelector = (state: RootStateRecord, ensName: string) =>
+  state.getIn([ns, DASHBOARD_ALL_ADMINS, ensName]);

--- a/src/modules/dashboard/selectors/colony.js
+++ b/src/modules/dashboard/selectors/colony.js
@@ -21,7 +21,10 @@ import {
 
 type ENSNameFromRouter = (state: RootStateRecord, props: Object) => ENSName;
 
-export const ensNameFromRouter: ENSNameFromRouter = (state, props) =>
+/*
+ * Input selectors
+ */
+export const ensNameFromRouterSelector: ENSNameFromRouter = (state, props) =>
   props.match.params.ensName;
 
 export const allColoniesSelector = (state: RootStateRecord) =>
@@ -42,35 +45,29 @@ export const colonyENSNamesSelector = (state: RootStateRecord) =>
     ImmutableMap(),
   );
 
+/*
+ * Selectors
+ */
 export const routerColonySelector = createSelector(
   coloniesSelector,
-  ensNameFromRouter,
+  ensNameFromRouterSelector,
   (colonies, ensName) => colonies.get(ensName),
 );
 
-export const singleColonySelector = (
-  state: RootStateRecord,
-  ensName: ENSName,
-) => state.getIn([ns, DASHBOARD_ALL_COLONIES, DASHBOARD_COLONIES, ensName]);
-
-export const domainsIndexSelector = createSelector(
-  singleColonySelector,
-  colony =>
-    colony ? colony.getIn(['record', 'databases', 'domainsIndex']) : undefined,
-);
+export const colonySelector = (state: RootStateRecord, ensName: ENSName) =>
+  state.getIn([ns, DASHBOARD_ALL_COLONIES, DASHBOARD_COLONIES, ensName]);
 
 export const domainSelector = createSelector(
   (state, domainId) => domainId,
-  singleColonySelector,
+  colonySelector,
   (domainId, colony) =>
     colony ? colony.getIn(['record', 'domains', domainId]) : undefined,
 );
 
 export const colonyAvatarHashSelector = createSelector(
+  (state: RootStateRecord, ensName: ENSName) => ensName,
   coloniesSelector,
-  (state, props) => props.ensName,
-  (colonies, ensName) =>
-    ensName ? colonies.getIn([ensName, 'record', 'avatar']) : null,
+  (ensName, colonies) => colonies.getIn([ensName, 'record', 'avatar']),
 );
 
 export const colonyAvatarDataSelector = createSelector(
@@ -79,14 +76,14 @@ export const colonyAvatarDataSelector = createSelector(
   (hash, state) => (state && hash ? state.get(hash) : null),
 );
 
-export const allColonyENSNames = createSelector(
+export const allColonyENSNamesSelector = createSelector(
   coloniesSelector,
-  colonies => colonies.keySeq().toArray(), // TODO don't use a selector for this
+  colonies => colonies.keySeq(),
 );
 
 export const colonyENSNameSelector = createSelector(
   colonyENSNamesSelector,
-  (state, props) => props.colonyAddress,
+  (state, props) => props.colonyAddress, // TODO use a string argument
   (ensNames, colonyAddress) => ensNames.get(colonyAddress),
 );
 

--- a/src/modules/dashboard/selectors/comments.js
+++ b/src/modules/dashboard/selectors/comments.js
@@ -3,7 +3,7 @@
 import { createSelector } from 'reselect';
 import { Map as ImmutableMap } from 'immutable';
 
-import type { RootStateRecord } from '~immutable';
+import type { RootStateRecord, TaskDraftId } from '~immutable';
 
 import {
   DASHBOARD_ALL_COMMENTS,
@@ -11,13 +11,13 @@ import {
 } from '../constants';
 
 /*
- * Tasks selectors
+ * Input selectors
  */
 export const allCommentsSelector = (state: RootStateRecord) =>
   state.getIn([ns, DASHBOARD_ALL_COMMENTS], ImmutableMap());
 
-export const tasksCommentsSelector = createSelector(
+export const taskCommentsSelector = createSelector(
   allCommentsSelector,
-  (state, props) => props.id,
-  (allComments, id) => allComments.get(id, ImmutableMap()),
+  (state: RootStateRecord, draftId: TaskDraftId) => draftId,
+  (allComments, draftId) => allComments.get(draftId, ImmutableMap()),
 );

--- a/src/modules/dashboard/selectors/domains.js
+++ b/src/modules/dashboard/selectors/domains.js
@@ -1,21 +1,14 @@
 /* @flow */
-import { createSelector } from 'reselect';
 
 import type { RootStateRecord } from '~immutable';
 
 import { DASHBOARD_NAMESPACE as ns, DASHBOARD_ALL_DOMAINS } from '../constants';
 
 /*
- * Getters
- */
-const getColonyDomains = (state: RootStateRecord, ensName: string) =>
-  state.getIn([ns, DASHBOARD_ALL_DOMAINS, ensName]);
-
-/*
- * Selectors
+ * Input selectors
  */
 // eslint-disable-next-line import/prefer-default-export
-export const colonyDomainsSelector = createSelector(
-  getColonyDomains,
-  domains => domains,
-);
+export const colonyDomainsSelector = (
+  state: RootStateRecord,
+  ensName: string,
+) => state.getIn([ns, DASHBOARD_ALL_DOMAINS, ensName]);

--- a/src/modules/dashboard/selectors/tokens.js
+++ b/src/modules/dashboard/selectors/tokens.js
@@ -8,6 +8,7 @@ import type {
   RootStateRecord,
   TokenReferenceType,
 } from '~immutable';
+import type { Address } from '~types';
 
 import {
   DASHBOARD_ALL_TOKENS,
@@ -19,40 +20,38 @@ import {
 /*
  * Getters
  */
-const getTokenAddressFromProps = (
-  state: RootStateRecord,
-  { tokenAddress }: { tokenAddress: string },
-) => tokenAddress;
-
-const getAllTokens = (state: RootStateRecord) =>
-  state.getIn([ns, DASHBOARD_ALL_TOKENS]);
-
-const getTokens = (state: RootStateRecord) =>
-  state.getIn([ns, DASHBOARD_ALL_TOKENS, DASHBOARD_TOKENS], ImmutableMap());
-
-export const getTokenWithIcon = (
+const getTokenWithIcon = (
   tokenAddress: string,
   allTokens: ?AllTokensRecord,
 ) => {
-  if (!allTokens) return undefined; // TODO why can this be undefined?
+  // allTokens _will_ be defined. The following code is not included in the bundle:
+  // eslint-disable-next-line
+  /*:: if (!allTokens) throw Error(); */
+
   const token = allTokens.getIn([DASHBOARD_TOKENS, tokenAddress]);
   const icon = allTokens.getIn([DASHBOARD_TOKEN_ICONS, tokenAddress]);
   return token ? token.set('icon', icon) : undefined;
 };
 
 /*
+ * Input selectors
+ */
+export const allTokensSelector = (state: RootStateRecord) =>
+  state.getIn([ns, DASHBOARD_ALL_TOKENS]);
+
+export const tokensSelector = (state: RootStateRecord) =>
+  state.getIn([ns, DASHBOARD_ALL_TOKENS, DASHBOARD_TOKENS], ImmutableMap());
+
+export const tokenSelector = (state: RootStateRecord, tokenAddress: Address) =>
+  state.getIn([ns, DASHBOARD_ALL_TOKENS, DASHBOARD_TOKENS], tokenAddress);
+
+/*
  * Selectors
  */
-export const tokenSelector = createSelector(
-  getTokenAddressFromProps,
-  getTokens,
-  (tokenAddress, tokens) => tokens.get(tokenAddress),
-);
-
 // TODO get token/icon separately for much better selector performance
 export const tokenWithIconSelector = createSelector(
-  getTokenAddressFromProps,
-  getAllTokens,
+  (state: RootStateRecord, tokenAddress: Address) => tokenAddress,
+  allTokensSelector,
   getTokenWithIcon,
 );
 
@@ -64,6 +63,6 @@ export const nativeFromColonyTokensSelector = createSelector<
   *,
 >(
   (state, tokens) => (tokens.find(({ isNative }) => !!isNative) || {}).address,
-  getAllTokens,
+  allTokensSelector,
   getTokenWithIcon,
 );

--- a/src/modules/users/fetchers.js
+++ b/src/modules/users/fetchers.js
@@ -3,8 +3,8 @@
 import {
   currentUserColonyPermissionsSelector,
   userAvatarByAddressSelector,
-  singleUserSelector,
-  singleUserByUsernameSelector,
+  userByUsernameSelector,
+  userSelector,
 } from './selectors';
 import {
   userPermissionsFetch,
@@ -21,13 +21,13 @@ export const currentUserColonyPermissionsFetcher = Object.freeze({
 
 export const userFetcher = Object.freeze({
   fetch: userFetch,
-  select: singleUserSelector,
+  select: userSelector,
   ttl: 60 * 1000,
 });
 
 export const userByUsernameFetcher = Object.freeze({
   fetch: userByUsernameFetch,
-  select: singleUserByUsernameSelector,
+  select: userByUsernameSelector,
   ttl: 60 * 1000,
 });
 

--- a/src/modules/users/selectors/users.js
+++ b/src/modules/users/selectors/users.js
@@ -1,6 +1,5 @@
 /* @flow */
 
-import { createSelector } from 'reselect';
 import { Map as ImmutableMap } from 'immutable';
 
 import type {
@@ -30,7 +29,7 @@ const getUsernameFromUserData = (user?: DataRecordType<UserRecordType>) =>
   user && user.getIn(['record', 'profile', 'username']);
 
 /*
- * Username/address selectors
+ * Username/address input selectors
  */
 export const userAddressSelector = (state: RootStateRecord, username: string) =>
   state
@@ -43,12 +42,12 @@ export const usernameSelector = (state: RootStateRecord, address: string) =>
   );
 
 /*
- * User selectors
+ * User input selectors
  */
-export const singleUserSelector = (state: RootStateRecord, address: string) =>
+export const userSelector = (state: RootStateRecord, address: string) =>
   state.getIn([ns, USERS_ALL_USERS, USERS_USERS, address]);
 
-export const singleUserByUsernameSelector = (
+export const userByUsernameSelector = (
   state: RootStateRecord,
   username: string,
 ) =>
@@ -74,7 +73,7 @@ usersExceptSelector.transform = (
     .toJS();
 
 /*
- * Avatar selectors
+ * Avatar input selectors
  */
 export const userAvatarByAddressSelector = (
   state: RootStateRecord,
@@ -82,25 +81,25 @@ export const userAvatarByAddressSelector = (
 ) => state.getIn([ns, USERS_ALL_USERS, USERS_AVATARS, address]);
 
 /*
- * Current user getters
+ * Current user input selectors
  */
-const getCurrentUser = (state: RootStateRecord) =>
+export const currentUserSelector = (state: RootStateRecord) =>
   state.getIn([ns, USERS_CURRENT_USER]);
-const getCurrentUserAddress = (state: RootStateRecord) =>
+export const currentUserAddressSelector = (state: RootStateRecord) =>
   state.getIn([
     ns,
     USERS_CURRENT_USER,
     USERS_CURRENT_USER_PROFILE,
     'walletAddress',
   ]);
-const getCurrentUserBalance = (state: RootStateRecord) =>
+export const currentUserBalanceSelector = (state: RootStateRecord) =>
   state.getIn(
     [ns, USERS_CURRENT_USER, USERS_CURRENT_USER_PROFILE, 'balance'],
     0,
   );
-const getCurrentUserTransactions = (state: RootStateRecord) =>
+export const currentUserTransactionsSelector = (state: RootStateRecord) =>
   state.getIn([ns, USERS_CURRENT_USER, USERS_CURRENT_USER_TRANSACTIONS]);
-const getCurrentUserColonyPermissions = (
+export const currentUserColonyPermissionsSelector = (
   state: RootStateRecord,
   ensName: ENSName,
 ) =>
@@ -110,38 +109,12 @@ const getCurrentUserColonyPermissions = (
     USERS_CURRENT_USER_PERMISSIONS,
     ensName,
   ]);
-const getCurrentUserMetadata = (state: RootStateRecord) =>
+export const currentUserMetadataSelector = (state: RootStateRecord) =>
   state.getIn([ns, USERS_CURRENT_USER, USERS_CURRENT_USER_METADATA]);
 
 /*
- * Current user selectors
+ * User permissions getters
  */
-export const currentUserSelector = createSelector(
-  getCurrentUser,
-  user => user,
-);
-export const currentUserAddressSelector = createSelector(
-  getCurrentUserAddress,
-  address => address,
-);
-export const currentUserBalanceSelector = createSelector(
-  getCurrentUserBalance,
-  balance => balance,
-);
-export const currentUserTransactionsSelector = createSelector(
-  getCurrentUserTransactions,
-  transactions => transactions,
-);
-export const currentUserColonyPermissionsSelector = createSelector(
-  getCurrentUserColonyPermissions,
-  permissions => permissions,
-);
-export const currentUserMetadataSelector = createSelector(
-  getCurrentUserMetadata,
-  metadata => metadata,
-);
-
-// TODO this doesn't quite fit here, maybe move?
 export const canEnterRecoveryMode = (permissions?: UserPermissionsType) =>
   !!(permissions && permissions.canEnterRecoveryMode);
 


### PR DESCRIPTION
## Description

* Clean up selectors in preparation for not relying on reselect, and rather using the `useSelector` effect
* Adjust comments to reflect whether the selectors are 'input selectors' of the form `(state, ?prop) => state` or use `createSelector` (transformed/composed selectors)
* Use simple input selectors where possible
* Use a single property as the second argument of input selectors (where possible), as opposed to a props object
* Rename some selectors to reflect what they are (so as to differentiate them from 'getters' which do not use the state)
* Remove a defunct `domainsIndex` selector

Contributes tangentially to #939 
