### PR TITLE
Fetch tokens in colony subscriber saga

### DIFF
--- a/src/modules/dashboard/sagas/colony.js
+++ b/src/modules/dashboard/sagas/colony.js
@@ -475,7 +475,11 @@ function* colonySubStart({ payload: { colonyAddress }, meta }: *): Saga<*> {
 
     const reduceTokenToDispatch = (acc, token) =>
       token.balance === undefined
-        ? [...acc, put(fetchColonyTokenBalance(colonyAddress, token.address))]
+        ? [
+            ...acc,
+            put(fetchColonyTokenBalance(colonyAddress, token.address)),
+            put(fetchToken(token.address)),
+          ]
         : acc;
 
     while (true) {


### PR DESCRIPTION
## Description

We didn't see any tokens next to tasks in a list if the colony was loaded using the subscriber. That's because the subscriber only fetched balances, but not the actual token info!

**New stuff** ✨

* Fetch tokens info for each token in the colony's store from the `colonySubStart ` saga

Resolves #1626 
