### PR TITLE
Move token checks to core module, use in payouts

### DIFF
--- a/src/modules/admin/components/Tokens/TokenCard.jsx
+++ b/src/modules/admin/components/Tokens/TokenCard.jsx
@@ -12,10 +12,7 @@ import { SpinnerLoader } from '~core/Preloaders';
 import CopyableAddress from '~core/CopyableAddress';
 import TokenIcon from '~dashboard/HookedTokenIcon';
 
-import {
-  tokenIsETH,
-  tokenBalanceIsNotPositive,
-} from '../../../dashboard/checks';
+import { tokenIsETH, tokenBalanceIsNotPositive } from '../../../core/checks';
 
 import { tokenFetcher } from '../../../dashboard/fetchers';
 

--- a/src/modules/core/checks.js
+++ b/src/modules/core/checks.js
@@ -1,6 +1,12 @@
 /* @flow */
 
-import type { TransactionType } from '~immutable';
+import type {
+  TokenReferenceType,
+  TokenType,
+  TransactionType,
+} from '~immutable';
+
+import { ZERO_ADDRESS } from '~utils/web3/constants';
 
 /*
  * Transactions
@@ -9,3 +15,15 @@ export const isMultisig = (tx: TransactionType<*, *>) => !!tx.multisig;
 export const isPendingMultisig = (tx: TransactionType<*, *>) =>
   !!tx.multisig &&
   !(tx.multisig.missingSignees && tx.multisig.missingSignees.length);
+
+/*
+ * Tokens
+ */
+export const tokenBalanceIsPositive = ({ balance }: TokenReferenceType) =>
+  !!balance && balance.gten(0);
+
+export const tokenBalanceIsNotPositive = ({ balance }: TokenReferenceType) =>
+  !!balance && balance.lten(0);
+
+export const tokenIsETH = ({ address }: TokenType | TokenReferenceType) =>
+  address === ZERO_ADDRESS;

--- a/src/modules/core/components/PayoutsList/PayoutsList.jsx
+++ b/src/modules/core/components/PayoutsList/PayoutsList.jsx
@@ -6,6 +6,8 @@ import cx from 'classnames';
 
 import type { TaskPayoutType } from '~immutable';
 
+import { tokenIsETH } from '../../checks';
+
 import { Tooltip } from '../Popover';
 import Numeral from '../Numeral';
 
@@ -30,17 +32,14 @@ type Props = {|
 const displayName = 'PayoutsList';
 
 const PayoutsList = ({ payouts, maxLines = 1, nativeToken }: Props) => {
-  /**
-   * @todo Improve sorting of payouts (payouts list).
-   */
   const sortedPayouts = payouts.sort(({ token: a }, { token: b }) => {
-    if (a.symbol === nativeToken && b.symbol === 'ETH') {
+    if (a.symbol === nativeToken && tokenIsETH(b)) {
       return -1;
     }
-    if (b.symbol === nativeToken && a.symbol === 'ETH') {
+    if (b.symbol === nativeToken && tokenIsETH(a)) {
       return 1;
     }
-    if (a.symbol === nativeToken || a.symbol === 'ETH') {
+    if (a.symbol === nativeToken || tokenIsETH(a)) {
       return -1;
     }
     return 1;

--- a/src/modules/core/components/TokenEditDialog/TokenCheckbox.jsx
+++ b/src/modules/core/components/TokenEditDialog/TokenCheckbox.jsx
@@ -1,6 +1,5 @@
 /* @flow */
 
-// $FlowFixMe until hooks flow types
 import React from 'react';
 import { defineMessages } from 'react-intl';
 
@@ -12,7 +11,7 @@ import Heading from '~core/Heading';
 import { SpinnerLoader } from '~core/Preloaders';
 import TokenIcon from '~dashboard/HookedTokenIcon';
 
-import { tokenIsETH } from '../../../dashboard/checks';
+import { tokenIsETH } from '../../checks';
 import { tokenFetcher } from '../../../dashboard/fetchers';
 
 import styles from './TokenEditDialog.css';

--- a/src/modules/dashboard/checks.js
+++ b/src/modules/dashboard/checks.js
@@ -1,29 +1,10 @@
 /* @flow */
 
-import type {
-  ColonyType,
-  TaskType,
-  TokenReferenceType,
-  TokenType,
-  TaskUserType,
-} from '~immutable';
+import type { ColonyType, TaskType, TaskUserType } from '~immutable';
 
 import type { Address } from '~types';
 
-import { ZERO_ADDRESS } from '~utils/web3/constants';
 import { TASK_STATE } from '~immutable';
-
-/*
- * Tokens
- */
-export const tokenBalanceIsPositive = ({ balance }: TokenReferenceType) =>
-  !!balance && balance.gten(0);
-
-export const tokenBalanceIsNotPositive = ({ balance }: TokenReferenceType) =>
-  !!balance && balance.lten(0);
-
-export const tokenIsETH = ({ address }: TokenType | TokenReferenceType) =>
-  address === ZERO_ADDRESS;
 
 /*
  * Colony

--- a/src/modules/dashboard/components/TaskEditDialog/WrappedPayout.jsx
+++ b/src/modules/dashboard/components/TaskEditDialog/WrappedPayout.jsx
@@ -6,7 +6,7 @@ import React, { useCallback, useMemo } from 'react';
 import type { TaskType, TokenType } from '~immutable';
 import type { $Pick } from '~types';
 
-import { tokenIsETH } from '../../checks';
+import { tokenIsETH } from '../../../core/checks';
 
 import Payout from './Payout.jsx';
 


### PR DESCRIPTION
## Description

This PR moves the `isTokenETH` check to the `core` module (as it made more sense there) and uses it in the `PayoutsList` sorting

**Changes** 🏗

- Moved `isTokenETH` to `core` checks
- Use `isTokenETH` instead of the symbol as Scott noted [here](https://github.com/JoinColony/colonyDapp/issues/1134#issuecomment-491876446)

Resolves #1134.