### PR TITLE
Fix Mainnet Task Skills Minor Spelling Error

### DIFF
--- a/src/modules/dashboard/components/TaskSkills/taskSkillsTree.mainnet.ts
+++ b/src/modules/dashboard/components/TaskSkills/taskSkillsTree.mainnet.ts
@@ -400,7 +400,7 @@ const taskSkills: ConsumableItem[] = [
   },
   {
     id: 74,
-    name: 'V  ideo Production',
+    name: 'Video Production',
     parent: -7,
   },
   {


### PR DESCRIPTION
## Description

This is very minor PR that removes some leftover spacing in the _Video Production_ task skill name.

Resolves #1786 