### PR TITLE
Show colony address on colony home view

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyMeta/ColonyMeta.jsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMeta/ColonyMeta.jsx
@@ -12,6 +12,7 @@ import Heading from '~core/Heading';
 import Icon from '~core/Icon';
 import Link from '~core/Link';
 import ExternalLink from '~core/ExternalLink';
+import CopyableAddress from '~core/CopyableAddress';
 import HookedColonyAvatar from '~dashboard/HookedColonyAvatar';
 import HookedUserAvatar from '~users/HookedUserAvatar';
 import ColonySubscribe from './ColonySubscribe.jsx';
@@ -21,6 +22,10 @@ import { rolesFetcher } from '../../../fetchers';
 import styles from './ColonyMeta.css';
 
 const MSG = defineMessages({
+  addressLabel: {
+    id: 'dashboard.ColonyHome.ColonyMeta.addressLabel',
+    defaultMessage: 'Address',
+  },
   websiteLabel: {
     id: 'dashboard.ColonyHome.ColonyMeta.websiteLabel',
     defaultMessage: 'Website',
@@ -81,7 +86,7 @@ const ColonyMeta = ({
         />
         <ColonySubscribe colonyAddress={colonyAddress} />
       </div>
-      <section className={styles.headingWrapper}>
+      <section>
         <Heading appearance={{ margin: 'none', size: 'medium', theme: 'dark' }}>
           <>
             <span title={displayName}>
@@ -110,6 +115,13 @@ const ColonyMeta = ({
           <p>{description}</p>
         </section>
       )}
+      <section className={styles.dynamicTextSection}>
+        <Heading
+          appearance={{ margin: 'none', size: 'small', theme: 'dark' }}
+          text={MSG.addressLabel}
+        />
+        <CopyableAddress>{colonyAddress}</CopyableAddress>
+      </section>
       {website && (
         <section className={styles.dynamicTextSection}>
           <Heading


### PR DESCRIPTION
## Description

This PR simply uses the `CopyableAddress` component on the `ColonyMeta` component to show the colony address.

<img width="1245" alt="Screenshot 2019-08-01 at 13 13 46" src="https://user-images.githubusercontent.com/5450382/62289255-87d01f80-b45e-11e9-9e49-30662ed0b531.png">


**New stuff** ✨

* Add a section on the colony home view to show the colony address, and make it copyable

Resolves #1605 
