### PR TITLE
Add loading indicator when subscribing/unsubscribing to a colony

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyMeta/ColonySubscribe.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMeta/ColonySubscribe.css
@@ -28,3 +28,9 @@
 .unsubscribe {
   background: var(--golden);
 }
+
+.spinnerContainer {
+  position: absolute;
+  top: 132px;
+  left: 134px;
+}

--- a/src/modules/dashboard/components/ColonyHome/ColonyMeta/ColonySubscribe.jsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMeta/ColonySubscribe.jsx
@@ -97,12 +97,11 @@ const ColonySubscribe = ({ colonyAddress }: Props) => {
           <ActionButton
             button={({ onClick, disabled, loading }) =>
               loading ? (
-                // @FIXME: Fix my position!
-                <SpinnerLoader
-                  className={styles.unsubscribe}
-                  appearance={{ theme: 'primary', size: 'small' }}
-                  loadingText={MSG.changingSubscription}
-                />
+                <div className={styles.spinnerContainer}>
+                  <SpinnerLoader
+                    appearance={{ theme: 'primary', size: 'medium' }}
+                  />
+                </div>
               ) : (
                 <Button
                   className={styles.unsubscribe}
@@ -130,12 +129,11 @@ const ColonySubscribe = ({ colonyAddress }: Props) => {
           <ActionButton
             button={({ onClick, disabled, loading }) =>
               loading ? (
-                <SpinnerLoader
-                  className={styles.subscribe}
-                  // @FIXME: Fix my position!
-                  appearance={{ theme: 'primary', size: 'small' }}
-                  loadingText={MSG.changingSubscription}
-                />
+                <div className={styles.spinnerContainer}>
+                  <SpinnerLoader
+                    appearance={{ theme: 'primary', size: 'medium' }}
+                  />
+                </div>
               ) : (
                 <Button
                   className={styles.subscribe}


### PR DESCRIPTION
## Description

This PR replicates @rdig 's fix for the "new task" button for colony subscription. Adding throttling and a loading indicator.



**Changes** 🏗

* Click events on colony subcribe/unsubscribe button is throttled
* A loading indicator is shown whilst the op takes place

## TODO

- [x] Fix loading indicator position


Closes #1483