### PR TITLE
Colony Wizard expand list to see Wallet Actions

### DIFF
--- a/src/modules/dashboard/components/CreateColonyWizard/StepConfirmTransactions.css
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepConfirmTransactions.css
@@ -1,6 +1,10 @@
 .main {
-  padding-top: 158px;
+  padding-top: 100px;
   width: 460px;
+}
+
+.main div {
+  max-height: none;
 }
 
 .container {


### PR DESCRIPTION
## Description

As it says on the tin, this PR fixes the Colony Wizard list, that if wallet actions are needed _(Metamask, Ledger, Trezor)_, those warnings will be actually seen by the user.

There were two ways of solving this:
- Like I did here, just remove the max height declaration
- Leaving the that intact, and redo the `GasStationContent` styles that only the actual transactions part would scroll, and not the control buttons

I choose the first method, due to it's simplicity, as the second one, would have required a pretty substantial refactor of the Gas Station.

**Changes**

- [x] `GasStationContent` rendered under `StepConfirmTransactions` no longer has  a defined max height

**Demo**

![Screenshot from 2019-08-16 00-18-15](https://user-images.githubusercontent.com/1193222/63127732-c7008380-bfbb-11e9-813f-e2051b4bdd2f.png)

Resolves #1538