### PR TITLE
Add TokenAuthority deployment to create Colony txs

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -59,6 +59,8 @@
     "transaction.network.createToken.title": "Create Token",
     "transaction.network.createColony.title": "Create Colony",
     "transaction.colony.registerColonyLabel.title": "Create Colony Name",
+    "transaction.token.createTokenAuthority.title": "Deploy Token Authority",
+    "transaction.token.setAuthority.title": "Set Token Authority",
     "transaction.colony.addExtension.title": "Add {contractName} Extension to Colony",
     "transaction.colony.setRootRole.setOneTxRole.title": "Give Permission to OneTxPayment Extension",
     "transaction.colony.setRootRole.setOldRolesRole.title": "Give Permission to OldRoles Extension",

--- a/src/lib/ColonyManager/constants.js
+++ b/src/lib/ColonyManager/constants.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+export const COLONY_CONTEXT: 'colony' = 'colony';
+
 export const NETWORK_CONTEXT: 'network' = 'network';
 
-export const COLONY_CONTEXT: 'colony' = 'colony';
+export const TOKEN_CONTEXT: 'token' = 'token';

--- a/src/lib/ColonyManager/types.js
+++ b/src/lib/ColonyManager/types.js
@@ -1,8 +1,11 @@
 /* @flow */
 
-import { COLONY_CONTEXT, NETWORK_CONTEXT } from './constants';
+import { COLONY_CONTEXT, NETWORK_CONTEXT, TOKEN_CONTEXT } from './constants';
 
-export type ColonyContext = typeof COLONY_CONTEXT | typeof NETWORK_CONTEXT;
+export type ColonyContext =
+  | typeof COLONY_CONTEXT
+  | typeof NETWORK_CONTEXT
+  | typeof TOKEN_CONTEXT;
 
 export type ENSName = string;
 

--- a/src/modules/core/constants.js
+++ b/src/modules/core/constants.js
@@ -12,4 +12,5 @@ export const CORE_IPFS_DATA = 'ipfsData';
 export {
   COLONY_CONTEXT,
   NETWORK_CONTEXT,
+  TOKEN_CONTEXT,
 } from '../../lib/ColonyManager/constants';


### PR DESCRIPTION
## Description

This `TokenAuthority` contract is used to determine who may control the Colony's newly deployed token. It must first be deployed, and then set as the authority for the token with `setToken`.

**New stuff** ✨

* Added `TokenAuthority` deploy and `setAuthority` transactions to the create Colony saga
* Added i18n messages for the new transactions

**Changes** 🏗

* Added a `TOKEN_CONTEXT` to the `ColonyManager`, and ability to have more contexts in the future

Resolves #1248 
