### PR TITLE
Use lower case address for blockies

### DIFF
--- a/src/lib/identicon/index.js
+++ b/src/lib/identicon/index.js
@@ -3,13 +3,18 @@
 import blockies from '../blockies';
 
 const iconCache = {};
-export default function getIcon(seed: string) {
+
+/**
+ * Generate a blockie with the given seed (usually lowercase address).
+ * Optionally set the resulting size in pixels.
+ */
+export default function getIcon(seed: string, size?: number) {
   if (iconCache[seed]) {
     return iconCache[seed];
   }
   const canvasElm = blockies({
     size: 5,
-    scale: 10,
+    scale: size ? parseInt(size / 5, 10) : 10,
     seed,
   });
 

--- a/src/modules/core/components/Avatar/Avatar.jsx
+++ b/src/modules/core/components/Avatar/Avatar.jsx
@@ -36,7 +36,11 @@ const Avatar = ({
   title,
 }: Props) => {
   const avatar = notSet ? null : avatarURL || getIcon(seed);
-  const imageStyle = avatar ? { backgroundImage: `url(${avatar})` } : {};
+  // if using a blockie, do pixelated image scaling
+  const imageRendering = avatarURL ? undefined : 'pixelated';
+  const imageStyle = avatar
+    ? { backgroundImage: `url(${avatar})`, imageRendering }
+    : {};
   const mainClass = size ? styles[size] : styles.main;
   return (
     <figure

--- a/src/modules/core/components/ColonyAvatar/ColonyAvatar.jsx
+++ b/src/modules/core/components/ColonyAvatar/ColonyAvatar.jsx
@@ -42,7 +42,7 @@ const ColonyAvatar = ({
       className={className}
       notSet={notSet}
       placeholderIcon="at-sign-circle"
-      seed={colonyAddress}
+      seed={colonyAddress && colonyAddress.toLowerCase()}
       size={size}
       title={colonyDisplayName || colonyName || colonyAddress}
     />

--- a/src/modules/core/components/UserAvatar/UserAvatar.jsx
+++ b/src/modules/core/components/UserAvatar/UserAvatar.jsx
@@ -49,7 +49,7 @@ const UserAvatar = ({
         className={className}
         notSet={notSet}
         placeholderIcon="circle-person"
-        seed={address}
+        seed={address && address.toLowerCase()}
         size={size}
         title={showInfo ? '' : username || address}
       />


### PR DESCRIPTION
## Description

This results in our blockies being the same as everyone else's! And also no more blurry blockies!

**New stuff** ✨

* Can optionally pass a `size` in pixels to blockies `getIcon`

**Changes** 🏗

* `ColonyAvatar` and `UserAvatar` pass `address` as lowercase for `Avatar` `seed`
* `Avatar` sets pixelated image rendering for when blockies are used

Resolves #1371 
Resolves https://github.com/JoinColony/colonyDapp/issues/1366#issuecomment-506548272
