### PR TITLE
Handle inbox items dynamically

### DIFF
--- a/src/modules/admin/sagas/index.js
+++ b/src/modules/admin/sagas/index.js
@@ -241,9 +241,7 @@ function* colonyMintTokens({
        * Notification
        */
       const decoratedLog = yield call(decorateLog, tokenClient, mintLog);
-      yield putNotification(
-        normalizeTransactionLog(tokenAddress, decoratedLog),
-      );
+      yield putNotification(normalizeTransactionLog(decoratedLog));
     }
 
     yield put<Action<typeof ACTIONS.COLONY_MINT_TOKENS_SUCCESS>>({

--- a/src/modules/dashboard/sagas/colonyCreate.js
+++ b/src/modules/dashboard/sagas/colonyCreate.js
@@ -454,7 +454,7 @@ function* colonyCreate({
       colonyManager.networkClient,
       colonyLabelRegisteredLog,
     );
-    yield putNotification(normalizeTransactionLog(colonyAddress, decoratedLog));
+    yield putNotification(normalizeTransactionLog(decoratedLog));
     return null;
   } catch (error) {
     yield putError(ACTIONS.COLONY_CREATE_ERROR, error, meta);

--- a/src/modules/dashboard/sagas/domains.js
+++ b/src/modules/dashboard/sagas/domains.js
@@ -107,7 +107,7 @@ function* domainCreate({
      * Notification
      */
     const decoratedLog = yield call(decorateLog, colonyClient, domainAddedLog);
-    yield putNotification(normalizeTransactionLog(colonyAddress, decoratedLog));
+    yield putNotification(normalizeTransactionLog(decoratedLog));
   } catch (error) {
     yield putError(ACTIONS.DOMAIN_CREATE_ERROR, error, meta);
   } finally {

--- a/src/modules/dashboard/sagas/roles.js
+++ b/src/modules/dashboard/sagas/roles.js
@@ -94,7 +94,7 @@ function* colonyAdminAdd({
       colonyClient,
       colonyRoleSetLog,
     );
-    yield putNotification(normalizeTransactionLog(colonyAddress, decoratedLog));
+    yield putNotification(normalizeTransactionLog(decoratedLog));
     yield put(fetchRoles(colonyAddress));
   } catch (error) {
     yield putError(ACTIONS.COLONY_ADMIN_ADD_ERROR, error, meta);
@@ -151,7 +151,7 @@ function* colonyAdminRemove({
       colonyClient,
       colonyRoleSetLog,
     );
-    yield putNotification(normalizeTransactionLog(colonyAddress, decoratedLog));
+    yield putNotification(normalizeTransactionLog(decoratedLog));
     yield put(fetchRoles(colonyAddress));
   } catch (error) {
     yield putError(ACTIONS.COLONY_ADMIN_REMOVE_ERROR, error, meta);

--- a/src/modules/users/data/queries.js
+++ b/src/modules/users/data/queries.js
@@ -436,7 +436,6 @@ export const getUserInboxActivity: Query<
     walletAddress,
   }) {
     const {
-      contract: { address: colonyNetworkAddress },
       events: { ColonyLabelRegistered },
     } = colonyNetworkClient;
 
@@ -528,31 +527,17 @@ export const getUserInboxActivity: Query<
         );
 
         return [
-          ...eventsFromColony.map(event =>
-            normalizeTransactionLog(colonyAddress, event),
-          ),
-          ...eventsFromNetwork.map(event =>
-            normalizeTransactionLog(colonyNetworkAddress, event),
-          ),
-          ...eventsFromToken.map(event =>
-            normalizeTransactionLog(tokenAddress, event),
-          ),
-          ...eventsFromTransfer.map(event =>
-            normalizeTransactionLog(tokenAddress, event),
-          ),
-          ...eventsFromRoleAssignment.map(event =>
-            normalizeTransactionLog(colonyAddress, event),
-          ),
+          ...eventsFromColony.map(normalizeTransactionLog),
+          ...eventsFromNetwork.map(normalizeTransactionLog),
+          ...eventsFromToken.map(normalizeTransactionLog),
+          ...eventsFromTransfer.map(normalizeTransactionLog),
+          ...eventsFromRoleAssignment.map(normalizeTransactionLog),
         ];
       }),
     );
 
     const contractEvents = flatten(aggregatedContractEvents);
-    const storeEvents = userInboxStore
-      .all()
-      .map(event =>
-        normalizeDDBStoreEvent(userInboxStore.address.toString(), event),
-      );
+    const storeEvents = userInboxStore.all().map(normalizeDDBStoreEvent);
 
     return storeEvents.concat(contractEvents);
   },


### PR DESCRIPTION
## Description

This PR adds different renderers for different inbox event types so we can simplify the InboxItem component

**New stuff** ✨
* TBD

**Changes** 🏗
* Extrapolate contract and store addresses based on the events we get for normalization

## TODO

- [x] Get  contract and store addresses right out of the event we're normalizing
- [ ] Hook event types to a specific rendered so we can keep the inbox item component dummy

(Resolves | Contributes to) #31415
