### PR TITLE
Fix colony creation ENS normalization

### DIFF
--- a/src/modules/dashboard/components/CreateColonyWizard/CreateColonyCardRow.jsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/CreateColonyCardRow.jsx
@@ -24,6 +24,7 @@ type Row = {
 
 type FormValues = {
   colonyName: string,
+  displayName: string,
   username: string,
   tokenName: string,
   tokenSymbol: string,
@@ -51,7 +52,7 @@ const formatUsername = (currentUser, values, option) => {
 
 const formatColonyName = (values, option: { valueKey: string }) => {
   const normalized = normalize(values[option.valueKey]);
-  return `${normalized} (colony.io/colony/${normalized})`;
+  return `${values.displayName} (colony.io/colony/${normalized})`;
 };
 
 const CardRow = ({ cardOptions, values, currentUser }: CardProps): any[] => {

--- a/src/modules/dashboard/components/CreateColonyWizard/StepConfirmTransactions.jsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepConfirmTransactions.jsx
@@ -13,6 +13,8 @@ import { groupedTransactions } from '../../../core/selectors';
 import Heading from '~core/Heading';
 import GasStationContent from '../../../users/components/GasStation/GasStationContent';
 import { useSelector } from '~utils/hooks';
+import { getNormalizedDomainText } from '~utils/strings';
+import { log } from '~utils/debug';
 
 import {
   getGroupStatus,
@@ -78,7 +80,11 @@ const StepConfirmTransactions = ({ wizardValues: { colonyName } }: Props) => {
     getGroupStatus(newestGroup) === 'succeeded' &&
     getGroupKey(newestGroup) === 'group.transaction.batch.createColony'
   ) {
-    return <Redirect to={`/colony/${colonyName}`} />;
+    const normalizedColonyName = getNormalizedDomainText(colonyName);
+    // This should never happen
+    if (!normalizedColonyName)
+      log.error(`The colonyName '${colonyName}' could not be normalized`);
+    return <Redirect to={`/colony/${normalizedColonyName || colonyName}`} />;
   }
 
   const colonyTransaction = findTransactionGroupByKey(

--- a/src/modules/dashboard/sagas/colony.js
+++ b/src/modules/dashboard/sagas/colony.js
@@ -24,6 +24,7 @@ import {
   selectAsJS,
   putNotification,
 } from '~utils/saga/effects';
+import { getNormalizedDomainText } from '~utils/strings';
 import { ACTIONS } from '~redux';
 import { CONTEXT, getContext } from '~context';
 
@@ -77,7 +78,7 @@ import { NOTIFICATION_EVENT_COLONY_ENS_CREATED } from '~users/Inbox/events';
 function* colonyCreate({
   meta,
   payload: {
-    colonyName,
+    colonyName: givenColonyName,
     displayName,
     tokenAddress: givenTokenAddress,
     tokenChoice,
@@ -92,6 +93,8 @@ function* colonyCreate({
    */
   const walletAddress = yield select(walletAddressSelector);
   const currentUser = yield* selectAsJS(currentUserSelector);
+  const colonyName = yield call(getNormalizedDomainText, givenColonyName);
+  if (!colonyName) throw new Error(`Invalid colonyName '${givenColonyName}'`);
 
   /*
    * Define a manifest of transaction ids and their respective channels.

--- a/src/utils/strings/index.js
+++ b/src/utils/strings/index.js
@@ -125,7 +125,7 @@ export const addressEquals = (a: ?string, b: ?string) =>
 export const getNormalizedDomainText = (domain: string) => {
   if (!domain) return null;
   try {
-    const normalized = ensNormalize(domain);
+    const normalized: string = ensNormalize(domain);
     return normalized;
   } catch (e) {
     return null;


### PR DESCRIPTION
## Description

The `colonyName` was not being normalized before being used in the `registerColonyLabel` transaction, nor before being used to redirect the user to the colony's home once created.

**Changes** 🏗

* Normalize `colonyName` in `createColony` saga
* Normalize `colonyName` before redirecting in `StepConfirmTransactions`
* Use `displayName` where is should be used in `CreateColonyCardRow`
* Add return type to `getNormalizedDomainText`
