### PR TITLE
Fix 404 redirection when creating a new colony

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.jsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.jsx
@@ -90,21 +90,22 @@ const ColonyHome = ({
     [colonyName],
   );
 
+  const colonyArgs = [colonyAddress || undefined];
   const {
     data: colony,
     isFetching: isFetchingColony,
     error: colonyError,
-  } = useDataSubscriber<*>(colonySubscriber, [colonyAddress], [colonyAddress]);
+  } = useDataSubscriber<*>(colonySubscriber, colonyArgs, colonyArgs);
 
   const { data: permissions } = useDataFetcher<UserPermissionsType>(
     currentUserColonyPermissionsFetcher,
-    [colonyAddress],
-    [colonyAddress],
+    colonyArgs,
+    colonyArgs,
   );
 
   const nativeTokenRef: ?TokenReferenceType = useSelector(
     colonyNativeTokenSelector,
-    [colonyAddress],
+    colonyArgs,
   );
 
   const transform = useCallback(mergePayload({ colonyAddress }), [


### PR DESCRIPTION
## Description

A bug was introduced in #1511 that (in some cases) causes a 404 redirection upon successfully creating a new colony; this is due to the redux-selected `colonyAddress` in `ColonyHome` 
(the component that starts the subscription) being `null` rather than `undefined`, and as a consequence, colony subscription actions are dispatched without the correct payload. 

This PR fixes that in a simple way.


**Changes** 🏗

* Ensure that the arguments for starting a colony subscription are `undefined` rather than `null` if not set, to make sure that actions are not dispatched without proper payloads
