### PR TITLE
Fetch contract data in colonySubStart saga

### DIFF
--- a/src/modules/dashboard/actionCreators/colony.js
+++ b/src/modules/dashboard/actionCreators/colony.js
@@ -38,6 +38,22 @@ export const fetchColonyTaskMetadata = (
   meta: { key: createAddress(colonyAddress) },
 });
 
+export const fetchColonyTokenBalance = (
+  colonyAddress: Address,
+  tokenAddress: Address,
+): Action<typeof ACTIONS.COLONY_TOKEN_BALANCE_FETCH> => ({
+  type: ACTIONS.COLONY_TOKEN_BALANCE_FETCH,
+  payload: { colonyAddress, tokenAddress },
+});
+
+export const fetchColonyCanMintNativeToken = (
+  colonyAddress: Address,
+): Action<typeof ACTIONS.COLONY_CAN_MINT_NATIVE_TOKEN_FETCH> => ({
+  type: ACTIONS.COLONY_CAN_MINT_NATIVE_TOKEN_FETCH,
+  payload: { colonyAddress },
+  meta: { key: createAddress(colonyAddress) },
+});
+
 export const colonySubStart = (
   colonyAddress: Address,
 ): Action<typeof ACTIONS.COLONY_SUB_START> => ({


### PR DESCRIPTION
## Description

When we were only using the colony fetcher to get data for a colony, we had actions being happily dispatched to fetch additional data such as token balances and whether we can mint tokens. With subscribers, we broke all that! This PR adds fetching for this additional data in the subscriber.

**Changes** 🏗

* Fetch `canMintNativeToken` in `colonySubStart` if not already set
* Fetch token balances for those with undefined balances in `colonySubStart`

Resolves #1594 
