### PR TITLE
Fix Task Edit Dialog filter for users with partially replicated profies

### DIFF
--- a/src/modules/dashboard/components/TaskEditDialog/TaskEditDialog.tsx
+++ b/src/modules/dashboard/components/TaskEditDialog/TaskEditDialog.tsx
@@ -112,14 +112,17 @@ const supFilter = (data, filterValue) => {
 
   const filtered = data.filter(
     user =>
-      user &&
       filterValue &&
-      (user.profile.username
-        .toLowerCase()
-        .includes(filterValue.toLowerCase()) ||
-        user.profile.walletAddress
+      user &&
+      user.profile &&
+      ((user.profile.username &&
+        user.profile.username
           .toLowerCase()
-          .includes(filterValue.toLowerCase())),
+          .includes(filterValue.toLowerCase())) ||
+        (user.profile.walletAddress &&
+          user.profile.walletAddress
+            .toLowerCase()
+            .includes(filterValue.toLowerCase()))),
   );
 
   const customValue = {


### PR DESCRIPTION
## Description

This PR fixes a very niche case in the task edit dialog's Single User Picker.

While you _can_ paste in an address that doesn't have a profile claimed, if you would paste in an address that has a profile, but that is partially replicated, the filter method would crash since it would try to call `toLowerCase` on an `undefined` value.

This fixes that edge case by checking the existence of that prop before trying to call the string's method.

**Changes**

- [x] `TaskEditDialog` check for the existence of the user profile before filtering

**Screenshot**

![Screenshot from 2019-09-02 13-03-01](https://user-images.githubusercontent.com/1193222/64107141-8017d980-cd82-11e9-876a-2a5a3a4b0906.png)

Resolves #1788 