### PR TITLE
Make native token hook more defensive

### DIFF
--- a/src/modules/core/components/Assignment/Assignment.jsx
+++ b/src/modules/core/components/Assignment/Assignment.jsx
@@ -56,7 +56,7 @@ type Props = {|
    */
   pending?: boolean,
   /** We need to be aware of the native token to adjust the UI */
-  nativeToken: TokenReferenceType,
+  nativeToken: ?TokenReferenceType,
   /** Should the funding be rendered (if set) */
   showFunding?: boolean,
 |};
@@ -132,7 +132,7 @@ const Assignment = ({
                 />
               </span>
             )}
-            {payouts && payouts.length > 0 ? (
+            {nativeToken && payouts && payouts.length > 0 ? (
               <PayoutsList
                 payouts={payouts}
                 nativeToken={nativeToken}

--- a/src/modules/core/components/PayoutsList/PayoutsList.jsx
+++ b/src/modules/core/components/PayoutsList/PayoutsList.jsx
@@ -26,17 +26,14 @@ type Props = {|
   /** Maximum lines to show before switching to popover */
   maxLines?: number,
   /** Native token of the displayed Colony */
-  nativeToken: TokenReferenceType,
+  nativeToken: ?TokenReferenceType,
 |};
 
 const displayName = 'PayoutsList';
 
-const PayoutsList = ({
-  payouts,
-  maxLines = 1,
-  nativeToken: { address: nativeTokenAddress },
-  nativeToken,
-}: Props) => {
+const PayoutsList = ({ payouts, maxLines = 1, nativeToken }: Props) => {
+  const { address: nativeTokenAddress } = nativeToken || {};
+
   const sortedPayouts = payouts.sort(({ token: a }, { token: b }) => {
     if (a.address === nativeTokenAddress && tokenIsETH(b)) {
       return -1;
@@ -59,7 +56,7 @@ const PayoutsList = ({
         {firstPayouts.map(payout => (
           <Numeral
             className={cx(styles.payoutNumber, {
-              [styles.native]: payout.token.address === nativeToken.address,
+              [styles.native]: payout.token.address === nativeTokenAddress,
             })}
             key={payout.token.address}
             prefix={`${payout.token.symbol} `}

--- a/src/modules/dashboard/hooks/useColonyNativeToken.js
+++ b/src/modules/dashboard/hooks/useColonyNativeToken.js
@@ -4,7 +4,7 @@
 import { useCallback } from 'react';
 import { useMappedState } from 'redux-react-hook';
 
-import type { ColonyType } from '~immutable';
+import type { ColonyType, TokenReferenceType } from '~immutable';
 import type { Address } from '~types';
 
 import { useDataFetcher } from '~utils/hooks';
@@ -13,7 +13,9 @@ import { colonyFetcher } from '../fetchers';
 import { colonyNativeTokenSelector } from '../selectors';
 
 // eslint-disable-next-line import/prefer-default-export
-export const useColonyNativeToken = (colonyAddress: ?Address) => {
+export const useColonyNativeToken = (
+  colonyAddress: ?Address,
+): ?TokenReferenceType => {
   const { data: fetchedColony } = useDataFetcher<ColonyType>(
     colonyFetcher,
     [colonyAddress],


### PR DESCRIPTION
## Description

Bug fix. This PR aims to fix an issue where native token reference properties were being accessed before the token had been loaded.

**Changes** 🏗

* Return a maybe type from the native token reference hook
* Conditional usage of token reference all places the hook is used

Resolves #1327 
