### PR TITLE
Validate that the token balance exists before setting a task worker payout

### DIFF
--- a/src/data/types/TaskEvents.js
+++ b/src/data/types/TaskEvents.js
@@ -59,7 +59,7 @@ export type TaskEvents = {|
     typeof PAYOUT_SET,
     {|
       amount: string,
-      token: string,
+      token: Address,
     |},
   >,
   PAYOUT_REMOVED: EventDefinition<typeof PAYOUT_REMOVED, void>,

--- a/src/modules/dashboard/data/commands/task.js
+++ b/src/modules/dashboard/data/commands/task.js
@@ -397,7 +397,7 @@ export const setTaskPayout: Command<
   TaskStoreMetadata,
   {|
     amount: BigNumber,
-    token: string,
+    token: Address,
   |},
   {|
     event: Event<typeof TASK_EVENT_TYPES.PAYOUT_SET>,

--- a/src/redux/types/actions/task.js
+++ b/src/redux/types/actions/task.js
@@ -280,7 +280,7 @@ export type TaskActionTypes = {|
   >,
   TASK_SET_PAYOUT: TaskActionType<
     typeof ACTIONS.TASK_SET_PAYOUT,
-    {| token: string, amount: BigNumber |},
+    {| token: Address, amount: BigNumber |},
   >,
   TASK_SET_PAYOUT_ERROR: TaskErrorActionType<
     typeof ACTIONS.TASK_SET_PAYOUT_ERROR,
@@ -321,7 +321,7 @@ export type TaskActionTypes = {|
   TASK_SET_WORKER_OR_PAYOUT: TaskActionType<
     typeof ACTIONS.TASK_SET_WORKER_OR_PAYOUT,
     {|
-      payouts?: Array<{| token: string, amount: BigNumber |}>,
+      payouts?: Array<{| token: Address, amount: BigNumber |}>,
       workerAddress?: Address,
     |},
   >,
@@ -331,7 +331,7 @@ export type TaskActionTypes = {|
   TASK_SET_WORKER_OR_PAYOUT_SUCCESS: TaskActionType<
     typeof ACTIONS.TASK_SET_WORKER_OR_PAYOUT_SUCCESS,
     {|
-      payouts?: Array<{| amount: BigNumber, token: string |}>,
+      payouts?: Array<{| amount: BigNumber, token: Address |}>,
       workerAddress?: Address,
     |},
   >,


### PR DESCRIPTION
## Description

This PR carries out the suggestion in #1597 to validate that the given token balance exists in the colony pot before setting the task worker payout.

**Changes** 🏗

* Validate that the balance exists in the colony pot for the given token when attempting to set a task payout
* Ensure token addresses are of the `Address` type


## TODOs

- [ ] Check that this works

Resolves #1535 
