### PR TITLE
Convert to string before storing payout in OrbitDB

### DIFF
--- a/src/data/types/TaskEvents.js
+++ b/src/data/types/TaskEvents.js
@@ -1,7 +1,5 @@
 /* @flow */
 
-import type BigNumber from 'bn.js';
-
 import { TASK_EVENT_TYPES, TASK_STATUS } from '../constants';
 
 import type { EventDefinition } from './events';
@@ -59,7 +57,7 @@ export type TaskEvents = {|
   PAYOUT_SET: EventDefinition<
     typeof PAYOUT_SET,
     {|
-      amount: BigNumber,
+      amount: string,
       token: string,
     |},
   >,

--- a/src/modules/dashboard/data/commands/task.js
+++ b/src/modules/dashboard/data/commands/task.js
@@ -375,7 +375,7 @@ export const setTaskPayout: Command<
   async execute(taskStore, { amount, token }) {
     const eventHash = await taskStore.append(
       createEvent(TASK_EVENT_TYPES.PAYOUT_SET, {
-        amount,
+        amount: amount.toString(10),
         token,
       }),
     );

--- a/src/modules/dashboard/data/reducers/task.js
+++ b/src/modules/dashboard/data/reducers/task.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import BigNumber from 'bn.js';
+
 import type { EventReducer } from '~data/types';
 
 import { TASK_EVENT_TYPES } from '~data/constants';
@@ -111,7 +113,7 @@ export const taskReducer: EventReducer<
       const { amount, token } = event.payload;
       return {
         ...task,
-        payout: amount,
+        payout: new BigNumber(amount),
         paymentTokenAddress: token,
       };
     }


### PR DESCRIPTION
## Description

The payout amount was attempting to be stored in the task store as a `BigNumber`, which was causing the signature verification for the store to fail when loaded again. Orbit doesn't play nice with objects.

**Changes** 🏗

* Task store event `PAYOUT_SET` param `amount` changed to string
* Convert `amount` BN to string in `setTaskPayout`
* Convert `amount` from string to BN to use as `payout` in task data reducer

Resolves #1352 
