### PR TITLE
Hide Colony Recovery for Non-Founders

### DIFF
--- a/src/modules/dashboard/checks.ts
+++ b/src/modules/dashboard/checks.ts
@@ -150,5 +150,5 @@ export const canFinalizeTask = (
 /*
  * Permissions
  */
-export const canRecoverColony = (permissions: ?UserPermissionsType) =>
+export const canRecoverColony = (permissions: UserPermissionsType | null) =>
   permissions && permissions.canEnterRecoveryMode && isFounder(permissions);

--- a/src/modules/dashboard/checks.ts
+++ b/src/modules/dashboard/checks.ts
@@ -146,3 +146,9 @@ export const canFinalizeTask = (
   (isManager(task, userAddress) ||
     isFounder(permissions) ||
     isAdmin(permissions));
+
+/*
+ * Permissions
+ */
+export const canRecoverColony = (permissions: ?UserPermissionsType) =>
+  permissions && permissions.canEnterRecoveryMode && isFounder(permissions);

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
@@ -31,7 +31,11 @@ import {
   canAdminister,
   canCreateTask as canCreateTaskCheck,
 } from '../../../users/checks';
-import { isInRecoveryMode as isInRecoveryModeCheck } from '../../checks';
+import {
+  isInRecoveryMode as isInRecoveryModeCheck,
+  isFounder,
+} from '../../checks';
+
 import ColonyDomains from './ColonyDomains';
 import ColonyMeta from './ColonyMeta';
 import TabContribute from './TabContribute';
@@ -179,7 +183,7 @@ const ColonyHome = ({
   ) {
     return (
       <LoadingTemplate loadingText={MSG.loadingText}>
-        {showRecoverOption && colonyAddress && (
+        {showRecoverOption && colonyAddress && isFounder(permissions as UserPermissionsType) && (
           <DialogActionButton
             dialog="ConfirmDialog"
             dialogProps={{

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
@@ -33,7 +33,7 @@ import {
 } from '../../../users/checks';
 import {
   isInRecoveryMode as isInRecoveryModeCheck,
-  isFounder,
+  canRecoverColony,
 } from '../../checks';
 
 import ColonyDomains from './ColonyDomains';
@@ -183,7 +183,7 @@ const ColonyHome = ({
   ) {
     return (
       <LoadingTemplate loadingText={MSG.loadingText}>
-        {showRecoverOption && colonyAddress && isFounder(permissions as UserPermissionsType) && (
+        {showRecoverOption && colonyAddress && canRecoverColony(permissions as UserPermissionsType) && (
           <DialogActionButton
             dialog="ConfirmDialog"
             dialogProps={{

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
@@ -183,23 +183,25 @@ const ColonyHome = ({
   ) {
     return (
       <LoadingTemplate loadingText={MSG.loadingText}>
-        {showRecoverOption && colonyAddress && canRecoverColony(permissions as UserPermissionsType) && (
-          <DialogActionButton
-            dialog="ConfirmDialog"
-            dialogProps={{
-              appearance: { theme: 'danger' },
-              heading: MSG.recoverColonyHeading,
-              children: <FormattedMessage {...MSG.recoverColonyParagraph} />,
-              cancelButtonText: MSG.recoverColonyCancelButton,
-              confirmButtonText: MSG.recoverColonyConfirmButton,
-            }}
-            submit={ActionTypes.COLONY_RECOVER_DB}
-            error={ActionTypes.COLONY_RECOVER_DB_ERROR}
-            success={ActionTypes.COLONY_RECOVER_DB_SUCCESS}
-            text={MSG.recoverColonyButton}
-            values={{ colonyAddress }}
-          />
-        )}
+        {showRecoverOption &&
+          colonyAddress &&
+          canRecoverColony(permissions as UserPermissionsType) && (
+            <DialogActionButton
+              dialog="ConfirmDialog"
+              dialogProps={{
+                appearance: { theme: 'danger' },
+                heading: MSG.recoverColonyHeading,
+                children: <FormattedMessage {...MSG.recoverColonyParagraph} />,
+                cancelButtonText: MSG.recoverColonyCancelButton,
+                confirmButtonText: MSG.recoverColonyConfirmButton,
+              }}
+              submit={ActionTypes.COLONY_RECOVER_DB}
+              error={ActionTypes.COLONY_RECOVER_DB_ERROR}
+              success={ActionTypes.COLONY_RECOVER_DB_SUCCESS}
+              text={MSG.recoverColonyButton}
+              values={{ colonyAddress }}
+            />
+          )}
       </LoadingTemplate>
     );
   }


### PR DESCRIPTION
## Description

This PR is a simple fix to prevent showing the Colony DB Recovery button to non-founders 

_(Although they couldn't actually use that feature, since it checks for permissions prior to firing that action)_

**New stuff**

- [x] `dashboard` module `isFounder` check

**Changes**

- [x] `ColonyHome` check if founder before showing the recovery button

**Note**

Rebased on the TS `master` branch