### PR TITLE
Fetch only claimed token balances for colonies

### DIFF
--- a/src/modules/admin/sagas/index.js
+++ b/src/modules/admin/sagas/index.js
@@ -117,6 +117,10 @@ function* colonyClaimToken({
     yield put<Action<typeof ACTIONS.COLONY_UNCLAIMED_TRANSACTIONS_FETCH>>(
       fetchColonyUnclaimedTransactions(colonyAddress),
     );
+    yield put<Action<typeof ACTIONS.COLONY_TOKEN_BALANCE_FETCH>>({
+      type: ACTIONS.COLONY_TOKEN_BALANCE_FETCH,
+      payload: { colonyAddress, tokenAddress },
+    });
   } catch (error) {
     return yield putError(ACTIONS.COLONY_CLAIM_TOKEN_ERROR, error, meta);
   } finally {

--- a/src/modules/dashboard/sagas/colony.js
+++ b/src/modules/dashboard/sagas/colony.js
@@ -339,7 +339,8 @@ function* colonyTokenBalanceFetch({
 }: Action<typeof ACTIONS.COLONY_TOKEN_BALANCE_FETCH>) {
   try {
     const balance = yield* executeQuery(getColonyTokenBalance, {
-      args: { colonyAddress, tokenAddress },
+      args: { tokenAddress },
+      metadata: { colonyAddress },
     });
 
     yield put({


### PR DESCRIPTION
## Description

Couple of fixes for weird behaviour. Big thing is that the displayed token balances are now just the claimed amount - in other words, just the amount that you can use!

**Changes** 🏗

* `getColonyTokenBalance` query now fetches only claimed balances (in all pots)
* `COLONY_SUB_EVENTS` reducer preserves `canMintNativeToken` and token balances - these would previously disappear when new store events came in 😢 
* Refetch token balance after claiming token

Resolves #1560 
