### PR TITLE
Improve task assignment & user picker

### DIFF
--- a/src/modules/core/components/Assignment/Assignment.jsx
+++ b/src/modules/core/components/Assignment/Assignment.jsx
@@ -9,6 +9,7 @@ import type { TaskPayoutType, TokenReferenceType, UserType } from '~immutable';
 import type { Address } from '~types';
 
 import Icon from '~core/Icon';
+import MaskedAddress from '~core/MaskedAddress';
 import PayoutsList from '~core/PayoutsList';
 import HookedUserAvatar from '~users/HookedUserAvatar';
 
@@ -40,10 +41,14 @@ const MSG = defineMessages({
 const UserAvatar = HookedUserAvatar({ fetchUser: false });
 
 type Props = {|
+  /** The worker that is assigned */
   worker: ?UserType,
+  /** The address of the above worker (used in the case of unclaimed worker profile) */
+  workerAddress: ?Address,
   /** List of payouts per token that has been set for a task */
   payouts?: Array<TaskPayoutType>,
-  renderAvatar?: (address: Address, user: UserType) => Node,
+  /** Provide a custom component to render the user avatar */
+  renderAvatar?: (address: Address, user: ?UserType) => Node,
   /** current user reputation */
   reputation?: number,
   /** The assignment has to be confirmed first and can therefore appear as pending,
@@ -52,10 +57,11 @@ type Props = {|
   pending?: boolean,
   /** We need to be aware of the native token to adjust the UI */
   nativeToken: TokenReferenceType,
+  /** Should the funding be rendered (if set) */
   showFunding?: boolean,
 |};
 
-const defaultRenderAvatar = (address: Address, user: UserType) => (
+const defaultRenderAvatar = (address: Address, user: ?UserType) => (
   <UserAvatar
     address={address}
     className={styles.recipientAvatar}
@@ -72,6 +78,7 @@ const Assignment = ({
   reputation,
   showFunding,
   worker,
+  workerAddress,
 }: Props) => {
   const fundingWithNativeToken =
     payouts &&
@@ -81,9 +88,9 @@ const Assignment = ({
   return (
     <div>
       <div className={styles.displayContainer}>
-        {worker ? (
+        {workerAddress ? (
           <div className={styles.avatarContainer}>
-            {renderAvatar(worker.profile.walletAddress, worker)}
+            {renderAvatar(workerAddress, worker)}
           </div>
         ) : (
           <Icon
@@ -107,7 +114,11 @@ const Assignment = ({
             </div>
           ) : (
             <div className={styles.placeholder}>
-              <FormattedMessage {...MSG.placeholder} />
+              {workerAddress ? (
+                <MaskedAddress address={workerAddress} />
+              ) : (
+                <FormattedMessage {...MSG.placeholder} />
+              )}
             </div>
           )}
         </div>

--- a/src/modules/core/components/SingleUserPicker/SingleUserPicker.css
+++ b/src/modules/core/components/SingleUserPicker/SingleUserPicker.css
@@ -52,7 +52,7 @@
 .baseInput {
   flex: 1 1 0;
   margin-left: 10px;
-  max-width: 380px;
+  max-width: 340px;
   vertical-align: baseline;
   border: none;
   border-bottom: 1px solid var(--colony-black);

--- a/src/modules/core/components/SingleUserPicker/SingleUserPicker.jsx
+++ b/src/modules/core/components/SingleUserPicker/SingleUserPicker.jsx
@@ -190,7 +190,9 @@ const SingleUserPicker = ({
                 onFocus={handleActiveUserClick}
                 tabIndex="0"
               >
-                {$value.profile.displayName || $value.profile.username}
+                {$value.profile.displayName ||
+                  $value.profile.username ||
+                  $value.profile.walletAddress}
               </div>
             )}
             {/* eslint-enable jsx-a11y/click-events-have-key-events */}

--- a/src/modules/dashboard/components/Task/TaskInviteDialog.jsx
+++ b/src/modules/dashboard/components/Task/TaskInviteDialog.jsx
@@ -95,6 +95,7 @@ const TaskInviteDialog = ({
                   reputation={reputation}
                   showFunding={false}
                   worker={currentUser}
+                  workerAddress={walletAddress}
                 />
               </DialogSection>
               <DialogSection>

--- a/src/modules/dashboard/components/TaskAssignment/TaskAssignment.jsx
+++ b/src/modules/dashboard/components/TaskAssignment/TaskAssignment.jsx
@@ -35,6 +35,7 @@ const TaskAssignment = ({ colonyAddress, draftId }: Props) => {
       payouts={payouts}
       reputation={reputation}
       worker={worker}
+      workerAddress={workerAddress}
     />
   ) : (
     <SpinnerLoader />

--- a/src/modules/dashboard/components/TaskEditDialog/TaskEditDialog.jsx
+++ b/src/modules/dashboard/components/TaskEditDialog/TaskEditDialog.jsx
@@ -25,6 +25,7 @@ import DialogSection from '~core/Dialog/DialogSection.jsx';
 import Heading from '~core/Heading';
 import DialogBox from '~core/Dialog/DialogBox.jsx';
 import { SpinnerLoader } from '~core/Preloaders';
+import { UserProfileRecord, UserRecord } from '~immutable';
 import { ACTIONS } from '~redux';
 import HookedUserAvatar from '~users/HookedUserAvatar';
 import { mapPayload, mergePayload, pipe } from '~utils/actions';
@@ -183,9 +184,17 @@ const TaskEditDialog = ({
 
   // Get user (worker) assigned to this task
   const {
-    data: existingWorker,
+    data: existingWorkerObj,
     isFetching: isFetchingExistingWorker,
   } = useDataFetcher<UserType>(userFetcher, [workerAddress], [workerAddress]);
+  const existingWorker =
+    !!workerAddress && !existingWorkerObj
+      ? UserRecord({
+          profile: UserProfileRecord({
+            walletAddress: workerAddress,
+          }),
+        }).toJS()
+      : existingWorkerObj;
 
   const users = useMemo(
     () =>


### PR DESCRIPTION
## Description

Enhancement. This PR aims to display the assigned user's wallet address in cases where said user's profile is unclaimed.

**Changes** 🏗

* Add `workerAddress` prop to `Assignment` core component
  * Make `user` a maybe type for rendering the avatar
* Create a `UserRecord` for assigned user in `TaskEditDialog` if user object can't be fetched (profile unclaimed)

**Screenshots** 📷 

<img width="1178" alt="Screen Shot 2019-06-12 at 8 33 59 PM" src="https://user-images.githubusercontent.com/3052635/59397250-84b78d80-8d51-11e9-8e88-bc59f3eedf3f.png">

<img width="1177" alt="Screen Shot 2019-06-12 at 8 34 10 PM" src="https://user-images.githubusercontent.com/3052635/59397254-8a14d800-8d51-11e9-83aa-7526f372bd50.png">


Resolves #1323 
