### PR TITLE
Properly react on message signing errors

### DIFF
--- a/src/lib/ipfs/IPFSNode.ts
+++ b/src/lib/ipfs/IPFSNode.ts
@@ -1,10 +1,10 @@
 import IPFS from 'ipfs';
 
 import { sleep } from '../../utils/time';
-import { isDev } from '../../utils/debug';
 
 import devConfig from './ipfsConfig.development';
 import prodConfig from './ipfsConfig.production';
+import qaConfig from './ipfsConfig.qa';
 
 import { B58String, IPFSNodeOptions, IPFSPeer } from './types';
 import PinnerConnector from './PinnerConnector';
@@ -14,8 +14,14 @@ import PinnerConnector from './PinnerConnector';
 const PINNING_ROOM = process.env.PINNING_ROOM;
 const TIMEOUT = process.env.CI ? 50000 : 10000;
 
+const configMap = {
+  mainnet: prodConfig,
+  local: devConfig,
+  goerli: qaConfig,
+};
+
 class IPFSNode {
-  static getIpfsConfig = isDev ? devConfig : prodConfig;
+  static getIpfsConfig = configMap[process.env.NETWORK];
 
   /** Turn a `swarm.peers()` result item into its B58 representation (Qm....) */
   static peerToB58String = (peerItem: IPFSPeer): B58String =>

--- a/src/lib/ipfs/ipfsConfig.production.ts
+++ b/src/lib/ipfs/ipfsConfig.production.ts
@@ -1,7 +1,3 @@
-/**
- * @todo Use our own star server for IPFS
- * @body Suggestion: `Swarm: ['/dns4/ws-star.discovery.libp2p.io/tcp/443/wss/p2p-websocket-star']`
- */
 const config = () => ({
   repo: 'colonyIpfs',
   // config gets merged with the IPFS default config

--- a/src/lib/ipfs/ipfsConfig.qa.ts
+++ b/src/lib/ipfs/ipfsConfig.qa.ts
@@ -1,7 +1,3 @@
-/**
- * @todo Use our own star server for IPFS
- * @body Suggestion: `Swarm: ['/dns4/ws-star.discovery.libp2p.io/tcp/443/wss/p2p-websocket-star']`
- */
 const config = () => ({
   repo: 'colonyIpfs',
   // config gets merged with the IPFS default config

--- a/src/modules/core/components/Fields/Form/ActionForm.tsx
+++ b/src/modules/core/components/Fields/Form/ActionForm.tsx
@@ -20,6 +20,7 @@ const MSG = defineMessages({
 const displayName = 'Form.ActionForm';
 
 type OnError = (error: any, bag: FormikBag<any, any>, values?: any) => void;
+type OnSuccess = (result: any, bag: FormikBag<any, any>, values: any) => void;
 
 interface ExtendedFormikConfig {
   validateOnChange?: boolean;
@@ -48,7 +49,7 @@ interface Props extends ExtendedFormikConfig {
   error: ActionTypeString;
 
   /** Function to call after successful action was dispatched */
-  onSuccess?: (result: any, bag: FormikBag<any, any>, values: any) => void;
+  onSuccess?: OnSuccess;
 
   /** Function to call after error action was dispatched */
   onError?: OnError;
@@ -62,11 +63,15 @@ const defaultOnError: OnError = (err, { setStatus }) => {
   setStatus({ error: MSG.defaultError });
 };
 
+const defaultOnSuccess: OnSuccess = (err, { setStatus }) => {
+  setStatus({});
+};
+
 const ActionForm = ({
   submit,
   success,
   error,
-  onSuccess,
+  onSuccess = defaultOnSuccess,
   onError = defaultOnError,
   transform,
   ...props
@@ -77,7 +82,8 @@ const ActionForm = ({
     success,
     transform,
   });
-  const handleSubmit = (values, formikBag) =>
+  const handleSubmit = (values, formikBag) => {
+    formikBag.setStatus({});
     asyncFunction(values).then(
       res => {
         formikBag.setSubmitting(false);
@@ -90,6 +96,7 @@ const ActionForm = ({
         if (typeof onError === 'function') onError(err, formikBag, values);
       },
     );
+  };
   return <Form {...props} onSubmit={handleSubmit} />;
 };
 

--- a/src/modules/core/reducers/messages.ts
+++ b/src/modules/core/reducers/messages.ts
@@ -35,6 +35,13 @@ const coreMessagesReducer: ReducerType<CoreMessagesRecord> = (
         }),
       );
     }
+    case ActionTypes.MESSAGE_ERROR: {
+      const { messageId } = action.meta;
+      return state.updateIn(
+        [CORE_MESSAGES_LIST, messageId, 'status'],
+        () => TRANSACTION_STATUSES.FAILED,
+      );
+    }
     case ActionTypes.MESSAGE_CANCEL: {
       const { id } = action.payload;
       return state.deleteIn([CORE_MESSAGES_LIST, id]);

--- a/src/modules/core/sagas/index.ts
+++ b/src/modules/core/sagas/index.ts
@@ -18,3 +18,4 @@ export default function* rootSaga() {
 }
 
 export * from './transactions';
+export * from './messages';

--- a/src/modules/core/sagas/messages.ts
+++ b/src/modules/core/sagas/messages.ts
@@ -1,0 +1,55 @@
+import nanoid from 'nanoid';
+import { call, put, take } from 'redux-saga/effects';
+
+import { putError } from '~utils/saga/effects';
+import { ActionTypes } from '~redux/index';
+import { AllActions } from '~redux/types/actions';
+import { Context, getContext } from '~context/index';
+
+export function* signMessage(purpose, message) {
+  const wallet = yield getContext(Context.WALLET);
+  const messageId = `${nanoid(10)}-signMessage`;
+  /*
+   * @NOTE Initiate the message signing process
+   */
+  const messageString = JSON.stringify(message);
+  yield put<AllActions>({
+    type: ActionTypes.MESSAGE_CREATED,
+    payload: {
+      id: messageId,
+      purpose,
+      message: messageString,
+      createdAt: new Date(),
+    },
+  });
+
+  /*
+   * @NOTE Wait (block) until there's a matching action
+   * and get its generated id for the async listener
+   */
+  const {
+    meta: { id },
+  } = yield take(
+    (action: AllActions) =>
+      action.type === ActionTypes.MESSAGE_SIGN &&
+      action.payload.id === messageId,
+  );
+  try {
+    const signature = yield call([wallet, wallet.signMessage], {
+      message: messageString,
+    });
+
+    yield put<AllActions>({
+      type: ActionTypes.MESSAGE_SIGNED,
+      payload: { id: messageId, signature },
+      meta: { id },
+    });
+    return signature;
+  } catch (caughtError) {
+    yield putError(ActionTypes.MESSAGE_ERROR, caughtError, {
+      messageId,
+      id,
+    });
+    throw caughtError;
+  }
+}

--- a/src/modules/dashboard/components/TaskComments/TaskComments.tsx
+++ b/src/modules/dashboard/components/TaskComments/TaskComments.tsx
@@ -11,7 +11,7 @@ import { Address } from '~types/index';
 
 import { ActionTypes } from '~redux/index';
 import withDialog from '~core/Dialog/withDialog';
-import { ActionForm, FormStatus, TextareaAutoresize } from '~core/Fields';
+import { ActionForm, TextareaAutoresize } from '~core/Fields';
 import Button from '~core/Button';
 import unfinishedProfileOpener from '~users/UnfinishedProfile';
 
@@ -131,7 +131,6 @@ const TaskComments = ({
         {({
           isSubmitting,
           isValid,
-          status,
           handleSubmit,
           values,
         }: FormikProps<FormValues>) => (
@@ -165,7 +164,6 @@ const TaskComments = ({
                */
               maxLength={956}
             />
-            <FormStatus status={status} />
             <div className={styles.commentControls}>
               <Button
                 loading={isSubmitting}

--- a/src/modules/users/components/ConnectWalletWizard/ConnectWalletWizard.ts
+++ b/src/modules/users/components/ConnectWalletWizard/ConnectWalletWizard.ts
@@ -1,4 +1,4 @@
-import { compose, withProps } from 'recompose';
+import { withProps } from 'recompose';
 import ledgerWallet from '@colony/purser-ledger';
 import trezorWallet from '@colony/purser-trezor';
 
@@ -48,11 +48,9 @@ const stepFunction = (step: number, { method }: StepValues) => {
   }
 };
 
-const ConnectWalletContainer = compose(
-  withWizard({
-    steps: stepFunction,
-    stepCount: 3,
-  }),
-)(WizardTemplate);
+const ConnectWalletContainer = withWizard({
+  steps: stepFunction,
+  stepCount: 3,
+})(WizardTemplate);
 
 export default ConnectWalletContainer;

--- a/src/modules/users/components/CreateWalletWizard/CreateWalletWizard.ts
+++ b/src/modules/users/components/CreateWalletWizard/CreateWalletWizard.ts
@@ -1,16 +1,12 @@
-import compose from 'recompose/compose';
+import WizardTemplate from '~pages/WizardTemplate/WizardTemplate';
 
 import withWizard from '../../../core/components/Wizard/withWizard';
-import CreateWalletWizard from './CreateWalletWizard';
-
 import StepCreatePhrase from './StepCreatePhrase';
 import StepBackupPhrase from './StepBackupPhrase';
 import StepProveMnemonic from './StepProveMnemonic';
 
 const steps = [StepCreatePhrase, StepBackupPhrase, StepProveMnemonic];
 
-const CreateWalletContainer = compose(withWizard({ steps }))(
-  CreateWalletWizard,
-);
+const CreateWalletContainer = withWizard({ steps })(WizardTemplate);
 
 export default CreateWalletContainer;

--- a/src/modules/users/components/CreateWalletWizard/CreateWalletWizard.tsx
+++ b/src/modules/users/components/CreateWalletWizard/CreateWalletWizard.tsx
@@ -1,1 +1,0 @@
-export { default } from '~pages/WizardTemplate/WizardTemplate';

--- a/src/modules/users/components/GasStation/MessageCardDetails/MessageCardControls.tsx
+++ b/src/modules/users/components/GasStation/MessageCardDetails/MessageCardControls.tsx
@@ -35,10 +35,6 @@ const MessageCardControls = ({ message: { id } }: Props) => {
         error={ActionTypes.MESSAGE_ERROR}
         validationSchema={validationSchema}
         initialValues={{ id }}
-        transform={(action: any) => ({
-          ...action,
-          meta: { id },
-        })}
       >
         {({ isSubmitting }: FormikProps<FormValues>) => (
           <Button

--- a/src/redux/types/actions/message.ts
+++ b/src/redux/types/actions/message.ts
@@ -11,5 +11,8 @@ export type MessageActionTypes =
       ActionTypes.MESSAGE_SIGNED,
       { id: string; message?: string; signature: string }
     >
-  | ErrorActionType<ActionTypes.MESSAGE_ERROR, void>
+  | ErrorActionType<
+      ActionTypes.MESSAGE_ERROR,
+      { id: string; messageId: string }
+    >
   | ActionTypeWithPayload<ActionTypes.MESSAGE_CANCEL, { id: string }>;

--- a/src/utils/saga/effects.ts
+++ b/src/utils/saga/effects.ts
@@ -47,12 +47,6 @@ export const putError = (type: string, error: Error, meta: object = {}) => {
     payload: error,
   };
   log.error(error);
-  Object.assign(action.meta, {
-    error: {
-      message: error.message,
-      stack: error.stack,
-    },
-  });
   return put(action);
 };
 


### PR DESCRIPTION
## Description

Errors yielded in the comment signing process are now properly handled (including MetaMask rejections). The message to sign will be marked as `FAILED` when that happens and both of the forms are reset. The user can then try again to sign the same message using another gas station entry.

See also this [comment](https://github.com/JoinColony/colonyDapp/issues/1718#issuecomment-526381075).

**New stuff**

* Snuck in a little fix for selecting IPFS environments.

**Changes** 🏗

* Extracted `signMessage* function into `core`
* Fix form errors reset for action form
* Use `ActionForm` in the task comment form component
* Properly manage meta ids to be able to use the asycListeners and reset the forms accordingly
* Properly handle the `MESSAGE_CANCEL` action
* Remove form status form TaskComments (as it didn't make a lot of sense since errors are handled in the gas station)

Resolves #1718 
