### PR TITLE
Add missing check if since colonyAddress is optional

### DIFF
--- a/src/modules/dashboard/components/TaskList/TaskList.jsx
+++ b/src/modules/dashboard/components/TaskList/TaskList.jsx
@@ -133,9 +133,10 @@ const TaskList = ({
     colonyAddress,
   ]);
 
-  const { record: colonyName } = useSelector(colonyNameSelector, [
-    colonyAddress,
-  ]);
+  const data = useSelector(colonyNameSelector, [colonyAddress]);
+
+  const colonyName = colonyAddress ? data.record : undefined;
+
   return (
     <>
       {filteredTasksData.length === 0 && colonyAddress ? (


### PR DESCRIPTION
## Description

The `taskList` appears in multiple occurrences all over the dapp, in the case of the dashboard, the ColonyName selector has nothing to select therefore it needs a condition. This created an error which prevented rendering the Dashboard correctly.