### PR TITLE
Remove wallet transactions and add Etherscan link

### DIFF
--- a/src/modules/core/components/WalletLink/WalletLink.jsx
+++ b/src/modules/core/components/WalletLink/WalletLink.jsx
@@ -1,0 +1,52 @@
+/* @flow */
+
+import type { MessageDescriptor, MessageValues } from 'react-intl';
+
+import React from 'react';
+
+import ExternalLink from '~core/ExternalLink';
+import { DEFAULT_NETWORK } from '../../constants';
+
+type Props = {|
+  /*
+   * Allows for link style customization (Eg: we need to disquise the link as a button)
+   * Don't abuse it!
+   */
+  className?: string,
+  /** Wallet address */
+  walletAddress: string,
+  /** Optionally override current network */
+  network?: string,
+  /** A string or a `messageDescriptor` that make up the link's text. Defaults to `hash`. */
+  text?: MessageDescriptor | string,
+  /** Values for text (react-intl interpolation) */
+  textValues?: MessageValues,
+|};
+
+const displayName = 'WalletLink';
+
+const WalletLink = ({
+  className,
+  walletAddress,
+  network = DEFAULT_NETWORK,
+  text,
+  textValues,
+}: Props) => {
+  const linkText = text || walletAddress;
+  const tld = network === 'tobalaba' ? 'com' : 'io';
+  const networkSubdomain = network === 'homestead' ? '' : `${network}.`;
+  // eslint-disable-next-line max-len
+  const href = `https://${networkSubdomain}etherscan.${tld}/address/${walletAddress}`;
+  return (
+    <ExternalLink
+      className={className}
+      href={href}
+      text={linkText}
+      textValues={textValues}
+    />
+  );
+};
+
+WalletLink.displayName = displayName;
+
+export default WalletLink;

--- a/src/modules/core/components/WalletLink/WalletLink.md
+++ b/src/modules/core/components/WalletLink/WalletLink.md
@@ -1,0 +1,16 @@
+Link to an external resource to provide extra information about a particular wallet address and its transactions.
+
+### Normal wallet link
+
+```jsx
+<WalletLink walletAddress="0xdbcFA7301786e76A30D5B6A51F84BB4a2e9EA53d" />
+```
+
+### Wallet link with custom text
+
+```jsx
+<WalletLink
+  walletAddress="0xdbcFA7301786e76A30D5B6A51F84BB4a2e9EA53d"
+  text="This is the link text"
+/>
+```

--- a/src/modules/core/components/WalletLink/index.js
+++ b/src/modules/core/components/WalletLink/index.js
@@ -1,0 +1,3 @@
+/* @flow */
+
+export { default } from './WalletLink.jsx';

--- a/src/modules/dashboard/components/Wallet/Wallet.css
+++ b/src/modules/dashboard/components/Wallet/Wallet.css
@@ -23,6 +23,10 @@
   margin-top: 65px;
 }
 
+.linkText {
+  margin-top: 75px;
+}
+
 .walletDetails {
   display: flex;
   margin-bottom: 40px;
@@ -30,6 +34,18 @@
 
 .tokenLink {
   font-weight: var(--weight-medium);
+  color: var(--sky-blue);
+}
+
+.walletLink {
+  margin-left: 5px;
+  font-size: var(--size-tiny);
+  font-weight: var(--weight-semi);
+  color: var(--sky-blue);
+}
+
+.walletLink:hover {
+  text-decoration: underline;
   color: var(--sky-blue);
 }
 

--- a/src/modules/dashboard/components/Wallet/Wallet.jsx
+++ b/src/modules/dashboard/components/Wallet/Wallet.jsx
@@ -5,23 +5,19 @@ import React, { useCallback } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
 import type { DialogType } from '~core/Dialog';
-import type { ContractTransactionType, TokenReferenceType } from '~immutable';
+import type { TokenReferenceType } from '~immutable';
 import type { Address } from '~types';
 
-import { Tab, Tabs, TabList, TabPanel } from '~core/Tabs';
 import CopyableAddress from '~core/CopyableAddress';
 import Button from '~core/Button';
 import Heading from '~core/Heading';
 import QRCode from '~core/QRCode';
+import WalletLink from '~core/WalletLink';
 import { SpinnerLoader } from '~core/Preloaders';
-import WalletTransactions from '../WalletTransactions';
 import TokenList from '~admin/Tokens/TokenList.jsx';
 
 import { useDataFetcher } from '~utils/hooks';
-import {
-  currentUserTokenTransfersFetcher,
-  currentUserTokensFetcher,
-} from '../../../users/fetchers';
+import { currentUserTokensFetcher } from '../../../users/fetchers';
 
 import styles from './Wallet.css';
 
@@ -42,9 +38,17 @@ const MSG = defineMessages({
     id: 'dashboard.Wallet.helpText',
     defaultMessage: "Don't see the tokens you are looking for?",
   },
+  linkText: {
+    id: 'dashboard.Wallet.linkText',
+    defaultMessage: 'View your transactions on Etherscan {link}',
+  },
   linkEditToken: {
     id: 'dashboard.Wallet.linkEditToken',
     defaultMessage: 'Edit Tokens Here',
+  },
+  linkViewTransactions: {
+    id: 'dashboard.Wallet.linkViewTransactions',
+    defaultMessage: 'Here',
   },
 });
 
