### PR TITLE
Correctly compare CreateColonyWizard step

### DIFF
--- a/src/modules/dashboard/components/CreateColonyWizard/CreateColonyWizard.js
+++ b/src/modules/dashboard/components/CreateColonyWizard/CreateColonyWizard.js
@@ -61,7 +61,7 @@ const stepFunction = (
 
     /* Standard wizard flow  */
     if (step === 0) {
-      if (usernameCreated && stepArray[0].name === 'StepUserName') {
+      if (usernameCreated && stepArray[0] === StepUserName) {
         stepArray.shift();
         return stepArray[step];
       }


### PR DESCRIPTION
## Description

We were using the `name` property of the `StepUserName` to compare against a string literal. This breaks in minified builds, since the `name` of the component is minified. Instead, we can just compare against the component itself.

**Changes** 🏗

* Correctly compare components in `CreateColonyWizard`.

Resolves #1441 
Resolves #1362
