### PR TITLE
"Properly" re-initialize description value

### DIFF
--- a/src/modules/dashboard/components/TaskDescription/TaskDescription.jsx
+++ b/src/modules/dashboard/components/TaskDescription/TaskDescription.jsx
@@ -2,8 +2,6 @@
 
 import type { FormikProps } from 'formik';
 
-import { ContentState, EditorState } from 'draft-js';
-
 // $FlowFixMe upgrade react
 import React, { useCallback } from 'react';
 import { defineMessages } from 'react-intl';
@@ -11,6 +9,7 @@ import { defineMessages } from 'react-intl';
 import type { TaskProps } from '~immutable';
 
 import { pipe, mapPayload, mergePayload } from '~utils/actions';
+import { useInitEditorState } from '~utils/hooks';
 import { MultiLineEdit, ActionForm } from '~core/Fields';
 import { ACTIONS } from '~redux';
 
@@ -41,6 +40,9 @@ const TaskDescription = ({
     ),
     [colonyAddress, draftId],
   );
+
+  const descriptionValue = useInitEditorState(description);
+
   if (disabled && !description) {
     return null;
   }
@@ -48,9 +50,7 @@ const TaskDescription = ({
     <ActionForm
       enableReinitialize
       initialValues={{
-        description: EditorState.createWithContent(
-          ContentState.createFromText(description || ''),
-        ),
+        description: descriptionValue,
       }}
       submit={ACTIONS.TASK_SET_DESCRIPTION}
       success={ACTIONS.TASK_SET_DESCRIPTION_SUCCESS}

--- a/src/utils/hooks/index.js
+++ b/src/utils/hooks/index.js
@@ -6,6 +6,7 @@ import type { InputSelector } from 'reselect';
 // $FlowFixMe (not possible until we upgrade flow to 0.87)
 import { useEffect, useCallback, useMemo, useRef } from 'react';
 import { useDispatch, useMappedState } from 'redux-react-hook';
+import { ContentState, EditorState } from 'draft-js';
 
 import type { Action } from '~redux';
 import type { ActionTransformFnType } from '~utils/actions';
@@ -572,3 +573,22 @@ export const useMainClasses = (
     className,
     styles,
   ]);
+
+/*
+ * This hook initializes the editor state for draft-js from a string
+ * so that it works properly when used with formiks enableReinitialze property
+ */
+export const useInitEditorState = (text: string = '') => {
+  const prevText = usePrevious(text);
+  let editorState;
+  if (prevText !== text) {
+    editorState = EditorState.createWithContent(
+      ContentState.createFromText(text),
+    );
+  }
+  const prevEditorState = usePrevious(editorState);
+  if (prevText === text) {
+    return prevEditorState;
+  }
+  return editorState;
+};


### PR DESCRIPTION
## Description

This PR adds a new hook to initialize the draft-js states when used in combination with formik and the `enableReinitialize` property. As formik does a deep equality check for these values it assumes that the `editorState` has changed on every re-render. We're fixing this by only setting the editor state when the actual text value has changed.

**New stuff** ✨

* `useInitEditorState` hook

**Changes** 🏗

* Use that hook to initialize the task description value

Resolves #1618.
