### PR TITLE
Transactions and Messages items inside the Gas Station now have a unique key

### DIFF
--- a/src/modules/users/components/GasStation/transactionGroup.ts
+++ b/src/modules/users/components/GasStation/transactionGroup.ts
@@ -10,8 +10,8 @@ export type TransactionOrMessageGroups = TransactionOrMessageGroup[];
 
 // get the group id (mostly used as a unique identifier for the group)
 export const getGroupId = (txOrMessageGroup: TransactionOrMessageGroup) =>
-  (txOrMessageGroup[0].group && txOrMessageGroup[0].group.key) ||
-  txOrMessageGroup[0].id;
+  txOrMessageGroup[0].id ||
+  (txOrMessageGroup[0].group && txOrMessageGroup[0].group.key);
 
 // Get the group key (mostly used for i18n)
 export const getGroupKey = (txGroup: TransactionOrMessageGroup) =>


### PR DESCRIPTION
## Description

This PR fixes a React warning when similar transactions _(Eg: mint tokens)_ or messages _(Eg: comment on a task)_ would generate the same list item `key`. This was because the helper method, `getGroupId` would prioritize selecting the transaction's group `key` _(which is not unique)_ before the transaction's id.

The change I've introduced changes this order, prioritizing the `id` _(which is unique, and is a combination of the `key` string and the actual `id`)_, before the `key`.

We're using this helper method just in the component in question, so this change does not a have a negative impact on other parts of the dApp.

**Changes**

- [x] Gas Station `getGroupId` now prioritizes transaction id before the group key

Resovles #1753 
