### PR TITLE
Don't show Mint Tokens link for Colonies that brought they're own tokens

### DIFF
--- a/src/modules/dashboard/data/queries/colonies.ts
+++ b/src/modules/dashboard/data/queries/colonies.ts
@@ -533,7 +533,7 @@ export const getColonyCanMintNativeToken: Query<
   async execute(colonyClient) {
     // wrap this in a try/catch since it will fail if tokens can't be minted
     try {
-      await colonyClient.mintTokens.call({ amount: new BigNumber(1) });
+      await colonyClient.mintTokens.estimate({ amount: new BigNumber(1) });
     } catch (error) {
       return false;
     }


### PR DESCRIPTION
## Description

This PR fixes the logic that displays the _Mint Tokens_ dialog link in the admin section, for users that created the Colony using an external token (byot).

Before it was just using the colony's `canMintNativeToken` value for this check, but this PR also adds the check for the `isExternal` value from the token reference.

It's now using the same logic to display this, as we do on the Colony Home mint tokens widget.

**Changes**

- [x] admin `Tokens` also check the token reference when deciding to show the mint tokens dialog

**Screenshot**

![Screenshot from 2019-08-22 16-50-40](https://user-images.githubusercontent.com/1193222/63520959-403d3080-c4fe-11e9-9a6a-51316ee85048.png)

Resolves #1750 
