### PR TITLE
Use EventStore for comments store

### DIFF
--- a/src/data/blueprints/comments.js
+++ b/src/data/blueprints/comments.js
@@ -2,32 +2,13 @@
 
 import type { StoreBlueprint } from '~types/index';
 
-import * as yup from 'yup';
-import { FeedStore } from '../../lib/database/stores';
+import { EventStore } from '../../lib/database/stores';
 import { getPermissiveStoreAccessController } from '../accessControllers';
 
 const commentsStore: StoreBlueprint = {
   getAccessController: getPermissiveStoreAccessController,
   name: 'comments',
-  schema: yup.object({
-    signature: yup.string().required(),
-    content: yup.object({
-      id: yup.string().required(),
-      author: yup
-        .string()
-        .address()
-        .required(),
-      timestamp: yup.date().default(() => Date.now()),
-      body: yup.string().required(),
-      metadata: yup.object({
-        /*
-         * TODO When the time is right, add attachments
-         */
-        mentions: yup.array().of(yup.string().required()),
-      }),
-    }),
-  }),
-  type: FeedStore,
+  type: EventStore,
 };
 
 export default commentsStore;

--- a/src/data/stores.js
+++ b/src/data/stores.js
@@ -86,7 +86,7 @@ export const getCommentsStore = (ddb: DDB) => async ({
   commentsStoreAddress,
 }: {
   commentsStoreAddress: string | OrbitDBAddress,
-}) => ddb.getStore<FeedStore>(commentsStoreBlueprint, commentsStoreAddress);
+}) => ddb.getStore<EventStore>(commentsStoreBlueprint, commentsStoreAddress);
 
 export const createTaskStore = (
   colonyClient: ColonyClientType,
@@ -111,7 +111,7 @@ export const createTaskStore = (
         colonyENSName,
       },
     }),
-    ddb.createStore<FeedStore>(commentsStoreBlueprint),
+    ddb.createStore<EventStore>(commentsStoreBlueprint),
   ]);
   return { taskStore, commentsStore };
 };

--- a/src/modules/dashboard/components/TaskComments/TaskComments.jsx
+++ b/src/modules/dashboard/components/TaskComments/TaskComments.jsx
@@ -96,7 +96,6 @@ const TaskComments = ({
       .asyncFunction({
         commentData: {
           body: comment,
-          timestamp: new Date(),
           author: walletAddress,
         },
         draftId,

--- a/src/modules/dashboard/data/commands/schemas.js
+++ b/src/modules/dashboard/data/commands/schemas.js
@@ -68,7 +68,6 @@ export const PostCommentCommandArgsSchema = yup.object({
         .string()
         .address()
         .required(),
-      timestamp: yup.date().default(() => Date.now()),
       body: yup.string().required(),
       metadata: yup.object({
         /*

--- a/src/modules/dashboard/data/commands/task.js
+++ b/src/modules/dashboard/data/commands/task.js
@@ -3,7 +3,7 @@
 import nanoid from 'nanoid';
 
 import type { Address, ENSName, OrbitDBAddress } from '~types';
-import type { FeedStore, EventStore } from '~lib/database/stores';
+import type { EventStore } from '~lib/database/stores';
 import type { TaskDraftId } from '~immutable';
 import type {
   ColonyClientContext,
@@ -85,7 +85,7 @@ export const createTask: Command<
   |},
   {|
     colonyStore: EventStore,
-    commentsStore: FeedStore,
+    commentsStore: EventStore,
     draftId: string,
     taskStore: EventStore,
   |},
@@ -227,18 +227,17 @@ export const postComment: CommentCommand<
       id: string,
       author: Address,
       body: string,
-      timestamp: number,
       metadata?: {|
         mentions: string[],
       |},
     |},
   |},
-  FeedStore,
+  EventStore,
 > = ({ ddb, metadata }) => ({
   schema: PostCommentCommandArgsSchema,
   async execute(args) {
     const commentStore = await getCommentsStore(ddb)(metadata);
-    await commentStore.add(createCommentPostedEvent(args));
+    await commentStore.append(createCommentPostedEvent(args));
     return commentStore;
   },
 });

--- a/src/modules/dashboard/data/queries/comments.js
+++ b/src/modules/dashboard/data/queries/comments.js
@@ -2,12 +2,7 @@
 
 import type { OrbitDBAddress } from '~types';
 
-import type {
-  ContextWithMetadata,
-  DDBContext,
-  Event,
-  Query,
-} from '~data/types';
+import type { ContextWithMetadata, DDBContext, Query } from '~data/types';
 
 import { getCommentsStore } from '~data/stores';
 import { TASK_EVENT_TYPES } from '~data/constants';
@@ -23,6 +18,7 @@ export type CommentQueryContext = ContextWithMetadata<
 
 export type CommentQuery<I: *, R: *> = Query<CommentQueryContext, I, R>;
 
+// TODO in #580 replace with fetching feed items
 // eslint-disable-next-line import/prefer-default-export
 export const getTaskComments: CommentQuery<*, *> = ({
   ddb,
@@ -32,9 +28,6 @@ export const getTaskComments: CommentQuery<*, *> = ({
     const commentsStore = await getCommentsStore(ddb)({
       commentsStoreAddress,
     });
-    return commentsStore
-      .all()
-      .filter(({ type }) => type === COMMENT_POSTED)
-      .map(({ payload }: Event<typeof COMMENT_POSTED>) => payload);
+    return commentsStore.all().filter(({ type }) => type === COMMENT_POSTED);
   },
 });

--- a/src/modules/dashboard/sagas/task.js
+++ b/src/modules/dashboard/sagas/task.js
@@ -552,6 +552,7 @@ function* taskWorkerUnassign({
   }
 }
 
+// TODO in #580 replace with fetching feed items
 function* taskFetchComments({
   payload: { colonyENSName, draftId },
   meta,

--- a/src/redux/types/actions/task.js
+++ b/src/redux/types/actions/task.js
@@ -10,7 +10,6 @@ import type {
   ErrorActionType,
   UniqueActionType,
 } from '~redux';
-import type { Event } from '../../../data/types';
 
 import { ACTIONS } from '~redux';
 
@@ -110,7 +109,7 @@ export type TaskActionTypes = {|
   >,
   TASK_FETCH_COMMENTS_SUCCESS: NonUniqueTaskActionType<
     typeof ACTIONS.TASK_FETCH_COMMENTS_SUCCESS,
-    {| comments: $ElementType<Event<'COMMENT_POSTED'>, 'payload'>[] |}, // todo use constant
+    {| comments: Object[] |}, // TODO in #580 replace with fetching feed items
   >,
   TASK_FINALIZE: TaskActionType<
     typeof ACTIONS.TASK_FINALIZE,


### PR DESCRIPTION
## Description

This PR converts the task comments store to an `EventStore`; this will make it much simpler to combine task comments and events (e.g. task title set) into a single task feed (see #580 ).

* Convert comments stores from `FeedStore` to `EventStore`
* Remove redundant `timestamp` from comment event payload (this exists in every `EventStore` event in `event.meta.timestamp`)
* Remove event payload mapping for `getTaskComments` query (since we want `event.meta`)
* Add TODOs for #580

Contributes to #580 
