### PR TITLE
Do not debounce token info fetching

### DIFF
--- a/src/modules/dashboard/sagas/token.js
+++ b/src/modules/dashboard/sagas/token.js
@@ -2,14 +2,7 @@
 
 import type { Saga } from 'redux-saga';
 
-import {
-  call,
-  delay,
-  fork,
-  put,
-  takeEvery,
-  takeLatest,
-} from 'redux-saga/effects';
+import { call, fork, put, takeEvery } from 'redux-saga/effects';
 
 import type { Action } from '~redux';
 
@@ -40,10 +33,6 @@ function* tokenInfoFetch({
       meta,
     });
   }
-
-  // Debounce with 1000ms, since this is intended to run directly following
-  // user keyboard input.
-  yield delay(1000);
 
   try {
     /**
@@ -124,5 +113,5 @@ export default function* tokenSagas(): Saga<void> {
   yield takeEvery(ACTIONS.TOKEN_CREATE, tokenCreate);
   // Note that this is `takeLatest` because it runs on user keyboard input
   // and uses the `delay` saga helper.
-  yield takeLatest(ACTIONS.TOKEN_INFO_FETCH, tokenInfoFetch);
+  yield takeEvery(ACTIONS.TOKEN_INFO_FETCH, tokenInfoFetch);
 }


### PR DESCRIPTION
## Description

When getting the token info for the wizard (BYOT) we decided to debounce the fetching of token information for that address. As we are using the debounced saga for general fetching of tokens as well, this lead to problems where in a few cases the token fetcher would be illegitimately debounced (and cancelled).

As no one is ever going to type a token address via the keyboard (but rather c+p it) I decided to remove the debounce altogether here.

**Changes** 🏗

* Remove debounce from `TOKEN_INFO_FETCH`

Resolves #1723.
