### PR TITLE
Check for newest transactions

### DIFF
--- a/src/modules/dashboard/components/CreateColonyWizard/StepConfirmTransactions.jsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepConfirmTransactions.jsx
@@ -18,6 +18,7 @@ import {
   getGroupStatus,
   findTransactionGroupByKey,
   getGroupKey,
+  findNewestGroup,
 } from '../../../users/components/GasStation/transactionGroup';
 
 const MSG = defineMessages({
@@ -72,9 +73,10 @@ const displayName = 'dashboard.CreateColonyWizard.StepConfirmTransactions';
 
 const StepConfirmTransactions = ({ wizardValues: { colonyName } }: Props) => {
   const transactionGroups = useSelector(groupedTransactions);
+  const newestGroup = findNewestGroup(transactionGroups);
   if (
-    getGroupStatus(transactionGroups[0]) === 'succeeded' &&
-    getGroupKey(transactionGroups[0]) === 'group.transaction.batch.createColony'
+    getGroupStatus(newestGroup) === 'succeeded' &&
+    getGroupKey(newestGroup) === 'group.transaction.batch.createColony'
   ) {
     return <Redirect to={`/colony/${colonyName}`} />;
   }

--- a/src/modules/users/components/GasStation/transactionGroup.js
+++ b/src/modules/users/components/GasStation/transactionGroup.js
@@ -21,6 +21,13 @@ export const findTransactionGroupByKey = (
   key: string,
 ) => txGroups.find(transactionGroup => getGroupKey(transactionGroup) === key);
 
+// Since we are not currently delete old transactions we sometimes need to check
+// for the newest one
+export const findNewestGroup = (txGroups: TransactionGroups) => {
+  txGroups.sort((a, b) => new Date(b[0].createdAt) - new Date(a[0].createdAt));
+  return txGroups[0];
+};
+
 // Get the index of the first transaction in a group that is ready to sign
 export const getActiveTransactionIdx = (txGroup: TransactionGroup) => {
   // Select the pending selection so that the user can't sign the next one


### PR DESCRIPTION
## Description

This is just a mini tini bug. When checking if all transactions within a transactionGroup have succeeded, we have to make sure we are checking the newest one, because we currently don't delete older transactions. After this change I was able to create two colonies and got redirected successfully.

Closes #1184
