### PR TITLE
Only update description if it has changed

### DIFF
--- a/src/modules/dashboard/data/commands/task.js
+++ b/src/modules/dashboard/data/commands/task.js
@@ -203,9 +203,10 @@ export const setTaskDescription: Command<
   TaskStore,
   TaskStoreMetadata,
   {|
+    currentDescription: ?string,
     description: string,
   |},
-  {|
+  ?{|
     event: Event<typeof TASK_EVENT_TYPES.TASK_DESCRIPTION_SET>,
     taskStore: TaskStore,
   |},
@@ -214,7 +215,10 @@ export const setTaskDescription: Command<
   context: [CONTEXT.COLONY_MANAGER, CONTEXT.DDB_INSTANCE, CONTEXT.WALLET],
   prepare: prepareTaskStoreCommand,
   schema: SetTaskDescriptionCommandArgsSchema,
-  async execute(taskStore, { description }) {
+  async execute(taskStore, { currentDescription, description }) {
+    if (description === currentDescription) {
+      return null;
+    }
     const eventHash = await taskStore.append(
       createEvent(TASK_EVENT_TYPES.TASK_DESCRIPTION_SET, {
         description,

--- a/src/modules/dashboard/sagas/task.js
+++ b/src/modules/dashboard/sagas/task.js
@@ -239,21 +239,28 @@ function* taskSetDescription({
   payload: { colonyAddress, draftId, description },
 }: Action<typeof ACTIONS.TASK_SET_DESCRIPTION>): Saga<void> {
   try {
-    const { event } = yield* executeCommand(setTaskDescription, {
+    const {
+      record: { description: currentDescription },
+    } = yield* selectAsJS(taskSelector, draftId);
+    const eventData = yield* executeCommand(setTaskDescription, {
       args: {
+        currentDescription,
         description,
       },
       metadata: { colonyAddress, draftId },
     });
-    yield put<Action<typeof ACTIONS.TASK_SET_DESCRIPTION_SUCCESS>>({
-      type: ACTIONS.TASK_SET_DESCRIPTION_SUCCESS,
-      meta,
-      payload: {
-        colonyAddress,
-        draftId,
-        event,
-      },
-    });
+    if (eventData) {
+      const { event } = eventData;
+      yield put<Action<typeof ACTIONS.TASK_SET_DESCRIPTION_SUCCESS>>({
+        type: ACTIONS.TASK_SET_DESCRIPTION_SUCCESS,
+        meta,
+        payload: {
+          colonyAddress,
+          draftId,
+          event,
+        },
+      });
+    }
   } catch (error) {
     yield putError(ACTIONS.TASK_SET_DESCRIPTION_ERROR, error, meta);
   }


### PR DESCRIPTION
## Description

This PR adds logic to check the existing task description, and only logs a changed event if the description has changed.

**Changes** 🏗

* Pass existing task description to `setTaskDescription` command, check if the new description is different
* Handle possible `null` case (unchanged) in `taskSetDescription` saga

**Demo** 🎥 

![Task Description Diffing](https://user-images.githubusercontent.com/3052635/59966708-e7452200-94e5-11e9-9cc9-22fa21a8da9d.gif)

Resolves #1324 

