### PR TITLE
Empty out inbox items on logout 

### DIFF
--- a/src/modules/users/reducers/currentUser/activities.js
+++ b/src/modules/users/reducers/currentUser/activities.js
@@ -26,6 +26,9 @@ const inboxItemsReducer: ReducerType<
       const { activities } = action.payload;
       return List(activities.map(activity => InboxItemRecord(activity)));
     }
+    case ACTIONS.USER_LOGOUT_SUCCESS: {
+      return List();
+    }
     default:
       return state;
   }


### PR DESCRIPTION
## Description

Set inbox items to an empty list when logging out.

Resolves #1349

