### PR TITLE
Re-add address check for getFullDomain

### DIFF
--- a/src/lib/ENS/ENS.js
+++ b/src/lib/ENS/ENS.js
@@ -16,7 +16,7 @@ const EXTERNAL_PREFIX = '$';
 
 class ENS {
   static getFullDomain = (scope: 'user' | 'colony', name: string) =>
-    `${name}.${scope}.${COLONY_NETWORK_ENS_NAME}`;
+    isAddress(name) ? name : `${name}.${scope}.${COLONY_NETWORK_ENS_NAME}`;
 
   static stripDomainParts = (scope: 'user' | 'colony', domain: string) =>
     domain.split(`.${scope}.${COLONY_NETWORK_ENS_NAME}`)[0];


### PR DESCRIPTION
## Description

This PR adds back in the address check that was removed in #1615 because I thought it would be unnecessary. Turns out it seems to be needed after all. This _should_ fix this error:

<img width="530" alt="Screen Shot 2019-07-26 at 10 50 33 AM" src="https://user-images.githubusercontent.com/2174084/61941298-7dfa7800-af97-11e9-8957-75211d2de793.png">


TIL: don't touch anything you don't know about!

**Changes** 🏗

* Check whether domain is an address in `getFullDomain` and return it.
