### PR TITLE
Add new colony role hook

### DIFF
--- a/src/immutable/Domain.js
+++ b/src/immutable/Domain.js
@@ -7,6 +7,8 @@ import { Record } from 'immutable';
 type Shared = {|
   id: number,
   name: string,
+  // Empty if root, but we don't actually store root domain yet anyway
+  parentId?: number,
 |};
 
 export type DomainType = $ReadOnly<Shared>;
@@ -18,6 +20,7 @@ export type DomainId = $PropertyType<DomainRecordType, 'id'>;
 const defaultValues: $Shape<Shared> = {
   id: undefined,
   name: undefined,
+  parentId: undefined,
 };
 
 const DomainRecord: RecordFactory<Shared> = Record(defaultValues);

--- a/src/immutable/state/dashboard/AllRoles.js
+++ b/src/immutable/state/dashboard/AllRoles.js
@@ -8,6 +8,12 @@ import type { Address } from '~types';
 
 import type { DataRecordType } from '../../Data';
 
+export type UserRolesObject = { [role: $Keys<typeof COLONY_ROLES>]: boolean };
+
+export type DomainRolesObject = { [userAddress: string]: UserRolesObject };
+
+export type ColonyRolesObject = { [domainId: number]: DomainRolesObject };
+
 export type ColonyRolesMap = ImmutableMapType<
   number,
   ImmutableMapType<

--- a/src/modules/dashboard/data/queries/colonies.js
+++ b/src/modules/dashboard/data/queries/colonies.js
@@ -496,6 +496,8 @@ export const getColonyDomains: Query<
       .map(({ payload: { domainId, name } }) => ({
         id: domainId,
         name,
+        // All will have parent of root for now
+        parentId: 1,
       }));
   },
 };

--- a/src/modules/dashboard/reducers/allDomains.js
+++ b/src/modules/dashboard/reducers/allDomains.js
@@ -38,7 +38,7 @@ const allDomainsReducer: ReducerType<AllDomainsMap, DomainActions> = (
           );
     }
     case ACTIONS.DOMAIN_EDIT_SUCCESS: {
-      const { colonyAddress, domainName, domainId } = action.payload;
+      const { colonyAddress, domainName, domainId, parentId } = action.payload;
       const path = [colonyAddress, 'record'];
       return state.updateIn(
         path,
@@ -46,7 +46,7 @@ const allDomainsReducer: ReducerType<AllDomainsMap, DomainActions> = (
           domains &&
           domains
             .filter(domain => domain.id !== domainId)
-            .add(DomainRecord({ id: domainId, name: domainName })),
+            .add(DomainRecord({ id: domainId, name: domainName, parentId })),
       );
     }
     case ACTIONS.COLONY_DOMAINS_FETCH_SUCCESS: {

--- a/src/modules/dashboard/reducers/allRoles.js
+++ b/src/modules/dashboard/reducers/allRoles.js
@@ -44,13 +44,19 @@ const allRolesReducer: ReducerType<AllRolesMap, RolesActions> = (
       const {
         payload: { roles, colonyAddress, domainId, userAddress },
       } = action;
-      const record = ImmutableMap(Object.entries(roles));
+      // Map keys instead of doing entries to appease the type gods
+      const record = ImmutableMap(
+        Object.keys(roles).map(role => [role, roles[role]]),
+      );
       return state.getIn([colonyAddress, 'record'])
         ? state.mergeIn(
             [colonyAddress, 'record', domainId, userAddress],
             record,
           )
-        : state.setIn([colonyAddress, 'record', domainId, userAddress], record);
+        : state.setIn(
+            [colonyAddress, 'record'],
+            ImmutableMap([[domainId, ImmutableMap([[userAddress, record]])]]),
+          );
     }
     default:
       return state;

--- a/src/modules/dashboard/sagas/domains.js
+++ b/src/modules/dashboard/sagas/domains.js
@@ -95,7 +95,8 @@ function* domainCreate({
     yield put<Action<typeof ACTIONS.DOMAIN_CREATE_SUCCESS>>({
       type: ACTIONS.DOMAIN_CREATE_SUCCESS,
       meta,
-      payload: { colonyAddress, domain: { id, name } },
+      // For now parentId is just root domain
+      payload: { colonyAddress, domain: { id, name, parentId: 1 } },
     });
 
     // const colonyManager = yield* getContext(CONTEXT.COLONY_MANAGER);
@@ -139,7 +140,8 @@ function* domainEdit({
     yield put<Action<typeof ACTIONS.DOMAIN_EDIT_SUCCESS>>({
       type: ACTIONS.DOMAIN_EDIT_SUCCESS,
       meta,
-      payload: { colonyAddress, domainId, domainName },
+      // For now parentId is just root domain
+      payload: { colonyAddress, domainId, domainName, parentId: 1 },
     });
   } catch (error) {
     return yield putError(ACTIONS.DOMAIN_EDIT_ERROR, error, meta);

--- a/src/redux/types/actions/domain.js
+++ b/src/redux/types/actions/domain.js
@@ -35,7 +35,12 @@ export type DomainActionTypes = {|
   DOMAIN_EDIT_ERROR: ErrorActionType<typeof ACTIONS.DOMAIN_EDIT_ERROR, void>,
   DOMAIN_EDIT_SUCCESS: UniqueActionType<
     typeof ACTIONS.DOMAIN_EDIT_SUCCESS,
-    {| colonyAddress: string, domainId: number, domainName: string |},
+    {|
+      colonyAddress: string,
+      domainId: number,
+      domainName: string,
+      parentId: number,
+    |},
     void,
   >,
   DOMAIN_CREATE_TX: ActionType<typeof ACTIONS.DOMAIN_CREATE_TX>,


### PR DESCRIPTION
## Description

This PR adds a react hook for getting domain specific roles for a colony. The `useRoles` hook accepts a `colonyAddress` and whether it should `includeParentRoles`, which allows fetching either just the roles set in single specific domain, or the _effective_ roles (includes roles set in parent domains).

**New stuff** ✨

* `useRoles` hook
* `includeParentRoles` util
* Include `parentId` in the `Domain` immutable type, and set this in the `allDomain` redux state, allowing to traverse up the domains tree
* `useUserDomainRoles` hook for a single user's roles in a domain

**Changes** 🏗

* -

**Deletions** ⚰️

* -

## TODO

- [x] Add fetcher for a single user's roles in a domain

Resolves #1696 
