### PR TITLE
Filter out events that we would like to see in inbox

### DIFF
--- a/src/modules/users/data/queries.js
+++ b/src/modules/users/data/queries.js
@@ -544,7 +544,7 @@ export const getUserInboxActivity: Query<
     cleanedEvents = cleanedEvents
       .concat(cleanedMintEvents)
       .concat(transferEvents);
-    const transformedEvents = await Promise.all(
+    const transformedEvents = (await Promise.all(
       /*
        * @note Remove the first four log entries.
        *
@@ -592,7 +592,7 @@ export const getUserInboxActivity: Query<
           };
           return transformedEvent;
         }),
-    );
+    )).filter(({ event }) => !!event);
     return userInboxStore
       .all()
       .map(({ meta: { id, timestamp, sourceUserAddress }, payload }) =>


### PR DESCRIPTION
## Description

Some contract events don't need to be shown in our inbox, therefore, we filter for having an event property, to show only relevant events within the query.

Resolves #1348
