### PR TITLE
De-duplicate Mainnet Task Skills Tree IDs

### DIFF
--- a/src/modules/dashboard/components/TaskSkills/taskSkillsTree.mainnet.js
+++ b/src/modules/dashboard/components/TaskSkills/taskSkillsTree.mainnet.js
@@ -156,12 +156,12 @@ const taskSkills: ConsumableItem[] = [
     parent: -2,
   },
   {
-    id: 31,
+    id: 85,
     name: 'Quality Assurance',
     parent: -2,
   },
   {
-    id: 32,
+    id: 86,
     name: 'Developer Relations',
     parent: -2,
   },


### PR DESCRIPTION
## Description

This PR _"fixes"_ the duplicated main net skill ids by assigning them the next available one:
- Quality Assurance
- Developer Relations

**Changes**

- [x] `mainnet` task skills tree ids deduplicated

Resolves #1703 