### PR TITLE
Cancel erroneous sagas

### DIFF
--- a/src/modules/admin/sagas/index.js
+++ b/src/modules/admin/sagas/index.js
@@ -39,7 +39,7 @@ import { colonyNativeTokenSelector } from '../../dashboard/selectors';
 function* colonyTransactionsFetch({
   payload: { colonyAddress },
   meta,
-}: Action<typeof ACTIONS.COLONY_TRANSACTIONS_FETCH>): Saga<void> {
+}: Action<typeof ACTIONS.COLONY_TRANSACTIONS_FETCH>): Saga<*> {
   try {
     const transactions = yield* executeQuery(getColonyTransactions, {
       metadata: {
@@ -53,14 +53,15 @@ function* colonyTransactionsFetch({
       payload: { colonyAddress, transactions },
     });
   } catch (error) {
-    yield putError(ACTIONS.COLONY_TRANSACTIONS_FETCH_ERROR, error, meta);
+    return yield putError(ACTIONS.COLONY_TRANSACTIONS_FETCH_ERROR, error, meta);
   }
+  return null;
 }
 
 function* colonyUnclaimedTransactionsFetch({
   payload: { colonyAddress },
   meta,
-}: Action<typeof ACTIONS.COLONY_UNCLAIMED_TRANSACTIONS_FETCH>): Saga<void> {
+}: Action<typeof ACTIONS.COLONY_UNCLAIMED_TRANSACTIONS_FETCH>): Saga<*> {
   try {
     const transactions = yield* executeQuery(getColonyUnclaimedTransactions, {
       metadata: { colonyAddress },
@@ -74,12 +75,13 @@ function* colonyUnclaimedTransactionsFetch({
       payload: { colonyAddress, transactions },
     });
   } catch (error) {
-    yield putError(
+    return yield putError(
       ACTIONS.COLONY_UNCLAIMED_TRANSACTIONS_FETCH_ERROR,
       error,
       meta,
     );
   }
+  return null;
 }
 
 /*
@@ -88,7 +90,7 @@ function* colonyUnclaimedTransactionsFetch({
 function* colonyClaimToken({
   payload: { colonyAddress, tokenAddress },
   meta,
-}: Action<typeof ACTIONS.COLONY_CLAIM_TOKEN>): Saga<void> {
+}: Action<typeof ACTIONS.COLONY_CLAIM_TOKEN>): Saga<*> {
   let txChannel;
   try {
     txChannel = yield call(getTxChannel, meta.id);
@@ -116,17 +118,18 @@ function* colonyClaimToken({
       fetchColonyUnclaimedTransactions(colonyAddress),
     );
   } catch (error) {
-    yield putError(ACTIONS.COLONY_CLAIM_TOKEN_ERROR, error, meta);
+    return yield putError(ACTIONS.COLONY_CLAIM_TOKEN_ERROR, error, meta);
   } finally {
     if (txChannel) txChannel.close();
   }
+  return null;
 }
 
 function* colonyUpdateTokens({
   payload: { colonyAddress, tokens },
   payload,
   meta,
-}: Action<typeof ACTIONS.COLONY_UPDATE_TOKENS>): Saga<void> {
+}: Action<typeof ACTIONS.COLONY_UPDATE_TOKENS>): Saga<*> {
   try {
     /*
      * @todo Consider fetching tokens from state
@@ -148,14 +151,15 @@ function* colonyUpdateTokens({
     // successfully updating them
     yield put({ type: ACTIONS.COLONY_UPDATE_TOKENS_SUCCESS, payload });
   } catch (error) {
-    yield putError(ACTIONS.COLONY_UPDATE_TOKENS_ERROR, error, meta);
+    return yield putError(ACTIONS.COLONY_UPDATE_TOKENS_ERROR, error, meta);
   }
+  return null;
 }
 
 function* colonyMintTokens({
   payload: { amount, colonyAddress },
   meta,
-}: Action<typeof ACTIONS.COLONY_MINT_TOKENS>): Saga<void> {
+}: Action<typeof ACTIONS.COLONY_MINT_TOKENS>): Saga<*> {
   let txChannel;
   try {
     txChannel = yield call(getTxChannel, meta.id);
@@ -252,10 +256,11 @@ function* colonyMintTokens({
       meta,
     });
   } catch (error) {
-    yield putError(ACTIONS.COLONY_MINT_TOKENS_ERROR, error, meta);
+    return yield putError(ACTIONS.COLONY_MINT_TOKENS_ERROR, error, meta);
   } finally {
     if (txChannel) txChannel.close();
   }
+  return null;
 }
 
 export default function* adminSagas(): Saga<void> {

--- a/src/modules/core/sagas/ipfs.js
+++ b/src/modules/core/sagas/ipfs.js
@@ -38,7 +38,7 @@ export function* ipfsUpload(data: string): Saga<string> {
 function* ipfsDataUpload({
   meta,
   payload: { ipfsData },
-}: Action<typeof ACTIONS.IPFS_DATA_UPLOAD>): Saga<void> {
+}: Action<typeof ACTIONS.IPFS_DATA_UPLOAD>): Saga<*> {
   try {
     const ipfsNode = yield* getContext(CONTEXT.IPFS_NODE);
 
@@ -50,14 +50,15 @@ function* ipfsDataUpload({
       payload: { ipfsHash, ipfsData },
     });
   } catch (error) {
-    yield putError(ACTIONS.IPFS_DATA_UPLOAD_ERROR, error, meta);
+    return yield putError(ACTIONS.IPFS_DATA_UPLOAD_ERROR, error, meta);
   }
+  return null;
 }
 
 function* ipfsDataFetch({
   meta,
   payload: { ipfsHash },
-}: Action<typeof ACTIONS.IPFS_DATA_FETCH>): Saga<void> {
+}: Action<typeof ACTIONS.IPFS_DATA_FETCH>): Saga<*> {
   try {
     const ipfsNode = yield* getContext(CONTEXT.IPFS_NODE);
     const ipfsData = yield call([ipfsNode, ipfsNode.getString], ipfsHash);
@@ -68,8 +69,9 @@ function* ipfsDataFetch({
       payload: { ipfsHash, ipfsData },
     });
   } catch (error) {
-    yield putError(ACTIONS.IPFS_DATA_FETCH_ERROR, error, meta);
+    return yield putError(ACTIONS.IPFS_DATA_FETCH_ERROR, error, meta);
   }
+  return null;
 }
 
 export default function* ipfsSagas(): Saga<void> {

--- a/src/modules/core/sagas/network.js
+++ b/src/modules/core/sagas/network.js
@@ -10,7 +10,7 @@ import { CONTEXT, getContext } from '~context';
 import { ACTIONS } from '~redux';
 import { putError } from '~utils/saga/effects';
 
-function* networkFetch(): Saga<void> {
+function* networkFetch(): Saga<*> {
   try {
     const colonyManager = yield* getContext(CONTEXT.COLONY_MANAGER);
 
@@ -35,8 +35,9 @@ function* networkFetch(): Saga<void> {
       },
     });
   } catch (error) {
-    yield putError(ACTIONS.NETWORK_FETCH_ERROR, error);
+    return yield putError(ACTIONS.NETWORK_FETCH_ERROR, error);
   }
+  return null;
 }
 
 export default function* networkSagas(): Saga<void> {

--- a/src/modules/core/sagas/setupOnBeforeUnload.js
+++ b/src/modules/core/sagas/setupOnBeforeUnload.js
@@ -21,7 +21,7 @@ const pinnerIsBusy = (ipfsNode: IPFSNode) => ipfsNode.pinner.busy;
 
 const ddbIsBusy = (ddb: DDB) => ddb.busy;
 
-export default function* setupOnBeforeUnload(): Saga<void> {
+export default function* setupOnBeforeUnload(): Saga<*> {
   const ipfsNode = yield getContext('ipfsNode');
   const ddb = yield getContext('ddb');
   const handleBeforeunload = evt => {

--- a/src/modules/core/sagas/setupUserContext.js
+++ b/src/modules/core/sagas/setupUserContext.js
@@ -52,7 +52,7 @@ function* setupDDBResolver(
   colonyManager: ColonyManagerType,
   ddb: DDBType,
   ens: ENSCache,
-) {
+): Saga<*> {
   const { networkClient } = colonyManager;
 
   yield call([ddb, ddb.registerResolver], (identifier: string) =>
@@ -67,7 +67,7 @@ function* setupDDBResolver(
  */
 export default function* setupUserContext(
   action: Action<typeof ACTIONS.WALLET_CREATE>,
-): Saga<void> {
+): Saga<*> {
   const {
     meta,
     payload: { method },
@@ -159,6 +159,7 @@ export default function* setupUserContext(
 
     yield call(setupOnBeforeUnload);
   } catch (caughtError) {
-    yield putError(ACTIONS.WALLET_CREATE_ERROR, caughtError, meta);
+    return yield putError(ACTIONS.WALLET_CREATE_ERROR, caughtError, meta);
   }
+  return null;
 }

--- a/src/modules/dashboard/sagas/colony.js
+++ b/src/modules/dashboard/sagas/colony.js
@@ -51,7 +51,7 @@ import { createAddress } from '~types';
 function* colonyNameCheckAvailability({
   payload: { colonyName },
   meta,
-}: Action<typeof ACTIONS.COLONY_NAME_CHECK_AVAILABILITY>): Saga<void> {
+}: Action<typeof ACTIONS.COLONY_NAME_CHECK_AVAILABILITY>): Saga<*> {
   try {
     yield delay(300);
 
@@ -69,12 +69,13 @@ function* colonyNameCheckAvailability({
       payload: undefined,
     });
   } catch (caughtError) {
-    yield putError(
+    return yield putError(
       ACTIONS.COLONY_NAME_CHECK_AVAILABILITY_ERROR,
       caughtError,
       meta,
     );
   }
+  return null;
 }
 
 function* colonyProfileUpdate({
@@ -87,7 +88,7 @@ function* colonyProfileUpdate({
     guideline,
     website,
   },
-}: Action<typeof ACTIONS.COLONY_PROFILE_UPDATE>): Saga<void> {
+}: Action<typeof ACTIONS.COLONY_PROFILE_UPDATE>): Saga<*> {
   try {
     yield* executeCommand(updateColonyProfile, {
       args: {
@@ -112,14 +113,15 @@ function* colonyProfileUpdate({
       },
     });
   } catch (error) {
-    yield putError(ACTIONS.COLONY_PROFILE_UPDATE_ERROR, error, meta);
+    return yield putError(ACTIONS.COLONY_PROFILE_UPDATE_ERROR, error, meta);
   }
+  return null;
 }
 
 function* colonyFetch({
   payload: { colonyAddress },
   meta,
-}: Action<typeof ACTIONS.COLONY_FETCH>): Saga<void> {
+}: Action<typeof ACTIONS.COLONY_FETCH>): Saga<*> {
   try {
     const payload = yield* executeQuery(getColony, {
       args: { colonyAddress },
@@ -155,14 +157,15 @@ function* colonyFetch({
       payload: { colonyAddress },
     });
   } catch (error) {
-    yield putError(ACTIONS.COLONY_FETCH_ERROR, error, meta);
+    return yield putError(ACTIONS.COLONY_FETCH_ERROR, error, meta);
   }
+  return null;
 }
 
 function* colonyAddressFetch({
   payload: { colonyName },
   meta,
-}: Action<typeof ACTIONS.COLONY_ADDRESS_FETCH>): Saga<void> {
+}: Action<typeof ACTIONS.COLONY_ADDRESS_FETCH>): Saga<*> {
   try {
     const colonyAddress = yield call(getColonyAddress, colonyName);
 
@@ -175,14 +178,15 @@ function* colonyAddressFetch({
       payload: { colonyAddress, colonyName },
     });
   } catch (error) {
-    yield putError(ACTIONS.COLONY_ADDRESS_FETCH_ERROR, error, meta);
+    return yield putError(ACTIONS.COLONY_ADDRESS_FETCH_ERROR, error, meta);
   }
+  return null;
 }
 
 function* colonyNameFetch({
   payload: { colonyAddress },
   meta,
-}: Action<typeof ACTIONS.COLONY_NAME_FETCH>): Saga<void> {
+}: Action<typeof ACTIONS.COLONY_NAME_FETCH>): Saga<*> {
   try {
     const colonyName = yield call(getColonyName, colonyAddress);
     yield put<Action<typeof ACTIONS.COLONY_NAME_FETCH_SUCCESS>>({
@@ -191,14 +195,15 @@ function* colonyNameFetch({
       payload: { colonyAddress, colonyName },
     });
   } catch (error) {
-    yield putError(ACTIONS.COLONY_NAME_FETCH_ERROR, error, meta);
+    return yield putError(ACTIONS.COLONY_NAME_FETCH_ERROR, error, meta);
   }
+  return null;
 }
 
 function* colonyAvatarUpload({
   meta,
   payload: { colonyAddress, data },
-}: Action<typeof ACTIONS.COLONY_AVATAR_UPLOAD>): Saga<void> {
+}: Action<typeof ACTIONS.COLONY_AVATAR_UPLOAD>): Saga<*> {
   try {
     // first attempt upload to IPFS
     const ipfsHash = yield call(ipfsUpload, data);
@@ -222,14 +227,15 @@ function* colonyAvatarUpload({
       payload: { hash: ipfsHash },
     });
   } catch (error) {
-    yield putError(ACTIONS.COLONY_AVATAR_UPLOAD_ERROR, error, meta);
+    return yield putError(ACTIONS.COLONY_AVATAR_UPLOAD_ERROR, error, meta);
   }
+  return null;
 }
 
 function* colonyAvatarRemove({
   meta,
   payload: { colonyAddress },
-}: Action<typeof ACTIONS.COLONY_AVATAR_REMOVE>): Saga<void> {
+}: Action<typeof ACTIONS.COLONY_AVATAR_REMOVE>): Saga<*> {
   try {
     const ipfsHash = yield select(colonyAvatarHashSelector, colonyAddress);
     /*
@@ -251,8 +257,9 @@ function* colonyAvatarRemove({
       payload: undefined,
     });
   } catch (error) {
-    yield putError(ACTIONS.COLONY_AVATAR_REMOVE_ERROR, error, meta);
+    return yield putError(ACTIONS.COLONY_AVATAR_REMOVE_ERROR, error, meta);
   }
+  return null;
 }
 
 function* colonyRecoveryModeEnter({
@@ -279,10 +286,15 @@ function* colonyRecoveryModeEnter({
 
     yield put(fetchColony(colonyAddress));
   } catch (error) {
-    yield putError(ACTIONS.COLONY_RECOVERY_MODE_ENTER_ERROR, error, meta);
+    return yield putError(
+      ACTIONS.COLONY_RECOVERY_MODE_ENTER_ERROR,
+      error,
+      meta,
+    );
   } finally {
     txChannel.close();
   }
+  return null;
 }
 
 function* colonyUpgradeContract({
@@ -312,10 +324,11 @@ function* colonyUpgradeContract({
 
     yield put(fetchColony(colonyAddress));
   } catch (error) {
-    yield putError(ACTIONS.COLONY_VERSION_UPGRADE_ERROR, error, meta);
+    return yield putError(ACTIONS.COLONY_VERSION_UPGRADE_ERROR, error, meta);
   } finally {
     txChannel.close();
   }
+  return null;
 }
 
 function* colonyTokenBalanceFetch({
@@ -338,8 +351,9 @@ function* colonyTokenBalanceFetch({
       },
     });
   } catch (error) {
-    yield putError(ACTIONS.COLONY_TOKEN_BALANCE_FETCH_ERROR, error);
+    return yield putError(ACTIONS.COLONY_TOKEN_BALANCE_FETCH_ERROR, error);
   }
+  return null;
 }
 
 /*
@@ -349,7 +363,7 @@ function* colonyTokenBalanceFetch({
 function* colonyTaskMetadataFetch({
   meta,
   payload: { colonyAddress },
-}: Action<typeof ACTIONS.COLONY_TASK_METADATA_FETCH>): Saga<void> {
+}: Action<typeof ACTIONS.COLONY_TASK_METADATA_FETCH>): Saga<*> {
   try {
     const colonyTasks = yield* executeQuery(getColonyTasks, {
       metadata: { colonyAddress },
@@ -360,14 +374,19 @@ function* colonyTaskMetadataFetch({
       payload: { colonyAddress, colonyTasks },
     });
   } catch (error) {
-    yield putError(ACTIONS.COLONY_TASK_METADATA_FETCH_ERROR, error, meta);
+    return yield putError(
+      ACTIONS.COLONY_TASK_METADATA_FETCH_ERROR,
+      error,
+      meta,
+    );
   }
+  return null;
 }
 
 function* colonyCanMintNativeTokenFetch({
   meta,
   payload: { colonyAddress },
-}: Action<typeof ACTIONS.COLONY_CAN_MINT_NATIVE_TOKEN_FETCH>): Saga<void> {
+}: Action<typeof ACTIONS.COLONY_CAN_MINT_NATIVE_TOKEN_FETCH>): Saga<*> {
   try {
     const canMintNativeToken = yield* executeQuery(
       getColonyCanMintNativeToken,
@@ -383,18 +402,19 @@ function* colonyCanMintNativeTokenFetch({
       payload: { canMintNativeToken, colonyAddress },
     });
   } catch (error) {
-    yield putError(
+    return yield putError(
       ACTIONS.COLONY_CAN_MINT_NATIVE_TOKEN_FETCH_ERROR,
       error,
       meta,
     );
   }
+  return null;
 }
 
 function* colonyNativeTokenUnlock({
   meta,
   payload: { colonyAddress },
-}: Action<typeof ACTIONS.COLONY_NATIVE_TOKEN_UNLOCK>): Saga<void> {
+}: Action<typeof ACTIONS.COLONY_NATIVE_TOKEN_UNLOCK>): Saga<*> {
   const txChannel = yield call(getTxChannel, meta.id);
 
   try {
@@ -413,10 +433,15 @@ function* colonyNativeTokenUnlock({
 
     yield put(fetchColony(colonyAddress));
   } catch (error) {
-    yield putError(ACTIONS.COLONY_NATIVE_TOKEN_UNLOCK_ERROR, error, meta);
+    return yield putError(
+      ACTIONS.COLONY_NATIVE_TOKEN_UNLOCK_ERROR,
+      error,
+      meta,
+    );
   } finally {
     txChannel.close();
   }
+  return null;
 }
 
 export default function* colonySagas(): Saga<void> {

--- a/src/modules/dashboard/sagas/colonyCreate.js
+++ b/src/modules/dashboard/sagas/colonyCreate.js
@@ -297,12 +297,11 @@ function* colonyCreate({
     } = yield takeFrom(createColony.channel, ACTIONS.TRANSACTION_SUCCEEDED);
 
     if (!colonyAddress) {
-      yield putError(
+      return yield putError(
         ACTIONS.COLONY_CREATE_ERROR,
         new Error('Missing colony address'),
         meta,
       );
-      return null;
     }
 
     /*

--- a/src/modules/dashboard/sagas/domains.js
+++ b/src/modules/dashboard/sagas/domains.js
@@ -26,7 +26,7 @@ import { getColonyDomains } from '../data/queries';
 function* colonyDomainsFetch({
   meta,
   payload: { colonyAddress },
-}: Action<typeof ACTIONS.COLONY_DOMAINS_FETCH>): Saga<void> {
+}: Action<typeof ACTIONS.COLONY_DOMAINS_FETCH>): Saga<*> {
   try {
     const domains = yield* executeQuery(getColonyDomains, {
       metadata: { colonyAddress },
@@ -43,14 +43,15 @@ function* colonyDomainsFetch({
       },
     });
   } catch (error) {
-    yield putError(ACTIONS.COLONY_DOMAINS_FETCH_ERROR, error, meta);
+    return yield putError(ACTIONS.COLONY_DOMAINS_FETCH_ERROR, error, meta);
   }
+  return null;
 }
 
 function* domainCreate({
   payload: { colonyAddress, domainName: name, parentDomainId = 1 },
   meta,
-}: Action<typeof ACTIONS.DOMAIN_CREATE>): Saga<void> {
+}: Action<typeof ACTIONS.DOMAIN_CREATE>): Saga<*> {
   const txChannel = yield call(getTxChannel, meta.id);
   try {
     /*
@@ -109,10 +110,11 @@ function* domainCreate({
     const decoratedLog = yield call(decorateLog, colonyClient, domainAddedLog);
     yield putNotification(normalizeTransactionLog(colonyAddress, decoratedLog));
   } catch (error) {
-    yield putError(ACTIONS.DOMAIN_CREATE_ERROR, error, meta);
+    return yield putError(ACTIONS.DOMAIN_CREATE_ERROR, error, meta);
   } finally {
     txChannel.close();
   }
+  return null;
 }
 
 export default function* domainSagas(): Saga<void> {

--- a/src/modules/dashboard/sagas/roles.js
+++ b/src/modules/dashboard/sagas/roles.js
@@ -40,14 +40,15 @@ function* colonyRolesFetch({
       payload: roles,
     });
   } catch (error) {
-    yield putError(ACTIONS.COLONY_ROLES_FETCH_ERROR, error, meta);
+    return yield putError(ACTIONS.COLONY_ROLES_FETCH_ERROR, error, meta);
   }
+  return null;
 }
 
 function* colonyAdminAdd({
   payload: { newAdmin, colonyAddress },
   meta,
-}: Action<typeof ACTIONS.COLONY_ADMIN_ADD>): Saga<void> {
+}: Action<typeof ACTIONS.COLONY_ADMIN_ADD>): Saga<*> {
   const txChannel = yield call(getTxChannel, meta.id);
   try {
     /*
@@ -97,17 +98,18 @@ function* colonyAdminAdd({
     yield putNotification(normalizeTransactionLog(colonyAddress, decoratedLog));
     yield put(fetchRoles(colonyAddress));
   } catch (error) {
-    yield putError(ACTIONS.COLONY_ADMIN_ADD_ERROR, error, meta);
+    return yield putError(ACTIONS.COLONY_ADMIN_ADD_ERROR, error, meta);
   } finally {
     if (txChannel) txChannel.close();
   }
+  return null;
 }
 
 function* colonyAdminRemove({
   payload: { user, colonyAddress },
   payload,
   meta,
-}: Action<typeof ACTIONS.COLONY_ADMIN_REMOVE>): Saga<void> {
+}: Action<typeof ACTIONS.COLONY_ADMIN_REMOVE>): Saga<*> {
   let txChannel;
   try {
     txChannel = yield call(getTxChannel, meta.id);
@@ -154,10 +156,11 @@ function* colonyAdminRemove({
     yield putNotification(normalizeTransactionLog(colonyAddress, decoratedLog));
     yield put(fetchRoles(colonyAddress));
   } catch (error) {
-    yield putError(ACTIONS.COLONY_ADMIN_REMOVE_ERROR, error, meta);
+    return yield putError(ACTIONS.COLONY_ADMIN_REMOVE_ERROR, error, meta);
   } finally {
     if (txChannel) txChannel.close();
   }
+  return null;
 }
 
 export default function* rolesSagas(): Saga<void> {

--- a/src/modules/dashboard/sagas/task.js
+++ b/src/modules/dashboard/sagas/task.js
@@ -109,7 +109,7 @@ export function* fetchColonyTaskMetadata(colonyAddress: Address): Saga<*> {
 function* taskCreate({
   meta,
   payload: { colonyAddress },
-}: Action<typeof ACTIONS.TASK_CREATE>): Saga<void> {
+}: Action<typeof ACTIONS.TASK_CREATE>): Saga<*> {
   try {
     const {
       record: { colonyName },
@@ -151,8 +151,9 @@ function* taskCreate({
       put(replace(`/colony/${colonyName}/task/${draftId}`)),
     ]);
   } catch (error) {
-    yield putError(ACTIONS.TASK_CREATE_ERROR, error, meta);
+    return yield putError(ACTIONS.TASK_CREATE_ERROR, error, meta);
   }
+  return null;
 }
 
 /**
@@ -199,7 +200,7 @@ const getTaskFetchSuccessPayload = (
 function* taskFetch({
   meta,
   payload: { colonyAddress, draftId },
-}: Action<typeof ACTIONS.TASK_FETCH>): Saga<void> {
+}: Action<typeof ACTIONS.TASK_FETCH>): Saga<*> {
   try {
     const taskData = yield* executeQuery(getTask, {
       metadata: { colonyAddress, draftId },
@@ -210,15 +211,16 @@ function* taskFetch({
       meta,
     });
   } catch (error) {
-    yield putError(ACTIONS.TASK_FETCH_ERROR, error, meta);
+    return yield putError(ACTIONS.TASK_FETCH_ERROR, error, meta);
   }
+  return null;
 }
 
 /*
  * Given all colonies in the current state, fetch all tasks for all
  * colonies (in parallel).
  */
-function* taskFetchAll(): Saga<void> {
+function* taskFetchAll(): Saga<*> {
   const colonyAddresss = yield select(allColonyNamesSelector);
   yield all(
     colonyAddresss.map(colonyAddress =>
@@ -230,7 +232,7 @@ function* taskFetchAll(): Saga<void> {
 function* taskSetDescription({
   meta,
   payload: { colonyAddress, draftId, description },
-}: Action<typeof ACTIONS.TASK_SET_DESCRIPTION>): Saga<void> {
+}: Action<typeof ACTIONS.TASK_SET_DESCRIPTION>): Saga<*> {
   try {
     const {
       record: { description: currentDescription },
@@ -255,14 +257,15 @@ function* taskSetDescription({
       });
     }
   } catch (error) {
-    yield putError(ACTIONS.TASK_SET_DESCRIPTION_ERROR, error, meta);
+    return yield putError(ACTIONS.TASK_SET_DESCRIPTION_ERROR, error, meta);
   }
+  return null;
 }
 
 function* taskSetTitle({
   meta,
   payload: { colonyAddress, draftId, title },
-}: Action<typeof ACTIONS.TASK_SET_TITLE>): Saga<void> {
+}: Action<typeof ACTIONS.TASK_SET_TITLE>): Saga<*> {
   try {
     const { event } = yield* executeCommand(setTaskTitle, {
       args: { title },
@@ -278,14 +281,15 @@ function* taskSetTitle({
       },
     });
   } catch (error) {
-    yield putError(ACTIONS.TASK_SET_TITLE_ERROR, error, meta);
+    return yield putError(ACTIONS.TASK_SET_TITLE_ERROR, error, meta);
   }
+  return null;
 }
 
 function* taskSetDomain({
   meta,
   payload: { colonyAddress, draftId, domainId },
-}: Action<typeof ACTIONS.TASK_SET_DOMAIN>): Saga<void> {
+}: Action<typeof ACTIONS.TASK_SET_DOMAIN>): Saga<*> {
   try {
     const { event } = yield* executeCommand(setTaskDomain, {
       args: { domainId },
@@ -301,8 +305,9 @@ function* taskSetDomain({
       },
     });
   } catch (error) {
-    yield putError(ACTIONS.TASK_SET_DOMAIN_ERROR, error, meta);
+    return yield putError(ACTIONS.TASK_SET_DOMAIN_ERROR, error, meta);
   }
+  return null;
 }
 
 /*
@@ -313,7 +318,7 @@ function* taskSetDomain({
 function* taskCancel({
   meta,
   payload: { colonyAddress, draftId },
-}: Action<typeof ACTIONS.TASK_CANCEL>): Saga<void> {
+}: Action<typeof ACTIONS.TASK_CANCEL>): Saga<*> {
   try {
     const { event } = yield* executeCommand(cancelTask, {
       args: { draftId },
@@ -330,8 +335,9 @@ function* taskCancel({
       },
     });
   } catch (error) {
-    yield putError(ACTIONS.TASK_CANCEL_ERROR, error, meta);
+    return yield putError(ACTIONS.TASK_CANCEL_ERROR, error, meta);
   }
+  return null;
 }
 
 /*
@@ -342,7 +348,7 @@ function* taskCancel({
 function* taskClose({
   meta,
   payload: { colonyAddress, draftId },
-}: Action<typeof ACTIONS.TASK_CLOSE>): Saga<void> {
+}: Action<typeof ACTIONS.TASK_CLOSE>): Saga<*> {
   try {
     const { event } = yield* executeCommand(closeTask, {
       metadata: { colonyAddress, draftId },
@@ -358,8 +364,9 @@ function* taskClose({
       },
     });
   } catch (error) {
-    yield putError(ACTIONS.TASK_CLOSE_ERROR, error, meta);
+    return yield putError(ACTIONS.TASK_CLOSE_ERROR, error, meta);
   }
+  return null;
 }
 
 /*
@@ -368,7 +375,7 @@ function* taskClose({
 function* taskSetSkill({
   payload: { colonyAddress, draftId, skillId },
   meta,
-}: Action<typeof ACTIONS.TASK_SET_SKILL>): Saga<void> {
+}: Action<typeof ACTIONS.TASK_SET_SKILL>): Saga<*> {
   try {
     const { event } = yield* executeCommand(setTaskSkill, {
       args: { skillId },
@@ -385,8 +392,9 @@ function* taskSetSkill({
       meta,
     });
   } catch (error) {
-    yield putError(ACTIONS.TASK_SET_SKILL_ERROR, error, meta);
+    return yield putError(ACTIONS.TASK_SET_SKILL_ERROR, error, meta);
   }
+  return null;
 }
 
 /*
@@ -395,7 +403,7 @@ function* taskSetSkill({
 function* taskSetPayout({
   payload: { colonyAddress, draftId, token, amount },
   meta,
-}: Action<typeof ACTIONS.TASK_SET_PAYOUT>): Saga<void> {
+}: Action<typeof ACTIONS.TASK_SET_PAYOUT>): Saga<*> {
   try {
     const { event } = yield* executeCommand(setTaskPayout, {
       args: { token, amount },
@@ -412,8 +420,9 @@ function* taskSetPayout({
       meta,
     });
   } catch (error) {
-    yield putError(ACTIONS.TASK_SET_PAYOUT_ERROR, error, meta);
+    return yield putError(ACTIONS.TASK_SET_PAYOUT_ERROR, error, meta);
   }
+  return null;
 }
 
 /*
@@ -422,7 +431,7 @@ function* taskSetPayout({
 function* taskSetDueDate({
   payload: { colonyAddress, draftId, dueDate },
   meta,
-}: Action<typeof ACTIONS.TASK_SET_DUE_DATE>): Saga<void> {
+}: Action<typeof ACTIONS.TASK_SET_DUE_DATE>): Saga<*> {
   try {
     const { event } = yield* executeCommand(setTaskDueDate, {
       args: { dueDate: dueDate.getTime() },
@@ -438,8 +447,9 @@ function* taskSetDueDate({
       meta,
     });
   } catch (error) {
-    yield putError(ACTIONS.TASK_SET_DUE_DATE_ERROR, error, meta);
+    return yield putError(ACTIONS.TASK_SET_DUE_DATE_ERROR, error, meta);
   }
+  return null;
 }
 
 /*
@@ -448,7 +458,7 @@ function* taskSetDueDate({
 function* taskFinalize({
   payload: { colonyAddress, draftId },
   meta,
-}: Action<typeof ACTIONS.TASK_FINALIZE>): Saga<void> {
+}: Action<typeof ACTIONS.TASK_FINALIZE>): Saga<*> {
   try {
     const colonyManager = yield* getContext(CONTEXT.COLONY_MANAGER);
     const colonyClient = yield call(
@@ -564,14 +574,15 @@ function* taskFinalize({
       meta,
     });
   } catch (error) {
-    yield putError(ACTIONS.TASK_FINALIZE_ERROR, error, meta);
+    return yield putError(ACTIONS.TASK_FINALIZE_ERROR, error, meta);
   }
+  return null;
 }
 
 function* taskSendWorkInvite({
   payload: { colonyAddress, draftId },
   meta,
-}: Action<typeof ACTIONS.TASK_SEND_WORK_INVITE>): Saga<void> {
+}: Action<typeof ACTIONS.TASK_SEND_WORK_INVITE>): Saga<*> {
   try {
     const { workerAddress } = yield select(taskSelector, draftId);
     const { event } = yield* executeCommand(sendWorkInvite, {
@@ -588,14 +599,15 @@ function* taskSendWorkInvite({
       meta,
     });
   } catch (error) {
-    yield putError(ACTIONS.TASK_SEND_WORK_INVITE_ERROR, error, meta);
+    return yield putError(ACTIONS.TASK_SEND_WORK_INVITE_ERROR, error, meta);
   }
+  return null;
 }
 
 function* taskSendWorkRequest({
   payload: { colonyAddress, draftId },
   meta,
-}: Action<typeof ACTIONS.TASK_SEND_WORK_REQUEST>): Saga<void> {
+}: Action<typeof ACTIONS.TASK_SEND_WORK_REQUEST>): Saga<*> {
   try {
     const walletAddress = yield select(walletAddressSelector);
     const { event } = yield* executeCommand(createWorkRequest, {
@@ -627,14 +639,15 @@ function* taskSendWorkRequest({
       meta,
     });
   } catch (error) {
-    yield putError(ACTIONS.TASK_SEND_WORK_REQUEST_ERROR, error, meta);
+    return yield putError(ACTIONS.TASK_SEND_WORK_REQUEST_ERROR, error, meta);
   }
+  return null;
 }
 
 function* taskWorkerAssign({
   payload: { colonyAddress, draftId, workerAddress },
   meta,
-}: Action<typeof ACTIONS.TASK_WORKER_ASSIGN>): Saga<void> {
+}: Action<typeof ACTIONS.TASK_WORKER_ASSIGN>): Saga<*> {
   try {
     const walletAddress = yield select(walletAddressSelector);
     const {
@@ -668,14 +681,15 @@ function* taskWorkerAssign({
       });
     }
   } catch (error) {
-    yield putError(ACTIONS.TASK_WORKER_ASSIGN_ERROR, error, meta);
+    return yield putError(ACTIONS.TASK_WORKER_ASSIGN_ERROR, error, meta);
   }
+  return null;
 }
 
 function* taskWorkerUnassign({
   payload: { colonyAddress, draftId, workerAddress },
   meta,
-}: Action<typeof ACTIONS.TASK_WORKER_UNASSIGN>): Saga<void> {
+}: Action<typeof ACTIONS.TASK_WORKER_UNASSIGN>): Saga<*> {
   try {
     const { event } = yield* executeCommand(unassignWorker, {
       args: { workerAddress },
@@ -691,14 +705,15 @@ function* taskWorkerUnassign({
       meta,
     });
   } catch (error) {
-    yield putError(ACTIONS.TASK_WORKER_UNASSIGN_ERROR, error, meta);
+    return yield putError(ACTIONS.TASK_WORKER_UNASSIGN_ERROR, error, meta);
   }
+  return null;
 }
 
 function* taskSetWorkerAndPayouts({
   payload: { colonyAddress, draftId, payouts, workerAddress },
   meta,
-}: Action<typeof ACTIONS.TASK_SET_WORKER_AND_PAYOUTS>): Saga<void> {
+}: Action<typeof ACTIONS.TASK_SET_WORKER_AND_PAYOUTS>): Saga<*> {
   try {
     yield call(taskWorkerAssign, {
       meta: { key: draftId },
@@ -737,14 +752,19 @@ function* taskSetWorkerAndPayouts({
       },
     });
   } catch (error) {
-    yield putError(ACTIONS.TASK_SET_WORKER_AND_PAYOUTS_ERROR, error, meta);
+    return yield putError(
+      ACTIONS.TASK_SET_WORKER_AND_PAYOUTS_ERROR,
+      error,
+      meta,
+    );
   }
+  return null;
 }
 
 function* taskFeedItemsSubStart({
   payload: { colonyAddress, draftId },
   meta,
-}: *): Saga<void> {
+}: *): Saga<*> {
   let channel;
   try {
     channel = yield call(executeSubscription, subscribeTaskFeedItems, {
@@ -773,7 +793,7 @@ function* taskFeedItemsSubStart({
       });
     }
   } catch (caughtError) {
-    yield putError(ACTIONS.TASK_FEED_ITEMS_SUB_ERROR, caughtError, meta);
+    return yield putError(ACTIONS.TASK_FEED_ITEMS_SUB_ERROR, caughtError, meta);
   } finally {
     if (channel && typeof channel.close == 'function') {
       channel.close();
@@ -784,7 +804,7 @@ function* taskFeedItemsSubStart({
 function* taskSubStart({
   payload: { colonyAddress, draftId },
   meta,
-}: *): Saga<void> {
+}: *): Saga<*> {
   // This could be generalised (it's very similar to the above function),
   // but it's probably worth waiting to see, as this pattern will likely change
   // as it gets used elsewhere.
@@ -816,7 +836,7 @@ function* taskSubStart({
       });
     }
   } catch (caughtError) {
-    yield putError(ACTIONS.TASK_SUB_ERROR, caughtError, meta);
+    return yield putError(ACTIONS.TASK_SUB_ERROR, caughtError, meta);
   } finally {
     if (channel && typeof channel.close == 'function') {
       channel.close();
@@ -827,7 +847,7 @@ function* taskSubStart({
 function* taskCommentAdd({
   payload: { author, colonyAddress, comment, draftId, taskTitle },
   meta,
-}: Action<typeof ACTIONS.TASK_COMMENT_ADD>): Saga<void> {
+}: Action<typeof ACTIONS.TASK_COMMENT_ADD>): Saga<*> {
   try {
     const walletAddress = yield select(walletAddressSelector);
     const currentUsername = yield select(usernameSelector, walletAddress);
@@ -907,11 +927,12 @@ function* taskCommentAdd({
       });
     }
   } catch (error) {
-    yield putError(ACTIONS.TASK_COMMENT_ADD_ERROR, error, meta);
+    return yield putError(ACTIONS.TASK_COMMENT_ADD_ERROR, error, meta);
   }
+  return null;
 }
 
-export default function* tasksSagas(): any {
+export default function* tasksSagas(): Saga<void> {
   yield takeEvery(ACTIONS.TASK_CANCEL, taskCancel);
   yield takeEvery(ACTIONS.TASK_CLOSE, taskClose);
   yield takeEvery(ACTIONS.TASK_COMMENT_ADD, taskCommentAdd);

--- a/src/modules/dashboard/sagas/token.js
+++ b/src/modules/dashboard/sagas/token.js
@@ -27,7 +27,7 @@ import { NETWORK_CONTEXT } from '../../core/constants';
 function* tokenInfoFetch({
   payload: { tokenAddress },
   meta,
-}: Action<typeof ACTIONS.TOKEN_INFO_FETCH>): Saga<void> {
+}: Action<typeof ACTIONS.TOKEN_INFO_FETCH>): Saga<*> {
   // if trying to fetch info for Ether, return hardcoded
   if (tokenAddress === ZERO_ADDRESS) {
     yield put<Action<typeof ACTIONS.TOKEN_INFO_FETCH_SUCCESS>>({
@@ -60,14 +60,15 @@ function* tokenInfoFetch({
       meta,
     });
   } catch (error) {
-    yield putError(ACTIONS.TOKEN_INFO_FETCH_ERROR, error, meta);
+    return yield putError(ACTIONS.TOKEN_INFO_FETCH_ERROR, error, meta);
   }
+  return null;
 }
 
 function* tokenCreate({
   payload: { tokenName: name, tokenSymbol: symbol },
   meta,
-}: Action<typeof ACTIONS.TOKEN_CREATE>): Saga<void> {
+}: Action<typeof ACTIONS.TOKEN_CREATE>): Saga<*> {
   const txChannel = yield call(getTxChannel, meta.id);
 
   try {
@@ -99,10 +100,11 @@ function* tokenCreate({
 
     yield takeFrom(txChannel, ACTIONS.TRANSACTION_SUCCEEDED);
   } catch (error) {
-    yield putError(ACTIONS.TOKEN_CREATE_ERROR, error, meta);
+    return yield putError(ACTIONS.TOKEN_CREATE_ERROR, error, meta);
   } finally {
     txChannel.close();
   }
+  return null;
 }
 
 export default function* tokenSagas(): Saga<void> {

--- a/src/modules/users/sagas/inbox.js
+++ b/src/modules/users/sagas/inbox.js
@@ -46,8 +46,12 @@ function* markAllNotificationsAsRead(): Saga<*> {
       },
     );
   } catch (error) {
-    yield putError(ACTIONS.INBOX_MARK_ALL_NOTIFICATIONS_READ_ERROR, error);
+    return yield putError(
+      ACTIONS.INBOX_MARK_ALL_NOTIFICATIONS_READ_ERROR,
+      error,
+    );
   }
+  return null;
 }
 
 /*  We use a timestamp here for the item being marked as read */
@@ -80,12 +84,9 @@ function* markNotificationAsRead({
       timestamp: activity.get('timestamp'),
     }));
     /* If the activity is not found, do nothing */
-    if (
-      !(
-        inboxItems && inboxItems.some(({ id: activityId }) => activityId === id)
-      )
-    )
-      return;
+    if (!(inboxItems && inboxItems.some(item => item.id === id))) {
+      return null;
+    }
 
     const exceptFor =
       Array.from(new Set([...inboxItems, ...currentExceptFor]))
@@ -102,7 +103,7 @@ function* markNotificationAsRead({
       exceptFor.every(item => currentExceptFor.includes(item)) &&
       timestamp <= currentReadUntil
     ) {
-      return;
+      return null;
     }
 
     const readUntil =
@@ -131,8 +132,9 @@ function* markNotificationAsRead({
       payload: { readUntil, exceptFor },
     });
   } catch (error) {
-    yield putError(ACTIONS.INBOX_MARK_NOTIFICATION_READ_ERROR, error);
+    return yield putError(ACTIONS.INBOX_MARK_NOTIFICATION_READ_ERROR, error);
   }
+  return null;
 }
 
 export default function* inboxSagas(): Saga<void> {

--- a/src/modules/users/sagas/user.js
+++ b/src/modules/users/sagas/user.js
@@ -71,7 +71,7 @@ import { createTransaction, getTxChannel } from '../../core/sagas/transactions';
 function* userTokenTransfersFetch(
   // eslint-disable-next-line no-unused-vars
   action: Action<typeof ACTIONS.USER_TOKEN_TRANSFERS_FETCH>,
-): Saga<void> {
+): Saga<*> {
   try {
     const userColonyAddresses = yield* selectAsJS(currentUserColoniesSelector);
     const transactions = yield* executeQuery(getUserColonyTransactions, {
@@ -85,8 +85,9 @@ function* userTokenTransfersFetch(
       payload: { transactions },
     });
   } catch (error) {
-    yield putError(ACTIONS.USER_TOKEN_TRANSFERS_FETCH_ERROR, error);
+    return yield putError(ACTIONS.USER_TOKEN_TRANSFERS_FETCH_ERROR, error);
   }
+  return null;
 }
 
 function* userAddressFetch({
@@ -133,7 +134,7 @@ function* userFetch({
 function* currentUserGetBalance(
   // eslint-disable-next-line no-unused-vars
   action: Action<typeof ACTIONS.CURRENT_USER_GET_BALANCE>,
-): Saga<void> {
+): Saga<*> {
   try {
     const walletAddress = yield select(walletAddressSelector);
     if (!walletAddress) {
@@ -148,13 +149,15 @@ function* currentUserGetBalance(
       payload: { balance },
     });
   } catch (error) {
-    yield putError(ACTIONS.CURRENT_USER_GET_BALANCE_ERROR, error);
+    return yield putError(ACTIONS.CURRENT_USER_GET_BALANCE_ERROR, error);
   }
+  return null;
 }
+
 function* userProfileUpdate({
   meta,
   payload,
-}: Action<typeof ACTIONS.USER_PROFILE_UPDATE>): Saga<void> {
+}: Action<typeof ACTIONS.USER_PROFILE_UPDATE>): Saga<*> {
   try {
     const walletAddress = yield select(walletAddressSelector);
     yield* executeCommand(updateUserProfile, {
@@ -175,12 +178,14 @@ function* userProfileUpdate({
       payload: user,
     });
   } catch (error) {
-    yield putError(ACTIONS.USER_PROFILE_UPDATE_ERROR, error, meta);
+    return yield putError(ACTIONS.USER_PROFILE_UPDATE_ERROR, error, meta);
   }
+  return null;
 }
+
 function* userAvatarRemove({
   meta,
-}: Action<typeof ACTIONS.USER_AVATAR_REMOVE>): Saga<void> {
+}: Action<typeof ACTIONS.USER_AVATAR_REMOVE>): Saga<*> {
   try {
     const walletAddress = yield select(walletAddressSelector);
     yield* executeCommand(removeUserAvatar, {
@@ -195,13 +200,15 @@ function* userAvatarRemove({
       meta,
     });
   } catch (error) {
-    yield putError(ACTIONS.USER_AVATAR_REMOVE_ERROR, error, meta);
+    return yield putError(ACTIONS.USER_AVATAR_REMOVE_ERROR, error, meta);
   }
+  return null;
 }
+
 function* userAvatarUpload({
   meta,
   payload,
-}: Action<typeof ACTIONS.USER_AVATAR_UPLOAD>): Saga<void> {
+}: Action<typeof ACTIONS.USER_AVATAR_UPLOAD>): Saga<*> {
   try {
     const walletAddress = yield select(walletAddressSelector);
     const ipfsHash = yield call(ipfsUpload, payload.data);
@@ -222,13 +229,15 @@ function* userAvatarUpload({
       },
     });
   } catch (error) {
-    yield putError(ACTIONS.USER_AVATAR_UPLOAD_ERROR, error, meta);
+    return yield putError(ACTIONS.USER_AVATAR_UPLOAD_ERROR, error, meta);
   }
+  return null;
 }
+
 function* usernameCheckAvailability({
   meta,
   payload: { username },
-}: Action<typeof ACTIONS.USERNAME_CHECK_AVAILABILITY>): Saga<void> {
+}: Action<typeof ACTIONS.USERNAME_CHECK_AVAILABILITY>): Saga<*> {
   try {
     yield delay(300);
 
@@ -246,8 +255,13 @@ function* usernameCheckAvailability({
       payload: undefined,
     });
   } catch (error) {
-    yield putError(ACTIONS.USERNAME_CHECK_AVAILABILITY_ERROR, error, meta);
+    return yield putError(
+      ACTIONS.USERNAME_CHECK_AVAILABILITY_ERROR,
+      error,
+      meta,
+    );
   }
+  return null;
 }
 
 function* usernameCreate({
@@ -305,7 +319,8 @@ function* usernameCreate({
   }
   return null;
 }
-function* userLogout(): Saga<void> {
+
+function* userLogout(): Saga<*> {
   const ddb = yield* getContext(CONTEXT.DDB_INSTANCE);
 
   try {
@@ -332,14 +347,15 @@ function* userLogout(): Saga<void> {
       put(push(`/dashboard`)),
     ]);
   } catch (error) {
-    yield putError(ACTIONS.USER_LOGOUT_ERROR, error);
+    return yield putError(ACTIONS.USER_LOGOUT_ERROR, error);
   }
+  return null;
 }
 
 function* userPermissionsFetch({
   payload: { colonyAddress },
   meta,
-}: Action<typeof ACTIONS.USER_PERMISSIONS_FETCH>): Saga<void> {
+}: Action<typeof ACTIONS.USER_PERMISSIONS_FETCH>): Saga<*> {
   try {
     const walletAddress = yield select(walletAddressSelector);
     if (!walletAddress) {
@@ -355,10 +371,12 @@ function* userPermissionsFetch({
       meta,
     });
   } catch (error) {
-    yield putError(ACTIONS.USER_PERMISSIONS_FETCH_ERROR, error, meta);
+    return yield putError(ACTIONS.USER_PERMISSIONS_FETCH_ERROR, error, meta);
   }
+  return null;
 }
-function* userTokensFetch(): Saga<void> {
+
+function* userTokensFetch(): Saga<*> {
   try {
     const walletAddress = yield select(walletAddressSelector);
     const { metadataStoreAddress } = yield select(currentUserMetadataSelector);
@@ -377,9 +395,11 @@ function* userTokensFetch(): Saga<void> {
       payload: { tokens },
     });
   } catch (error) {
-    yield putError(ACTIONS.USER_TOKENS_FETCH_ERROR, error);
+    return yield putError(ACTIONS.USER_TOKENS_FETCH_ERROR, error);
   }
+  return null;
 }
+
 /**
  * Diff the current user tokens and the list sent as payload, and work out
  * which tokens need adding and which need removing. Then append the relevant
@@ -387,7 +407,7 @@ function* userTokensFetch(): Saga<void> {
  */
 function* userTokensUpdate(
   action: Action<typeof ACTIONS.USER_TOKENS_UPDATE>,
-): Saga<void> {
+): Saga<*> {
   try {
     const { tokens } = action.payload;
     const walletAddress = yield select(walletAddressSelector);
@@ -404,9 +424,11 @@ function* userTokensUpdate(
     yield put({ type: ACTIONS.USER_TOKENS_FETCH });
     yield put({ type: ACTIONS.USER_TOKENS_UPDATE_SUCCESS });
   } catch (error) {
-    yield putError(ACTIONS.USER_TOKENS_UPDATE_ERROR, error);
+    return yield putError(ACTIONS.USER_TOKENS_UPDATE_ERROR, error);
   }
+  return null;
 }
+
 function* userSubscribedColoniesFetch(): Saga<*> {
   try {
     const walletAddress = yield select(walletAddressSelector);
@@ -422,8 +444,12 @@ function* userSubscribedColoniesFetch(): Saga<*> {
       payload: colonyAddresses,
     });
   } catch (error) {
-    yield putError(ACTIONS.USER_SUBSCRIBED_COLONIES_FETCH_SUCCESS, error);
+    return yield putError(
+      ACTIONS.USER_SUBSCRIBED_COLONIES_FETCH_SUCCESS,
+      error,
+    );
   }
+  return null;
 }
 
 function* userColonySubscribe({
@@ -450,8 +476,13 @@ function* userColonySubscribe({
       meta,
     });
   } catch (caughtError) {
-    yield putError(ACTIONS.USER_COLONY_SUBSCRIBE_ERROR, caughtError, meta);
+    return yield putError(
+      ACTIONS.USER_COLONY_SUBSCRIBE_ERROR,
+      caughtError,
+      meta,
+    );
   }
+  return null;
 }
 
 function* userColonyUnsubscribe({
@@ -479,8 +510,13 @@ function* userColonyUnsubscribe({
       meta,
     });
   } catch (caughtError) {
-    yield putError(ACTIONS.USER_COLONY_UNSUBSCRIBE_ERROR, caughtError, meta);
+    return yield putError(
+      ACTIONS.USER_COLONY_UNSUBSCRIBE_ERROR,
+      caughtError,
+      meta,
+    );
   }
+  return null;
 }
 
 function* userSubscribedTasksFetch(): Saga<*> {
@@ -499,9 +535,11 @@ function* userSubscribedTasksFetch(): Saga<*> {
       payload: userTasks,
     });
   } catch (error) {
-    yield putError(ACTIONS.USER_SUBSCRIBED_TASKS_FETCH_ERROR, error);
+    return yield putError(ACTIONS.USER_SUBSCRIBED_TASKS_FETCH_ERROR, error);
   }
+  return null;
 }
+
 function* userTaskSubscribe({
   payload,
 }: Action<typeof ACTIONS.USER_TASK_SUBSCRIBE>): Saga<*> {
@@ -527,14 +565,15 @@ function* userTaskSubscribe({
       });
     }
   } catch (error) {
-    yield putError(ACTIONS.USER_TASK_SUBSCRIBE_ERROR, error);
+    return yield putError(ACTIONS.USER_TASK_SUBSCRIBE_ERROR, error);
   }
+  return null;
 }
 
 function* inboxItemsFetch({
   payload: { walletAddress },
   meta,
-}: Action<typeof ACTIONS.INBOX_ITEMS_FETCH>): Saga<void> {
+}: Action<typeof ACTIONS.INBOX_ITEMS_FETCH>): Saga<*> {
   try {
     const { inboxStoreAddress, metadataStoreAddress } = yield select(
       currentUserMetadataSelector,
@@ -575,8 +614,9 @@ function* inboxItemsFetch({
       meta,
     });
   } catch (error) {
-    yield putError(ACTIONS.INBOX_ITEMS_FETCH_ERROR, error, meta);
+    return yield putError(ACTIONS.INBOX_ITEMS_FETCH_ERROR, error, meta);
   }
+  return null;
 }
 
 export default function* setupUsersSagas(): Saga<void> {

--- a/src/modules/users/sagas/wallet.js
+++ b/src/modules/users/sagas/wallet.js
@@ -34,7 +34,7 @@ const hardwareWallets = {
 
 function* fetchAccounts(
   action: Action<typeof ACTIONS.WALLET_FETCH_ACCOUNTS>,
-): Saga<void> {
+): Saga<*> {
   const { walletType } = action.payload;
 
   try {
@@ -46,13 +46,14 @@ function* fetchAccounts(
       payload: { allAddresses: wallet.otherAddresses.map(createAddress) },
     });
   } catch (err) {
-    yield putError(ACTIONS.WALLET_FETCH_ACCOUNTS_ERROR, err);
+    return yield putError(ACTIONS.WALLET_FETCH_ACCOUNTS_ERROR, err);
   }
+  return null;
 }
 
 function* openMnemonicWallet(
   action: Action<typeof ACTIONS.WALLET_CREATE>,
-): Saga<void> {
+): Saga<*> {
   const { connectwalletmnemonic } = action.payload;
   return yield call(softwareWallet.open, {
     mnemonic: connectwalletmnemonic,
@@ -62,7 +63,7 @@ function* openMnemonicWallet(
 /**
  * Watch for changes in Metamask account, and log the user out when they happen.
  */
-function* metamaskWatch(walletAddress: Address): Saga<void> {
+function* metamaskWatch(walletAddress: Address): Saga<*> {
   const channel = eventChannel(emit => {
     accountChangeHook(({ selectedAddress }: { selectedAddress: string }) =>
       emit(createAddress(selectedAddress)),
@@ -87,7 +88,7 @@ function* metamaskWatch(walletAddress: Address): Saga<void> {
   }
 }
 
-function* openMetamaskWallet(): Saga<void> {
+function* openMetamaskWallet(): Saga<*> {
   const wallet = yield call(metamaskWallet.open);
   yield spawn(metamaskWatch, createAddress(wallet.address));
   return wallet;
@@ -95,7 +96,7 @@ function* openMetamaskWallet(): Saga<void> {
 
 function* openHardwareWallet(
   action: Action<typeof ACTIONS.WALLET_CREATE>,
-): Saga<void> {
+): Saga<*> {
   const { hardwareWalletChoice, method } = action.payload;
   const wallet = yield call(hardwareWallets[method].open, {
     /**
@@ -112,7 +113,7 @@ function* openHardwareWallet(
 
 function* openKeystoreWallet(
   action: Action<typeof ACTIONS.WALLET_CREATE>,
-): Saga<void> {
+): Saga<*> {
   const { keystore, password } = action.payload;
   return yield call(softwareWallet.open, {
     keystore,
@@ -122,7 +123,7 @@ function* openKeystoreWallet(
 
 function* openTrufflepigWallet({
   payload: { accountIndex },
-}: Action<typeof ACTIONS.WALLET_CREATE>): Saga<void> {
+}: Action<typeof ACTIONS.WALLET_CREATE>): Saga<*> {
   const loader = yield create(TrufflepigLoader);
   const { privateKey } = yield call([loader, loader.getAccount], accountIndex);
   return yield call(softwareWallet.open, {
@@ -130,9 +131,7 @@ function* openTrufflepigWallet({
   });
 }
 
-function* createWallet(
-  action: Action<typeof ACTIONS.WALLET_CREATE>,
-): Saga<void> {
+function* createWallet(action: Action<typeof ACTIONS.WALLET_CREATE>): Saga<*> {
   const { mnemonic } = action.payload;
   return yield call(softwareWallet.open, {
     mnemonic,


### PR DESCRIPTION
## Description

This PR fixes bugs (well, the same bug numerous times) where caught errors in saga tasks were dispatched as error actions, but the task was not cancelled (e.g. by returning in the saga function). This will also cancel forked tasks.

**Changes** 🏗

* Ensure sagas are cancelled when a fatal error is encountered

Resolves #1456 
