### PR TITLE
Parse extension deploy logs for less error-prone colony creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,6 +211,7 @@
         "scroll-into-view-if-needed": "^2.2.16",
         "sugar-core": "^2.0.4",
         "sugar-date": "^2.0.4",
+        "web3-eth-abi": "1.0.0-beta.36",
         "web3-utils": "^1.0.0-beta.27",
         "yup": "^0.27.0"
     }

--- a/src/utils/web3/eventLogs/eventParsers.js
+++ b/src/utils/web3/eventLogs/eventParsers.js
@@ -4,6 +4,7 @@ import type {
   ColonyClient as ColonyClientType,
   TokenClient as TokenClientType,
 } from '@colony/colony-js-client';
+import Web3EthAbi from 'web3-eth-abi';
 
 import BigNumber from 'bn.js';
 import { FUNDING_POT_TYPE_PAYMENT } from '@colony/colony-js-client';
@@ -215,4 +216,27 @@ export const parseUserTransferEvent = async ({
     to,
     token,
   });
+};
+
+// Obtain the deployed extension address from an `ExtensionDeployed` log
+export const parseExtensionDeployedLog = (log: *) => {
+  const { _extension: extensionAddress } = Web3EthAbi.decodeLog(
+    [
+      {
+        type: 'string',
+        name: '_name',
+      },
+      {
+        type: 'address',
+        name: '_colony',
+      },
+      {
+        type: 'address',
+        name: '_extension',
+      },
+    ],
+    log.data,
+    log.topics,
+  );
+  return extensionAddress;
 };


### PR DESCRIPTION
## Description

This PR makes some adjustments to the colony creation process, so that the reported bug in #1491 shouldn't occur again. 

Though I wasn't able to reproduce it, the reported bug looks like it might happen when a transaction is successful, but the node queried for the constant call directly afterwards doesn't have the updated state yet, and so it reports the old state (where the extension contract in question hasn't been deployed yet). 

The approach taken in this PR is to parse the event log from the successful transaction in order to obtain the deployed extension contract address immediately, rather than doing a call.


**New stuff** ✨

* Define a util to parse `ExtensionDeployed` event logs, based on `web3-eth-abi`, as these cannot easily be decoded with colonyJS
* Add `web3-eth-abi` dependency (the same version as used elsewhere in dependencies)

**Changes** 🏗

* During colony creation, use the event log parser to get the deployed extension address from the deployment transaction, rather than doing a lookup that sometimes failed


Resolves #1491 
