### PR TITLE
Add time taken to debug logs

### DIFF
--- a/src/lib/database/stores/Store.js
+++ b/src/lib/database/stores/Store.js
@@ -80,8 +80,11 @@ class Store {
   }
 
   async _loadEntries() {
+    const startLoading = Date.now();
     await this.ready();
-
+    log.verbose(
+      `Loaded store "${this._name}" in ${Date.now() - startLoading} ms`,
+    );
     try {
       await this.replicate();
     } catch (caughtError) {

--- a/src/lib/ipfs/PinnerConnector.js
+++ b/src/lib/ipfs/PinnerConnector.js
@@ -124,6 +124,7 @@ class PinnerConnector {
   }
 
   async requestReplication(address: string) {
+    const startRequesting = Date.now();
     log.verbose(`Requesting replication for store ${address}`);
     const request = this._replicationRequests.get(address);
     if (request && request.isPending) {
@@ -135,7 +136,7 @@ class PinnerConnector {
     try {
       log.verbose('Waiting for pinner to be ready...');
       await this.ready;
-      log.verbose('Pinner is ready now!');
+      log.verbose(`Pinner is ready now in ${Date.now() - startRequesting} ms!`);
     } catch (caughtError) {
       log.warn('Could not request replication; not connected to any pinners.');
       return 0;

--- a/src/utils/saga/effects.js
+++ b/src/utils/saga/effects.js
@@ -133,6 +133,7 @@ export function* executeQuery<D, M, A, R>(
   },
 ): Saga<R> {
   log.verbose(`Executing query "${query.name}"`, { args, metadata });
+  const startQuery = Date.now();
 
   const executeDeps = yield call(getExecuteDependencies, query, {
     // The metadata object is cloned to satisfy flow.
@@ -141,7 +142,10 @@ export function* executeQuery<D, M, A, R>(
 
   const result = yield call(query.execute, executeDeps, { ...args });
 
-  log.verbose(`Executed query "${query.name}"`, result);
+  log.verbose(
+    `Executed query "${query.name}" in ${Date.now() - startQuery} ms`,
+    result,
+  );
   return result;
 }
 
@@ -201,6 +205,7 @@ export function* executeCommand<D, M, A, R>(
   |},
 ): Saga<R> {
   log.verbose(`Executing command "${command.name}"`, { args, metadata });
+  const startCommand = Date.now();
 
   // The args and metadata objects are cloned to satisfy flow.
   const maybeSanitizedArgs = {
@@ -212,7 +217,10 @@ export function* executeCommand<D, M, A, R>(
 
   const result = yield call(command.execute, executeDeps, maybeSanitizedArgs);
 
-  log.verbose(`Executed command "${command.name}"`, result);
+  log.verbose(
+    `Executed command "${command.name}" in ${Date.now() - startCommand} ms`,
+    result,
+  );
   return result;
 }
 


### PR DESCRIPTION
## Description

Some processes when loading data are taking to long therefore we would like to know how long they take exactly.

This PR is adding the milliseconds it took to load queries and commands, to connect to the pinner and to load stores.

Resolves #1636
