### PR TITLE
Fix EthersWrappedWallet to wait for unsent transactions

### DIFF
--- a/src/modules/core/sagas/transactions/transactionChannel.js
+++ b/src/modules/core/sagas/transactions/transactionChannel.js
@@ -3,8 +3,6 @@
 import type { ContractResponse } from '@colony/colony-js-client';
 import { END, eventChannel } from 'redux-saga';
 
-import { log } from '~utils/debug';
-
 import type {
   TransactionRecordType,
   TransactionParams,
@@ -35,9 +33,7 @@ const channelGetTransactionReceipt = async ({ id, params }, sentTx, emit) => {
   } = sentTx;
   if (receiptPromise) {
     try {
-      log.debug('#1071 / before receipt promise');
       const receipt = await receiptPromise;
-      log.debug('#1071 / after receipt promise');
       emit(transactionReceiptReceived(id, { receipt, params }));
       return receipt;
     } catch (caughtError) {


### PR DESCRIPTION
## Description

Transactions would sometimes stall and never return a receipt. This was caused by sometimes submitting a transaction to the connected node and calling `getTransaction` before the node had processed the transaction.

**Changes** 🏗

* Adjust `EthersWrappedWallet.sendTransaction` such that it waits for transactions to send properly
* Correctly set the `gasLimit` of transactions in `EthersWrappedWallet`

Resolves #1071 
