### PR TITLE
WalletLink handle mainnet Etherscan links

### DIFF
--- a/src/modules/core/components/WalletLink/WalletLink.jsx
+++ b/src/modules/core/components/WalletLink/WalletLink.jsx
@@ -34,7 +34,8 @@ const WalletLink = ({
 }: Props) => {
   const linkText = text || walletAddress;
   const tld = network === 'tobalaba' ? 'com' : 'io';
-  const networkSubdomain = network === 'homestead' ? '' : `${network}.`;
+  const networkSubdomain =
+    network === 'homestead' || network === 'mainnet' ? '' : `${network}.`;
   // eslint-disable-next-line max-len
   const href = `https://${networkSubdomain}etherscan.${tld}/address/${walletAddress}`;
   return (


### PR DESCRIPTION
## Description

This PR fixes a bug where the user _(from the Wallet page)_ would be redirected to https://mainnet.etherscan.io which would error out, since for `mainnet` etherscan is using the root domain, and not a subdomain.

This was because we would only account for the `homestead` network name.

**Changes** 

 - [x] `WalletLink` also account for `mainnet` _(not just `homestead`)_

Resolves #1670 
