### PR TITLE
Fix Ether token info state + friends

### DIFF
--- a/src/modules/dashboard/reducers/allTokens.js
+++ b/src/modules/dashboard/reducers/allTokens.js
@@ -70,5 +70,5 @@ const tokensReducer: ReducerType<
 
 export default withDataRecordMap<AllTokensMap, TokenRecordType>(
   ACTIONS.TOKEN_INFO_FETCH,
-  ImmutableMap(),
+  INITIAL_STATE,
 )(tokensReducer);

--- a/src/modules/dashboard/sagas/token.js
+++ b/src/modules/dashboard/sagas/token.js
@@ -31,7 +31,7 @@ function* tokenInfoFetch({
 }: Action<typeof ACTIONS.TOKEN_INFO_FETCH>): Saga<*> {
   // if trying to fetch info for Ether, return hardcoded
   if (tokenAddress === ZERO_ADDRESS) {
-    yield put<Action<typeof ACTIONS.TOKEN_INFO_FETCH_SUCCESS>>({
+    return yield put<Action<typeof ACTIONS.TOKEN_INFO_FETCH_SUCCESS>>({
       type: ACTIONS.TOKEN_INFO_FETCH_SUCCESS,
       payload: {
         isVerified: true,
@@ -73,8 +73,9 @@ function* tokenInfoFetch({
       meta,
     });
   } catch (error) {
-    yield putError(ACTIONS.TOKEN_INFO_FETCH_ERROR, error, meta);
+    return yield putError(ACTIONS.TOKEN_INFO_FETCH_ERROR, error, meta);
   }
+  return null;
 }
 
 function* tokenCreate({

--- a/src/modules/users/sagas/user.js
+++ b/src/modules/users/sagas/user.js
@@ -81,7 +81,8 @@ function* userTokenTransfersFetch(
     const transactions = yield* executeQuery(getUserColonyTransactions, {
       args: {
         walletAddress,
-        userColonyAddresses: userColonyAddresses.record || [],
+        userColonyAddresses:
+          (userColonyAddresses && userColonyAddresses.record) || [],
       },
     });
     yield put<Action<typeof ACTIONS.USER_TOKEN_TRANSFERS_FETCH_SUCCESS>>({

--- a/src/modules/users/selectors/user.js
+++ b/src/modules/users/selectors/user.js
@@ -145,7 +145,10 @@ export const currentUserRecentTokensSelector = createSelector(
   (tokens, transactions) =>
     Array.from(
       new Map([
-        ...((tokens && tokens.record && tokens.record.entries()) || []),
+        ...((tokens &&
+          tokens.record &&
+          tokens.record.map(token => [token.address, token])) ||
+          []),
         ...((transactions && transactions.record) || []).map(({ token }) => [
           token,
           { address: token },

--- a/src/utils/web3/eventLogs/blocks.js
+++ b/src/utils/web3/eventLogs/blocks.js
@@ -11,7 +11,8 @@ export const getLogDate = async (
   { blockHash }: { blockHash: string },
 ) => {
   const { timestamp } = await provider.getBlock(blockHash);
-  return new Date(timestamp);
+  // timestamp is seconds, Date wants ms
+  return new Date(timestamp * 1000);
 };
 
 /*


### PR DESCRIPTION
## Description

No longer is there a spinner in token lists - it is now Ether, as it always should have been! No longer do we have duplicate tokens in token selection lists! No longer do we have weird dates on transaction lists!

**Changes** 🏗

* `tokensReducer` initial state is now set correctly
* `currentUserRecentTokensSelector` now correctly removes duplicates
* `getLogDate` correctly passes milliseconds to JS `Date`
* `userTokenTransfersFetch` doesn't try to access property on `undefined` - wasn't logged anywhere, but I ran into it, prevented user token transfers from being fetched when the user has no colonies yet loaded

Resolves #1519
Resolves #1544 
Contributes to #1537
