### PR TITLE
Properly Handle Task Title Removal

### DIFF
--- a/src/immutable/Task.ts
+++ b/src/immutable/Task.ts
@@ -1,4 +1,4 @@
-import { $Keys, $ReadOnly } from 'utility-types';
+import { $Keys } from 'utility-types';
 
 import { RecordOf, Record, List, Set as ImmutableSet } from 'immutable';
 
@@ -18,7 +18,7 @@ export type TaskCurrentState = $Keys<typeof TASK_STATE>;
  * @todo Support full task workflow for taskId
  * @todo Support full task workflow for evaluator
  */
-type Shared = {
+interface Shared {
   colonyAddress: Address;
   createdAt: Date;
   creatorAddress: string; // Address of the task creator
@@ -34,21 +34,19 @@ type Shared = {
   workerAddress: Address;
   // specificationHash?: string,
   // taskId?: number, // On-chain ID, when the task is all grown up :'-)
-};
+}
 
-export type TaskType = $ReadOnly<
-  Shared & {
-    invites: Address[];
-    payouts: TaskPayoutType[];
-    requests: Address[];
-  }
->;
+export interface TaskType extends Shared {
+  invites: Address[];
+  payouts: TaskPayoutType[];
+  requests: Address[];
+}
 
-type TaskRecordProps = Shared & {
+interface TaskRecordProps extends Shared {
   invites: ImmutableSet<Address>;
   payouts: List<TaskPayoutRecordType>;
   requests: ImmutableSet<Address>;
-};
+}
 
 export type TaskProps<T extends keyof TaskType> = Pick<TaskType, T>;
 

--- a/src/modules/dashboard/components/TaskFeed/TaskFeedEvent.tsx
+++ b/src/modules/dashboard/components/TaskFeed/TaskFeedEvent.tsx
@@ -341,15 +341,11 @@ const TaskFeedEventTitleSet = ({
       <FormattedMessage
         {...MSG.titleRemoved}
         values={{
-          user: (
-            <span title={user} className={styles.highlight}>
-              {user}
-            </span>
-          ),
+          user: renderInteractiveUsername(userRecord),
         }}
       />
     );
-  }  
+  }
   return (
     <FormattedMessage
       {...MSG.titleSet}

--- a/src/modules/dashboard/components/TaskFeed/TaskFeedEvent.tsx
+++ b/src/modules/dashboard/components/TaskFeed/TaskFeedEvent.tsx
@@ -73,6 +73,10 @@ const MSG = defineMessages({
     id: 'dashboard.TaskFeedEvent.titleSet',
     defaultMessage: 'Task title set to {title} by {user}',
   },
+  titleRemoved: {
+    id: 'dashboard.TaskFeedEvent.titleRemoved',
+    defaultMessage: 'Task title removed by {user}',
+  },
   workInviteSent: {
     id: 'dashboard.TaskFeedEvent.workInviteSent',
     defaultMessage: '{user} invited {invitedUser} to work on the task',
@@ -332,6 +336,20 @@ const TaskFeedEventTitleSet = ({
   },
 }: any) => {
   const { record: userRecord } = useSelector(userSelector, [userAddress]);
+  if (!title) {
+    return (
+      <FormattedMessage
+        {...MSG.titleRemoved}
+        values={{
+          user: (
+            <span title={user} className={styles.highlight}>
+              {user}
+            </span>
+          ),
+        }}
+      />
+    );
+  }  
   return (
     <FormattedMessage
       {...MSG.titleSet}

--- a/src/modules/dashboard/components/TaskList/TaskListItem.css
+++ b/src/modules/dashboard/components/TaskList/TaskListItem.css
@@ -3,15 +3,26 @@
 @value cellPaddingVertical: 25px;
 @value cellPaddingHorizontal: 40px;
 
+.globalLink:nth-child(n+2) tr {
+  border-width: 1px;
+  border-style: solid;
+  border-left: 0;
+  border-right: 0;
+  border-bottom: 0;
+  border-color: var(--grey-blue-1);
+}
+
 td.taskDetails {
   flex-wrap: wrap;
-  padding: cellPaddingVertical cellPaddingHorizontal;
+  padding-left: cellPaddingHorizontal;
+  min-height: 70px;
   width: calc(100% - 230px);
   font-weight: var(--weight-semi);
 }
 
 .taskDetailsTitle {
   composes: inlineEllipsis from '~styles/text.css';
+  padding: cellPaddingVertical cellPaddingHorizontal cellPaddingVertical 0;
   max-width: 80ch;
   color: var(--colony-black);
 }

--- a/src/modules/dashboard/components/TaskList/TaskListItem.css
+++ b/src/modules/dashboard/components/TaskList/TaskListItem.css
@@ -14,15 +14,13 @@
 
 td.taskDetails {
   flex-wrap: wrap;
-  padding-left: cellPaddingHorizontal;
-  min-height: 70px;
+  padding: cellPaddingVertical cellPaddingHorizontal;
   width: calc(100% - 230px);
   font-weight: var(--weight-semi);
 }
 
 .taskDetailsTitle {
   composes: inlineEllipsis from '~styles/text.css';
-  padding: cellPaddingVertical cellPaddingHorizontal cellPaddingVertical 0;
   max-width: 80ch;
   color: var(--colony-black);
 }

--- a/src/modules/dashboard/components/TaskList/TaskListItem.css.d.ts
+++ b/src/modules/dashboard/components/TaskList/TaskListItem.css.d.ts
@@ -1,5 +1,6 @@
 export const cellPaddingVertical: string;
 export const cellPaddingHorizontal: string;
+export const globalLink: string;
 export const taskDetails: string;
 export const taskDetailsTitle: string;
 export const taskDetailsReputation: string;

--- a/src/modules/dashboard/components/TaskList/TaskListItem.tsx
+++ b/src/modules/dashboard/components/TaskList/TaskListItem.tsx
@@ -7,7 +7,7 @@ import {
 import React from 'react';
 
 import { Address, ENSName } from '~types/index';
-import { TaskPayoutType, TaskType } from '~immutable/index';
+import { TaskType } from '~immutable/index';
 import { useDataFetcher } from '~utils/hooks';
 import { colonyNameFetcher } from '../../fetchers';
 import { TableRow, TableCell } from '~core/Table';

--- a/src/modules/dashboard/components/TaskList/TaskListItem.tsx
+++ b/src/modules/dashboard/components/TaskList/TaskListItem.tsx
@@ -80,10 +80,10 @@ const TaskListItem = ({ data, intl: { formatMessage } }: Props) => {
     <TableRow>
       <TableCell className={styles.taskDetails}>
         <Link
-          title={title}
+          title={title || defaultTitle}
           className={styles.taskDetailsTitle}
           to={`/colony/${colonyName}/task/${draftId}`}
-          text={title}
+          text={title || defaultTitle}
         />
         {reputation && (
           <span className={styles.taskDetailsReputation}>

--- a/src/modules/dashboard/components/TaskList/TaskListItem.tsx
+++ b/src/modules/dashboard/components/TaskList/TaskListItem.tsx
@@ -83,12 +83,7 @@ const TaskListItem = ({ data, intl: { formatMessage } }: Props) => {
     >
       <TableRow>
         <TableCell className={styles.taskDetails}>
-          <Link
-            title={title || defaultTitle}
-            className={styles.taskDetailsTitle}
-            to={`/colony/${colonyName}/task/${draftId}`}
-            text={title || defaultTitle}
-          />
+          <p className={styles.taskDetailsTitle}>{title || defaultTitle}</p>
           {reputation && (
             <span className={styles.taskDetailsReputation}>
               <FormattedMessage

--- a/src/modules/dashboard/components/TaskList/TaskListItem.tsx
+++ b/src/modules/dashboard/components/TaskList/TaskListItem.tsx
@@ -77,38 +77,41 @@ const TaskListItem = ({ data, intl: { formatMessage } }: Props) => {
   }
 
   return (
-    <TableRow>
-      <TableCell className={styles.taskDetails}>
-        <Link
-          title={title || defaultTitle}
-          className={styles.taskDetailsTitle}
-          to={`/colony/${colonyName}/task/${draftId}`}
-          text={title || defaultTitle}
-        />
-        {reputation && (
-          <span className={styles.taskDetailsReputation}>
-            <FormattedMessage
-              {...MSG.reputation}
-              values={{ reputation: reputation.toString() }}
-            />
-          </span>
-        )}
-      </TableCell>
-      <TableCell className={styles.taskPayouts}>
-        {!!availableTokens && (
-          <PayoutsList
-            payouts={payouts as TaskPayoutType[]}
-            nativeToken={nativeTokenRef}
-            tokenOptions={availableTokens}
+    <Link
+      className={styles.globalLink}
+      to={`/colony/${colonyName}/task/${draftId}`}
+    >
+      <TableRow>
+        <TableCell className={styles.taskDetails}>
+          <Link
+            title={title || defaultTitle}
+            className={styles.taskDetailsTitle}
+            to={`/colony/${colonyName}/task/${draftId}`}
+            text={title || defaultTitle}
           />
-        )}
-      </TableCell>
-      <TableCell className={styles.userAvatar}>
-        {workerAddress && (
-          <UserAvatar showInfo size="xs" address={workerAddress} />
-        )}
-      </TableCell>
-    </TableRow>
+          {reputation && (
+            <span className={styles.taskDetailsReputation}>
+              <FormattedMessage
+                {...MSG.reputation}
+                values={{ reputation: reputation.toString() }}
+              />
+            </span>
+          )}
+        </TableCell>
+        <TableCell className={styles.taskPayouts}>
+          {!!availableTokens && (
+            <PayoutsList
+              payouts={payouts}
+              nativeToken={nativeTokenRef}
+              tokenOptions={availableTokens}
+            />
+          )}
+        </TableCell>
+        <TableCell className={styles.userAvatar}>
+          {workerAddress && <UserAvatar size="xs" address={workerAddress} />}
+        </TableCell>
+      </TableRow>
+    </Link>
   );
 };
 


### PR DESCRIPTION
## Description

This PR fixes a potential serious problem with a task becoming un-clickable when the title was removed.

In this PR, while fixing that to show _Untitle Task_, if the title is removed, I've also added some minor improvements:
- Increased task list item click-able area
- Task Feed now acknowledges task title removal

**Changes**

- [x] `TaskListItem` display `Untitled Task` if the title was removed _(set to `""`)_
- [x] `TaskListItem` wrap whole item / task in a `Link`
- [x] `TaskFeed` show a different message for a _task title removed_ event 

**Screenshots**

![Screenshot from 2019-08-22 17-48-39](https://user-images.githubusercontent.com/1193222/63528903-74b7e900-c50c-11e9-8127-e3d6121404e2.png)

![Screenshot from 2019-08-22 18-23-26](https://user-images.githubusercontent.com/1193222/63528905-74b7e900-c50c-11e9-8622-b9863da42146.png)

Resolves #1748 