### PR TITLE
Token Card display correct ETH decimals

### DIFF
--- a/src/modules/admin/components/Tokens/TokenCard.jsx
+++ b/src/modules/admin/components/Tokens/TokenCard.jsx
@@ -79,7 +79,7 @@ const TokenCard = ({
         <Numeral
           className={styles.balanceNumeral}
           integerSeparator=""
-          unit={token ? token.decimals : 18}
+          unit={token && token.decimals ? token.decimals : 18}
           value={balance || 0}
         />
       </div>


### PR DESCRIPTION
## Description

This PR fixes the ETH value not being properly formatted. This was due to the fact that we just checked for the existence of the token object (which we had), and in that case use the `decimals` value.

This was broken because the ETH token object looks like this:
```js
{
  name: 'ETH',
  address: '0x...',
  decimals: undefined
  ...
}
```

So we were passing `undefined`  as a `unit` prop to the `Numeral` component, which was glad to use it and not throw an error.

The fix, checks if also the `decimals` value is set, and if it not (true in the case of ETH), use `18` as a `unit` value

**Changes**

- [x] `TokenCard` check if `decimals` value is actually set

**Demos**

![Screenshot from 2019-08-06 20-47-17](https://user-images.githubusercontent.com/1193222/62563643-1b08bb00-b88c-11e9-8110-bdc7b04edd2b.png)

Resolves #1625 
