### PR TITLE
Fix redirect for new users

### DIFF
--- a/cypress/integration/claim-username.js
+++ b/cypress/integration/claim-username.js
@@ -26,17 +26,11 @@ describe('Claims a username', () => {
     cy.get('button[data-test="confirmTruffleAccount"]', { timeout: 2000 })
       .contains('Go to Colony')
       .click();
-  });
 
-  it('Open the Claim Username flow', () => {
     /*
-     * Click the Avatar Dropdown
+     * The app redirects to the 'claim username' flow
      */
-    cy.get('button[data-test="avatarDropdown"]').click();
-    /*
-     * Click on the Get Started link
-     */
-    cy.get('a[data-test="pickUserCreation"').click();
+    cy.location('pathname', { timeout: 10000 }).should('eq', '/create-user');
   });
 
   it('Go through the flow and claim a (ENS) username', () => {

--- a/src/modules/users/components/AvatarDropdown/AvatarDropdownPopover.jsx
+++ b/src/modules/users/components/AvatarDropdown/AvatarDropdownPopover.jsx
@@ -81,11 +81,7 @@ class AvatarDropdownPopover extends Component<Props> {
       <DropdownMenuSection separator>
         {!username && (
           <DropdownMenuItem>
-            <NavLink
-              to={CREATE_USER_ROUTE}
-              text={MSG.buttonGetStarted}
-              data-test="pickUserCreation"
-            />
+            <NavLink to={CREATE_USER_ROUTE} text={MSG.buttonGetStarted} />
           </DropdownMenuItem>
         )}
         {username && (

--- a/src/routes/DisconnectedOnlyRoute.jsx
+++ b/src/routes/DisconnectedOnlyRoute.jsx
@@ -4,14 +4,16 @@ import React from 'react';
 import { Route, Redirect } from 'react-router-dom';
 import type { ComponentType } from 'react';
 
-import { DASHBOARD_ROUTE } from './routeConstants';
+import { CREATE_USER_ROUTE, DASHBOARD_ROUTE } from './routeConstants';
 
 const DisconnectedOnlyRoute = ({
   component: Component,
+  didClaimProfile,
   isConnected,
   ...rest
 }: {
   component: ComponentType<*>,
+  didClaimProfile?: boolean,
   isConnected?: boolean,
 }) => (
   <Route
@@ -21,7 +23,7 @@ const DisconnectedOnlyRoute = ({
         const redirectTo =
           props.location.state && props.location.state.redirectTo;
         const location = {
-          pathname: DASHBOARD_ROUTE,
+          pathname: didClaimProfile ? DASHBOARD_ROUTE : CREATE_USER_ROUTE,
           ...redirectTo,
           state: { hasBackLink: false },
         };

--- a/src/routes/Routes.jsx
+++ b/src/routes/Routes.jsx
@@ -20,7 +20,10 @@ import UserProfileEdit from '~users/UserProfileEdit';
 
 import AdminDashboard from '~admin/AdminDashboard';
 
-import { walletAddressSelector } from '../modules/users/selectors';
+import {
+  currentUsernameSelector,
+  walletAddressSelector,
+} from '../modules/users/selectors';
 
 import {
   CONNECT_ROUTE,
@@ -44,99 +47,112 @@ import DisconnectedOnlyRoute from './DisconnectedOnlyRoute.jsx';
 // We cannot add types to this component's props because of how we're using
 // `connect` and importing it elsewhere: https://github.com/flow-typed/flow-typed/issues/1946
 // eslint-disable-next-line react/prop-types
-const Routes = ({ walletAddress }) => {
-  const isConnected = !!walletAddress;
-  return (
-    <Switch>
-      <Route
-        exact
-        path="/"
-        render={() => (
-          <Redirect to={isConnected ? DASHBOARD_ROUTE : CONNECT_ROUTE} />
-        )}
-      />
-      <Route exact path={NOT_FOUND_ROUTE} component={FourOFour} />
-      <DisconnectedOnlyRoute
-        isConnected={isConnected}
-        path={CONNECT_ROUTE}
-        component={ConnectWalletWizard}
-      />
-      <DisconnectedOnlyRoute
-        isConnected={isConnected}
-        path={CREATE_WALLET_ROUTE}
-        component={CreateWalletWizard}
-      />
-      <ConnectedOnlyRoute
-        exact
-        isConnected={isConnected}
-        path={COLONY_HOME_ROUTE}
-        component={ColonyHome}
-        backRoute={DASHBOARD_ROUTE}
-      />
-      <ConnectedOnlyRoute
-        isConnected={isConnected}
-        path={INBOX_ROUTE}
-        component={Inbox}
-      />
-      <ConnectedOnlyRoute
-        isConnected={isConnected}
-        path={WALLET_ROUTE}
-        component={Wallet}
-        hasBackLink={false}
-        appearance={{ theme: 'transparent' }}
-      />
-      <ConnectedOnlyRoute
-        isConnected={isConnected}
-        path={DASHBOARD_ROUTE}
-        component={Dashboard}
-        hasBackLink={false}
-        appearance={{ theme: 'transparent' }}
-      />
-      <ConnectedOnlyRoute
-        exact
-        isConnected={isConnected}
-        path={ADMIN_DASHBOARD_ROUTE}
-        component={AdminDashboard}
-        appearance={{ theme: 'transparent' }}
-        hasBackLink={false}
-      />
-      <ConnectedOnlyRoute
-        exact
-        isConnected={isConnected}
-        path={TASK_ROUTE}
-        component={Task}
-      />
-      <ConnectedOnlyRoute
-        isConnected={isConnected}
-        path={CREATE_COLONY_ROUTE}
-        component={CreateColonyWizard}
-        hasNavigation={false}
-      />
-      <ConnectedOnlyRoute
-        isConnected={isConnected}
-        path={CREATE_USER_ROUTE}
-        component={CreateUserWizard}
-        hasNavigation={false}
-      />
-      <ConnectedOnlyRoute
-        isConnected={isConnected}
-        path={USER_ROUTE}
-        component={UserProfile}
-        appearance={{ theme: 'transparent' }}
-      />
-      <ConnectedOnlyRoute
-        isConnected={isConnected}
-        path={USER_EDIT_ROUTE}
-        component={UserProfileEdit}
-        appearance={{ theme: 'transparent' }}
-      />
-    </Switch>
-  );
-};
+const Routes = ({ isConnected, didClaimProfile }) => (
+  <Switch>
+    <Route
+      exact
+      path="/"
+      render={() => {
+        const connectedRoute = didClaimProfile
+          ? DASHBOARD_ROUTE
+          : CREATE_USER_ROUTE;
+        return <Redirect to={isConnected ? connectedRoute : CONNECT_ROUTE} />;
+      }}
+    />
+    <Route exact path={NOT_FOUND_ROUTE} component={FourOFour} />
+    <DisconnectedOnlyRoute
+      isConnected={isConnected}
+      didClaimProfile={didClaimProfile}
+      path={CONNECT_ROUTE}
+      component={ConnectWalletWizard}
+    />
+    <DisconnectedOnlyRoute
+      isConnected={isConnected}
+      didClaimProfile={didClaimProfile}
+      path={CREATE_WALLET_ROUTE}
+      component={CreateWalletWizard}
+    />
+    <ConnectedOnlyRoute
+      exact
+      isConnected={isConnected}
+      didClaimProfile={didClaimProfile}
+      path={COLONY_HOME_ROUTE}
+      component={ColonyHome}
+      backRoute={DASHBOARD_ROUTE}
+    />
+    <ConnectedOnlyRoute
+      isConnected={isConnected}
+      didClaimProfile={didClaimProfile}
+      path={INBOX_ROUTE}
+      component={Inbox}
+    />
+    <ConnectedOnlyRoute
+      isConnected={isConnected}
+      didClaimProfile={didClaimProfile}
+      path={WALLET_ROUTE}
+      component={Wallet}
+      hasBackLink={false}
+      appearance={{ theme: 'transparent' }}
+    />
+    <ConnectedOnlyRoute
+      isConnected={isConnected}
+      didClaimProfile={didClaimProfile}
+      path={DASHBOARD_ROUTE}
+      component={Dashboard}
+      hasBackLink={false}
+      appearance={{ theme: 'transparent' }}
+    />
+    <ConnectedOnlyRoute
+      exact
+      isConnected={isConnected}
+      didClaimProfile={didClaimProfile}
+      path={ADMIN_DASHBOARD_ROUTE}
+      component={AdminDashboard}
+      appearance={{ theme: 'transparent' }}
+      hasBackLink={false}
+    />
+    <ConnectedOnlyRoute
+      exact
+      isConnected={isConnected}
+      didClaimProfile={didClaimProfile}
+      path={TASK_ROUTE}
+      component={Task}
+    />
+    <ConnectedOnlyRoute
+      isConnected={isConnected}
+      didClaimProfile={didClaimProfile}
+      path={CREATE_COLONY_ROUTE}
+      component={CreateColonyWizard}
+      hasNavigation={false}
+    />
+    <ConnectedOnlyRoute
+      isConnected={isConnected}
+      didClaimProfile={didClaimProfile}
+      path={CREATE_USER_ROUTE}
+      component={CreateUserWizard}
+      hasNavigation={false}
+    />
+    <ConnectedOnlyRoute
+      isConnected={isConnected}
+      didClaimProfile={didClaimProfile}
+      path={USER_ROUTE}
+      component={UserProfile}
+      appearance={{ theme: 'transparent' }}
+    />
+    <ConnectedOnlyRoute
+      isConnected={isConnected}
+      didClaimProfile={didClaimProfile}
+      path={USER_EDIT_ROUTE}
+      component={UserProfileEdit}
+      appearance={{ theme: 'transparent' }}
+    />
+  </Switch>
+);
 
 const RoutesContainer = connect(
   state => ({
-    walletAddress: walletAddressSelector(state),
+    didClaimProfile: !!currentUsernameSelector(state),
+    isConnected: !!walletAddressSelector(state),
   }),
   null,
 )(Routes);


### PR DESCRIPTION
## Description

This PR makes some changes to the redirection behaviour such that new users that haven't claimed their profile will be redirected to the `/create-user` route rather than `/dashboard`.


**New stuff** ✨

* Add `didClaimProfile` prop to routes component


**Changes** 🏗

* Redirect to the create user route if: on the index (`/`) route, and the user becomes connected, and they have not claimed their profile
* Redirect to the create user route when: on a disconnected route, and the user becomes connected, and they have not claimed their profile
* Pass `isConnected` boolean prop to routes component (replacing `walletAddress` string)


Resolves #1471 
