### PR TITLE
Set colonyAddress when incrementally loading task

### DIFF
--- a/src/modules/dashboard/reducers/tasks.js
+++ b/src/modules/dashboard/reducers/tasks.js
@@ -175,12 +175,16 @@ const tasksReducer: ReducerType<
     }
 
     case ACTIONS.TASK_SUB_EVENT: {
-      const { draftId, event } = action.payload;
+      const { colonyAddress, draftId, event } = action.payload;
       const path = [draftId, 'record'];
       const nextState = state.getIn(path)
         ? state
         : // $FlowFixMe just flow being silly
-          state.set(draftId, DataRecord({ record: TaskRecord() }));
+          state.set(
+            draftId,
+            // $FlowFixMe this is all the data we have yet
+            DataRecord({ record: TaskRecord({ colonyAddress, draftId }) }),
+          );
       // $FlowFixMe just flow being silly
       return nextState.updateIn(
         path,


### PR DESCRIPTION
## Description

The first `TASK_SUB_EVENT` to be dispatched which stores task data in redux should also set the `colonyAddress` of that task, since it is not contained within any DDB events.

**Changes** 🏗

* Now set `colonyAddress` and `draftId` on the `TaskRecord` when first setting it in redux as the result of a `TASK_SUB_EVENT`.

Resolves #1330 
