### PR TITLE
Update remote provider to use new Infura endpoint

### DIFF
--- a/src/modules/core/sagas/utils/getProvider.js
+++ b/src/modules/core/sagas/utils/getProvider.js
@@ -15,7 +15,7 @@ export function* getProvider(network: string = defaultNetwork): Saga<any> {
     return yield create(providers.JsonRpcProvider);
   }
 
-  // TODO: Use InfuraProvider instead of JsonRpcProvider and the following
+  // @todo: Use InfuraProvider instead of JsonRpcProvider and the following
   // switch statement once we have upgraded to ethers v4.
 
   let host;


### PR DESCRIPTION
## Description

This pull request replaces `getDefaultProvider` with `JsonRpcProvider` when connecting to a remote network in order to specify the new Infura endpoint based on recent [Infura Updates](https://blog.infura.io/infura-dashboard-transition-update-c670945a922a).

We are currently using [ethers 3.0](https://docs.ethers.io/ethers.js/v3.0/html/api-providers.html), which does not support the latest Infura endpoint, so we need to use `JsonRpcProvider` (`InfuraProvider` inherits from `JsonRpcProvider`) until we upgrade to ethers 4.0.

`INFURA_PROJECT_ID` will need to be added as an environment variable for use in production but a default project id has been provided if the environment variable is missing.

Closes #998
