### PR TITLE
Restrict 30s `sendTransaction` timeout to dev mode

### DIFF
--- a/src/modules/core/sagas/transactions/sendTransaction.js
+++ b/src/modules/core/sagas/transactions/sendTransaction.js
@@ -5,6 +5,7 @@ import type { ContractResponse } from '@colony/colony-js-client';
 import { call, put, take } from 'redux-saga/effects';
 
 import { ACTIONS } from '~redux';
+import { isDev } from '~utils/debug';
 import { selectAsJS } from '~utils/saga/effects';
 import type {
   TransactionRecordType,
@@ -51,8 +52,10 @@ async function getMethodTransactionPromise<
       gasPrice: gasPriceOverride || gasPrice,
     },
     restOptions,
-    // DEBUG-#1071 to have the timeout rather sooner than later. Remove this!
-    { timeoutMs: 30 * 1000 },
+    /*
+     * Use a 30s timeout for dev mode only
+     */
+    isDev ? { timeoutMs: 30 * 1000 } : {},
     { waitForMining: false },
   );
   if (method.restoreOperation && multisig) {


### PR DESCRIPTION
## Description

This makes some initial #1071 mitigation (that we missed) dev-mode only; unless Ganache is configured with some non-standard block time, this should be fine.

**Changes** 🏗

* Restrict 30s `sendTransaction` timeout to dev mode
