### PR TITLE
Don't overwrite initial state if token is ether

### DIFF
--- a/src/modules/dashboard/reducers/allTokens.js
+++ b/src/modules/dashboard/reducers/allTokens.js
@@ -38,6 +38,15 @@ const tokensReducer: ReducerType<
         name,
         symbol,
       });
+
+      /* If the token is ether there is no data about it in the db
+      we initialise it only here in the reducer
+      If we do not have this condition here the ether token info
+      gets overwritten with empty values.  */
+      if (tokenAddress === ZERO_ADDRESS) {
+        return INITIAL_STATE;
+      }
+
       return state.get(tokenAddress)
         ? state.setIn([tokenAddress, 'record'], record)
         : state.set(tokenAddress, DataRecord<TokenRecordType>({ record }));


### PR DESCRIPTION
## Description

The token info for ether gets added in the reducer. When we fetch the token info for ether it gets overwritten with undefined values since there's no token data for ether in the database. 

Resolves #1358
