### PR TITLE
Use dApp version of ganache-cli@6.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
         "extfs": "^0.0.7",
         "file-loader": "^2.0.0",
         "flow-bin": "^0.84.0",
+        "ganache-cli": "6.4.1",
         "gh-pages": "^2.0.0",
         "html-webpack-plugin": "^3.2.0",
         "http-proxy": "^1.17.0",

--- a/scripts/start_ganache.js
+++ b/scripts/start_ganache.js
@@ -3,15 +3,36 @@
 const path = require('path');
 const waitOn = require('wait-on');
 const { spawn } = require('child_process');
-const { NETWORK_ROOT } = require('./paths');
+const { ROOT_PATH } = require('./paths');
 
 let stdio;
 
 const startGanache = async () => {
-  const process = spawn('yarn', ['start:blockchain:client'], {
-    stdio,
-    cwd: NETWORK_ROOT,
-  });
+  const process = spawn(
+    'yarn',
+    [
+      'ganache-cli',
+      '--acctKeys', './src/lib/colonyNetwork/ganache-accounts.json',
+      '--noVMErrorsOnRPCResponse',
+      '--gasLimit', '6721975',
+      '--account', '0x0355596cdb5e5242ad082c4fe3f8bbe48c9dba843fe1f99dd8272f487e70efae,100000000000000000000',
+      '--account', '0xe9aebe8791ad1ebd33211687e9c53f13fe8cca53b271a6529c7d7ba05eda5ce2,100000000000000000000',
+      '--account', '0x6f36842c663f5afc0ef3ac986ec62af9d09caa1bbf59a50cdb7334c9cc880e65,100000000000000000000',
+      '--account', '0xf184b7741073fc5983df87815e66425928fa5da317ef18ef23456241019bd9c7,100000000000000000000',
+      '--account', '0x7770023bfebe3c8e832b98d6c0874f75580730baba76d7ec05f2780444cc7ed3,100000000000000000000',
+      '--account', '0xa9442c0092fe38933fcf2319d5cf9fd58e3be5409a26e2045929f9d2a16fb090,100000000000000000000',
+      '--account', '0x06af2c8000ab1b096f2ee31539b1e8f3783236eba5284808c2b17cfb49f0f538,100000000000000000000',
+      '--account', '0x7edaec9e5f8088a10b74c1d86108ce879dccded88fa9d4a5e617353d2a88e629,100000000000000000000',
+      '--account', '0xe31c452e0631f67a629e88790d3119ea9505fae758b54976d2bf12bd8300ef4a,100000000000000000000',
+      '--account', '0x5e383d2f98ac821c555333e5bb6109ca41ae89d613cb84887a2bdb933623c4e3,100000000000000000000',
+      '--account', '0x33d2f6f6cc410c1d46d58f17efdd2b53a71527b27eaa7f2edcade351feb87425,100000000000000000000',
+      '--account', '0x32400a48ff16119c134eef44e2627502ce6e367bc4810be07642275a9db47bf7,100000000000000000000',
+    ],
+    {
+      stdio,
+      cwd: ROOT_PATH,
+    },
+  );
   await waitOn({ resources: ['tcp:8545'] });
   return process;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6891,6 +6891,15 @@ g-status@^2.0.2:
     matcher "^1.0.0"
     simple-git "^1.85.0"
 
+ganache-cli@6.4.1:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.4.1.tgz#77c1682883a544dcad160b0e8155e282aefb4f1f"
+  integrity sha512-MUZ1DNnmlTrXnH6EuINuew75AI9d/wbIC0WpZCJo5Endsf6ZwEvfnfxGMpEnVizRri1mon2WWxLGAmALDxVcRQ==
+  dependencies:
+    bn.js "4.11.8"
+    source-map-support "0.5.9"
+    yargs "11.1.0"
+
 gar@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/gar/-/gar-1.0.4.tgz#f777bc7db425c0572fdeb52676172ca1ae9888b8"
@@ -16948,7 +16957,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.6, source-map-support@^0.5.9:
+source-map-support@0.5.9, source-map-support@^0.5.6, source-map-support@^0.5.9:
   version "0.5.9"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
   integrity sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==
@@ -19853,6 +19862,24 @@ yargs-promise@^1.1.0:
   resolved "https://registry.yarnpkg.com/yargs-promise/-/yargs-promise-1.1.0.tgz#97ebb5198df734bb3b11745133ae5b501b16ab1f"
   integrity sha1-l+u1GY33NLs7EXRRM65bUBsWqx8=
 
+yargs@11.1.0, yargs@^11.0.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
+  integrity sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^9.0.2"
+
 yargs@12.0.2:
   version "12.0.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.2.tgz#fe58234369392af33ecbef53819171eff0f5aadc"
@@ -19870,24 +19897,6 @@ yargs@12.0.2:
     which-module "^2.0.0"
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^10.1.0"
-
-yargs@^11.0.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
-  integrity sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==
-  dependencies:
-    cliui "^4.0.0"
-    decamelize "^1.1.1"
-    find-up "^2.1.0"
-    get-caller-file "^1.0.1"
-    os-locale "^2.0.0"
-    require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
-    set-blocking "^2.0.0"
-    string-width "^2.0.0"
-    which-module "^2.0.0"
-    y18n "^3.2.1"
-    yargs-parser "^9.0.2"
 
 yargs@^12.0.2:
   version "12.0.5"


### PR DESCRIPTION
## Description

The version being used from the colonyNetwork submodule was crashing when estimating a createColony transaction. This is a bug with ganache (we're pretty sure).
