### PR TITLE
Claim Username Wizard pick latest Transaction Group

### DIFF
--- a/src/modules/dashboard/components/CreateUserWizard/StepConfirmTransaction.tsx
+++ b/src/modules/dashboard/components/CreateUserWizard/StepConfirmTransaction.tsx
@@ -7,7 +7,7 @@ import { useSelector } from '~utils/hooks';
 import { currentUserSelector } from '../../../users/selectors';
 import { userDidClaimProfile } from '../../../users/checks';
 import { groupedTransactions } from '../../../core/selectors';
-import { findTransactionGroupByKey } from '~users/GasStation/transactionGroup';
+import { findTransactionGroupByKey, findNewestGroup } from '~users/GasStation/transactionGroup';
 import Heading from '~core/Heading';
 import Link from '~core/Link';
 import GasStationContent from '~users/GasStation/GasStationContent';
@@ -36,7 +36,7 @@ const StepConfirmTransaction = () => {
   }
 
   const colonyTransaction = findTransactionGroupByKey(
-    transactionGroups,
+    [findNewestGroup(transactionGroups)],
     'group.transaction.batch.createUser',
   );
 

--- a/src/modules/dashboard/components/CreateUserWizard/StepConfirmTransaction.tsx
+++ b/src/modules/dashboard/components/CreateUserWizard/StepConfirmTransaction.tsx
@@ -7,7 +7,10 @@ import { useSelector } from '~utils/hooks';
 import { currentUserSelector } from '../../../users/selectors';
 import { userDidClaimProfile } from '../../../users/checks';
 import { groupedTransactions } from '../../../core/selectors';
-import { findTransactionGroupByKey, findNewestGroup } from '~users/GasStation/transactionGroup';
+import {
+  findTransactionGroupByKey,
+  findNewestGroup,
+} from '~users/GasStation/transactionGroup';
 import Heading from '~core/Heading';
 import Link from '~core/Link';
 import GasStationContent from '~users/GasStation/GasStationContent';


### PR DESCRIPTION
## Description

This PR fixes a issue where you would navigate back and fourth when creating a new user.

This was because the selected transaction presented to you to sign was always the first, even though, if you navigated back, then fourth, you would have a new transaction generated for you.

This PR fixes that by selecting the latest `group.transaction.batch.createUser` transaction group in the list 

**Changes**

- [x] `StepConfirmTransaction` use `findNewestGroup` to select the latest tx group created

Resolves #1391 