### PR TITLE
Add missing `keyPath` to `TOKEN_INFO_FETCH` action

### DIFF
--- a/src/modules/dashboard/actionCreators/token.js
+++ b/src/modules/dashboard/actionCreators/token.js
@@ -1,11 +1,17 @@
 /* @flow */
 
+import nanoid from 'nanoid';
+
 import type { Address } from '~types';
+import type { Action } from '~redux';
 
 import { ACTIONS } from '~redux';
 
 // eslint-disable-next-line import/prefer-default-export
-export const fetchToken = (tokenAddress: Address) => ({
+export const fetchToken = (
+  tokenAddress: Address,
+): Action<typeof ACTIONS.TOKEN_INFO_FETCH> => ({
   type: ACTIONS.TOKEN_INFO_FETCH,
   payload: { tokenAddress },
+  meta: { id: nanoid(), keyPath: [tokenAddress] },
 });

--- a/src/modules/dashboard/sagas/colony.js
+++ b/src/modules/dashboard/sagas/colony.js
@@ -13,7 +13,6 @@ import {
   select,
 } from 'redux-saga/effects';
 import { replace } from 'connected-react-router';
-import nanoid from 'nanoid';
 
 import type { Action } from '~redux';
 
@@ -50,7 +49,7 @@ import { networkVersionSelector } from '../../core/selectors';
 
 import { subscribeToColony } from '../../users/actionCreators';
 
-import { fetchColony } from '../actionCreators';
+import { fetchColony, fetchToken } from '../actionCreators';
 import { colonyAvatarHashSelector } from '../selectors';
 
 import { getColonyContext } from './shared';
@@ -379,11 +378,7 @@ function* colonyFetch({
       Object.keys(tokens).reduce(
         (effects, tokenAddress) => [
           ...effects,
-          put<Action<typeof ACTIONS.TOKEN_INFO_FETCH>>({
-            type: ACTIONS.TOKEN_INFO_FETCH,
-            meta: { id: nanoid() },
-            payload: { tokenAddress },
-          }),
+          put(fetchToken(tokenAddress)),
           put<Action<typeof ACTIONS.COLONY_TOKEN_BALANCE_FETCH>>({
             type: ACTIONS.COLONY_TOKEN_BALANCE_FETCH,
             meta: { keyPath: [colonyName, tokenAddress] },

--- a/src/redux/types/actions/token.js
+++ b/src/redux/types/actions/token.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import type { Action, ErrorActionType, UniqueActionType } from '../index';
+import type { WithKeyPathDepth1 } from '~types';
 
 import { ACTIONS } from '../../index';
 
@@ -20,11 +21,11 @@ export type TokenActionTypes = {|
     {|
       tokenAddress: string,
     |},
-    void,
+    WithKeyPathDepth1,
   >,
   TOKEN_INFO_FETCH_ERROR: ErrorActionType<
     typeof ACTIONS.TOKEN_INFO_FETCH_ERROR,
-    void,
+    WithKeyPathDepth1,
   >,
   TOKEN_INFO_FETCH_SUCCESS: UniqueActionType<
     typeof ACTIONS.TOKEN_INFO_FETCH_SUCCESS,
@@ -34,6 +35,6 @@ export type TokenActionTypes = {|
       symbol: string,
       tokenAddress: string,
     |},
-    void,
+    WithKeyPathDepth1,
   >,
 |};


### PR DESCRIPTION
## Description

This PR fixes a bug on master when creating a colony.

* Add the missing `keyPath` (token address) to `TOKEN_INFO_FETCH` actions
* Use the `fetchToken` action creator
