### PR TITLE
Notification Items Fetch Missing Data

### DIFF
--- a/src/data/normalizers/index.ts
+++ b/src/data/normalizers/index.ts
@@ -55,13 +55,14 @@ export const normalizeTransactionLog = (
   contractAddress: string,
   {
     event: { eventName, ...event },
-    log: { logIndex, transactionHash, address: tokenAddress },
+    log: { logIndex, transactionHash, address: tokenAddress, ...log },
     timestamp,
     transaction: { from },
   }: TransactionLog,
 ): NormalizedEvent => ({
   type: eventName,
   payload: {
+    ...log,
     ...event,
     tokenAddress,
   },

--- a/src/data/normalizers/index.ts
+++ b/src/data/normalizers/index.ts
@@ -18,7 +18,7 @@ type NormalizedEvent = {
     actorId: string; // Wallet address for orbit-db events or tx sender address for tx logs
     timestamp: number;
     version: typeof VERSION;
-    tokenAddress?: string,
+    tokenAddress?: string;
   };
 };
 

--- a/src/data/normalizers/index.ts
+++ b/src/data/normalizers/index.ts
@@ -18,6 +18,7 @@ type NormalizedEvent = {
     actorId: string; // Wallet address for orbit-db events or tx sender address for tx logs
     timestamp: number;
     version: typeof VERSION;
+    tokenAddress?: string,
   };
 };
 
@@ -26,6 +27,7 @@ type TransactionLog = {
   log: {
     logIndex: number;
     transactionHash: string;
+    address: string;
   };
   timestamp: number;
   transaction: {
@@ -54,7 +56,7 @@ export const normalizeTransactionLog = (
   contractAddress: string,
   {
     event: { eventName, ...event },
-    log: { logIndex, transactionHash },
+    log: { logIndex, transactionHash, address: tokenAddress },
     timestamp,
     transaction: { from },
   }: TransactionLog,
@@ -68,6 +70,7 @@ export const normalizeTransactionLog = (
     actorId: from,
     timestamp,
     version: VERSION,
+    tokenAddress,
   },
 });
 

--- a/src/data/normalizers/index.ts
+++ b/src/data/normalizers/index.ts
@@ -18,7 +18,6 @@ type NormalizedEvent = {
     actorId: string; // Wallet address for orbit-db events or tx sender address for tx logs
     timestamp: number;
     version: typeof VERSION;
-    tokenAddress?: string;
   };
 };
 
@@ -62,7 +61,10 @@ export const normalizeTransactionLog = (
   }: TransactionLog,
 ): NormalizedEvent => ({
   type: eventName,
-  payload: event,
+  payload: {
+    ...event,
+    tokenAddress,
+  },
   meta: {
     id: `${transactionHash}_${logIndex}`,
     sourceType: CONTRACT_EVENT_SOURCE,
@@ -70,7 +72,6 @@ export const normalizeTransactionLog = (
     actorId: from,
     timestamp,
     version: VERSION,
-    tokenAddress,
   },
 });
 

--- a/src/modules/users/data/utils.ts
+++ b/src/modules/users/data/utils.ts
@@ -99,7 +99,7 @@ export const decorateColonyEventPayload = ({ payload, ...event }: any) => ({
       switch (event.type) {
         case 'ColonyRoleSet':
           return {
-            colonyAddress: payload.sourceId,
+            colonyAddress: event.meta.sourceId,
             targetUserAddress: payload.address,
           };
         case 'DomainAdded':

--- a/src/modules/users/data/utils.ts
+++ b/src/modules/users/data/utils.ts
@@ -109,7 +109,7 @@ export const decorateColonyEventPayload = ({ payload, ...event }: any) => ({
         case 'Mint':
           return {
             colonyAddress: payload.address,
-            tokenAddress: event.meta.tokenAddress,
+            tokenAddress: payload.tokenAddress,
           };
         case 'ColonyLabelRegistered':
           return {

--- a/src/modules/users/data/utils.ts
+++ b/src/modules/users/data/utils.ts
@@ -104,7 +104,7 @@ export const decorateColonyEventPayload = ({ payload, ...event }: any) => ({
           };
         case 'DomainAdded':
           return {
-            colonyAddress: payload.sourceId,
+            colonyAddress: event.meta.sourceId,
           };
         case 'Mint':
           return {

--- a/src/modules/users/data/utils.ts
+++ b/src/modules/users/data/utils.ts
@@ -109,7 +109,7 @@ export const decorateColonyEventPayload = ({ payload, ...event }: any) => ({
         case 'Mint':
           return {
             colonyAddress: payload.address,
-            tokenAddress: payload.sourceId,
+            tokenAddress: event.meta.tokenAddress,
           };
         case 'ColonyLabelRegistered':
           return {


### PR DESCRIPTION
## Description

This PR fixes inbox events that wouldn't get the proper data, hence they would show messages without the actual values. This events were: _Domain Added, Tokens Minted, Admins added / removed_.

This was because, for the most part, the decorator util got the value for `colonyAddress` from an invalid location _(`payload.sourceId`)_. This was not the correct location, hence the reducer having trouble creating the inbox event record.

In this PR for the _Domain Added and Roles Changed_ events, we simply point the decorator to the right place. For the _Token Minted_ event on the other hand, we also had to provide to actual `tokenAddress` value, before selecting it in the decorator.

**Changes**

- [x] `user` `data` util get correct value for `colonyAddress` for domain added events
- [x] `user` `data` util get correct value for `colonyAddress` for roles added events
- [x] `user` `data` util get correct value for `tokenAddress` for mint events, but also select the correct value for it when passing it down from the `normalizer`

**Screenshot**

![Screenshot from 2019-08-28 13-08-10](https://user-images.githubusercontent.com/1193222/63846735-099b6600-c995-11e9-8eaf-471f53e7c87e.png)

Resolves #1756 