### PR TITLE
Cache purser identities

### DIFF
--- a/src/data/PurserIdentityProvider.ts
+++ b/src/data/PurserIdentityProvider.ts
@@ -1,6 +1,7 @@
 /* eslint-disable class-methods-use-this */
 
 import OrbitDBKeystore from 'orbit-db-keystore';
+import localForage from 'localforage';
 import { IdentityProvider } from './types';
 
 import PurserIdentity from './PurserIdentity';
@@ -16,6 +17,8 @@ const PROVIDER_TYPE = 'ethereum';
 class PurserIdentityProvider<I extends PurserIdentity>
   implements IdentityProvider<I> {
   _options: Options;
+
+  _localCache: LocalForage;
 
   _type: ProviderType;
 
@@ -34,6 +37,12 @@ class PurserIdentityProvider<I extends PurserIdentity>
     this._options = options;
     this._purserWallet = purserWallet;
     this._keystore = OrbitDBKeystore.create(`./keystore/${this.walletAddress}`);
+    this._localCache = localForage.createInstance({
+      // Make sure it uses indexedDB
+      driver: localForage.INDEXEDDB,
+      name: 'purser-identity-cache',
+      storeName: 'purser-identity-cache',
+    });
   }
 
   get type() {
@@ -53,6 +62,21 @@ class PurserIdentityProvider<I extends PurserIdentity>
       throw new Error('Could not get wallet address. Is it unlocked?');
     }
 
+    await this._localCache.ready();
+    const cachedIdentity: PurserIdentity = await this._localCache.getItem(
+      this.walletAddress,
+    );
+    if (cachedIdentity) {
+      return new PurserIdentity(
+        cachedIdentity.id,
+        cachedIdentity.publicKey,
+        cachedIdentity.signatures.id,
+        cachedIdentity.signatures.publicKey,
+        cachedIdentity.type,
+        this,
+      );
+    }
+
     // Always create a key per wallet address. This is stored on indexedDB
     const orbitKey =
       (await this._keystore.getKey(this.walletAddress)) ||
@@ -69,7 +93,7 @@ class PurserIdentityProvider<I extends PurserIdentity>
       message: publicKey + idSignature,
     });
 
-    return new PurserIdentity(
+    const identity = new PurserIdentity(
       this.walletAddress,
       publicKey,
       idSignature,
@@ -77,6 +101,8 @@ class PurserIdentityProvider<I extends PurserIdentity>
       this._type,
       this,
     );
+    await this._localCache.setItem(this.walletAddress, identity.toJSON());
+    return identity;
   }
 
   async sign(identity: PurserIdentity, data: any): Promise<string> {

--- a/src/data/PurserIdentityProvider.ts
+++ b/src/data/PurserIdentityProvider.ts
@@ -62,10 +62,17 @@ class PurserIdentityProvider<I extends PurserIdentity>
       throw new Error('Could not get wallet address. Is it unlocked?');
     }
 
-    await this._localCache.ready();
-    const cachedIdentity: PurserIdentity = await this._localCache.getItem(
-      this.walletAddress,
-    );
+    let cachedIdentity: PurserIdentity;
+
+    try {
+      cachedIdentity = await this._localCache.getItem(this.walletAddress);
+    } catch (e) {
+      console.warn(
+        `Could not initialize local storage. If we're not in a browser, that's fine.`,
+        e,
+      );
+    }
+
     if (cachedIdentity) {
       return new PurserIdentity(
         cachedIdentity.id,
@@ -101,6 +108,15 @@ class PurserIdentityProvider<I extends PurserIdentity>
       this._type,
       this,
     );
+    try {
+      await this._localCache.ready();
+    } catch (e) {
+      console.warn(
+        `Could not initialize local storage. If we're not in a browser, that's fine.`,
+        e,
+      );
+      return identity;
+    }
     await this._localCache.setItem(this.walletAddress, identity.toJSON());
     return identity;
   }

--- a/src/lib/database/stores/EventStore.ts
+++ b/src/lib/database/stores/EventStore.ts
@@ -46,10 +46,28 @@ class EventStore extends Store {
   }
 
   async getLSCache(): Promise<AllEvents[] | void> {
+    try {
+      await localStorage.ready();
+    } catch (e) {
+      console.warn(
+        `Could not initialize local storage. If we're not in a browser, that's fine.`,
+        e,
+      );
+      return undefined;
+    }
     return localStorage.getItem(`colony.orbitCache.${this.address.toString()}`);
   }
 
   async setLSCache() {
+    try {
+      await localStorage.ready();
+    } catch (e) {
+      console.warn(
+        `Could not initialize local storage. If we're not in a browser, that's fine.`,
+        e,
+      );
+      return undefined;
+    }
     return localStorage.setItem(
       `colony.orbitCache.${this.address.toString()}`,
       this.all(),


### PR DESCRIPTION
## Description

This PR adds a cache for purser identitie so users doesn't have to generate a new orbit key every time they log in. They create a key the first time they log in then after that they just have to unlock their wallet.

**Changes** 🏗

* `PurserIdentityProvider` now uses `localforage` for a identity cache


## TODO
- [x] Add `localforage` to PurserIdentityProvider
- [x] Check if there is a serialized identity for the current wallet address
- [x] Load that identity instead of creating a new one

Closes #1296