### PR TITLE
Fix description field (for good this time?)

### DIFF
--- a/src/modules/core/components/Fields/InlineEdit/MultiLineEdit/MultiLineEdit.tsx
+++ b/src/modules/core/components/Fields/InlineEdit/MultiLineEdit/MultiLineEdit.tsx
@@ -127,11 +127,13 @@ const MultiLineEdit = ({
   );
   const onBlur = useCallback(
     (evt: FocusEvent) => {
+      const content = editorState.getCurrentContent();
+      const newValue =
+        (content.hasText() && content.getPlainText().trim()) || '';
+      if (newValue !== $value) {
+        setValue(newValue);
+      }
       if (onEditorBlur) {
-        const content = editorState.getCurrentContent();
-        const newValue =
-          (content.hasText() && content.getPlainText().trim()) || '';
-        if (newValue !== $value) setValue(newValue);
         onEditorBlur(evt, newValue);
       }
     },

--- a/src/modules/core/components/Fields/InlineEdit/MultiLineEdit/MultiLineEdit.tsx
+++ b/src/modules/core/components/Fields/InlineEdit/MultiLineEdit/MultiLineEdit.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useCallback, useState } from 'react';
+import React, { ReactNode, useCallback, useEffect, useState } from 'react';
 import {
   EditorState as EditorStateType,
   ContentState,
@@ -12,7 +12,6 @@ import 'draft-js/dist/Draft.css';
 import { asField, InputLabel } from '~core/Fields';
 import InputStatus from '~core/Fields/InputStatus';
 import { getMainClasses } from '~utils/css';
-import { usePrevious } from '~utils/hooks';
 
 import styles from './MultiLineEdit.css';
 
@@ -90,6 +89,11 @@ interface Props {
 const HANDLED = 'handled';
 const NOT_HANDLED = 'not-handled';
 
+const createEditorState = ($value: string) =>
+  $value
+    ? EditorState.createWithContent(ContentState.createFromText($value))
+    : EditorState.createEmpty();
+
 const MultiLineEdit = ({
   $error,
   $id,
@@ -113,14 +117,10 @@ const MultiLineEdit = ({
   readOnly = false,
   spellCheck = false,
 }: Props) => {
-  const prevValue = usePrevious($value);
-  const initialEditorState =
-    $value && prevValue !== $value
-      ? EditorState.createWithContent(ContentState.createFromText($value))
-      : EditorState.createEmpty();
-  const [editorState, setEditorState] = useState<EditorStateType>(
-    initialEditorState,
+  const [editorState, setEditorState] = useState<EditorStateType>(() =>
+    createEditorState($value),
   );
+  useEffect(() => setEditorState(createEditorState($value)), [$value]);
   const handleReturn = useCallback(
     () => (!allowReturns ? HANDLED : NOT_HANDLED),
     [allowReturns],

--- a/src/modules/dashboard/components/TaskDescription/TaskDescription.tsx
+++ b/src/modules/dashboard/components/TaskDescription/TaskDescription.tsx
@@ -3,8 +3,7 @@ import { FormikProps } from 'formik';
 import { defineMessages } from 'react-intl';
 
 import { TaskProps } from '~immutable/index';
-import { pipe, mapPayload, mergePayload } from '~utils/actions';
-import { useInitEditorState } from '~utils/hooks';
+import { pipe, mergePayload } from '~utils/actions';
 import { MultiLineEdit, ActionForm } from '~core/Fields';
 import { ActionTypes } from '~redux/index';
 
@@ -26,25 +25,15 @@ const TaskDescription = ({
   draftId,
 }: Props) => {
   const transform = useCallback(
-    pipe(
-      mapPayload(({ description: editor }) => ({
-        description: editor.getCurrentContent().getPlainText(),
-      })),
-      mergePayload({ colonyAddress, draftId }),
-    ),
+    pipe(mergePayload({ colonyAddress, draftId })),
     [colonyAddress, draftId],
   );
 
-  const descriptionValue = useInitEditorState(description);
-
-  if (disabled && !description) {
-    return null;
-  }
   return (
     <ActionForm
       enableReinitialize
       initialValues={{
-        description: descriptionValue,
+        description,
       }}
       submit={ActionTypes.TASK_SET_DESCRIPTION}
       success={ActionTypes.TASK_SET_DESCRIPTION_SUCCESS}

--- a/src/utils/hooks/index.ts
+++ b/src/utils/hooks/index.ts
@@ -2,7 +2,6 @@ import { Collection, Map as ImmutableMapType } from 'immutable';
 import { Selector } from 'reselect';
 import { useEffect, useCallback, useMemo, useRef } from 'react';
 import { useDispatch, useMappedState } from 'redux-react-hook';
-import { ContentState, EditorState } from 'draft-js';
 
 import { Action, AllActions, ActionTypes } from '~redux/index';
 import { Address } from '~types/index';
@@ -515,25 +514,6 @@ export const useMainClasses = (
     className,
     styles,
   ]);
-
-/*
- * This hook initializes the editor state for draft-js from a string
- * so that it works properly when used with formiks enableReinitialze property
- */
-export const useInitEditorState = (text = '') => {
-  const prevText = usePrevious(text);
-  let editorState;
-  if (prevText !== text) {
-    editorState = EditorState.createWithContent(
-      ContentState.createFromText(text),
-    );
-  }
-  const prevEditorState = usePrevious(editorState);
-  if (prevText === text) {
-    return prevEditorState;
-  }
-  return editorState;
-};
 
 /*
  * Proxy the new redux state of roles to the old structure of founder and


### PR DESCRIPTION
## Description

This PR aims to fix the description field sometimes not rendering properly. We stored the state of the field as an `EditorState` object in formik which caused all sorts of troubles (when comparing it to the data before, etc.). With the change we're storing it as a `string` now when the user blurs out of the field. This should give formik the opportunity to compare the old and new values properly.

**Changes** 🏗

* Store `MultiLineEdit` state as a string in formik
* Convert `MultiLineEdit` into a functional component

**Deletions** ⚰️

* Remove `useInitEditorState` hook

Resolves #1740 
