### PR TITLE
Ensure min/max task payout limits are enforced correctly

### DIFF
--- a/src/modules/dashboard/components/TaskEditDialog/TaskEditDialog.jsx
+++ b/src/modules/dashboard/components/TaskEditDialog/TaskEditDialog.jsx
@@ -237,13 +237,8 @@ const TaskEditDialog = ({
                 ),
             }),
           )
-          .when('worker', {
-            is: workerShape,
-            then: yup
-              .array()
-              .min(minTokens)
-              .max(maxTokens),
-          }),
+          .min(minTokens)
+          .max(maxTokens),
         worker: workerShape,
       });
     },


### PR DESCRIPTION
## Description

This PR makes a small adjustment to the validation of the task payouts form, such that the min/max limits are set regardless of role. I'm not sure what the reasoning for limiting this to the worker role was.


**Changes** 🏗

* For the task edit dialog, set the min/max limits for creating task payouts regardless of role


Resolves #1473 