@@ -57,14 +61,6 @@ const Wallet = ({ walletAddress, openDialog }: Props) => {
   const { isFetching: isFetchingTokens, data: tokens } = useDataFetcher<
     TokenReferenceType[],
   >(currentUserTokensFetcher, [], []);
-  const {
-    isFetching: isFetchingTransactions,
-    data: transactions,
-  } = useDataFetcher<ContractTransactionType[]>(
-    currentUserTokenTransfersFetcher,
-    [],
-    [],
-  );
   const editTokens = useCallback(
     () =>
       openDialog('UserTokenEditDialog', {
@@ -87,29 +83,11 @@ const Wallet = ({ walletAddress, openDialog }: Props) => {
             </CopyableAddress>
           </div>
         </div>
-        <Tabs>
-          <TabList>
-            <Tab>
-              <FormattedMessage {...MSG.tabTokens} />
-            </Tab>
-            <Tab>
-              <FormattedMessage {...MSG.tabTransactions} />
-            </Tab>
-          </TabList>
-          <TabPanel>
-            {isFetchingTokens ? (
-              <SpinnerLoader />
-            ) : (
-              <TokenList tokens={tokens || []} appearance={{ numCols: '3' }} />
-            )}
-          </TabPanel>
-          <TabPanel>
-            <WalletTransactions
-              transactions={transactions || undefined}
-              isLoading={isFetchingTransactions}
-            />
-          </TabPanel>
-        </Tabs>
+        {isFetchingTokens ? (
+          <SpinnerLoader />
+        ) : (
+          <TokenList tokens={tokens || []} appearance={{ numCols: '3' }} />
+        )}
       </main>
       <aside className={styles.sidebar}>
         <p className={styles.helpText}>
@@ -118,6 +96,20 @@ const Wallet = ({ walletAddress, openDialog }: Props) => {
             appearance={{ theme: 'blue', size: 'small' }}
             text={MSG.linkEditToken}
             onClick={editTokens}
+          />
+        </p>
+        <p className={styles.linkText}>
+          <FormattedMessage
+            {...MSG.linkText}
+            values={{
+              link: (
+                <WalletLink
+                  className={styles.walletLink}
+                  walletAddress={walletAddress}
+                  text={MSG.linkViewTransactions}
+                />
+              ),
+            }}
           />
         </p>
       </aside>

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -23,6 +23,7 @@ module.exports = {
         './src/modules/core/components/NavLink/NavLink.jsx',
         './src/modules/core/components/ExternalLink/ExternalLink.jsx',
         './src/modules/core/components/TransactionLink/TransactionLink.jsx',
+        './src/modules/core/components/WalletLink/WalletLink.jsx',
         './src/modules/core/components/Numeral/Numeral.jsx',
         './src/modules/core/components/Duration/Duration.jsx',
         './src/modules/core/components/TimeRelative/TimeRelative.jsx',


### PR DESCRIPTION
## Description

Remove wallet transaction list temporarily before launch and add Etherscan link to link to all transactions of one walletAddress.
To achieve this I basically got inspired by the core `TransactionLink` component which creates a very similar link but for one transaction hash.


## Current status
<img width="1083" alt="Screen Shot 2019-07-22 at 11 21 57" src="https://user-images.githubusercontent.com/6294044/61621308-fe0c9f00-ac72-11e9-989c-f2af22a4a7d5.png">


 
Resolves #1547
