### PR TITLE
Disable hardware wallets (temporarily)

### DIFF
--- a/src/modules/core/components/DecisionHub/DecisionOption.css
+++ b/src/modules/core/components/DecisionHub/DecisionOption.css
@@ -19,6 +19,11 @@
   }
 }
 
+.stateDisabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .themeAlt {
   composes: main;
   border: none;

--- a/src/modules/core/components/DecisionHub/DecisionOption.css.d.ts
+++ b/src/modules/core/components/DecisionHub/DecisionOption.css.d.ts
@@ -1,5 +1,6 @@
 export const main: string;
 export const themeAlt: string;
+export const stateDisabled: string;
 export const rowContent: string;
 export const rowIcon: string;
 export const tooltip: string;

--- a/src/modules/core/components/DecisionHub/DecisionOption.tsx
+++ b/src/modules/core/components/DecisionHub/DecisionOption.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useCallback } from 'react';
 import {
   MessageDescriptor,
   defineMessages,
@@ -32,6 +32,7 @@ interface Props {
     subtitle: MessageDescriptor | string;
     icon?: string;
     tooltip?: MessageDescriptor;
+    disabled?: boolean;
   };
   link?: string;
 
@@ -41,77 +42,73 @@ interface Props {
 
 const displayName = 'DecisionOption';
 
-class DecisionOption extends Component<Props> {
-  makeDecision = () => {
-    const {
-      option: { value },
-      setValue,
-    } = this.props;
-    setValue(value);
-  };
-
-  renderIcon = (tooltip, icon, title) => {
-    /* Wrap icon in tooltip wrapper only if tooltip propert exists */
-    if (tooltip && icon) {
-      return (
-        <Tooltip
-          placement="left"
-          trigger="hover"
-          content={
-            <span className={styles.tooltip}>
-              <FormattedMessage {...tooltip} />
-            </span>
-          }
-        >
-          <div className={styles.rowIcon}>
-            <Icon name={icon} title={title} appearance={{ size: 'small' }} />
-          </div>
-        </Tooltip>
-      );
-    }
-    if (icon) {
-      return (
-        <div className={styles.rowIcon}>
-          <Icon name={icon} title={title} />
-        </div>
-      );
-    }
-    return null;
-  };
-
-  render() {
-    const {
-      appearance,
-      option: { icon, subtitle, title, tooltip },
-      link,
-    } = this.props;
-    const Element = link ? Link : 'button';
-    const elmProps = link ? { to: link } : { onClick: this.makeDecision };
-
-    return (
-      <Element
-        type="submit"
-        className={getMainClasses(appearance, styles)}
-        {...elmProps}
+const DecisionOptionIcon = ({ icon, tooltip, title }: Props['option']) => {
+  if (icon) {
+    // Wrap the icon in a Tooltip wrapper only if the tooltip property exists
+    return tooltip ? (
+      <Tooltip
+        placement="left"
+        trigger="hover"
+        content={
+          <span className={styles.tooltip}>
+            <FormattedMessage {...tooltip} />
+          </span>
+        }
       >
-        {this.renderIcon(tooltip, icon, title)}
-        <div className={styles.rowContent}>
-          <Heading
-            appearance={{ size: 'small', weight: 'bold', margin: 'small' }}
-            text={title}
-          />
-          <Heading
-            appearance={{ size: 'tiny', weight: 'thin', margin: 'small' }}
-            text={subtitle}
-          />
+        <div className={styles.rowIcon}>
+          <Icon name={icon} title={title} appearance={{ size: 'small' }} />
         </div>
-        <Icon name="caret-right" title={MSG.iconTitle} />
-      </Element>
+      </Tooltip>
+    ) : (
+      <div className={styles.rowIcon}>
+        <Icon name={icon} title={title} />
+      </div>
     );
   }
-}
+  return null;
+};
 
-// @ts-ignore
+const DecisionOption = ({
+  appearance,
+  option: { title, subtitle, disabled },
+  option,
+  setValue,
+  link,
+}: Props) => {
+  const makeDecision = useCallback(
+    (value: string) => {
+      if (!disabled) setValue(value);
+    },
+    [setValue, disabled],
+  );
+
+  const Element = link ? Link : 'button';
+  const elmProps = link
+    ? { to: disabled ? '' : link }
+    : { onClick: makeDecision, disabled };
+
+  return (
+    <Element
+      type="submit"
+      className={getMainClasses(appearance, styles, { disabled })}
+      {...elmProps}
+    >
+      <DecisionOptionIcon {...option} />
+      <div className={styles.rowContent}>
+        <Heading
+          appearance={{ size: 'small', weight: 'bold', margin: 'small' }}
+          text={title}
+        />
+        <Heading
+          appearance={{ size: 'tiny', weight: 'thin', margin: 'small' }}
+          text={subtitle}
+        />
+      </div>
+      <Icon name="caret-right" title={MSG.iconTitle} />
+    </Element>
+  );
+};
+
 DecisionOption.displayName = displayName;
 
 export default asField({ initialValue: '' })(DecisionOption);

--- a/src/modules/core/components/DecisionHub/DecisionOption.tsx
+++ b/src/modules/core/components/DecisionHub/DecisionOption.tsx
@@ -70,17 +70,14 @@ const DecisionOptionIcon = ({ icon, tooltip, title }: Props['option']) => {
 
 const DecisionOption = ({
   appearance,
-  option: { title, subtitle, disabled },
+  option: { title, subtitle, disabled, value },
   option,
   setValue,
   link,
 }: Props) => {
-  const makeDecision = useCallback(
-    (value: string) => {
-      if (!disabled) setValue(value);
-    },
-    [setValue, disabled],
-  );
+  const makeDecision = useCallback(() => {
+    if (!disabled) setValue(value);
+  }, [setValue, value, disabled]);
 
   const Element = link ? Link : 'button';
   const elmProps = link

--- a/src/modules/users/components/ConnectWalletWizard/StepStart/StepStart.tsx
+++ b/src/modules/users/components/ConnectWalletWizard/StepStart/StepStart.tsx
@@ -34,7 +34,9 @@ const MSG = defineMessages({
   },
   trezorSubtitle: {
     id: 'users.ConnectWalletWizard.StepStart.trezorSubtitle',
-    defaultMessage: 'Log in using the Trezor hardware wallet',
+    defaultMessage: 'Coming soon',
+    // To be re-enabled for colonyDapp#1760
+    // defaultMessage: 'Log in using the Trezor hardware wallet',
   },
   ledgerTitle: {
     id: 'users.ConnectWalletWizard.StepStart.ledgerTitle',
@@ -46,7 +48,9 @@ const MSG = defineMessages({
   },
   ledgerSubtitle: {
     id: 'users.ConnectWalletWizard.StepStart.ledgerSubtitle',
-    defaultMessage: 'Log in using the Ledger hardware wallet',
+    defaultMessage: 'Coming soon',
+    // To be re-enabled for colonyDapp#1760
+    // defaultMessage: 'Log in using the Ledger hardware wallet',
   },
   mnemonicTitle: {
     id: 'users.ConnectWalletWizard.StepStart.mnemonicTitle',
@@ -96,18 +100,6 @@ const options = [
     icon: 'metamask',
   },
   {
-    value: WALLET_SPECIFICS.LEDGER,
-    title: MSG.ledgerTitle,
-    subtitle: MSG.ledgerSubtitle,
-    icon: 'wallet',
-  },
-  {
-    value: WALLET_SPECIFICS.TREZOR,
-    title: MSG.trezorTitle,
-    subtitle: MSG.trezorSubtitle,
-    icon: 'wallet',
-  },
-  {
     value: WALLET_SPECIFICS.MNEMONIC,
     title: MSG.mnemonicTitle,
     subtitle: MSG.mnemonicSubtitle,
@@ -118,6 +110,22 @@ const options = [
     title: MSG.JSONTitle,
     subtitle: MSG.JSONSubtitle,
     icon: 'file',
+  },
+  {
+    value: WALLET_SPECIFICS.LEDGER,
+    title: MSG.ledgerTitle,
+    subtitle: MSG.ledgerSubtitle,
+    icon: 'wallet',
+    // To be re-enabled for colonyDapp#1760
+    disabled: true,
+  },
+  {
+    value: WALLET_SPECIFICS.TREZOR,
+    title: MSG.trezorTitle,
+    subtitle: MSG.trezorSubtitle,
+    icon: 'wallet',
+    // To be re-enabled for colonyDapp#1760
+    disabled: true,
   },
 ];
 


### PR DESCRIPTION
## Description

This PR temporarily disables hardware wallets because #1760 does not have a working solution yet. 

**Note: pending a discussion with product**

**Changes** 🏗

* Add a `disabled` prop to the `DecisionOption` component, so that options can be functionally and visually disabled
* Convert the class component to a functional component with hooks
* Temporarily disable hardware wallets because of colonyDapp#1760, and move them down the list of wallets
