### PR TITLE
Hide TaskRequestWork when assigned with existing check

### DIFF
--- a/src/modules/dashboard/components/Task/Task.jsx
+++ b/src/modules/dashboard/components/Task/Task.jsx
@@ -44,6 +44,7 @@ import {
   isCreator,
   isFinalized,
   isPayoutsSet,
+  isWorkerSet,
 } from '../../checks';
 import { currentUserSelector } from '../../../users/selectors';
 import { colonyAddressFetcher } from '../../fetchers';
@@ -131,7 +132,8 @@ const Task = ({
     [draftId],
     [colonyAddress || undefined, draftId],
   );
-  const { description, domainId, dueDate, skillId, title } = task || {};
+  const { description, domainId, dueDate, skillId, title, workerAddress } =
+    task || {};
 
   const onEditTask = useCallback(
     () => {
@@ -296,7 +298,7 @@ const Task = ({
               )}
             </>
           )}
-          {!isTaskCreator && (
+          {(!isTaskCreator || !isWorkerSet(workerAddress)) && (
             <TaskRequestWork
               currentUser={currentUser}
               task={task}


### PR DESCRIPTION
## Description

Use existing check to see if we can hide the TaskRequestWork button after assigning a worker.

Resolves  #1328 
