### PR TITLE
Use subscriber for all task data

### DIFF
--- a/src/immutable/utils/data.js
+++ b/src/immutable/utils/data.js
@@ -11,6 +11,7 @@ export const shouldFetchData = (
   ttl: number,
   isFirstMount: boolean,
   fetchArgs: any[] = [],
+  alwaysFetch?: boolean,
 ): boolean => {
   // If there are arguments in the fetch args that are still undefined, don't fetch yet
   // Useful when using multiple fetchers consecutively (with depedencies on each other)
@@ -26,7 +27,8 @@ export const shouldFetchData = (
   if (data.get('error') && isFirstMount) return true;
 
   // If there's no record (and it's not fetching) and it's the first mount, fetch
-  if (typeof data.get('record') == 'undefined' && isFirstMount) return true;
+  if ((typeof data.get('record') == 'undefined' || alwaysFetch) && isFirstMount)
+    return true;
 
   // Check if the TTL is passed, if so, fetch again
   return !!(

--- a/src/modules/core/components/TransactionList/TransactionListItem.jsx
+++ b/src/modules/core/components/TransactionList/TransactionListItem.jsx
@@ -91,8 +91,8 @@ const TransactionListItem = ({
   /**
    * @todo Support fetching of tasks by `taskId`
    * */
-  // const { data: task } = useDataFetcher<TokenType>(
-  //   taskFetcher,
+  // const { data: task } = useDataSubscriber<TokenType>(
+  //   taskSubscriber,
   //   [taskId],
   //   [taskId],
   // );

--- a/src/modules/dashboard/components/Task/TaskInviteDialog.jsx
+++ b/src/modules/dashboard/components/Task/TaskInviteDialog.jsx
@@ -18,14 +18,14 @@ import Heading from '~core/Heading';
 import Payout from '~dashboard/TaskEditDialog/Payout';
 import DialogBox from '~core/Dialog/DialogBox.jsx';
 
-import { taskFetcher } from '../../fetchers';
+import { taskSubscriber } from '../../subscribers';
 
 import { useColonyNativeToken } from '../../hooks/useColonyNativeToken';
 import { useColonyTokens } from '../../hooks/useColonyTokens';
 
 import styles from './TaskInviteDialog.css';
 
-import { useDataFetcher } from '~utils/hooks';
+import { useDataSubscriber } from '~utils/hooks';
 import ACTIONS from '~redux/actions';
 
 const MSG = defineMessages({
@@ -55,10 +55,10 @@ const TaskInviteDialog = ({
   },
   currentUser,
 }: Props) => {
-  const { data: taskData } = useDataFetcher<TaskType>(
-    taskFetcher,
+  const { data: taskData } = useDataSubscriber<TaskType>(
+    taskSubscriber,
     [draftId],
-    [draftId],
+    [colonyAddress || undefined, draftId],
   );
 
   const nativeTokenReference = useColonyNativeToken(colonyAddress);

--- a/src/modules/dashboard/components/TaskList/TaskList.jsx
+++ b/src/modules/dashboard/components/TaskList/TaskList.jsx
@@ -10,9 +10,9 @@ import type { Address } from '~types';
 import type { DomainId, TaskDraftId, TaskType } from '~immutable';
 
 import { TASK_STATE } from '~immutable';
-import { useDataTupleFetcher } from '~utils/hooks';
+import { useDataTupleSubscriber } from '~utils/hooks';
 import { TASKS_FILTER_OPTIONS } from '../shared/tasksFilter';
-import { tasksByIdFetcher } from '../../fetchers';
+import { tasksByIdSubscriber } from '../../subscribers';
 
 import { Table, TableBody, TableCell, TableRow } from '~core/Table';
 import TaskListItem from './TaskListItem.jsx';
@@ -41,7 +41,10 @@ const TaskList = ({
   filterOption,
   walletAddress,
 }: Props) => {
-  const tasksData = useDataTupleFetcher<TaskType>(tasksByIdFetcher, draftIds);
+  const tasksData = useDataTupleSubscriber<TaskType>(
+    tasksByIdSubscriber,
+    draftIds,
+  );
   const filter = useCallback(
     ({ creatorAddress, workerAddress, currentState, domainId }: TaskType) => {
       if (filteredDomainId && filteredDomainId !== domainId) return false;

--- a/src/modules/dashboard/reducers/taskFeedItems.js
+++ b/src/modules/dashboard/reducers/taskFeedItems.js
@@ -90,14 +90,6 @@ const mapTaskFeedItemEvent = (event: AllTaskEvents): TaskFeedItemRecordType =>
     ...getTaskFeedItemRecordProps(event),
   });
 
-const updateStateForSubscription = (
-  state: TaskFeedItemsMap,
-  draftId: string,
-): TaskFeedItemsMap =>
-  state.getIn([draftId, 'record'])
-    ? state
-    : state.set(draftId, DataRecord({ record: List() }));
-
 const taskFeedItemsReducer: ReducerType<
   TaskFeedItemsMap,
   {
@@ -106,24 +98,15 @@ const taskFeedItemsReducer: ReducerType<
   },
 > = (state = ImmutableMap(), action) => {
   switch (action.type) {
-    case ACTIONS.TASK_FEED_ITEMS_SUB_START: {
-      const { draftId } = action.payload;
-      return updateStateForSubscription(state, draftId);
-    }
-
     case ACTIONS.TASK_FEED_ITEMS_SUB_EVENTS: {
       const { draftId, events } = action.payload;
 
-      const newState = updateStateForSubscription(state, draftId);
-
-      return newState.setIn(
-        [draftId, 'record'],
-        List<TaskFeedItemRecordType>(
-          events
-            .filter(event => FEED_ITEM_TYPES.has(event.type))
-            .map(mapTaskFeedItemEvent),
-        ),
+      const record = List<TaskFeedItemRecordType>(
+        events
+          .filter(event => FEED_ITEM_TYPES.has(event.type))
+          .map(mapTaskFeedItemEvent),
       );
+      return state.set(draftId, DataRecord({ record }));
     }
 
     default:

--- a/src/modules/dashboard/reducers/tasks.js
+++ b/src/modules/dashboard/reducers/tasks.js
@@ -42,6 +42,7 @@ const taskEventReducer = (task: TaskRecordType, event: *): TaskRecordType => {
       return task.merge({
         createdAt: new Date(timestamp),
         creatorAddress,
+        currentState: TASK_STATE.ACTIVE,
         draftId,
         managerAddress: creatorAddress,
       });

--- a/src/modules/dashboard/subscribers.js
+++ b/src/modules/dashboard/subscribers.js
@@ -11,7 +11,11 @@ import {
   taskSubStart,
   taskSubStop,
 } from './actionCreators';
-import { taskFeedItemsSelector, taskSelector } from './selectors';
+import {
+  taskFeedItemsSelector,
+  taskSelector,
+  tasksByIdsSelector,
+} from './selectors';
 
 export const taskFeedItemsSubscriber = Object.freeze({
   select: taskFeedItemsSelector,
@@ -21,6 +25,12 @@ export const taskFeedItemsSubscriber = Object.freeze({
 
 export const taskSubscriber = Object.freeze({
   select: taskSelector,
+  start: taskSubStart,
+  stop: taskSubStop,
+});
+
+export const tasksByIdSubscriber = Object.freeze({
+  select: tasksByIdsSelector,
   start: taskSubStart,
   stop: taskSubStop,
 });


### PR DESCRIPTION
## Description

In all places we use task data, this is now loaded using data subscribers. This means two things: we don't end up with half-loaded data being put into redux and counted as "loaded", and we also benefit from the redux state being updated when new store events are added.

**New stuff** ✨

* `useDataTupleSubscriber`

**Changes** 🏗

* Added option of `alwaysFetch` to `shouldFetch` util function - if set to `true` then it returns that data should be loaded according to the standard rules, and additionally if it's not already being fetched on first mount of the component
* Fetch tasks data with `useDataTupleFetcher` in `TaskList`
* ~Simplify `taskFeedItemsReducer` and ensure that `isFetching` is not set during a subscription~ Make sure to unset `isFetching` when ending a subscription
* Make sure the `TASK_CREATED` event in the `taskEventReducer` sets `currentState` to active

**Deletions** ⚰️

* `useDataTupleFetcher`
* `tasksByIdFetcher`
* `taskFetcher`

## TODO

- [x] Remove the things I said I've removed
- [x] Decide what to do about `isFetching`
- [x] Make sure #1442 is fixed

Resolves #1450 
Resolves #1442 
Resolves #1449 
