### PR TITLE
Use correct decimals for displaying token amounts

### DIFF
--- a/src/modules/admin/components/Tokens/TokenCard.jsx
+++ b/src/modules/admin/components/Tokens/TokenCard.jsx
@@ -58,14 +58,14 @@ const TokenCard = ({
         }
       >
         <Numeral
-          value={balance || 0}
-          decimals={2}
           integerSeparator=""
-          unit="ether"
+          truncate={2}
+          unit={token.decimals || 18}
+          value={balance || 0}
         />
       </div>
       <div className={styles.cardFooter}>
-        {tokenIsETH(token) && <EthUsd value={balance || 0} decimals={3} />}
+        {tokenIsETH(token) && <EthUsd value={balance || 0} truncate={3} />}
       </div>
     </Card>
   ) : (

--- a/src/modules/admin/components/Tokens/TokenMintDialog.jsx
+++ b/src/modules/admin/components/Tokens/TokenMintDialog.jsx
@@ -85,7 +85,7 @@ const TokenMintDialog = ({
 }: Props) => {
   const transform = useCallback(
     pipe(
-      mapPayload(({ amount: inputAmount }) => ({
+      mapPayload(({ mintAmount: inputAmount }) => ({
         // shift by the token's decimals (or default of 18)
         amount: new BigNumber(
           moveDecimal(inputAmount, decimals ? parseInt(decimals, 10) : 18),

--- a/src/modules/core/components/EthUsd/EthUsd.jsx
+++ b/src/modules/core/components/EthUsd/EthUsd.jsx
@@ -25,12 +25,12 @@ type Appearance = {
 type Props = {|
   /** Appearance object for numeral */
   appearance?: Appearance,
-  /** Number of decimals to show */
-  decimals: number,
   /** Should the prefix be visible? */
   showPrefix: boolean,
   /** Should the suffix be visible? */
   showSuffix: boolean,
+  /** Number of decimals to show */
+  truncate: number,
   /** Ether unit the number is notated in (e.g. 'ether' = 10^18 wei) */
   unit?: string,
   /** Value in ether to convert to USD */
@@ -47,9 +47,9 @@ class EthUsd extends Component<Props, State> {
   static displayName = 'EthUsd';
 
   static defaultProps = {
-    decimals: 2,
     showPrefix: true,
     showSuffix: true,
+    truncate: 2,
     unit: 'ether',
   };
 
@@ -97,10 +97,10 @@ class EthUsd extends Component<Props, State> {
     const { valueUsd } = this.state;
     const {
       appearance,
-      decimals,
       intl: { formatMessage },
       showPrefix,
       showSuffix,
+      truncate,
       unit,
       value,
       ...rest
@@ -109,9 +109,9 @@ class EthUsd extends Component<Props, State> {
     return valueUsd || valueUsd === 0 ? (
       <Numeral
         appearance={appearance}
-        decimals={decimals}
         prefix={showPrefix ? '~ ' : ''}
         suffix={showSuffix ? ` ${suffixText}` : ''}
+        truncate={truncate}
         value={valueUsd}
         {...rest}
       />

--- a/src/modules/core/components/Numeral/Numeral.jsx
+++ b/src/modules/core/components/Numeral/Numeral.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import BN from 'bn.js';
 import formatNumber from 'format-number';
 import { fromWei } from 'ethjs-unit';
+import moveDecimal from 'move-decimal-point';
 
 import { getMainClasses } from '~utils/css';
 
@@ -19,37 +20,37 @@ type Props = {|
   appearance?: Appearance,
   /** Optional custom className, will overwrite appearance */
   className?: string,
-  /** Number of decimals to show after comma */
-  decimals?: number,
+  /** Separator for thousands (e.g. ',') */
+  integerSeparator?: string,
   /** Prefix the value with this string */
   prefix?: string,
   /** Suffix the value with this string */
   suffix?: string,
-  /** Ether unit the number is notated in (e.g. 'ether' = 10^18 wei) */
-  unit?: string,
+  /** Number of decimals to show after comma */
+  truncate?: number,
+  /** Number of decimals to format the number with, or unit from which to determine this (ether, gwei, etc.) */
+  unit?: number | string,
   /** Actual value */
   value: number | string | BN,
-  /** Separator for thousands (e.g. ',') */
-  integerSeparator?: string,
 |};
 
 const Numeral = ({
   appearance,
   className,
-  decimals: truncate,
   integerSeparator = ',',
   prefix,
   suffix,
+  truncate,
   unit,
   value,
   ...props
 }: Props) => {
-  let convertedNum;
-  if (BN.isBN(value)) {
-    convertedNum = unit ? fromWei(value, unit) : value.toString();
-  } else {
-    convertedNum = unit ? fromWei(value.toString(), unit) : value;
-  }
+  const convertedNum =
+    typeof unit === 'string'
+      ? // $FlowFixMe it's okay to pass radix regardless of type
+        fromWei(value.toString(10), unit)
+      : // $FlowFixMe same here
+        moveDecimal(value.toString(10), -(unit || 0));
 
   const formattedNumber = formatNumber({
     prefix,

--- a/src/modules/core/components/PayoutsList/PayoutsList.jsx
+++ b/src/modules/core/components/PayoutsList/PayoutsList.jsx
@@ -60,7 +60,7 @@ const PayoutsList = ({ payouts, maxLines = 1, nativeToken }: Props) => {
             key={payout.token.symbol}
             value={payout.amount}
             unit="ether"
-            decimals={1}
+            truncate={1}
             prefix={`${payout.token.symbol} `}
           />
         ))}
@@ -77,7 +77,7 @@ const PayoutsList = ({ payouts, maxLines = 1, nativeToken }: Props) => {
                   key={payout.token.symbol}
                   value={payout.amount}
                   unit="ether"
-                  decimals={1}
+                  truncate={1}
                   prefix={`${payout.token.symbol} `}
                 />
               ))}

--- a/src/modules/core/components/TransactionList/TransactionListItem.jsx
+++ b/src/modules/core/components/TransactionList/TransactionListItem.jsx
@@ -150,7 +150,7 @@ const TransactionListItem = ({
         <Numeral
           value={amount}
           unit="ether"
-          decimals={1}
+          truncate={1}
           /**
            * @todo : what should we show when we don't recognise the token?
            */

--- a/src/modules/dashboard/components/TaskFeed/TaskFeedCompleteInfo.jsx
+++ b/src/modules/dashboard/components/TaskFeed/TaskFeedCompleteInfo.jsx
@@ -122,8 +122,8 @@ const TaskFeedCompleteInfo = ({
                 values={{
                   amount: (
                     <Numeral
-                      decimals={decimals}
-                      unit="ether"
+                      truncate={2}
+                      unit={decimals}
                       value={getTaskPayoutAmountMinusNetworkFee(
                         amount,
                         networkFee,
@@ -139,8 +139,8 @@ const TaskFeedCompleteInfo = ({
                 values={{
                   amount: (
                     <Numeral
-                      decimals={decimals}
-                      unit="ether"
+                      truncate={2}
+                      unit={decimals}
                       value={getTaskPayoutNetworkFee(amount, networkFee)}
                     />
                   ),

--- a/src/modules/dashboard/reducers/allTokens.js
+++ b/src/modules/dashboard/reducers/allTokens.js
@@ -31,9 +31,10 @@ const tokensReducer: ReducerType<
 > = (state = INITIAL_STATE, action) => {
   switch (action.type) {
     case ACTIONS.TOKEN_INFO_FETCH_SUCCESS: {
-      const { name, symbol, tokenAddress } = action.payload;
+      const { name, symbol, decimals, tokenAddress } = action.payload;
       const record = TokenRecord({
         address: tokenAddress,
+        decimals,
         name,
         symbol,
       });

--- a/src/modules/pages/components/WizardTemplateColony/WizardTemplateColony.jsx
+++ b/src/modules/pages/components/WizardTemplateColony/WizardTemplateColony.jsx
@@ -69,19 +69,19 @@ const WizardTemplateColony = ({
               {new BN(balance).isZero() ? (
                 <div className={styles.noMoney}>
                   <Numeral
-                    decimals={0}
-                    value={ethBalance}
                     suffix=" ETH"
+                    truncate={0}
                     unit="ether"
+                    value={ethBalance}
                   />
                 </div>
               ) : (
                 <div className={styles.yeihMoney}>
                   <Numeral
-                    decimals={2}
-                    value={ethBalance}
                     suffix=" ETH"
+                    truncate={2}
                     unit="ether"
+                    value={ethBalance}
                   />
                 </div>
               )}

--- a/src/modules/users/components/GasStation/GasStationPrice/GasStationPrice.jsx
+++ b/src/modules/users/components/GasStation/GasStationPrice/GasStationPrice.jsx
@@ -270,17 +270,17 @@ class GasStationPrice extends Component<Props, State> {
                       {transactionFee ? (
                         <Fragment>
                           <Numeral
-                            decimals={6}
-                            value={transactionFee}
                             suffix=" ETH"
+                            truncate={6}
                             unit="ether"
+                            value={transactionFee}
                           />
                           <div className={styles.transactionFeeEthUsd}>
                             <EthUsd
                               appearance={{ size: 'small', theme: 'grey' }}
-                              decimals={3}
-                              value={transactionFee}
+                              truncate={3}
                               unit="ether"
+                              value={transactionFee}
                             />
                           </div>
                         </Fragment>


### PR DESCRIPTION
## Description

Tokens specify how many decimals should be used when displaying amounts, and in this PR we now take notice of this number of decimals.

**Changes** 🏗

* Fix typo in TokenMintDialog causing an incorrect amount of tokens to be minted
* Change allTokens reducer to include the token decimals
* Refactor Numeral component to rename decimals to truncate, and allow a number for the unit prop, thus allowing arbitrary number of decimal places to be displayed
* Changed TokenCard component to pass the token's decimals to the Numeral component as the unit

Resolves #1016 
