### PR TITLE
Redirect back to connected route after login

### DIFF
--- a/src/routes/ConnectedOnlyRoute.jsx
+++ b/src/routes/ConnectedOnlyRoute.jsx
@@ -25,19 +25,31 @@ const ConnectedOnlyRoute = ({
      * Render props that are passed directly to the route Component
      */
     render={props => {
+      const {
+        match: { params },
+        location,
+      } = props;
       if (isConnected) {
-        const {
-          match: { params },
-        } = props;
+        // We disable the back link for locations we redirect to from /connect
         return hasNavigation ? (
-          <NavigationWrapper {...rest}>
+          <NavigationWrapper
+            {...rest}
+            hasBackLink={location.state && location.state.hasBackLink}
+          >
             <Component {...props} params={params} />
           </NavigationWrapper>
         ) : (
           <Component {...props} params={params} />
         );
       }
-      return <Redirect to={CONNECT_ROUTE} />;
+      return (
+        <Redirect
+          to={{
+            pathname: CONNECT_ROUTE,
+            state: { redirectTo: location },
+          }}
+        />
+      );
     }}
   />
 );

--- a/src/routes/DisconnectedOnlyRoute.jsx
+++ b/src/routes/DisconnectedOnlyRoute.jsx
@@ -16,9 +16,19 @@ const DisconnectedOnlyRoute = ({
 }) => (
   <Route
     {...rest}
-    render={props =>
-      isConnected ? <Redirect to={DASHBOARD_ROUTE} /> : <Component {...props} />
-    }
+    render={props => {
+      if (isConnected) {
+        const redirectTo =
+          props.location.state && props.location.state.redirectTo;
+        const location = {
+          pathname: DASHBOARD_ROUTE,
+          ...redirectTo,
+          state: { hasBackLink: false },
+        };
+        return <Redirect to={location} />;
+      }
+      return <Component {...props} />;
+    }}
   />
 );
 


### PR DESCRIPTION
This PR redirects the user to the page they originally wanted to go before being redirected to `/connect` to login.

I also made changes to the behaviour of the back button. It will not be shown when the user comes from the `/connect` page.

Closes #929