### PR TITLE
Fix nav transparency for some pages

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.css
@@ -3,7 +3,7 @@
 .main {
   composes: stretchVertical stretchHorizontal from '~styles/layout.css';
   display: grid;
-  padding: 60px 80px;
+  padding: 130px 80px; /* vertical padding of 60px + nav height (70px) */
   overflow: auto;
   background: var(--gradient-default);
   grid-template-columns: minmax(200px, 260px) minmax(360px, auto) minmax(120px, 200px);

--- a/src/modules/users/components/Inbox/InboxContent/InboxContent.css
+++ b/src/modules/users/components/Inbox/InboxContent/InboxContent.css
@@ -1,6 +1,7 @@
 .contentContainer {
   display: flex;
   flex-direction: column;
+  padding-top: 70px; /* pad space for transparent navbar */
   width: 100%;
   max-width: 940px;
 }

--- a/src/routes/Routes.jsx
+++ b/src/routes/Routes.jsx
@@ -93,6 +93,7 @@ const Routes = ({ isConnected, username }) => {
         path={COLONY_HOME_ROUTE}
         component={ColonyHome}
         hasBackLink={false}
+        appearance={{ theme: 'transparent' }}
       />
       <ConnectedOnlyRoute
         isConnected={isConnected}
@@ -100,6 +101,7 @@ const Routes = ({ isConnected, username }) => {
         path={INBOX_ROUTE}
         component={Inbox}
         hasBackLink={false}
+        appearance={{ theme: 'transparent' }}
       />
       <ConnectedOnlyRoute
         isConnected={isConnected}


### PR DESCRIPTION
## Description

A couple of pages were using the wrong type of header nav! Now they look much prettier 😄 

**Changes** 🏗

* `ColonyHome` navbar is now transparent, component has greater padding to allow for it
* `UserInbox` navbar now transparent, `UserInboxContent` has greater padding to allow for it

Resolves #1361 
