### PR TITLE
Add domain dropdown to colony admin tokens

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,6 +1,8 @@
 {
     "home": "Home",
     "wallet": "Wallet",
+    "domain.all": "All Domains",
+    "domain.root": "root",
     "role.disabled": "Disabled",
     "role.member": "Member",
     "role.admin": "Admin",

--- a/src/modules/admin/components/Tokens/FundingBanner.css
+++ b/src/modules/admin/components/Tokens/FundingBanner.css
@@ -1,0 +1,16 @@
+.main {
+  padding: 30px 0 0;
+  border-top: 1px solid var(--temp-grey-5);
+  font-size: var(--size-normal);
+  text-align: center;
+}
+
+.address {
+  margin-top: 10px;
+  font-family: var(--family-monospace);
+  font-weight: var(--weight-medium);
+}
+
+.address > span + span {
+  margin-left: 10px;
+}

--- a/src/modules/admin/components/Tokens/FundingBanner.css.d.ts
+++ b/src/modules/admin/components/Tokens/FundingBanner.css.d.ts
@@ -1,0 +1,2 @@
+export const main: string;
+export const address: string;

--- a/src/modules/admin/components/Tokens/FundingBanner.tsx
+++ b/src/modules/admin/components/Tokens/FundingBanner.tsx
@@ -1,0 +1,51 @@
+import React, { useMemo } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import MaskedAddress from '~core/MaskedAddress';
+import { Address } from '~types/index';
+import { splitAddress } from '~utils/strings';
+
+import styles from './FundingBanner.css';
+
+const MSG = defineMessages({
+  tipText: {
+    id: 'admin.Tokens.FundingBanner.tipText',
+    defaultMessage: `Tip: to fund your colony, send tokens to your colony's address:`,
+  },
+});
+
+interface Props {
+  colonyAddress: Address;
+}
+
+const displayName = 'admin.Tokens.FundingBanner';
+
+const FundingBanner = ({ colonyAddress }: Props) => {
+  const formattedAddress = useMemo(() => {
+    const addressElements = splitAddress(colonyAddress);
+    if (!(addressElements instanceof Error)) {
+      return (
+        <div className={styles.address}>
+          <span>
+            {addressElements.header}
+            {addressElements.start}
+          </span>
+          <span>{addressElements.middle}</span>
+          <span>{addressElements.end}</span>
+        </div>
+      );
+    }
+    return <MaskedAddress address={colonyAddress} />;
+  }, [colonyAddress]);
+
+  return (
+    <div className={styles.main}>
+      <FormattedMessage {...MSG.tipText} />
+      {formattedAddress}
+    </div>
+  );
+};
+
+FundingBanner.displayName = displayName;
+
+export default FundingBanner;

--- a/src/modules/admin/components/Tokens/TokenCard.css
+++ b/src/modules/admin/components/Tokens/TokenCard.css
@@ -31,6 +31,10 @@
   color: var(--grey-dark);
 }
 
