### PR TITLE
Defer user profile store creation

### DIFF
--- a/src/modules/users/data/queries.js
+++ b/src/modules/users/data/queries.js
@@ -42,6 +42,7 @@ import {
   getUserProfileStore,
   getUserInboxStore,
   getUserMetadataStore,
+  getUserProfileStoreAddress,
 } from '~data/stores';
 import { getUserTasksReducer, getUserProfileReducer } from './reducers';
 import {
@@ -610,5 +611,22 @@ export const getUserInboxActivity: Query<
         (firstEvent, secondEvent) =>
           firstEvent.timestamp - secondEvent.timestamp,
       );
+  },
+};
+
+export const getProfileStoreAddress: Query<
+  {| ddb: DDB, metadata: {| walletAddress: string |} |},
+  {| walletAddress: string |},
+  void,
+  string,
+> = {
+  name: 'getProfileStoreAddress',
+  context: [CONTEXT.DDB_INSTANCE],
+  async prepare({ ddb }, metadata) {
+    return { ddb, metadata };
+  },
+  async execute({ ddb, metadata }) {
+    const orbitAddress = await getUserProfileStoreAddress(ddb)(metadata);
+    return orbitAddress.toString();
   },
 };


### PR DESCRIPTION
## Description

This PR uses the determinable store address generation to set the `orbitDBPath` param of the `registerUserLabel` transaction to the correct value before the store is created; instead, the store is created after the transaction succeeds.

**New stuff** ✨

* Add `getProfileStoreAddress` query

**Changes** 🏗

* Defer the creation of the user profile store (when creating a colony) until the `createUser` transaction has succeeded


Resolves #1237 