### PR TITLE
Colony Wizard only validate ENS if that field changes

### DIFF
--- a/src/modules/dashboard/components/CreateColonyWizard/StepColonyName.jsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepColonyName.jsx
@@ -1,7 +1,7 @@
 /* @flow */
 
 // $FlowFixMe upgrade flow
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import * as yup from 'yup';
 
@@ -95,8 +95,13 @@ const StepColonyName = ({ wizardForm, nextStep, wizardValues }: Props) => {
     profile: { username },
   } = currentUser;
 
+  const [currentENSName, setCurrentENSName] = useState(undefined);
+
   const validateDomain = useCallback(
     async (values: FormValues) => {
+      if (values && currentENSName === values.colonyName) {
+        return;
+      }
       try {
         // Let's check whether this is even valid first
         validationSchema.validateSyncAt('colonyName', values);
@@ -107,6 +112,7 @@ const StepColonyName = ({ wizardForm, nextStep, wizardValues }: Props) => {
       }
       try {
         await checkDomainTaken(values);
+        setCurrentENSName(values.colonyName);
       } catch (e) {
         const error = {
           colonyName: MSG.errorDomainTaken,
@@ -114,7 +120,7 @@ const StepColonyName = ({ wizardForm, nextStep, wizardValues }: Props) => {
         throw error;
       }
     },
-    [checkDomainTaken],
+    [checkDomainTaken, currentENSName, setCurrentENSName],
   );
 
   return (


### PR DESCRIPTION
## Description

This PR adds a fix to prevent the ENS validator to run each time _any_ field changes. 

The fix isn't that strait-forward, or clean, since `Form` runs the `validate` callback on every form value change _(this is where this issue stems from)_

The way I chose to fix this, is to make use of the component's state to keep track of the currently selected ens name, and only run the validator if the new form value is different from the known one.

**Changes**

- [x] `StepColonyName` only run the whole ENS validation if the `colonyName` field changes

Resolves #1614
