### PR TITLE
Fix setting task description

### DIFF
--- a/src/modules/dashboard/components/TaskDescription/TaskDescription.jsx
+++ b/src/modules/dashboard/components/TaskDescription/TaskDescription.jsx
@@ -39,6 +39,7 @@ const TaskDescription = ({
       })),
       mergePayload({ colonyAddress, draftId }),
     ),
+    [colonyAddress, draftId],
   );
   return (
     <ActionForm
@@ -57,7 +58,12 @@ const TaskDescription = ({
           name="description"
           placeholder={MSG.placeholder}
           readOnly={!isTaskCreator}
-          onEditorBlur={() => submitForm()}
+          onEditorBlur={() => {
+            /*
+             * Defer the form submission to let formik finish first.
+             */
+            setTimeout(submitForm, 0);
+          }}
         />
       )}
     </ActionForm>


### PR DESCRIPTION
## Description

I suspect that the recent formik update to `1.5.2` broke the task description form, which submits the form on blur. Solution: defer the call to submit the form until formik finishes doing something or other (that it didn't do before).

**Changes** 🏗

* Ensure that the `transform` function for the task description `ActionForm` has the correct inputs for `useCallback`
* Defer the task description form submission to let formik finish first.
