### PR TITLE
Logout the user when Metamask wallet changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
         "@colony/colony-js-contract-loader-network": "^1.12.0-beta.5",
         "@colony/purser-core": "^2.1.0",
         "@colony/purser-ledger": "^1.2.2",
-        "@colony/purser-metamask": "^2.1.0",
+        "@colony/purser-metamask": "^2.2.0",
         "@colony/purser-software": "^1.2.4",
         "@colony/purser-trezor": "^1.2.2",
         "@colony/redux-promise-listener": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -905,10 +905,10 @@
     "@ledgerhq/hw-transport-u2f" "^4.20.0"
     ethereumjs-tx "^1.3.6"
 
-"@colony/purser-metamask@^2.1.0":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@colony/purser-metamask/-/purser-metamask-2.1.1.tgz#670f48ab9103866aa582b2a4a4b1f77bba5a1748"
-  integrity sha512-lDy05YBhhlDu0V17tD2kvP6gwOFEz3CYqb3VEcgrCbYg2ut85Mwa89XRMxFQegcxQC4bcOLo3WlI/Wqqxu2S6w==
+"@colony/purser-metamask@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@colony/purser-metamask/-/purser-metamask-2.2.0.tgz#31d039db248c0f2b93d11af74f0327b91f1f0f0e"
+  integrity sha512-u0csExLqILvBRIP5xpDrO/CSlhsAJI2LCeLWth/DoOEItjOtud81/DBAt+XpnzAiCz3l9VeQBF8iFEhUHBJeUQ==
   dependencies:
     "@babel/runtime" "^7.1.2"
     "@colony/purser-core" "2.1.0"


### PR DESCRIPTION
## Description

If the user changes the current account in Metamask, we will now log the user out to prevent strange things from happening in the dApp. This uses the `purser-metamask` `accountChangeHook`.

**New stuff** ✨

* Spawn `metamaskWatch` saga in `openMetamaskWallet` to log the user out when Metamask account changes

**Changes** 🏗

* Update `redux-saga` flow-typed typings
* Upgrade `purser-metamask`

## TODO

- [x] Check the flow types are still good (cc @JamesLefrere)
- [x] Run the sagas past someone with approximate knowledge of forking/spawning

Resolves #756 
