### PR TITLE
Update task title on blur

### DIFF
--- a/src/modules/dashboard/components/TaskTitle/TaskTitle.jsx
+++ b/src/modules/dashboard/components/TaskTitle/TaskTitle.jsx
@@ -1,5 +1,7 @@
 /* @flow */
 
+import type { FormikProps } from 'formik';
+
 // $FlowFixMe upgrade react
 import React, { useCallback } from 'react';
 import { defineMessages } from 'react-intl';
@@ -37,12 +39,15 @@ const TaskTitle = ({ disabled, title, colonyAddress, draftId }: Props) => {
       transform={transform}
       initialValues={{ title }}
     >
-      <SingleLineEdit
-        maxLength={90}
-        name="title"
-        placeholder={MSG.placeholder}
-        readOnly={disabled}
-      />
+      {({ submitForm }: FormikProps<*>) => (
+        <SingleLineEdit
+          maxLength={90}
+          name="title"
+          placeholder={MSG.placeholder}
+          readOnly={disabled}
+          onBlur={() => setTimeout(submitForm, 0)}
+        />
+      )}
     </ActionForm>
   );
 };

--- a/src/modules/dashboard/data/commands/task.js
+++ b/src/modules/dashboard/data/commands/task.js
@@ -208,9 +208,10 @@ export const setTaskTitle: Command<
   TaskStore,
   TaskStoreMetadata,
   {|
+    currentTitle: ?string,
     title: string,
   |},
-  {|
+  ?{|
     event: Event<typeof TASK_EVENT_TYPES.TASK_TITLE_SET>,
     taskStore: TaskStore,
   |},
@@ -219,7 +220,8 @@ export const setTaskTitle: Command<
   context: [CONTEXT.COLONY_MANAGER, CONTEXT.DDB_INSTANCE, CONTEXT.WALLET],
   prepare: prepareTaskStoreCommand,
   schema: SetTaskTitleCommandArgsSchema,
-  async execute(taskStore, { title }) {
+  async execute(taskStore, { currentTitle, title }) {
+    if (title === currentTitle) return null;
     const eventHash = await taskStore.append(
       createEvent(TASK_EVENT_TYPES.TASK_TITLE_SET, {
         title,

--- a/src/modules/dashboard/sagas/task.js
+++ b/src/modules/dashboard/sagas/task.js
@@ -267,19 +267,25 @@ function* taskSetTitle({
   payload: { colonyAddress, draftId, title },
 }: Action<typeof ACTIONS.TASK_SET_TITLE>): Saga<*> {
   try {
-    const { event } = yield* executeCommand(setTaskTitle, {
-      args: { title },
+    const {
+      record: { title: currentTitle },
+    }: { record: TaskType } = yield* selectAsJS(taskSelector, draftId);
+    const eventData = yield* executeCommand(setTaskTitle, {
+      args: { currentTitle, title },
       metadata: { colonyAddress, draftId },
     });
-    yield put<Action<typeof ACTIONS.TASK_SET_TITLE_SUCCESS>>({
-      type: ACTIONS.TASK_SET_TITLE_SUCCESS,
-      meta,
-      payload: {
-        colonyAddress,
-        draftId,
-        event,
-      },
-    });
+    if (eventData) {
+      const { event } = eventData;
+      yield put<Action<typeof ACTIONS.TASK_SET_TITLE_SUCCESS>>({
+        type: ACTIONS.TASK_SET_TITLE_SUCCESS,
+        meta,
+        payload: {
+          colonyAddress,
+          draftId,
+          event,
+        },
+      });
+    }
   } catch (error) {
     return yield putError(ACTIONS.TASK_SET_TITLE_ERROR, error, meta);
   }


### PR DESCRIPTION
## Description

When clicking away from editing the task title, it now updates - this matches the behaviour of the description. It also won't add an event to the task store unless the title is different from its previous value.

**Changes** 🏗

* Update task title on blur of editing it
* Don't update task title if it's the same as it already was

Resolves #1424 
