### PR TITLE
Set correct navigation back messages and routes

### DIFF
--- a/src/modules/pages/components/NavigationWrapper/NavigationWrapper.jsx
+++ b/src/modules/pages/components/NavigationWrapper/NavigationWrapper.jsx
@@ -43,7 +43,7 @@ type Props = {|
   /*
    * If set, the the back link will redirect back to a specific route
    */
-  backRoute?: string,
+  backRoute?: string | ((props: Object) => string),
   /*
    * If set, it will change the default back link text
    */
@@ -51,7 +51,7 @@ type Props = {|
   /*
    * Works in conjuction with the above to provide message descriptor selector values
    */
-  backTextValues?: MessageValues,
+  backTextValues?: MessageValues | ((props: Object) => MessageValues),
   /*
    * Appearance object
    *
@@ -95,9 +95,15 @@ const NavigationWrapper = ({
           {hasBackLink && (
             <div className={styles.history}>
               <HistoryNavigation
-                backRoute={backRoute}
+                backRoute={
+                  typeof backRoute === 'function' ? backRoute(props) : backRoute
+                }
                 backText={backText}
-                backTextValues={backTextValues}
+                backTextValues={
+                  typeof backTextValues === 'function'
+                    ? backTextValues(props)
+                    : backTextValues
+                }
               />
             </div>
           )}

--- a/src/routes/ConnectedOnlyRoute.jsx
+++ b/src/routes/ConnectedOnlyRoute.jsx
@@ -36,9 +36,9 @@ const ConnectedOnlyRoute = ({
           <NavigationWrapper
             {...rest}
             hasBackLink={
-              hasBackLink === false
-                ? false
-                : location.state && location.state.hasBackLink
+              hasBackLink === undefined
+                ? location.state && location.state.hasBackLink
+                : hasBackLink
             }
           >
             <Component {...props} params={params} />

--- a/src/routes/Routes.jsx
+++ b/src/routes/Routes.jsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { withRouter, Route, Redirect, Switch } from 'react-router-dom';
 import { connect } from 'react-redux';
+import { defineMessages } from 'react-intl';
 
 import CreateColonyWizard from '~dashboard/CreateColonyWizard';
 import CreateUserWizard from '~dashboard/CreateUserWizard';
@@ -44,114 +45,145 @@ import {
 import ConnectedOnlyRoute from './ConnectedOnlyRoute.jsx';
 import DisconnectedOnlyRoute from './DisconnectedOnlyRoute.jsx';
 
+const MSG = defineMessages({
+  taskBack: {
+    id: 'routes.Routes.taskBack',
+    defaultMessage: 'Go to {colonyName}',
+  },
+  userProfileEditBack: {
+    id: 'routes.Routes.userProfileEditBack',
+    defaultMessage: 'Go to profile',
+  },
+});
+
 // We cannot add types to this component's props because of how we're using
 // `connect` and importing it elsewhere: https://github.com/flow-typed/flow-typed/issues/1946
 // eslint-disable-next-line react/prop-types
-const Routes = ({ isConnected, didClaimProfile }) => (
-  <Switch>
-    <Route
-      exact
-      path="/"
-      render={() => {
-        const connectedRoute = didClaimProfile
-          ? DASHBOARD_ROUTE
-          : CREATE_USER_ROUTE;
-        return <Redirect to={isConnected ? connectedRoute : CONNECT_ROUTE} />;
-      }}
-    />
-    <Route exact path={NOT_FOUND_ROUTE} component={FourOFour} />
-    <DisconnectedOnlyRoute
-      isConnected={isConnected}
-      didClaimProfile={didClaimProfile}
-      path={CONNECT_ROUTE}
-      component={ConnectWalletWizard}
-    />
-    <DisconnectedOnlyRoute
-      isConnected={isConnected}
-      didClaimProfile={didClaimProfile}
-      path={CREATE_WALLET_ROUTE}
-      component={CreateWalletWizard}
-    />
-    <ConnectedOnlyRoute
-      exact
-      isConnected={isConnected}
-      didClaimProfile={didClaimProfile}
-      path={COLONY_HOME_ROUTE}
-      component={ColonyHome}
-      backRoute={DASHBOARD_ROUTE}
-    />
-    <ConnectedOnlyRoute
-      isConnected={isConnected}
-      didClaimProfile={didClaimProfile}
-      path={INBOX_ROUTE}
-      component={Inbox}
-    />
-    <ConnectedOnlyRoute
-      isConnected={isConnected}
-      didClaimProfile={didClaimProfile}
-      path={WALLET_ROUTE}
-      component={Wallet}
-      hasBackLink={false}
-      appearance={{ theme: 'transparent' }}
-    />
-    <ConnectedOnlyRoute
-      isConnected={isConnected}
-      didClaimProfile={didClaimProfile}
-      path={DASHBOARD_ROUTE}
-      component={Dashboard}
-      hasBackLink={false}
-      appearance={{ theme: 'transparent' }}
-    />
-    <ConnectedOnlyRoute
-      exact
-      isConnected={isConnected}
-      didClaimProfile={didClaimProfile}
-      path={ADMIN_DASHBOARD_ROUTE}
-      component={AdminDashboard}
-      appearance={{ theme: 'transparent' }}
-      hasBackLink={false}
-    />
-    <ConnectedOnlyRoute
-      exact
-      isConnected={isConnected}
-      didClaimProfile={didClaimProfile}
-      path={TASK_ROUTE}
-      component={Task}
-    />
-    <ConnectedOnlyRoute
-      isConnected={isConnected}
-      didClaimProfile={didClaimProfile}
-      path={CREATE_COLONY_ROUTE}
-      component={CreateColonyWizard}
-      hasNavigation={false}
-    />
-    <ConnectedOnlyRoute
-      isConnected={isConnected}
-      didClaimProfile={didClaimProfile}
-      path={CREATE_USER_ROUTE}
-      component={CreateUserWizard}
-      hasNavigation={false}
-    />
-    <ConnectedOnlyRoute
-      isConnected={isConnected}
-      didClaimProfile={didClaimProfile}
-      path={USER_ROUTE}
-      component={UserProfile}
-      appearance={{ theme: 'transparent' }}
-    />
-    <ConnectedOnlyRoute
-      isConnected={isConnected}
-      didClaimProfile={didClaimProfile}
-      path={USER_EDIT_ROUTE}
-      component={UserProfileEdit}
-      appearance={{ theme: 'transparent' }}
-    />
-  </Switch>
-);
+const Routes = ({ isConnected, username }) => {
+  const didClaimProfile = !!username;
+  return (
+    <Switch>
+      <Route
+        exact
+        path="/"
+        render={() => {
+          const connectedRoute = didClaimProfile
+            ? DASHBOARD_ROUTE
+            : CREATE_USER_ROUTE;
+          return <Redirect to={isConnected ? connectedRoute : CONNECT_ROUTE} />;
+        }}
+      />
+      <Route exact path={NOT_FOUND_ROUTE} component={FourOFour} />
+      <DisconnectedOnlyRoute
+        isConnected={isConnected}
+        didClaimProfile={didClaimProfile}
+        path={CONNECT_ROUTE}
+        component={ConnectWalletWizard}
+      />
+      <DisconnectedOnlyRoute
+        isConnected={isConnected}
+        didClaimProfile={didClaimProfile}
+        path={CREATE_WALLET_ROUTE}
+        component={CreateWalletWizard}
+      />
+      <ConnectedOnlyRoute
+        exact
+        isConnected={isConnected}
+        didClaimProfile={didClaimProfile}
+        path={COLONY_HOME_ROUTE}
+        component={ColonyHome}
+        hasBackLink={false}
+      />
+      <ConnectedOnlyRoute
+        isConnected={isConnected}
+        didClaimProfile={didClaimProfile}
+        path={INBOX_ROUTE}
+        component={Inbox}
+        hasBackLink={false}
+      />
+      <ConnectedOnlyRoute
+        isConnected={isConnected}
+        didClaimProfile={didClaimProfile}
+        path={WALLET_ROUTE}
+        component={Wallet}
+        hasBackLink={false}
+        appearance={{ theme: 'transparent' }}
+      />
+      <ConnectedOnlyRoute
+        isConnected={isConnected}
+        didClaimProfile={didClaimProfile}
+        path={DASHBOARD_ROUTE}
+        component={Dashboard}
+        hasBackLink={false}
+        appearance={{ theme: 'transparent' }}
+      />
+      <ConnectedOnlyRoute
+        exact
+        isConnected={isConnected}
+        didClaimProfile={didClaimProfile}
+        path={ADMIN_DASHBOARD_ROUTE}
+        component={AdminDashboard}
+        appearance={{ theme: 'transparent' }}
+        hasBackLink={false}
+      />
+      <ConnectedOnlyRoute
+        exact
+        isConnected={isConnected}
+        didClaimProfile={didClaimProfile}
+        path={TASK_ROUTE}
+        component={Task}
+        backText={MSG.taskBack}
+        backTextValues={({
+          computedMatch: {
+            params: { colonyName },
+          },
+        }) => ({ colonyName })}
+        backRoute={({
+          computedMatch: {
+            params: { colonyName },
+          },
+        }) => `/colony/${colonyName}`}
+        hasBackLink
+      />
+      <ConnectedOnlyRoute
+        isConnected={isConnected}
+        didClaimProfile={didClaimProfile}
+        path={CREATE_COLONY_ROUTE}
+        component={CreateColonyWizard}
+        hasNavigation={false}
+      />
+      <ConnectedOnlyRoute
+        isConnected={isConnected}
+        didClaimProfile={didClaimProfile}
+        path={CREATE_USER_ROUTE}
+        component={CreateUserWizard}
+        hasNavigation={false}
+      />
+      <ConnectedOnlyRoute
+        isConnected={isConnected}
+        didClaimProfile={didClaimProfile}
+        path={USER_ROUTE}
+        component={UserProfile}
+        hasBackLink={false}
+        appearance={{ theme: 'transparent' }}
+      />
+      <ConnectedOnlyRoute
+        isConnected={isConnected}
+        didClaimProfile={didClaimProfile}
+        path={USER_EDIT_ROUTE}
+        component={UserProfileEdit}
+        appearance={{ theme: 'transparent' }}
+        backText={MSG.userProfileEditBack}
+        backRoute={`/user/${username}`}
+        hasBackLink
+      />
+    </Switch>
+  );
+};
 
 const RoutesContainer = connect(
   state => ({
-    didClaimProfile: !!currentUsernameSelector(state),
+    username: currentUsernameSelector(state),
     isConnected: !!walletAddressSelector(state),
   }),
   null,


### PR DESCRIPTION
## Description

Going "back" from a page is now significantly less confusing!

Note that the `colonyName` used for the Colony admin back is actually the username taken from the route match/props. Couldn't think of a nice way to get the actual name (would have to select the colony name, just starts making the `Routes` look messy) so I thought this was a reasonable tradeoff.

**Changes** 🏗

* Allow `NavigationWrapper` to accept functions for `backRoute` and `backTextValues`
* Make it possible to explicitly set `hasBackLink` true for `ConnectedOnlyRoute`
* Fix messages and routes for various page component back links

Resolves #1364 
