### PR TITLE
Colony Wizard validate after removing the Token Icon

### DIFF
--- a/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.jsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.jsx
@@ -85,7 +85,7 @@ const validationSchema = yup.object({
     .string()
     .required()
     .max(5, MSG.errorTokenSymbol),
-  tokenIcon: yup.array().min(1, MSG.errorTokenIcon),
+  tokenIcon: yup.array().max(1, MSG.errorTokenIcon),
 });
 
 type FormValues = {


### PR DESCRIPTION
## Description

This PR fixes a issue in the Colony Creation Wizard, where after removing the token icon _(add it, then remove it)_, the form validator would not allow you to progress any further.

This was due to the validator having a `min` check, which was set to `1`, but to set to required. So after adding a initial icon, removing it would not be allowed since it triggered the minimum check.

To fix this, I've removed that _(and relying on the default min)_, and added a `max` check to avoid any file uploader weirdness

**Changes**

- [x] `StepCreateToken` remove `min` validation check _(and add a `max` one)_

Resolves #1716 