### PR TITLE
Supply the correct user when checking permissions in access controllers

### DIFF
--- a/src/lib/database/accessControllers/ColonyAccessController.js
+++ b/src/lib/database/accessControllers/ColonyAccessController.js
@@ -41,7 +41,10 @@ class ColonyAccessController extends AbstractAccessController<
   }
 
   async save() {
-    const isAllowed = await this.can('is-colony-founder');
+    const isAllowed = await this.can(
+      'is-colony-founder',
+      this._purserWallet.address,
+    );
     if (!isAllowed)
       throw new Error('Cannot create colony database, user not allowed');
 
@@ -69,17 +72,19 @@ class ColonyAccessController extends AbstractAccessController<
     // Is the wallet signature valid?
     const {
       payload: { value: event },
+      identity: { id: user },
     } = entry;
-    return this.can(event.type, event);
+    return this.can(event.type, user, event);
   }
 
   async can<Context: {}>(
     actionId: string,
+    user: string,
     context: ?Context,
   ): Promise<boolean> {
     return this._manager.can(
-      this._purserWallet.address,
       actionId,
+      user,
       this._extendVerifyContext<Context>(context),
     );
   }

--- a/src/lib/database/accessControllers/PermissionManager.js
+++ b/src/lib/database/accessControllers/PermissionManager.js
@@ -46,8 +46,8 @@ export default class PermissionManager {
   }
 
   async can<Context: Object>(
-    user: string,
     actionId: ActionId,
+    user: string,
     context?: Context,
   ) {
     if (!(this._permissions && Object.keys(this._permissions).length))

--- a/src/lib/database/accessControllers/TaskAccessController.js
+++ b/src/lib/database/accessControllers/TaskAccessController.js
@@ -45,9 +45,12 @@ class TaskAccessController extends AbstractAccessController<
   }
 
   async save() {
-    const isAllowed = await this.can('is-colony-founder-or-admin');
+    const isAllowed = await this.can(
+      'is-colony-founder-or-admin',
+      this._purserWallet.address,
+    );
     if (!isAllowed)
-      throw new Error('Cannot create colony database, user not allowed');
+      throw new Error('Cannot create task database, user not allowed');
 
     const signingWalletAddress = this._purserWallet.address;
     const signature = await this._purserWallet.signMessage({
@@ -73,17 +76,19 @@ class TaskAccessController extends AbstractAccessController<
     // Is the wallet signature valid?
     const {
       payload: { value: event },
+      identity: { id: user },
     } = entry;
-    return this.can(event.type, event);
+    return this.can(event.type, user, event);
   }
 
   async can<Context: {}>(
     actionId: string,
+    user: string,
     context: ?Context,
   ): Promise<boolean> {
     return this._manager.can(
-      this._purserWallet.address,
       actionId,
+      user,
       this._extendVerifyContext<Context>(context),
     );
   }


### PR DESCRIPTION
## Description

This PR fixes a bug (uncovered by #1074 ) involving a colony created by one user not being loaded by another user; this was due to us checking the wrong user in the access controllers (in some cases).

**Changes** 🏗

* Adjust `can()` and `canAppend()` in access controllers such that we supply the correct user when checking; either the current wallet address, or if there is an entry, the address given in the 'identity' of the entry.
* Ensure that the arguments in all `can` methods are the same across access controllers.
