### PR TITLE
Disable link to user in the `UserInfo` tooltip

### DIFF
--- a/src/modules/core/components/UserInfo/UserInfo.jsx
+++ b/src/modules/core/components/UserInfo/UserInfo.jsx
@@ -29,7 +29,7 @@ const renderTooltipContent = (user?: UserType) => {
   return (
     <div className={styles.main}>
       {displayName && <p className={styles.displayName}>{displayName}</p>}
-      {username && <UserMention username={username} />}
+      {username && <UserMention username={username} hasLink={false} />}
       {walletAddress && (
         <p className={styles.walletAddress}>
           <MaskedAddress address={walletAddress} />


### PR DESCRIPTION
## Description
This PR fixes links to usernames that appear in the `UserInfo` tooltip component, since they can't be clicked, and they cause a DOM validation error by nesting an `<a>` tag under another.

**Changes**
* `UserInfo` now passes the `hasLink={false}` prop to the `UserMention` component

Resolves #1080 
