### PR TITLE
Simplify colony access controller hash

### DIFF
--- a/src/data/accessControllers/ColonyAccessController.js
+++ b/src/data/accessControllers/ColonyAccessController.js
@@ -50,18 +50,15 @@ class ColonyAccessController extends AbstractAccessController<
       throw new Error('Could not get wallet address. Is it unlocked?');
   }
 
-  async save() {
-    const isAllowed = await this.can('is-colony-founder', this.walletAddress);
-    if (!isAllowed)
-      throw new Error('Cannot create colony database, user not allowed');
+  async save({ onlyDetermineAddress }: { onlyDetermineAddress: boolean }) {
+    if (!onlyDetermineAddress) {
+      const isAllowed = await this.can('is-colony-founder', this.walletAddress);
+      if (!isAllowed) {
+        throw new Error('Cannot create colony database, user not allowed');
+      }
+    }
 
-    const signature = await this._purserWallet.signMessage({
-      message: this._colonyAddress + this.walletAddress,
-    });
-
-    return `/colony/${this._colonyAddress}/creator/${
-      this.walletAddress
-    }/${signature}`;
+    return `/colony/${this._colonyAddress}`;
   }
 
   async load() {

--- a/src/lib/database/DDB.js
+++ b/src/lib/database/DDB.js
@@ -263,7 +263,7 @@ class DDB {
          * @NOTE: Only necessary to pass in the whole access controller object
          * to orbit-db without it getting on our way. Also, the `onlyDetermineAddress`
          * flag is used so we don't check for the contract permission whilst determining
-         * store addresses (see TaskAccessController)
+         * store addresses (see {Colony,Task}AccessController)
          */
         accessController: { controller, onlyDetermineAddress: true },
         // @NOTE: For now, if a store gets the same address, we'll override it locally


### PR DESCRIPTION
## Description

Simplifies colony stores access controllers so we don't have to sign every time we create a new one

**Changes** 🏗

* No more signing from the store creator on the access controller hash
* Colony store addresses are now deterministic as well

Closes #1297 