### PR TITLE
Quick fix: output debug logs when not in development mode

### DIFF
--- a/src/utils/debug.js
+++ b/src/utils/debug.js
@@ -6,7 +6,9 @@ export const isVerbose = process.env.VERBOSE === 'true';
 export const log = (
   logger: any => void = console.error.bind(console),
   ...args: any
-) => (isDev ? logger(...args) : null);
+) =>
+  // This should be more configurable: tracked in colonyDapp#1435
+  isDev || isVerbose ? logger(...args) : null;
 
 log.warn = (...args: any) => log(console.warn.bind(console), ...args);
 


### PR DESCRIPTION
## Description

This PR provides a quick fix for outputting debug logs (including verbose logs) when not in development mode, for the purpose of debugging in the QA deployment.

This lessens the immediate need for #1435 but does not solve it.

**Changes** 🏗

* Add a quick fix for outputting debug logs when not in development mode
