### PR TITLE
Repair Docker build file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.circleci
+.github
+node_modules
+styleguide
+dist
+cypress
+docs
+integration-testing
+scripts
+ssl

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,13 +22,6 @@ ARG VERBOSE=false
 ARG COLONY_NETWORK_ENS_NAME=joincolony.eth
 ARG PINNING_ROOM=PINION_DEV_ROOM
 
-# @FIX Debian Jessie / Docker issue with apt.
-# See: https://stackoverflow.com/questions/46406847/docker-how-to-add-backports-to-sources-list-via-dockerfile
-RUN echo "deb http://archive.debian.org/debian/ jessie main\n" \
-        "deb-src http://archive.debian.org/debian/ jessie main\n" \
-        "deb http://security.debian.org jessie/updates main\n" \
-        "deb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
-
 # @FIX Allow the nginx service to start at build time, so that the installation will work
 # See: https://askubuntu.com/questions/365911/why-the-services-do-not-start-at-installation
 RUN sed -i "s|exit 101|exit 0|g" /usr/sbin/policy-rc.d


### PR DESCRIPTION
## Description

This PR fixes the Docker builds after the update to node `10.16.3`.

This was prompted because the `node:10.16.3` docker image, upon which ours is based, upgrades the underlying OS from debian `jessie` to debian `stretch`. This meant that us forcing it to use the hardcoded apt sources for jessie broke the package install system.

While I was at it, I also added a docker ignore file, to minimize the initial build context of the image. It ain't much, but it does shave 300 megs and about 4 seconds from the build context setup.

**New stuff**

- [x] Added `.dockerignore` file

**Changes**

- [x] Removed manual apt sources setup from `Dockerfile`