### PR TITLE
Add token address to task finalize event

### DIFF
--- a/src/data/types/TaskEvents.js
+++ b/src/data/types/TaskEvents.js
@@ -100,7 +100,6 @@ export type TaskEvents = {|
     typeof TASK_FINALIZED,
     {|
       amountPaid: string,
-      paymentId?: number,
       paymentTokenAddress?: Address,
       workerAddress: Address,
     |},

--- a/src/modules/dashboard/data/commands/task.js
+++ b/src/modules/dashboard/data/commands/task.js
@@ -439,7 +439,6 @@ export const finalizeTask: Command<
   TaskStoreMetadata,
   {|
     amountPaid: string,
-    paymentId?: number,
     paymentTokenAddress?: Address,
     workerAddress: Address,
   |},

--- a/src/modules/dashboard/data/reducers/task.js
+++ b/src/modules/dashboard/data/reducers/task.js
@@ -82,14 +82,13 @@ export const taskReducer: EventReducer<
     }
     case TASK_FINALIZED: {
       const {
-        payload: { amountPaid, paymentId, paymentTokenAddress, workerAddress },
+        payload: { amountPaid, paymentTokenAddress, workerAddress },
         meta: { timestamp },
       } = event;
       return {
         ...task,
         amountPaid,
         finalizedAt: new Date(timestamp),
-        paymentId,
         paymentTokenAddress,
         workerAddress,
       };

--- a/src/modules/dashboard/sagas/task.js
+++ b/src/modules/dashboard/sagas/task.js
@@ -476,11 +476,13 @@ function* taskFinalize({
 
     yield takeFrom(txChannel, ACTIONS.TRANSACTION_CREATED);
 
+    const { address: paymentTokenAddress } = token;
     const { event } = yield* executeCommand(finalizeTask, {
-      /**
-       * @todo Set the payment ID/payment token address when finalising a task
-       */
-      args: { amountPaid: amount.toString(), workerAddress },
+      args: {
+        paymentTokenAddress,
+        amountPaid: amount.toString(),
+        workerAddress,
+      },
       metadata: { colonyAddress, draftId },
     });
     yield put<Action<typeof ACTIONS.TASK_FINALIZE_SUCCESS>>({


### PR DESCRIPTION
## Description

Pass token address to finalizeTask command so we can use it on the task feed

**Changes** 🏗

* No need for `paymentId`
* Now the taskFinalize saga gives the command a token address

Closes #1220