### PR TITLE
Subscribe to colony after colony creation success

### DIFF
--- a/src/modules/dashboard/sagas/colonyCreate.js
+++ b/src/modules/dashboard/sagas/colonyCreate.js
@@ -324,8 +324,6 @@ function* colonyCreate({
       },
     });
 
-    yield put(subscribeToColony(colonyAddress));
-
     /*
      * Pass through colonyStore Address after colony store creation to colonyName creation
      */
@@ -454,6 +452,9 @@ function* colonyCreate({
       colonyLabelRegisteredLog,
     );
     yield putNotification(normalizeTransactionLog(colonyAddress, decoratedLog));
+
+    // Subscribe to the colony last, after successful colony creation
+    yield put(subscribeToColony(colonyAddress));
     return null;
   } catch (error) {
     yield putError(ACTIONS.COLONY_CREATE_ERROR, error, meta);


### PR DESCRIPTION
## Description

This PR alters the `colonyCreate` saga such that the subscription action is dispatched at the end (after all other steps have been completed successfully), so that the colony is not shown in a broken state in the UI.


**Changes** 🏗

* Subscribe to a newly-created colony at the end of the saga 


Resolves #1467 
