### PR TITLE
Fix "canFinalizeTask" check for draft release

### DIFF
--- a/src/modules/dashboard/checks.js
+++ b/src/modules/dashboard/checks.js
@@ -116,9 +116,5 @@ export const canRequestToWork = (task: TaskType, userAddress: Address) =>
     hasRequestedToWork(task, userAddress)
   );
 
-/**
- * @todo Fix `canFinalizeTask` check.
- * @body Use a task property indicating that work has been submitted
- */
 export const canFinalizeTask = (task: TaskType, userAddress: Address) =>
   isManager(task, userAddress) && isActive(task);

--- a/src/modules/dashboard/data/commands/task.js
+++ b/src/modules/dashboard/data/commands/task.js
@@ -86,7 +86,6 @@ const prepareTaskStoreCommand = async (
   });
 };
 
-// This is not a TaskCommand because we don't yet have a taskStoreAddress
 export const createTask: Command<
   {|
     colonyStore: ColonyStore,

--- a/src/modules/dashboard/data/reducers/task.js
+++ b/src/modules/dashboard/data/reducers/task.js
@@ -60,6 +60,7 @@ export const taskReducer: EventReducer<
         ...task,
         createdAt: new Date(timestamp),
         creatorAddress,
+        managerAddress: creatorAddress, // @NOTE: At least for the draft version, the creator will also be the manager
         draftId,
       };
     }


### PR DESCRIPTION
## Description

This PR changes the task query reducer to assign the task creator as the manager as well since that's what we'll have for the draft/final colony contribute release

**Changes** 🏗
- Assign task creator as manager as well

Resolves #1142
