### PR TITLE
Prevent names with periods (dots) when registering a ENS domain

### DIFF
--- a/src/lib/TextDecorator/schemas.ts
+++ b/src/lib/TextDecorator/schemas.ts
@@ -1,8 +1,7 @@
 /* eslint import/prefer-default-export: 0 */
 
-import { ENS_DOMAIN_REGEX } from '../../modules/validations';
-
 const USER_PREFIX = '@';
+const ENS_DOMAIN_REGEX = '^([A-Za-z0-9](?:[A-Za-z0-9-.]{0,255}[A-Za-z0-9])?)';
 
 export const USERNAME_SCHEMA = {
   prefix: USER_PREFIX,

--- a/src/modules/validations.ts
+++ b/src/modules/validations.ts
@@ -14,8 +14,7 @@ import en from '../i18n/en-validation.json';
 yup.setLocale(en);
 
 // eslint-disable-next-line import/prefer-default-export
-export const ENS_DOMAIN_REGEX =
-  '^([A-Za-z0-9](?:[A-Za-z0-9-.]{0,255}[A-Za-z0-9])?)';
+export const ENS_DOMAIN_REGEX = '^[A-Za-z0-9][^.]{1,255}$';
 
 /* Custom validators */
 function equalTo(ref, msg) {

--- a/src/modules/validations.ts
+++ b/src/modules/validations.ts
@@ -13,6 +13,14 @@ import en from '../i18n/en-validation.json';
 
 yup.setLocale(en);
 
+/*
+ * The ens domain regex is composed of
+ * ^ start match
+ * [A-Za-z0-9] allow upper case, lower case, numerals
+ * [^.] negate to not allow dots / periods
+ * {1,255} match at least 1 and at most 255 chars
+ * $ end match
+ */
 // eslint-disable-next-line import/prefer-default-export
 export const ENS_DOMAIN_REGEX = '^[A-Za-z0-9][^.]{1,255}$';
 


### PR DESCRIPTION
## Description

This PR fixes the Colony Wizard and the User wizard by preventing the validation of usernames that contain a dot `.` in them.

While at it, I also simplified the ENS domain regex to be more read-able:
- `^` start matching
- `[A-Za-z0-9]` allow upper  case, lower case, numerals
- `[^.]` negate to not allow dots / periods
- `{1,255}` match at least `1` and at most `255` chars
- `$` end matching

**Changes** 

- [x] `ensAddress` yup validator regex doesn't allow dots `.` any more

**Screenshots**

![Screenshot from 2019-09-05 17-18-31](https://user-images.githubusercontent.com/1193222/64350448-59b3a180-d001-11e9-95bc-72dd2c737e24.png)

![Screenshot from 2019-09-05 17-18-39](https://user-images.githubusercontent.com/1193222/64350449-5a4c3800-d001-11e9-83b5-04e946d9ce18.png)

Resolves #1798 