### PR TITLE
Fix network fee percentage display format

### DIFF
--- a/src/modules/dashboard/components/TaskClaimReward/TaskClaimRewardDialog.jsx
+++ b/src/modules/dashboard/components/TaskClaimReward/TaskClaimRewardDialog.jsx
@@ -2,7 +2,7 @@
 
 // $FlowFixMe until hooks flow types
 import React, { useCallback } from 'react';
-import { defineMessages, FormattedMessage, FormattedNumber } from 'react-intl';
+import { defineMessages, FormattedMessage } from 'react-intl';
 
 import type { TaskPayoutType } from '~immutable';
 import type { Address } from '~types';
@@ -207,11 +207,10 @@ const TaskClaimRewardDialog = ({
                   {...MSG.networkFee}
                   values={{
                     percentage: (
-                      <FormattedNumber
-                        // eslint-disable-next-line react/style-prop-object
-                        style="percent"
-                        value={networkFee}
-                        minimumFractionDigits={1}
+                      <Numeral
+                        value={networkFee * 1e2}
+                        suffix="%"
+                        truncate={1}
                       />
                     ),
                   }}

--- a/src/modules/dashboard/components/TaskEditDialog/NetworkFee/NetworkFee.jsx
+++ b/src/modules/dashboard/components/TaskEditDialog/NetworkFee/NetworkFee.jsx
@@ -2,7 +2,7 @@
 
 // $FlowFixMe until hooks flow types
 import React, { useMemo } from 'react';
-import { defineMessages, FormattedMessage, FormattedNumber } from 'react-intl';
+import { defineMessages, FormattedMessage } from 'react-intl';
 import BigNumber from 'bn.js';
 import moveDecimal from 'move-decimal-point';
 
@@ -90,12 +90,7 @@ const NetworkFee = ({ amount, decimals, symbol }: Props) => {
                 {...MSG.helpText}
                 values={{
                   percentage: (
-                    <FormattedNumber
-                      // eslint-disable-next-line react/style-prop-object
-                      style="percent"
-                      value={networkFee}
-                      minimumFractionDigits={1}
-                    />
+                    <Numeral value={networkFee * 1e2} suffix="%" truncate={1} />
                   ),
                 }}
               />


### PR DESCRIPTION
## Description

This PR adds `minimumFractionDigits=1` to `<FormattedNumber>`s showing the network fee (default is 0)


**Changes** 🏗

* Add minimum fraction digits to show the network fee with decimal precision

Closes #1561