### PR TITLE
Fix task default domain, allow unsetting optional task values

### DIFF
--- a/src/data/types/TaskEvents.js
+++ b/src/data/types/TaskEvents.js
@@ -51,7 +51,7 @@ export type TaskEvents = {|
   DUE_DATE_SET: EventDefinition<
     typeof DUE_DATE_SET,
     {|
-      dueDate: number,
+      dueDate?: number,
     |},
   >,
   PAYOUT_SET: EventDefinition<
@@ -64,7 +64,7 @@ export type TaskEvents = {|
   SKILL_SET: EventDefinition<
     typeof SKILL_SET,
     {|
-      skillId: number,
+      skillId?: number,
     |},
   >,
   TASK_CANCELLED: EventDefinition<

--- a/src/modules/dashboard/checks.js
+++ b/src/modules/dashboard/checks.js
@@ -111,5 +111,4 @@ export const canFinalizeTask = (task: TaskType, userAddress: Address) =>
   isManager(task, userAddress) &&
   isActive(task) &&
   isWorkerSet(task) &&
-  isDomainSet(task) &&
-  isSkillSet(task);
+  isDomainSet(task);

--- a/src/modules/dashboard/components/TaskDate/TaskDate.jsx
+++ b/src/modules/dashboard/components/TaskDate/TaskDate.jsx
@@ -69,7 +69,7 @@ const TaskDate = ({ colonyAddress, draftId, dueDate, disabled }: Props) => {
             error={ACTIONS.TASK_SET_DUE_DATE_ERROR}
             transform={transform}
           >
-            {({ submitForm }) => (
+            {({ submitForm, setFormikState }) => (
               <DatePicker
                 elementOnly
                 name="taskDueDate"
@@ -90,6 +90,24 @@ const TaskDate = ({ colonyAddress, draftId, dueDate, disabled }: Props) => {
                       appearance={{ theme: 'secondary' }}
                       text={{ id: 'button.cancel' }}
                       onClick={() => close(null, { cancelled: true })}
+                    />
+                    <Button
+                      appearance={{ theme: 'danger' }}
+                      disabled={!dueDate}
+                      text={{ id: 'button.remove' }}
+                      onClick={() => {
+                        setFormikState(state => ({
+                          ...state,
+                          values: {},
+                        }));
+                        const result = submitForm();
+                        // use of condition to make flow happy
+                        if (result) {
+                          result.then(() => {
+                            close();
+                          });
+                        }
+                      }}
                     />
                     <Button
                       appearance={{ theme: 'primary' }}

--- a/src/modules/dashboard/components/TaskDomains/TaskDomains.jsx
+++ b/src/modules/dashboard/components/TaskDomains/TaskDomains.jsx
@@ -1,8 +1,10 @@
 /* @flow */
 
+import type { IntlShape } from 'react-intl';
+
 // $FlowFixMe upgrade flow
-import React, { useCallback, useState } from 'react';
-import { defineMessages, FormattedMessage } from 'react-intl';
+import React, { useCallback, useMemo, useState } from 'react';
+import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 
 import type { DomainType, TaskProps } from '~immutable';
 
@@ -34,23 +36,34 @@ const MSG = defineMessages({
       other {Modify}
     }`,
   },
+  rootDomain: {
+    id: 'dashboard.TaskDomains.rootDomain',
+    defaultMessage: 'Root',
+  },
 });
 
 type Props = {|
   disabled?: boolean,
+  intl: IntlShape,
   ...TaskProps<{ colonyAddress: *, domainId: *, draftId: * }>,
 |};
 
 const displayName = 'dashboard.TaskDomains';
 
-const TaskDomains = ({ colonyAddress, domainId, draftId, disabled }: Props) => {
+const TaskDomains = ({
+  colonyAddress,
+  domainId,
+  draftId,
+  disabled,
+  intl: { formatMessage },
+}: Props) => {
   const setDomain = useAsyncFunction({
     submit: ACTIONS.TASK_SET_DOMAIN,
     success: ACTIONS.TASK_SET_DOMAIN_SUCCESS,
     error: ACTIONS.TASK_SET_DOMAIN_ERROR,
   });
 
-  const [selectedDomainId, setSelectedDomainId] = useState();
+  const [selectedDomainId, setSelectedDomainId] = useState(domainId);
 
   const handleSetDomain = useCallback(
     async (domainValue: Object) => {
@@ -73,16 +86,23 @@ const TaskDomains = ({ colonyAddress, domainId, draftId, disabled }: Props) => {
     { children?: *, parent?: *, ...DomainType }[],
   >(domainsFetcher, [colonyAddress], [colonyAddress]);
 
+  const domainsWithRoot = useMemo(
+    () =>
+      domains && [{ id: 1, name: formatMessage(MSG.rootDomain) }, ...domains],
+    [domains, formatMessage],
+  );
+
   return (
     <div className={styles.main}>
       <ItemsList
-        list={domains || []}
+        list={domainsWithRoot || []}
         itemDisplayPrefix="#"
         handleSetItem={handleSetDomain}
         name="taskDomains"
         connect={false}
         showArrow={false}
         itemId={domainId}
+        disabled={disabled}
       >
         <div className={styles.controls}>
           <Heading
@@ -109,4 +129,4 @@ const TaskDomains = ({ colonyAddress, domainId, draftId, disabled }: Props) => {
 
 TaskDomains.displayName = displayName;
 
-export default TaskDomains;
+export default injectIntl(TaskDomains);

--- a/src/modules/dashboard/components/TaskSkills/TaskSkills.jsx
+++ b/src/modules/dashboard/components/TaskSkills/TaskSkills.jsx
@@ -55,7 +55,7 @@ const TaskSkills = ({ colonyAddress, draftId, disabled, skillId }: Props) => {
         await setSkill({
           colonyAddress,
           draftId,
-          skillId: skillValue.id,
+          skillId: skillValue ? skillValue.id : undefined,
         });
       } catch (caughtError) {
         /**
@@ -76,6 +76,8 @@ const TaskSkills = ({ colonyAddress, draftId, disabled, skillId }: Props) => {
         connect={false}
         showArrow={false}
         itemId={skillId}
+        disabled={disabled}
+        nullable
       >
         <div className={styles.controls}>
           <Heading

--- a/src/modules/dashboard/data/commands/schemas.js
+++ b/src/modules/dashboard/data/commands/schemas.js
@@ -50,11 +50,11 @@ export const RemoveColonyAvatarCommandArgsSchema = yup.object({
 });
 
 export const SetTaskDueDateCommandArgsSchema = yup.object({
-  dueDate: yup.number().required(),
+  dueDate: yup.number(),
 });
 
 export const SetTaskSkillCommandArgsSchema = yup.object({
-  skillId: yup.number().required(),
+  skillId: yup.number(),
 });
 
 export const CreateTaskCommandArgsSchema = yup.object({

--- a/src/modules/dashboard/data/commands/task.js
+++ b/src/modules/dashboard/data/commands/task.js
@@ -264,7 +264,7 @@ export const setTaskDueDate: Command<
   TaskStore,
   TaskStoreMetadata,
   {|
-    dueDate: number,
+    dueDate?: number,
   |},
   {|
     event: Event<typeof TASK_EVENT_TYPES.DUE_DATE_SET>,
@@ -289,7 +289,7 @@ export const setTaskSkill: Command<
   TaskStore,
   TaskStoreMetadata,
   {|
-    skillId: number,
+    skillId?: number,
   |},
   {|
     event: Event<typeof TASK_EVENT_TYPES.SKILL_SET>,

--- a/src/modules/dashboard/data/reducers/task.js
+++ b/src/modules/dashboard/data/reducers/task.js
@@ -66,6 +66,7 @@ export const taskReducer: EventReducer<
         managerAddress: creatorAddress, // @NOTE: At least for the draft version, the creator will also be the manager
         draftId,
         status: TASK_STATE.ACTIVE,
+        domainId: 1,
       };
     }
     case TASK_TITLE_SET: {
@@ -121,7 +122,7 @@ export const taskReducer: EventReducer<
       const { dueDate } = event.payload;
       return {
         ...task,
-        dueDate: new Date(dueDate),
+        dueDate: dueDate ? new Date(dueDate) : undefined,
       };
     }
     case DOMAIN_SET: {

--- a/src/modules/dashboard/reducers/tasks.js
+++ b/src/modules/dashboard/reducers/tasks.js
@@ -45,12 +45,13 @@ const taskEventReducer = (task: TaskRecordType, event: *): TaskRecordType => {
         currentState: TASK_STATE.ACTIVE,
         draftId,
         managerAddress: creatorAddress,
+        domainId: 1,
       });
     }
 
     case DUE_DATE_SET: {
       const { dueDate } = event.payload;
-      return task.set('dueDate', new Date(dueDate));
+      return task.set('dueDate', dueDate ? new Date(dueDate) : undefined);
     }
 
     case DOMAIN_SET: {

--- a/src/redux/types/actions/task.js
+++ b/src/redux/types/actions/task.js
@@ -238,7 +238,7 @@ export type TaskActionTypes = {|
   >,
   TASK_SET_DUE_DATE: TaskActionType<
     typeof ACTIONS.TASK_SET_DUE_DATE,
-    $Required<TaskProps<{ dueDate: * }>>,
+    TaskProps<{ dueDate: * }>,
   >,
   TASK_SET_DUE_DATE_ERROR: TaskErrorActionType<
     typeof ACTIONS.TASK_SET_DUE_DATE_ERROR,
@@ -282,7 +282,7 @@ export type TaskActionTypes = {|
   >,
   TASK_SET_SKILL: TaskActionType<
     typeof ACTIONS.TASK_SET_SKILL,
-    $Required<TaskProps<{ skillId: * }>>,
+    TaskProps<{ skillId: * }>,
   >,
   TASK_SET_SKILL_ERROR: TaskErrorActionType<
     typeof ACTIONS.TASK_SET_SKILL_ERROR,


### PR DESCRIPTION
## Description

Tasks now initially exist in the root domain, hooray! You can also finalize without setting the skill (or due date, but that was already the case), and can unset the skill and due date.

**Changes** 🏗

* Tasks are now reduced with a default `domainId` of 1 (root domain)
* Fixed a bug where `ItemsList` could be opened when disabled
* Allow unsetting of task skill and due date
* Allow finalizing of task with no skill set

Resolves #1527 
