### PR TITLE
Throw transaction error after timeout

### DIFF
--- a/src/lib/ipfs/PinnerConnector.js
+++ b/src/lib/ipfs/PinnerConnector.js
@@ -87,7 +87,12 @@ class PinnerConnector {
       .finally(() => {
         this._readyPromise = undefined;
       });
-
+    this._readyPromise.catch(error =>
+      log.warn(
+        'Could not request replication; not connected to any pinners.',
+        error,
+      ),
+    );
     return this._readyPromise;
   }
 
@@ -122,7 +127,6 @@ class PinnerConnector {
       } = await request.promise;
       return count;
     }
-
     try {
       await this.ready;
     } catch (caughtError) {


### PR DESCRIPTION
## Description

Log error in the pinnerConnector since connecting to pinner times out and throw transaction error.

Previously the error didn't get caught because the `pEvent(` method was missing it's `await`. 
Resolves #1387
