### PR TITLE
Use actual transaction fee rather in TaskFeedCompleteInfo

### DIFF
--- a/src/modules/core/selectors/__tests__/transactions.test.js
+++ b/src/modules/core/selectors/__tests__/transactions.test.js
@@ -4,7 +4,11 @@ import { TransactionRecord } from '~immutable';
 
 import { CORE_NAMESPACE as ns } from '../../constants';
 
-import { groupedTransactions } from '../transactions';
+import {
+  groupedTransactions,
+  transactionByHash,
+  oneTransaction,
+} from '../transactions';
 
 jest.mock('../../../users/selectors', () => ({
   walletAddressSelector: () => '0xdeadbeef',
@@ -16,6 +20,7 @@ describe('Transaction selectors', () => {
     from: '0xdeadbeef',
     params: { taskId: 5 },
     identifier: 'coolony',
+    hash: '0x910ffad854fe8957f8ba2e581c891cdc8bacbcfdb1af3fc359c3ad1118175e26',
     group: {
       key: 'taskLifecycle',
       id: ['identifier', 'params.taskId'],
@@ -27,6 +32,7 @@ describe('Transaction selectors', () => {
     from: '0xdeadbeef',
     params: { taskId: 1 },
     identifier: 'othercolony',
+    hash: '0x910ffad854fe8957f8ba2e581c891cdc8bacbcfdb1af3fc359c3ad1118175e27',
     group: {
       key: 'taskLifecycle',
       id: 'taskLifecycle-1',
@@ -77,5 +83,44 @@ describe('Transaction selectors', () => {
       id: 'taskLifecycle-1',
       index: 1,
     });
+  });
+
+  test('transactionByHash selector', () => {
+    const state = fromJS({
+      [ns]: {
+        transactions: {
+          list: ImmutableMap({
+            tx1: TransactionRecord(tx1),
+            tx2: TransactionRecord(tx2),
+          }),
+        },
+      },
+    });
+    const found = transactionByHash(
+      state,
+      '0x910ffad854fe8957f8ba2e581c891cdc8bacbcfdb1af3fc359c3ad1118175e26',
+    );
+    const result = found.toJS();
+    expect(result.hash).toEqual(
+      '0x910ffad854fe8957f8ba2e581c891cdc8bacbcfdb1af3fc359c3ad1118175e26',
+    );
+  });
+
+  test('oneTransaction selector', () => {
+    const state = fromJS({
+      [ns]: {
+        transactions: {
+          list: ImmutableMap({
+            tx1: TransactionRecord(tx1),
+            tx2: TransactionRecord(tx2),
+          }),
+        },
+      },
+    });
+    const found = oneTransaction(state, 'tx2');
+
+    const result = found.toJS();
+    expect(result.from).toEqual('0xdeadbeef');
+    expect(result.identifier).toEqual('othercolony');
   });
 });

--- a/src/modules/core/selectors/transactions.js
+++ b/src/modules/core/selectors/transactions.js
@@ -40,6 +40,12 @@ export const allTransactions = createSelector(
     transactions.filter(tx => tx.from === walletAddress),
 );
 
+export const transactionByHash = (state: RootStateRecord, hash: string) =>
+  createSelector(
+    allTransactions,
+    transactions => transactions.find(tx => tx.hash === hash),
+  )(state);
+
 export const groupedTransactions = createSelector(
   allTransactions,
   transactions =>

--- a/src/modules/dashboard/components/TaskFeed/TaskFeed.jsx
+++ b/src/modules/dashboard/components/TaskFeed/TaskFeed.jsx
@@ -85,6 +85,7 @@ const TaskFeed = ({ colonyAddress, draftId }: Props) => {
                   if (rating) {
                     return <TaskFeedRating key={id} rating={rating} />;
                   }
+
                   return transaction ? (
                     <TaskFeedCompleteInfo key={id} transaction={transaction} />
                   ) : null;

--- a/src/modules/dashboard/components/TaskFeed/TaskFeedCompleteInfo.jsx
+++ b/src/modules/dashboard/components/TaskFeed/TaskFeedCompleteInfo.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { defineMessages, FormattedMessage, FormattedNumber } from 'react-intl';
 import BigNumber from 'bn.js';
 
-import type { TransactionRecordType, TokenType } from '~immutable';
+import type { ContractTransactionType, TokenType } from '~immutable';
 
 import Numeral from '~core/Numeral';
 import { SpinnerLoader } from '~core/Preloaders';
@@ -15,16 +15,17 @@ import { useReputationEarned } from '../../hooks/useReputationEarned';
 import { tokenFetcher } from '../../fetchers';
 import { taskSelector } from '../../selectors';
 import { friendlyUsernameSelector } from '../../../users/selectors';
+import { transactionByHash } from '../../../core/selectors';
 
 import styles from './TaskFeedCompleteInfo.css';
 
 const getTaskPayoutTransactionFee = (amount: BigNumber, fee: number) =>
-  amount.toNumber() * fee;
+  amount.multipliedBy(new BigNumber(fee));
 
 const getTaskPayoutAmountMinusTransactionFee = (
   amount: BigNumber,
   fee: number,
-) => amount.toNumber() - getTaskPayoutTransactionFee(amount, fee);
+) => amount.minus(getTaskPayoutTransactionFee(amount, fee));
 
 const MSG = defineMessages({
   eventTaskSentMessage: {
@@ -55,22 +56,13 @@ const MSG = defineMessages({
 });
 
 type Props = {|
-  transaction: TransactionRecordType<*, *>,
+  transaction: ContractTransactionType,
 |};
 
 const displayName = 'dashboard.TaskFeed.TaskFeedCompleteInfo';
 
 const TaskFeedCompleteInfo = ({
-  transaction: {
-    amount,
-    date,
-    hash,
-    taskId,
-    to,
-    token: tokenAddress,
-    gasLimit,
-    gasPrice,
-  },
+  transaction: { amount, date, hash, taskId, to, token: tokenAddress },
 }: Props) => {
   const {
     record: { reputation: taskReputation = 0 },
@@ -92,6 +84,7 @@ const TaskFeedCompleteInfo = ({
     rating,
     didFailToRate,
   );
+  const { gasPrice, gasLimit } = useSelector(transactionByHash, [hash]);
 
   const transactionFee =
     gasPrice && gasLimit && gasPrice.mul(new BigNumber(gasLimit));


### PR DESCRIPTION
## Description

In the TaskFeedCompleteInfo we use an approximation of the transaction fee although we can calculate it exactly. We need a new selector in the component that finds a transaction using its hash. Since I can not think of a way to test this in action currently I unit tested it together with another selector. Maybe we should make a rule to test all selectors, they are pretty important and easy to test. 

Closes #1231
