### PR TITLE
First change step then save values

### DIFF
--- a/src/modules/core/components/Wizard/withWizard.js
+++ b/src/modules/core/components/Wizard/withWizard.js
@@ -53,7 +53,7 @@ const withWizard = ({ steps, stepCount: maxSteps }: WizardArgs) => (
       this.setValues(values);
     };
 
-    prev = (values?: Values) => {
+    prev = () => {
       const { step: currentStep } = this.state;
       /* Inform developer if step has been changed
        * if we are already in the first step there
@@ -63,7 +63,6 @@ const withWizard = ({ steps, stepCount: maxSteps }: WizardArgs) => (
         return false;
       }
       this.setState(({ step }) => ({ step: step === 0 ? 0 : step - 1 }));
-      this.setValues(values);
       return true;
     };
 

--- a/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.jsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.jsx
@@ -116,7 +116,7 @@ const StepCreateToken = ({
         https://github.com/JoinColony/colonyDapp/issues/1057
       */
       const wizardValuesCopy = Object.assign({}, wizardValues);
-      previousStep(wizardValuesCopy);
+      previousStep();
       wizardValuesCopy.tokenChoice = 'select';
       nextStep(wizardValuesCopy);
     },

--- a/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.jsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.jsx
@@ -111,7 +111,7 @@ const StepSelectToken = ({
         https://github.com/JoinColony/colonyDapp/issues/1057
       */
       const wizardValuesCopy: FormValues = { ...wizardValues };
-      previousStep(wizardValuesCopy);
+      previousStep();
       wizardValuesCopy.tokenChoice = 'create';
       nextStep(wizardValuesCopy);
     },

--- a/src/modules/pages/components/WizardTemplateColony/WizardTemplateColony.jsx
+++ b/src/modules/pages/components/WizardTemplateColony/WizardTemplateColony.jsx
@@ -21,9 +21,8 @@ import styles from './WizardTemplateColony.css';
 
 export type Props = {|
   children: Node,
-  previousStep: (wizardValues?: Object) => void,
+  previousStep: () => void,
   hideQR: boolean,
-  wizardValues: Object,
 |};
 
 const MSG = defineMessages({
@@ -39,14 +38,10 @@ const WizardTemplateColony = ({
   children,
   previousStep,
   hideQR = false,
-  wizardValues,
 }: Props) => {
   const currentUser: UserType = useSelector(currentUserSelector);
   const { profile: { walletAddress, balance } = {} } = currentUser || {};
-  const customHandler = useCallback(() => previousStep(wizardValues), [
-    previousStep,
-    wizardValues,
-  ]);
+  const customHandler = useCallback(() => previousStep(), [previousStep]);
   const ethBalance = toWei(balance, 'ether');
   return (
     <main className={styles.layoutMain}>

--- a/src/modules/users/components/ConnectWalletWizard/StepHardware/StepHardware.jsx
+++ b/src/modules/users/components/ConnectWalletWizard/StepHardware/StepHardware.jsx
@@ -262,7 +262,7 @@ class StepHardware extends Component<Props> {
               <Button
                 text={MSG.buttonBack}
                 appearance={{ theme: 'secondary', size: 'large' }}
-                onClick={() => previousStep(values)}
+                onClick={() => previousStep()}
               />
               <Button
                 text={

--- a/src/modules/users/components/ConnectWalletWizard/StepJSONUpload/StepJSONUpload.jsx
+++ b/src/modules/users/components/ConnectWalletWizard/StepJSONUpload/StepJSONUpload.jsx
@@ -124,7 +124,7 @@ const StepJSONUpload = ({
       transform={transform}
       {...wizardForm}
     >
-      {({ status, isValid, values }) => (
+      {({ status, isValid }) => (
         <main>
           <div className={styles.content}>
             <Heading text={MSG.heading} appearance={{ size: 'medium' }} />
@@ -149,7 +149,7 @@ const StepJSONUpload = ({
             <Button
               appearance={{ theme: 'secondary', size: 'large' }}
               text={MSG.buttonBack}
-              onClick={() => previousStep(values)}
+              onClick={() => previousStep()}
             />
             <Button
               appearance={{ theme: 'primary', size: 'large' }}

--- a/src/modules/users/components/ConnectWalletWizard/StepMetaMask/StepMetaMask.jsx
+++ b/src/modules/users/components/ConnectWalletWizard/StepMetaMask/StepMetaMask.jsx
@@ -147,7 +147,7 @@ class MetaMask extends Component<Props, State> {
         transform={mergePayload(wizardValues)}
         {...wizardForm}
       >
-        {({ isSubmitting, status, values }) => (
+        {({ isSubmitting, status }) => (
           <main>
             <div className={styles.content}>
               <div className={styles.iconContainer}>
@@ -187,7 +187,7 @@ class MetaMask extends Component<Props, State> {
               <Button
                 text={MSG.buttonBack}
                 appearance={{ theme: 'secondary', size: 'large' }}
-                onClick={() => previousStep(values)}
+                onClick={() => previousStep()}
               />
               {isValid ? (
                 <Button

--- a/src/modules/users/components/ConnectWalletWizard/StepMnemonic/StepMnemonic.jsx
+++ b/src/modules/users/components/ConnectWalletWizard/StepMnemonic/StepMnemonic.jsx
@@ -81,7 +81,7 @@ const StepMnemonic = ({
       transform={transform}
       {...wizardForm}
     >
-      {({ isSubmitting, isValid, status, values }) => (
+      {({ isSubmitting, isValid, status }) => (
         <main>
           <div className={styles.content}>
             <Heading text={MSG.heading} appearance={{ size: 'medium' }} />
@@ -95,7 +95,7 @@ const StepMnemonic = ({
             <Button
               appearance={{ theme: 'secondary', size: 'large' }}
               text={MSG.buttonBackText}
-              onClick={() => previousStep(values)}
+              onClick={() => previousStep()}
             />
             <Button
               appearance={{ theme: 'primary', size: 'large' }}

--- a/src/modules/users/components/ConnectWalletWizard/StepTrufflePig/StepTrufflePig.jsx
+++ b/src/modules/users/components/ConnectWalletWizard/StepTrufflePig/StepTrufflePig.jsx
@@ -131,7 +131,7 @@ const StepTrufflePig = ({ previousStep, wizardForm, wizardValues }: Props) => {
       transform={transform}
       {...wizardForm}
     >
-      {({ status, isSubmitting, values }) => (
+      {({ status, isSubmitting }) => (
         <main>
           <div className={styles.content}>
             <div className={styles.iconContainer}>
@@ -174,7 +174,7 @@ const StepTrufflePig = ({ previousStep, wizardForm, wizardValues }: Props) => {
             <Button
               text={MSG.buttonBack}
               appearance={{ theme: 'secondary', size: 'large' }}
-              onClick={() => previousStep(values)}
+              onClick={() => previousStep()}
             />
             {isValid ? (
               <Button

--- a/src/modules/users/components/CreateWalletWizard/StepBackupPhrase.jsx
+++ b/src/modules/users/components/CreateWalletWizard/StepBackupPhrase.jsx
@@ -84,7 +84,7 @@ class StepBackupPhrase extends Component<Props, State> {
     return (
       <main className={styles.content}>
         <Form onSubmit={nextStep} {...wizardForm}>
-          {({ values }) => (
+          {() => (
             <Fragment>
               <div className={styles.title}>
                 <Heading
@@ -117,7 +117,7 @@ class StepBackupPhrase extends Component<Props, State> {
                 <Button
                   appearance={{ theme: 'ghost', colorSchema: 'noBorder' }}
                   text={MSG.backButton}
-                  onClick={() => previousStep(values)}
+                  onClick={() => previousStep()}
                 />
                 <Button
                   type="submit"

--- a/src/modules/users/components/CreateWalletWizard/StepProveMnemonic.jsx
+++ b/src/modules/users/components/CreateWalletWizard/StepProveMnemonic.jsx
@@ -101,7 +101,7 @@ const StepProveMnemonic = ({
         validateOnChange={false}
         {...wizardForm}
       >
-        {({ isSubmitting, status, values }) => (
+        {({ isSubmitting, status }) => (
           <Fragment>
             <section className={styles.titleSection}>
               <Heading
@@ -140,7 +140,7 @@ const StepProveMnemonic = ({
                 appearance={{ theme: 'secondary', size: 'large' }}
                 disabled={isSubmitting}
                 text={MSG.backButton}
-                onClick={() => previousStep(values)}
+                onClick={() => previousStep()}
               />
               <Button
                 appearance={{ theme: 'primary', size: 'large' }}


### PR DESCRIPTION
## Description

After investigating I came to the conclusion that it could be the order of state changes that prevents us from saving the wizard values correctly.
Previously we first called `this.setState({values, ... )` and then  `this.setState({step, ... )`,
consequently the `setValues` method stored the wizard values in another wizard step instead of overwriting the old ones. 

While testing I found out that this fixes it.
Made a loom to see how going back and forth works again.
https://www.loom.com/share/c68bfe96bd3d4652b9f3555e042d8875
 


Resolves #1390
