### PR TITLE
Correctly dispatch gas update action in GasStationPrice

### DIFF
--- a/src/modules/users/components/GasStation/GasStationPrice/GasStationPrice.jsx
+++ b/src/modules/users/components/GasStation/GasStationPrice/GasStationPrice.jsx
@@ -197,8 +197,8 @@ const GasStationPrice = ({ transaction: { id, gasLimit, error } }: Props) => {
                     name="transactionSpeed"
                     options={transactionSpeedOptions.map(option => ({
                       ...option,
-                      onClick: () => {
-                        updateGas(id, { gasPrice: currentGasPrice });
+                      onClick: e => {
+                        updateGas(gasPrices[e.target.value]);
                       },
                     }))}
                   />


### PR DESCRIPTION
## Description

The wrong value(s) were being passed to the `updateGas` function in `GasStationPrice`, resulting in a string being interpreted as a very crazy large number!

**Changes** 🏗

* Call `updateGas` with correct values, from the event in `onClick`, since the form values will not yet be updated

Resolves #1628 
