### PR TITLE
Wallet Interaction copy more generic

### DIFF
--- a/src/modules/users/components/GasStation/WalletInteraction/WalletInteraction.jsx
+++ b/src/modules/users/components/GasStation/WalletInteraction/WalletInteraction.jsx
@@ -13,7 +13,7 @@ import styles from './WalletInteraction.css';
 const MSG = defineMessages({
   walletPromptText: {
     id: 'users.GasStation.WalletInteraction.walletPromptText',
-    defaultMessage: `Please finish the transaction on {walletType, select,
+    defaultMessage: `Please finish this action on {walletType, select,
       metamask {MetaMask}
       hardware {your hardware wallet}
     }`,


### PR DESCRIPTION
## Description

This is a very small PR that just updated the copy displayed when a interaction is required with either a MetaMask wallet or a Hardware wallet

**Changes**

- [x] Update `WalletInteraction` copy as per Collin's suggestion: https://github.com/JoinColony/colonyDapp/issues/1691#issuecomment-523625765

Resolves #1691 