### PR TITLE
Display task trust info to all users

### DIFF
--- a/src/modules/dashboard/components/Task/Task.jsx
+++ b/src/modules/dashboard/components/Task/Task.jsx
@@ -253,7 +253,12 @@ const Task = ({
               <div className={styles.trustInfoIcon}>
                 <Icon
                   name="unlock"
-                  title={MSG.trustInfoTooltipHeading}
+                  /*
+                   * @NOTE Set to an empty string to prevent rendering
+                   * Otherwise it will overlap with the tooltip which is already
+                   * providing this functionality
+                   */
+                  title=""
                   appearance={{ size: 'small', theme: 'primary' }}
                 />
               </div>


### PR DESCRIPTION
## Description

This is a simple _"feature"_ to show the trust info icon / tooltip info to all users, including the task creator.

While I was at it, I removed the `title` value from that icon since it was overlapping when the tooltip was also rendered

**Changes**

- [x] `Task` show trust info icon/tooltip to all users
- [x] `Task` trust info prevent icon title overlapping tooltip

**Screenshot**

![Screenshot from 2019-08-19 12-36-18](https://user-images.githubusercontent.com/1193222/63255241-fb0acb80-c27d-11e9-8906-656432b33318.png)

Resolves #1667
