### PR TITLE
Disable "putNotification" until we have dismissable notifications

### DIFF
--- a/src/modules/admin/sagas/index.js
+++ b/src/modules/admin/sagas/index.js
@@ -11,13 +11,13 @@ import {
   putError,
   executeCommand,
   executeQuery,
-  putNotification,
+  // putNotification,
 } from '~utils/saga/effects';
 import { ACTIONS } from '~redux';
 
-import { CONTEXT, getContext } from '~context';
-import { decorateLog } from '~utils/web3/eventLogs/events';
-import { normalizeTransactionLog } from '~data/normalizers';
+// import { CONTEXT, getContext } from '~context';
+// import { decorateLog } from '~utils/web3/eventLogs/events';
+// import { normalizeTransactionLog } from '~data/normalizers';
 
 import { getColony } from '../../dashboard/data/queries';
 import {
@@ -235,19 +235,19 @@ function* colonyMintTokens({
         payload: { colonyAddress, tokenAddress },
       });
 
-      const colonyManager = yield* getContext(CONTEXT.COLONY_MANAGER);
-      const tokenClient = yield call(
-        [colonyManager, colonyManager.getTokenClient],
-        tokenAddress,
-      );
+      // const colonyManager = yield* getContext(CONTEXT.COLONY_MANAGER);
+      // const tokenClient = yield call(
+      //   [colonyManager, colonyManager.getTokenClient],
+      //   tokenAddress,
+      // );
 
       /*
        * Notification
        */
-      const decoratedLog = yield call(decorateLog, tokenClient, mintLog);
-      yield putNotification(
-        normalizeTransactionLog(tokenAddress, decoratedLog),
-      );
+      // const decoratedLog = yield call(decorateLog, tokenClient, mintLog);
+      // yield putNotification(
+      //   normalizeTransactionLog(tokenAddress, decoratedLog),
+      // );
     }
 
     yield put<Action<typeof ACTIONS.COLONY_MINT_TOKENS_SUCCESS>>({

--- a/src/modules/dashboard/sagas/colonyCreate.js
+++ b/src/modules/dashboard/sagas/colonyCreate.js
@@ -454,7 +454,8 @@ function* colonyCreate({
      * Notification
      */
 
-    // @TODO Add proper support for event normalization
+    // @NOTE Here we actually wanna emit the notification because that's gonna be
+    // on the colony founder inbox
     const decoratedLog = yield call(
       decorateLog,
       colonyManager.networkClient,

--- a/src/modules/dashboard/sagas/domains.js
+++ b/src/modules/dashboard/sagas/domains.js
@@ -10,13 +10,13 @@ import {
   takeFrom,
   executeQuery,
   executeCommand,
-  putNotification,
+  // putNotification,
 } from '~utils/saga/effects';
 import { ACTIONS } from '~redux';
 
-import { getContext, CONTEXT } from '~context';
-import { decorateLog } from '~utils/web3/eventLogs/events';
-import { normalizeTransactionLog } from '~data/normalizers';
+// import { getContext, CONTEXT } from '~context';
+// import { decorateLog } from '~utils/web3/eventLogs/events';
+// import { normalizeTransactionLog } from '~data/normalizers';
 
 import { createTransaction, getTxChannel } from '../../core/sagas';
 import { COLONY_CONTEXT } from '../../core/constants';
@@ -71,11 +71,11 @@ function* domainCreate({
     const {
       payload: {
         eventData: { domainId: id },
-        transaction: {
-          receipt: {
-            logs: [, domainAddedLog],
-          },
-        },
+        // transaction: {
+        //   receipt: {
+        //     logs: [, domainAddedLog],
+        //   },
+        // },
       },
     } = yield takeFrom(txChannel, ACTIONS.TRANSACTION_SUCCEEDED);
 
@@ -98,17 +98,17 @@ function* domainCreate({
       payload: { colonyAddress, domain: { id, name } },
     });
 
-    const colonyManager = yield* getContext(CONTEXT.COLONY_MANAGER);
-    const colonyClient = yield call(
-      [colonyManager, colonyManager.getColonyClient],
-      colonyAddress,
-    );
+    // const colonyManager = yield* getContext(CONTEXT.COLONY_MANAGER);
+    // const colonyClient = yield call(
+    //   [colonyManager, colonyManager.getColonyClient],
+    //   colonyAddress,
+    // );
 
     /*
      * Notification
      */
-    const decoratedLog = yield call(decorateLog, colonyClient, domainAddedLog);
-    yield putNotification(normalizeTransactionLog(colonyAddress, decoratedLog));
+    // const decoratedLog = yield call(decorateLog, colonyClient, domainAddedLog);
+    // yield putNotification(normalizeTransactionLog(colonyAddress, decoratedLog));
   } catch (error) {
     return yield putError(ACTIONS.DOMAIN_CREATE_ERROR, error, meta);
   } finally {

--- a/src/modules/dashboard/sagas/roles.js
+++ b/src/modules/dashboard/sagas/roles.js
@@ -5,17 +5,10 @@ import { call, fork, put, takeEvery } from 'redux-saga/effects';
 
 import type { Action } from '~redux';
 
-import {
-  executeQuery,
-  putError,
-  takeFrom,
-  putNotification,
-} from '~utils/saga/effects';
+import { executeQuery, putError, takeFrom } from '~utils/saga/effects';
 import { ACTIONS } from '~redux';
 
-import { decorateLog } from '~utils/web3/eventLogs/events';
-import { getContext, CONTEXT } from '~context';
-import { normalizeTransactionLog } from '~data/normalizers';
+// import { getContext, CONTEXT } from '~context';
 
 import { getColonyRoles } from '../data/queries';
 import { createTransaction, getTxChannel } from '../../core/sagas';
@@ -61,15 +54,16 @@ function* colonyAdminAdd({
       params: { address: newAdmin, setTo: true },
     });
 
-    const {
-      payload: {
-        transaction: {
-          receipt: {
-            logs: [colonyRoleSetLog],
-          },
-        },
-      },
-    } = yield takeFrom(txChannel, ACTIONS.TRANSACTION_SUCCEEDED);
+    // const {
+    //   payload: {
+    //     transaction: {
+    //       receipt: {
+    //         logs: [colonyRoleSetLog],
+    //       },
+    //     },
+    //   },
+    // } =
+    yield takeFrom(txChannel, ACTIONS.TRANSACTION_SUCCEEDED);
 
     /*
      * Dispatch the action to the admin in the Redux store;
@@ -81,21 +75,21 @@ function* colonyAdminAdd({
       meta,
     });
 
-    const colonyManager = yield* getContext(CONTEXT.COLONY_MANAGER);
-    const colonyClient = yield call(
-      [colonyManager, colonyManager.getColonyClient],
-      colonyAddress,
-    );
+    // const colonyManager = yield* getContext(CONTEXT.COLONY_MANAGER);
+    // const colonyClient = yield call(
+    //   [colonyManager, colonyManager.getColonyClient],
+    //   colonyAddress,
+    // );
 
     /*
-     * Notification
+     * @TODO Add dismissable notifications
      */
-    const decoratedLog = yield call(
-      decorateLog,
-      colonyClient,
-      colonyRoleSetLog,
-    );
-    yield putNotification(normalizeTransactionLog(colonyAddress, decoratedLog));
+    // const decoratedLog = yield call(
+    //   decorateLog,
+    //   colonyClient,
+    //   colonyRoleSetLog,
+    // );
+    // yield putNotification(normalizeTransactionLog(colonyAddress, decoratedLog));
     yield put(fetchRoles(colonyAddress));
   } catch (error) {
     return yield putError(ACTIONS.COLONY_ADMIN_ADD_ERROR, error, meta);
@@ -123,15 +117,16 @@ function* colonyAdminRemove({
       params: { address: user, setTo: false },
     });
 
-    const {
-      payload: {
-        transaction: {
-          receipt: {
-            logs: [colonyRoleSetLog],
-          },
-        },
-      },
-    } = yield takeFrom(txChannel, ACTIONS.TRANSACTION_SUCCEEDED);
+    // const {
+    //   payload: {
+    //     transaction: {
+    //       receipt: {
+    //         logs: [colonyRoleSetLog],
+    //       },
+    //     },
+    //   },
+    // } =
+    yield takeFrom(txChannel, ACTIONS.TRANSACTION_SUCCEEDED);
 
     yield put<Action<typeof ACTIONS.COLONY_ADMIN_REMOVE_SUCCESS>>({
       type: ACTIONS.COLONY_ADMIN_REMOVE_SUCCESS,
@@ -139,21 +134,21 @@ function* colonyAdminRemove({
       payload,
     });
 
-    const colonyManager = yield* getContext(CONTEXT.COLONY_MANAGER);
-    const colonyClient = yield call(
-      [colonyManager, colonyManager.getColonyClient],
-      colonyAddress,
-    );
+    // const colonyManager = yield* getContext(CONTEXT.COLONY_MANAGER);
+    // const colonyClient = yield call(
+    //   [colonyManager, colonyManager.getColonyClient],
+    //   colonyAddress,
+    // );
 
     /*
      * Notification
      */
-    const decoratedLog = yield call(
-      decorateLog,
-      colonyClient,
-      colonyRoleSetLog,
-    );
-    yield putNotification(normalizeTransactionLog(colonyAddress, decoratedLog));
+    // const decoratedLog = yield call(
+    //   decorateLog,
+    //   colonyClient,
+    //   colonyRoleSetLog,
+    // );
+    // yield putNotification(normalizeTransactionLog(colonyAddress, decoratedLog));
     yield put(fetchRoles(colonyAddress));
   } catch (error) {
     return yield putError(ACTIONS.COLONY_ADMIN_REMOVE_ERROR, error, meta);


### PR DESCRIPTION
## Description

This PR disables notifications that are optimistically dispatched using `putNotification`.

**Changes** 🏗

* Disable all `putNotification` calls except for the one related to registering a colony's ENS name

Contributes to #1530