### PR TITLE
Fix colony create wizard transform memoization

### DIFF
--- a/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.jsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.jsx
@@ -122,10 +122,21 @@ const StepCreateToken = ({
     },
     [wizardValues, nextStep, previousStep],
   );
+  const handleSubmit = useCallback(
+    ({ tokenIcon, ...values }) =>
+      nextStep({
+        ...values,
+        tokenIcon:
+          tokenIcon && tokenIcon.length
+            ? tokenIcon[0].uploaded.ipfsHash
+            : undefined,
+      }),
+    [nextStep],
+  );
 
   return (
     <Form
-      onSubmit={nextStep}
+      onSubmit={handleSubmit}
       validationSchema={validationSchema}
       {...wizardForm}
     >

--- a/src/modules/dashboard/sagas/colony.js
+++ b/src/modules/dashboard/sagas/colony.js
@@ -323,7 +323,7 @@ function* colonyCreate({
         displayName,
         token: {
           address: tokenAddress,
-          iconHash: tokenIcon ? tokenIcon[0].uploaded.ipfsHash : undefined,
+          iconHash: tokenIcon,
           isNative: true,
           name: tokenName,
           symbol: tokenSymbol,

--- a/src/redux/types/actions/colony.js
+++ b/src/redux/types/actions/colony.js
@@ -111,7 +111,7 @@ export type ColonyActionTypes = {|
       displayName: string,
       tokenName: string,
       tokenSymbol: string,
-      tokenIcon: {},
+      tokenIcon: string,
     |},
     void,
   >,


### PR DESCRIPTION
## Description

When setting the token icon, an object was passed to the next stage of the form. This was later recreated as another object, which caused memoized values to be recomputed. Since it was used in the `asyncFunction` transform memoization, this could cause the `asyncFunction` to be recomputed between submit and success actions, which would prevent the success action from correctly triggering the `onSuccess` function of the `ActionForm`.

**Note for reviewers:** do you understand why this has fixed it? There's still some confusion in my mind about exactly where the change of the values used to memoize the `transform` function happened, or why.

**Changes** 🏗

* `tokenIcon` in the colony creation wizard is now just the IPFS hash string of the uploaded icon
