### PR TITLE
Remove leftover inbox handling from profile reducer

### DIFF
--- a/src/modules/core/sagas/setupUserContext.js
+++ b/src/modules/core/sagas/setupUserContext.js
@@ -147,9 +147,7 @@ export default function* setupUserContext(
     try {
       yield put<Action<typeof ACTIONS.INBOX_ITEMS_FETCH>>({
         type: ACTIONS.INBOX_ITEMS_FETCH,
-        payload: {
-          walletAddress,
-        },
+        payload: undefined,
         meta,
       });
     } catch (caughtError) {

--- a/src/modules/users/reducers/userProfilesReducer.js
+++ b/src/modules/users/reducers/userProfilesReducer.js
@@ -13,7 +13,6 @@ const userProfilesReducer: ReducerType<
   UsersMap,
   {|
     CURRENT_USER_CREATE: *,
-    INBOX_ITEMS_FETCH_SUCCESS: *,
     USER_AVATAR_UPLOAD_SUCCESS: *,
     USER_FETCH_SUCCESS: *,
     USER_PROFILE_UPDATE_SUCCESS: *,
@@ -66,6 +65,6 @@ const userProfilesReducer: ReducerType<
 };
 
 export default withDataRecordMap<UsersMap, UserRecordType>(
-  new Set([ACTIONS.USER_FETCH, ACTIONS.INBOX_ITEMS_FETCH]),
+  new Set([ACTIONS.USER_FETCH]),
   ImmutableMap(),
 )(userProfilesReducer);

--- a/src/modules/users/sagas/user.js
+++ b/src/modules/users/sagas/user.js
@@ -580,10 +580,10 @@ function* userTaskSubscribe({
 }
 
 function* inboxItemsFetch({
-  payload: { walletAddress },
   meta,
 }: Action<typeof ACTIONS.INBOX_ITEMS_FETCH>): Saga<*> {
   try {
+    const walletAddress = yield select(walletAddressSelector);
     const { inboxStoreAddress, metadataStoreAddress } = yield select(
       currentUserMetadataSelector,
     );

--- a/src/redux/types/actions/inboxItems.js
+++ b/src/redux/types/actions/inboxItems.js
@@ -8,7 +8,7 @@ import { ACTIONS } from '../../index';
 export type InboxItemsActionTypes = {|
   INBOX_ITEMS_FETCH: UniqueActionType<
     typeof ACTIONS.INBOX_ITEMS_FETCH,
-    {| walletAddress: Address |},
+    void,
     void,
   >,
   INBOX_ITEMS_FETCH_ERROR: ErrorActionType<


### PR DESCRIPTION
## Description

This PR fixes the wrong behaviour when the current user reducer tries to handle the user inbox items.

**Deletions** ⚰️

* Remove inbox fetch success handler from the current user reducer
* Adjust action and saga to only get inbox items for the currently logged in user

**Note**

This was a P3 bug but as it yielded a weird redux state I thought it would be a good idea to fix this before it breaks other stuff.