+.nativeTokenText {
+  color: var(--grey-3);
+}
+
 .balanceContent {
   display: flex;
   justify-content: center;

--- a/src/modules/admin/components/Tokens/TokenCard.css.d.ts
+++ b/src/modules/admin/components/Tokens/TokenCard.css.d.ts
@@ -3,6 +3,7 @@ export const main: string;
 export const cardHeading: string;
 export const iconContainer: string;
 export const tokenSymbol: string;
+export const nativeTokenText: string;
 export const balanceContent: string;
 export const balanceNumeral: string;
 export const balanceNotPositive: string;

--- a/src/modules/admin/components/Tokens/TokenCard.tsx
+++ b/src/modules/admin/components/Tokens/TokenCard.tsx
@@ -30,6 +30,10 @@ interface Props<T> {
 const displayName = 'admin.Tokens.TokenCard';
 
 const MSG = defineMessages({
+  nativeToken: {
+    id: 'dashboard.TokenCard.nativeToken',
+    defaultMessage: ' (Native Token)',
+  },
   unknownToken: {
     id: 'admin.TokenCard.unknownToken',
     defaultMessage: 'Unknown Token',
@@ -80,7 +84,9 @@ const TokenCard = <
           )}
           {'isNative' in tokenReference &&
             (tokenReference as ColonyTokenReferenceType).isNative && (
-              <span>*</span>
+              <span className={styles.nativeTokenText}>
+                <FormattedMessage {...MSG.nativeToken} />
+              </span>
             )}
         </div>
       </div>

--- a/src/modules/admin/components/Tokens/TokenList.tsx
+++ b/src/modules/admin/components/Tokens/TokenList.tsx
@@ -21,6 +21,8 @@ interface Props<T> {
   tokens: T[];
 }
 
+const displayName = 'admin.Tokens.TokenList';
+
 const TokenList = <
   T extends ColonyTokenReferenceType | UserTokenReferenceType
 >({
@@ -49,5 +51,7 @@ const TokenList = <
     </CardList>
   </div>
 );
+
+TokenList.displayName = displayName;
 
 export default TokenList;

--- a/src/modules/admin/components/Tokens/Tokens.css
+++ b/src/modules/admin/components/Tokens/Tokens.css
@@ -1,7 +1,14 @@
 .main {
   display: grid;
+  height: 100%;
   grid-template-columns: minmax(700px, auto) 180px;
+  grid-template-rows: 1fr;
   column-gap: 80px;
+}
+
+.main main {
+  display: flex;
+  flex-direction: column;
 }
 
 .titleContainer {
@@ -17,4 +24,8 @@
 
 .sidebar li {
   padding: 10px 0;
+}
+
+.mainContent {
+  flex: 1;
 }

--- a/src/modules/admin/components/Tokens/Tokens.css.d.ts
+++ b/src/modules/admin/components/Tokens/Tokens.css.d.ts
@@ -1,3 +1,4 @@
 export const main: string;
 export const titleContainer: string;
 export const sidebar: string;
+export const mainContent: string;

--- a/src/modules/admin/components/Tokens/Tokens.tsx
+++ b/src/modules/admin/components/Tokens/Tokens.tsx
@@ -27,10 +27,6 @@ const MSG = defineMessages({
     id: 'dashboard.Tokens.labelSelectDomain',
     defaultMessage: 'Select a domain',
   },
-  nativeTokenText: {
-    id: 'dashboard.Tokens.nativeTokenText',
-    defaultMessage: '*Native token: {nativeToken}',
-  },
   navItemMintNewTokens: {
     id: 'dashboard.Tokens.navItemMintNewTokens',
     defaultMessage: 'Mint New tokens',

--- a/src/modules/admin/components/Tokens/Tokens.tsx
+++ b/src/modules/admin/components/Tokens/Tokens.tsx
@@ -40,7 +40,10 @@ const MSG = defineMessages({
   },
   title: {
     id: 'dashboard.Tokens.title',
-    defaultMessage: 'Token Balances',
+    defaultMessage: `Tokens{domainLabel, select,
+      root {}
+      other {: {domainLabel}} 
+    }`,
   },
 });
 
@@ -73,6 +76,11 @@ const Tokens = ({ canMintNativeToken, colonyAddress, openDialog }: Props) => {
       })),
     ],
     [domainsData],
+  );
+
+  const domainLabel = useMemo(
+    () => domains.find(({ value }) => value === selectedDomain).label,
+    [domains, selectedDomain],
   );
 
   const setFieldValue = useCallback((_, value) => setSelectedDomain(value), [
@@ -117,6 +125,7 @@ const Tokens = ({ canMintNativeToken, colonyAddress, openDialog }: Props) => {
         <div className={styles.titleContainer}>
           <Heading
             text={MSG.title}
+            textValues={{ domainLabel }}
             appearance={{ size: 'medium', theme: 'dark' }}
           />
           {isFetchingDomains ? (

--- a/src/modules/admin/components/Tokens/Tokens.tsx
+++ b/src/modules/admin/components/Tokens/Tokens.tsx
@@ -39,10 +39,7 @@ const MSG = defineMessages({
   },
   title: {
     id: 'dashboard.Tokens.title',
-    defaultMessage: `Tokens{domainLabel, select,
-      root {}
-      other {: {domainLabel}} 
-    }`,
+    defaultMessage: 'Tokens: {selectedDomainLabel}',
   },
 });
 
@@ -84,7 +81,7 @@ const Tokens = ({
     [domainsData],
   );
 
-  const domainLabel: string = useMemo(() => {
+  const selectedDomainLabel: string = useMemo(() => {
     const { label = '' } =
       domains.find(({ value }) => value === selectedDomain) || {};
     return typeof label === 'string' ? label : formatMessage(label);
@@ -132,7 +129,7 @@ const Tokens = ({
           <div className={styles.titleContainer}>
             <Heading
               text={MSG.title}
-              textValues={{ domainLabel }}
+              textValues={{ selectedDomainLabel }}
               appearance={{ size: 'medium', theme: 'dark' }}
             />
             {isFetchingDomains ? (

--- a/src/modules/admin/components/Tokens/Tokens.tsx
+++ b/src/modules/admin/components/Tokens/Tokens.tsx
@@ -17,6 +17,7 @@ import { useColonyNativeToken } from '../../../dashboard/hooks/useColonyNativeTo
 import { useColonyTokens } from '../../../dashboard/hooks/useColonyTokens';
 import { walletAddressSelector } from '../../../users/selectors';
 import { canEditTokens } from '../../checks';
+import FundingBanner from './FundingBanner';
 import TokenList from './TokenList';
 
 import styles from './Tokens.css';
@@ -78,10 +79,11 @@ const Tokens = ({ canMintNativeToken, colonyAddress, openDialog }: Props) => {
     [domainsData],
   );
 
-  const domainLabel = useMemo(
-    () => domains.find(({ value }) => value === selectedDomain).label,
-    [domains, selectedDomain],
-  );
+  const domainLabel = useMemo(() => {
+    const { label = '' } =
+      domains.find(({ value }) => value === selectedDomain) || {};
+    return label;
+  }, [domains, selectedDomain]);
 
   const setFieldValue = useCallback((_, value) => setSelectedDomain(value), [
     setSelectedDomain,
@@ -122,34 +124,39 @@ const Tokens = ({ canMintNativeToken, colonyAddress, openDialog }: Props) => {
   return (
     <div className={styles.main}>
       <main>
-        <div className={styles.titleContainer}>
-          <Heading
-            text={MSG.title}
-            textValues={{ domainLabel }}
-            appearance={{ size: 'medium', theme: 'dark' }}
-          />
-          {isFetchingDomains ? (
-            <SpinnerLoader />
-          ) : (
-            <Select
-              appearance={{ alignOptions: 'right', theme: 'alt' }}
-              connect={false}
-              elementOnly
-              label={MSG.labelSelectDomain}
-              name="selectDomain"
-              options={domains}
-              form={{ setFieldValue }}
-              $value={selectedDomain}
+        <div className={styles.mainContent}>
+          <div className={styles.titleContainer}>
+            <Heading
+              text={MSG.title}
+              textValues={{ domainLabel }}
+              appearance={{ size: 'medium', theme: 'dark' }}
+            />
+            {isFetchingDomains ? (
+              <SpinnerLoader />
+            ) : (
+              <Select
+                appearance={{ alignOptions: 'right', theme: 'alt' }}
+                connect={false}
+                elementOnly
+                label={MSG.labelSelectDomain}
+                name="selectDomain"
+                options={domains}
+                form={{ setFieldValue }}
+                $value={selectedDomain}
+              />
+            )}
+          </div>
+          {tokens && (
+            <TokenList
+              domainId={selectedDomain}
+              tokens={tokens}
+              appearance={{ numCols: '3' }}
             />
           )}
         </div>
-        {tokens && (
-          <TokenList
-            domainId={selectedDomain}
-            tokens={tokens}
-            appearance={{ numCols: '3' }}
-          />
-        )}
+        <div>
+          <FundingBanner colonyAddress={colonyAddress} />
+        </div>
       </main>
       <aside className={styles.sidebar}>
         <ul>


### PR DESCRIPTION
## Description

This PR adds the ability to view token balances by domain. It also adds a nifty tip for users, providing the colony address so they can fund their colony.

**New stuff** ✨

* `FundingBanner` component

**Changes** 🏗

* Render `FundingBanner` in the `Tokens` component
* Fetch domains, populate `Select` with results
* Dynamic title based on selected domain (if any)

**Deletions** ⚰️

* N/A (yet)

## TODO

- [x] Show token balances by selected domain (after #1768 is merged)
- [x] Find a new location for the asterisk text (`*Native Token: TKN`)

Resolves #1769 
Resolves #1859
