### PR TITLE
Pinner fixes: get head count safely, add missing errors

### DIFF
--- a/src/lib/ipfs/PinnerConnector.js
+++ b/src/lib/ipfs/PinnerConnector.js
@@ -207,7 +207,7 @@ class PinnerConnector {
         this.events.emit(type, { to, payload });
       }
     } catch (caughtError) {
-      log.error(new Error(`Could not parse pinner message: ${message.data}`));
+      log.error(new Error('Could not parse pinner message'));
     }
   };
 


### PR DESCRIPTION
## Description

This PR makes a few fixes to the pinner connector:

* Ensure that the head count promises are both resolved safely (sometimes the response is empty, we're not sure why yet, but so be it)
* Add missing errors for some events
* Remove message data from error logging (for pinner messages that couldn't be parsed) as an anti-spam measure
