### PR TITLE
Fix Dialog Component Vertical Alignment

### DIFF
--- a/src/modules/core/components/Dialog/Dialog.css
+++ b/src/modules/core/components/Dialog/Dialog.css
@@ -1,5 +1,4 @@
 .modal {
-  height: 100%;
   max-height: max-content;
   position: relative;
   z-index: var(--z-index-dialog);

--- a/src/modules/core/components/Dialog/FullscreenDialog.css
+++ b/src/modules/core/components/Dialog/FullscreenDialog.css
@@ -1,5 +1,4 @@
 .main {
-  height: 100%;
   max-height: max-content;
 }
 


### PR DESCRIPTION
## Description

This PR fixes the vertical alignment _(back to center of the viewport)_ of the `Dialog` and `FullscreenDialog` components

So for the life of me I couldn't find out where, or _what_, introduced this. I had a look in the past when I know the vertical alignment worked. I looked at the underlying `react-modal`, that didn't change. I checked the files themselves, they haven't been changed for a year.

So sad to say, I couldn't find a source for this. Given that, I had to fix them manually.

_(My only other suspicion is that we added some styles to a global wrapping component that somehow screw with the Dialog's height... somehow)_

**Changes** 

- [x] `Dialog` component remove `100%` height
- [x] `FullscreenDialog` component remove `100%` height

**Demos**

![Screenshot from 2019-08-20 12-34-49](https://user-images.githubusercontent.com/1193222/63336414-cb27fa80-c347-11e9-9bec-2de258c6f045.png)

![Screenshot from 2019-08-20 12-35-03](https://user-images.githubusercontent.com/1193222/63336415-cb27fa80-c347-11e9-9a24-a9da0d1cd311.png)

Resolves #1732
