### PR TITLE
Fix user inbox mention notifications

### DIFF
--- a/src/lib/database/DDB.js
+++ b/src/lib/database/DDB.js
@@ -206,7 +206,7 @@ class DDB {
     }
 
     const name = address.path;
-    if (name !== expectedStoreName) {
+    if (name.toLowerCase() !== expectedStoreName.toLowerCase()) {
       throw new Error(
         // eslint-disable-next-line max-len
         `Expected name matching blueprint "${expectedStoreName}" for store "${name}"`,


### PR DESCRIPTION
## Description

This PR adds `createAddress` to store blueprints to make sure we don't have troubles with different address formats. It also changes how DDB checks the generated store name against the expected store name (it's an assertion). That means user inbox stores are found and mentions work again!

**Changes** 🏗

* Use `name.toLowerCase() !== expectedStoreName.toLowerCase()`
* Use `createAddress` on blueprints

Closes #1529