### PR TITLE
Improve token input validations

### DIFF
--- a/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.jsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.jsx
@@ -175,6 +175,7 @@ const StepCreateToken = ({
                 name="tokenSymbol"
                 appearance={{ theme: 'fat' }}
                 maxLength="4"
+                formattingOptions={{ uppercase: true }}
                 label={MSG.labelTokenSymbol}
                 help={MSG.helpTokenSymbol}
               />


### PR DESCRIPTION
## Description

When creating a new token the user input should be validated properly.
Token symbols should always contain only capital letters and will be stored the same way.
Token names should only contain utf-8 encoded characters, so they don't need further validation I believe, please correct me if I am wrong. 

## Demo
![symbol](https://user-images.githubusercontent.com/6294044/59768728-259fce80-92a5-11e9-8ee9-6b317907cb0c.gif)


Resolves #1336
