### PR TITLE
Fix user inbox query

### DIFF
--- a/src/data/normalizers/index.js
+++ b/src/data/normalizers/index.js
@@ -36,12 +36,9 @@ type TransactionLog = {|
 export const normalizeDDBStoreEvent = (
   storeAddress: string,
   {
-    identity: { id: actorId },
-    payload: {
-      type,
-      value: args,
-      meta: { timestamp, id },
-    },
+    meta: { timestamp, id, userAddress: actorId },
+    payload: args,
+    type,
   }: Event<*>,
 ): NormalizedEvent => ({
   type,

--- a/src/modules/users/data/queries.js
+++ b/src/modules/users/data/queries.js
@@ -416,7 +416,6 @@ export const getUserInboxActivity: Query<
     userInboxStore: UserInboxStore,
     colonyClients: ColonyClient[],
     colonyNetworkClient: NetworkClient,
-    walletAddress: Address,
   |},
   {|
     userColonies: Address[],
@@ -457,15 +456,9 @@ export const getUserInboxActivity: Query<
       colonyClients,
       colonyNetworkClient: colonyManager.networkClient,
       userInboxStore,
-      walletAddress,
     };
   },
-  async execute({
-    userInboxStore,
-    colonyClients,
-    colonyNetworkClient,
-    walletAddress,
-  }) {
+  async execute({ userInboxStore, colonyClients, colonyNetworkClient }) {
     const {
       contract: { address: colonyNetworkAddress },
       events: { ColonyLabelRegistered },
@@ -486,7 +479,7 @@ export const getUserInboxActivity: Query<
           events: { DomainAdded, ColonyRoleSet },
           tokenClient,
           tokenClient: {
-            events: { Mint, Transfer },
+            events: { Mint },
             contract: { address: tokenAddress },
           },
         } = colonyClient;
@@ -548,16 +541,6 @@ export const getUserInboxActivity: Query<
           },
         );
 
-        const eventsFromTransfer = await getDecoratedEvents(
-          tokenClient,
-          {},
-          {
-            blocksBack: 400000,
-            to: walletAddress,
-            events: [Transfer],
-          },
-        );
-
         return [
           ...eventsFromColony.map(event =>
             normalizeTransactionLog(colonyAddress, event),
@@ -566,9 +549,6 @@ export const getUserInboxActivity: Query<
             normalizeTransactionLog(colonyNetworkAddress, event),
           ),
           ...eventsFromToken.map(event =>
-            normalizeTransactionLog(tokenAddress, event),
-          ),
-          ...eventsFromTransfer.map(event =>
             normalizeTransactionLog(tokenAddress, event),
           ),
           ...eventsFromRoleAssignment.map(event =>


### PR DESCRIPTION
## Description

The thing to particularly consider about this is that I've removed `Transfer` events from the query. Does it make sense to have them? The way it was, we'd pick up all sorts - in fact literally every token transfer to the current user, whether it happened in Colony or not. There's no easy way to improve this, so I've removed it.

Then the normalization - I'm not sure why it was the way it was, but it wasn't quite right! It meant that as soon as we started having inbox activity loaded from DDB it would break the query.

**Changes** 🏗

* Correctly destructure events in `normalizeDDBStoreEvent`

**Deletions** ⚰️

* Remove `Transfer` events from query, since we have no context about them

Resolves #1495 
