### PR TITLE
Fix re-rendering issue when adding domains

### DIFF
--- a/src/modules/admin/components/Organizations/Organizations.jsx
+++ b/src/modules/admin/components/Organizations/Organizations.jsx
@@ -65,15 +65,19 @@ type Props = {|
 |};
 
 const Organizations = ({ ensName }: Props) => {
-  const { data: admins, isFetching: isFetchingAdmins } = useDataFetcher<
-    string[],
-  >(adminsFetcher, [ensName], [ensName]);
+  const { data: admins } = useDataFetcher<string[]>(
+    adminsFetcher,
+    [ensName],
+    [ensName],
+  );
 
-  const { data: domains, isFetching: isFetchingDomains } = useDataFetcher<
-    DomainType[],
-  >(domainsFetcher, [ensName], [ensName]);
+  const { data: domains } = useDataFetcher<DomainType[]>(
+    domainsFetcher,
+    [ensName],
+    [ensName],
+  );
 
-  if (!domains || isFetchingDomains || !admins || isFetchingAdmins) {
+  if (!domains || !admins) {
     return <SpinnerLoader appearance={{ theme: 'primary', size: 'massive' }} />;
   }
 


### PR DESCRIPTION
This fixes the annoying re-rendering issue that we had when adding domains. Problem was that the main spinning loader was also rendered when domains were fetching and hence unmounted our tab components.

I fixed this by just checking for the existence of admins and domains which should be enough in this case.

Closes #1021.