### PR TITLE
Improve colony grid loading state

### DIFF
--- a/src/modules/dashboard/components/ColonyGrid/ColonyGridItem.css
+++ b/src/modules/dashboard/components/ColonyGrid/ColonyGridItem.css
@@ -2,3 +2,11 @@
 .main {
   composes: alignCenter from '~styles/text.css';
 }
+
+.loader {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 20px;
+  min-height: 65px;
+}

--- a/src/modules/dashboard/components/ColonyGrid/ColonyGridItem.jsx
+++ b/src/modules/dashboard/components/ColonyGrid/ColonyGridItem.jsx
@@ -20,7 +20,12 @@ type Props = ColonyProps<{ colonyAddress: * }>;
 const ColonyGridItem = ({ colonyAddress }: Props) => {
   const { isFetching, data: colony } = useColonyWithAddress(colonyAddress);
 
-  if (!colony || isFetching) return <SpinnerLoader />;
+  if (!colony || isFetching)
+    return (
+      <div className={styles.loader}>
+        <SpinnerLoader appearance={{ size: 'medium' }} />
+      </div>
+    );
 
   return (
     <div className={styles.main}>


### PR DESCRIPTION
## Description

This PR improves the colony grid loading state.

**Changes** 🏗

* Increase spinner size
* Align spinner to match the colony avatar & name

**Screenshots** 📷 

#### Before
<img width="830" alt="Screen Shot 2019-06-21 at 6 38 21 PM" src="https://user-images.githubusercontent.com/3052635/59956631-ff219500-9456-11e9-8ea4-391b50518c35.png">

#### After
<img width="813" alt="Screen Shot 2019-06-21 at 6 54 30 PM" src="https://user-images.githubusercontent.com/3052635/59956633-047edf80-9457-11e9-855b-a4aa4c312bce.png">

