### PR TITLE
Fix colony admin blockie

### DIFF
--- a/src/modules/admin/components/Profile/ColonyAvatarUploader.jsx
+++ b/src/modules/admin/components/Profile/ColonyAvatarUploader.jsx
@@ -67,7 +67,7 @@ const ColonyAvatarUploader = ({ colony: { colonyAddress }, colony }: Props) => {
            * But appends the current one to that
            */
           className={styles.main}
-          address={colonyAddress}
+          colonyAddress={colonyAddress}
           colony={colony}
           size="xl"
         />


### PR DESCRIPTION
## Description

The prop `colonyAddress` was incorrectly passed as `address`.

**Changes** 🏗

* Pass `colonyAddress` to `ColonyAvatar`

Resolves #1366 (unless further problems found in there, won't merge until that's clarified)
