### PR TITLE
Disable Remove Button when no Avatar is set

### DIFF
--- a/src/modules/admin/components/Profile/ColonyAvatarUploader.tsx
+++ b/src/modules/admin/components/Profile/ColonyAvatarUploader.tsx
@@ -70,6 +70,7 @@ const ColonyAvatarUploader = ({ colony: { colonyAddress }, colony }: Props) => {
       }
       upload={upload}
       remove={remove}
+      isSet={colony && !!colony.avatarHash}
     />
   );
 };

--- a/src/modules/core/components/AvatarUploader/AvatarUploader.tsx
+++ b/src/modules/core/components/AvatarUploader/AvatarUploader.tsx
@@ -45,6 +45,9 @@ interface Props {
 
   /** Function to handle the actual uploading of the file */
   upload: (fileData: FileReaderFile) => Promise<string>;
+
+  /** Used to control the state of the remove button (don't fire the remove action if not avatar is set) */
+  isSet?: boolean;
 }
 
 class AvatarUploader extends Component<Props> {
@@ -75,6 +78,7 @@ class AvatarUploader extends Component<Props> {
       placeholder,
       remove,
       upload,
+      isSet = true,
     } = this.props;
     // Formik is used for state and error handling through FileUpload, nothing else
     return (
@@ -101,6 +105,7 @@ class AvatarUploader extends Component<Props> {
               appearance={{ theme: 'danger' }}
               text={{ id: 'button.remove' }}
               onClick={remove}
+              disabled={!isSet}
               data-test="avatarUploaderRemove"
             />
             <Button

--- a/src/modules/users/components/UserProfileEdit/UserAvatarUploader.tsx
+++ b/src/modules/users/components/UserProfileEdit/UserAvatarUploader.tsx
@@ -54,6 +54,7 @@ const UserAvatarUploader = ({ user }: Props) => {
       }
       upload={upload}
       remove={remove}
+      isSet={user && user.profile && !!user.profile.avatarHash}
     />
   );
 };


### PR DESCRIPTION
## Description

This PR adds a small quality of life improvement to the core `AvatarUploader` component, by giving it a `isSet` prop based on which it will disable the _Remove_ button, if no value is set.

Using that we can make both the User Avatar Uploader and the Colony Avatar Uploader to behave a little more consistent and not allow the user to remove an avatar if one is not uploaded yet.

**Changes**

- [x] core `AvatarUploader` now has a `isSet` prop based on which it disables the _Remove_ button
- [x] `UserAvatarUploader` passes down the value of `user.profile.avatarHash` to the `isSet` prop
- [x] `ColonyAvatarUploader` passes down the value of `colony.avatarHash` to the `isSet` prop

**Screenshots**

User

![Screenshot from 2019-08-27 11-07-07](https://user-images.githubusercontent.com/1193222/63753420-b86b7380-c8bb-11e9-9472-51b4efa55869.png)
![Screenshot from 2019-08-27 11-07-30](https://user-images.githubusercontent.com/1193222/63753421-b86b7380-c8bb-11e9-8b32-1b57b7e83d42.png)

Colony

![Screenshot from 2019-08-27 11-09-43](https://user-images.githubusercontent.com/1193222/63753423-b86b7380-c8bb-11e9-960f-30351f743234.png)
![Screenshot from 2019-08-27 11-09-50](https://user-images.githubusercontent.com/1193222/63753424-b9040a00-c8bb-11e9-9010-db73f67164ca.png)

Resolves #1754 