### PR TITLE
Add second caching layer on indexeddb

### DIFF
--- a/src/lib/database/stores/EventStore.js
+++ b/src/lib/database/stores/EventStore.js
@@ -37,7 +37,7 @@ class EventStore extends Store {
   // https://github.com/babel/babel/issues/8417#issuecomment-415508558
   +_orbitStore: OrbitDBEventStore = this._orbitStore;
 
-  _cache: ?(Entry[]);
+  _cache: ?(Event<*>[]);
 
   constructor(orbitStore: OrbitDBStore, name: string, pinner: PinnerConnector) {
     super(orbitStore, name, pinner);
@@ -67,6 +67,10 @@ class EventStore extends Store {
   async loadEntries() {
     if (!this._ready && !this._cache) {
       this._cache = await this.getLSCache();
+      if (!this._cache) {
+        await super.loadEntries();
+        return;
+      }
     }
     super.loadEntries().catch(console.error);
   }

--- a/src/lib/database/stores/Store.js
+++ b/src/lib/database/stores/Store.js
@@ -99,6 +99,8 @@ class Store {
 
   async ready() {
     log.verbose(`Loading store "${this._name}"`);
+    // This *should* be fine. If we loaded the store once we don't need to load it again
+    // Replication will do the rest
     // eslint-disable-next-line no-underscore-dangle
     if (this._ready) return this._orbitStore._oplog.length;
     const headCountPromise = new Promise(resolve =>


### PR DESCRIPTION
## Description

This creates another layer for caching orbit entries using `localForage`. Entries are stored to it on `load`, `replicated` and `write` events. When a store is not `ready` yet (being loaded from IPFS) this cache is used. For every change afterwards the actual store data is used.

**New stuff** ✨

* Caching orbit EventStore data in `localForage`
