### PR TITLE
Correct ETH value in wallet

### DIFF
--- a/src/modules/admin/components/Tokens/TokenCard.jsx
+++ b/src/modules/admin/components/Tokens/TokenCard.jsx
@@ -85,11 +85,7 @@ const TokenCard = ({
       </div>
       <div className={styles.cardFooter}>
         {tokenIsETH(tokenReference) && (
-          <EthUsd
-            className={styles.ethUsdText}
-            value={balance || 0}
-            truncate={3}
-          />
+          <EthUsd className={styles.ethUsdText} value={balance || 0} />
         )}
       </div>
     </Card>


### PR DESCRIPTION
## Description

The ETH value in the wallet is not truncated correctly. The `truncate` property passed into the `EthUsd` component had not been set correctly, it should be using the default value of 2. 
