### PR TITLE
Show all users in redux store to be assigned as workers 

### DIFF
--- a/src/modules/dashboard/components/TaskEditDialog/TaskEditDialog.jsx
+++ b/src/modules/dashboard/components/TaskEditDialog/TaskEditDialog.jsx
@@ -32,6 +32,7 @@ import { taskSelector, taskRequestsSelector } from '../../selectors';
 import { useColonyTokens } from '../../hooks/useColonyTokens';
 
 import { userFetcher, usersByAddressFetcher } from '../../../users/fetchers';
+import { allUsersAddressesSelector } from '../../../users/selectors';
 import { createAddress } from '../../../../types';
 
 import styles from './TaskEditDialog.css';
@@ -163,9 +164,16 @@ const TaskEditDialog = ({
 
   // Get users that have requested to work on this task
   const userAddressesRequested = useSelector(taskRequestsSelector, [draftId]);
+  const userAddressesInStore = useSelector(allUsersAddressesSelector);
+
+  const userAddressesToPickFrom = userAddressesRequested.concat(
+    userAddressesInStore,
+  );
+  const uniqueUserAddressesToPickFrom = new Set(userAddressesToPickFrom);
+
   const userData = useDataMapFetcher<UserType>(
     usersByAddressFetcher,
-    userAddressesRequested,
+    Array.from(uniqueUserAddressesToPickFrom),
   );
 
   // Get user (worker) assigned to this task

--- a/src/modules/users/selectors/user.js
+++ b/src/modules/users/selectors/user.js
@@ -3,6 +3,7 @@
 import { createSelector } from 'reselect';
 
 import { Map as ImmutableMap } from 'immutable';
+import { isAddress } from 'web3-utils';
 
 import type {
   DataRecordType,
@@ -29,13 +30,28 @@ import {
 import { sortObjectsBy } from '~utils/arrays';
 
 /*
- * Username/address getters
+ * Username getters
  */
 const getUsernameFromUserData = (user?: DataRecordType<UserRecordType>) =>
   user && user.getIn(['record', 'profile', 'username']);
 
 /*
- * Username/address input selectors
+ * Address getters
+ */
+const getWalletAddressFromUserData = (
+  users: ImmutableMap<string, DataRecordType<UserRecordType>>,
+) => Object.keys(users.toJS()).filter(key => isAddress(key));
+
+export const allUsersSelector = (state: RootStateRecord) =>
+  state.getIn([ns, USERS_ALL_USERS, USERS_USERS], ImmutableMap());
+
+export const allUsersAddressesSelector = createSelector(
+  allUsersSelector,
+  users => getWalletAddressFromUserData(users),
+);
+
+/*
+ * Username input selectors
  */
 export const userAddressSelector = (state: RootStateRecord, username: string) =>
   state
@@ -54,8 +70,7 @@ export const userSelector = (state: RootStateRecord, address: Address) =>
   state.getIn([ns, USERS_ALL_USERS, USERS_USERS, address]);
 
 export const usersExceptSelector = createSelector(
-  (state: RootStateRecord) =>
-    state.getIn([ns, USERS_ALL_USERS, USERS_USERS], ImmutableMap()),
+  allUsersSelector,
   (allUsers, except: string[] | string = []) =>
     allUsers.filter((user, address) => ![].concat(except).includes(address)),
 );


### PR DESCRIPTION
## Description

Show all users in redux store to be assigned as workers instead of only the ones that have requested to work on a task. In my memory, the ones that have requested to work on a task were highlighted in the select options, but that doesn't seem to be the case anymore. 
So all I am doing here is to add an `allUsersAddressesSelector`to join them with the user addresses of the ones that have requested to work on a task. 
The existing `usersByAddressFetcher` then gets all user details that need to be shown in the  `SingleUserPicker`.



Resolves #1329
