### PR TITLE
Add colony admin "add domain" hint

### DIFF
--- a/src/modules/admin/components/Organizations/OrganizationAddDomains.tsx
+++ b/src/modules/admin/components/Organizations/OrganizationAddDomains.tsx
@@ -18,6 +18,10 @@ const MSG = defineMessages({
     id: 'admin.Organizations.OrganizationAddDomains.labelAddDomain',
     defaultMessage: 'Add New Domain',
   },
+  helpText: {
+    id: 'admin.Organizations.OrganizationAddDomains.helpText',
+    defaultMessage: 'This cannot be undone',
+  },
   placeholderAddAdmins: {
     id: 'admin.Organizations.OrganizationAddDomains.placeholderAddAdmins',
     defaultMessage: 'Search for a user or paste a wallet address',
@@ -60,11 +64,16 @@ const OrganizationAddDomains = ({ colonyAddress }: Props) => {
         {({ status, isSubmitting, isValid }) => (
           <div className={styles.inputWrapper}>
             <div className={styles.domainInput}>
-              <Input name="domainName" label={MSG.labelAddDomain} />
+              <Input
+                appearance={{ helpAlign: 'right', theme: 'fat' }}
+                help={MSG.helpText}
+                label={MSG.labelAddDomain}
+                name="domainName"
+              />
             </div>
             <div className={styles.submitButton}>
               <Button
-                appearance={{ theme: 'primary', size: 'medium' }}
+                appearance={{ theme: 'primary', size: 'large' }}
                 style={{ width: styles.wideButton }}
                 text={MSG.buttonAddDomain}
                 type="submit"

--- a/src/modules/admin/components/Profile/ColonyAvatarUploader.tsx
+++ b/src/modules/admin/components/Profile/ColonyAvatarUploader.tsx
@@ -17,7 +17,7 @@ const MSG = defineMessages({
   },
   labelUploader: {
     id: 'admin.Profile.ColonyAvatarUploader.labelUploader',
-    defaultMessage: 'at least 250px by 250px, up to 1MB',
+    defaultMessage: '(at least 250px by 250px, up to 1MB)',
   },
 });
 

--- a/src/modules/admin/components/Profile/ProfileEdit.tsx
+++ b/src/modules/admin/components/Profile/ProfileEdit.tsx
@@ -28,7 +28,7 @@ const MSG = defineMessages({
   },
   sendTokens: {
     id: 'admin.Profile.ProfileEdit.sendTokens',
-    defaultMessage: 'Send tokens to this address to fund your colony',
+    defaultMessage: '(Send tokens to this address to fund your colony)',
   },
   labelEnsName: {
     id: 'admin.Profile.ProfileEdit.labelEnsName',

--- a/src/modules/core/components/AvatarUploader/AvatarUploader.md
+++ b/src/modules/core/components/AvatarUploader/AvatarUploader.md
@@ -10,7 +10,7 @@ const upload = (file) => new Promise(resolve => setTimeout(resolve, 3000));
 
 <AvatarUploader
   label="Upload your avatar!"
-  help="It must be at least 250px by 250px"
+  help="(It must be at least 250px by 250px)"
   placeholder={
     <UserAvatar
       size="xl"

--- a/src/modules/core/components/Fields/Input/Input.tsx
+++ b/src/modules/core/components/Fields/Input/Input.tsx
@@ -14,6 +14,7 @@ interface Appearance {
   align?: 'right';
   direction?: 'horizontal';
   colorSchema?: 'dark' | 'grey' | 'transparent';
+  helpAlign?: 'right';
   size?: 'small';
 }
 

--- a/src/modules/core/components/Fields/InputLabel/InputLabel.css
+++ b/src/modules/core/components/Fields/InputLabel/InputLabel.css
@@ -50,6 +50,16 @@
   color: var(--text);
 }
 
+.helpAlignRight {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.helpAlignRight .help .paren {
+  display: none;
+}
+
 .extra {
   position: absolute;
   top: 0;

--- a/src/modules/core/components/Fields/InputLabel/InputLabel.css
+++ b/src/modules/core/components/Fields/InputLabel/InputLabel.css
@@ -56,10 +56,6 @@
   align-items: baseline;
 }
 
-.helpAlignRight .help .paren {
-  display: none;
-}
-
 .extra {
   position: absolute;
   top: 0;

--- a/src/modules/core/components/Fields/InputLabel/InputLabel.css.d.ts
+++ b/src/modules/core/components/Fields/InputLabel/InputLabel.css.d.ts
@@ -7,4 +7,6 @@ export const colorSchemaDark: string;
 export const labelText: string;
 export const error: string;
 export const help: string;
+export const helpAlignRight: string;
+export const paren: string;
 export const extra: string;

--- a/src/modules/core/components/Fields/InputLabel/InputLabel.css.d.ts
+++ b/src/modules/core/components/Fields/InputLabel/InputLabel.css.d.ts
@@ -8,5 +8,4 @@ export const labelText: string;
 export const error: string;
 export const help: string;
 export const helpAlignRight: string;
-export const paren: string;
 export const extra: string;

--- a/src/modules/core/components/Fields/InputLabel/InputLabel.md
+++ b/src/modules/core/components/Fields/InputLabel/InputLabel.md
@@ -7,5 +7,5 @@
 ### Input label with help text
 
 ```js
-<InputLabel label="Label text" help="With a little help from my friends" />
+<InputLabel label="Label text" help="(With a little help from my friends)" />
 ```

--- a/src/modules/core/components/Fields/InputLabel/InputLabel.tsx
+++ b/src/modules/core/components/Fields/InputLabel/InputLabel.tsx
@@ -15,6 +15,7 @@ interface Appearance {
   readonly theme: 'fat' | 'underlined' | 'minimal' | 'dotted';
   readonly direction: 'horizontal';
   readonly colorSchema: 'dark' | 'grey' | 'transparent';
+  readonly helpAlign: 'right';
   readonly size: 'small';
 }
 
@@ -50,6 +51,7 @@ const InputLabel = ({
     theme: undefined,
     colorSchema: undefined,
     direction: undefined,
+    helpAlign: undefined,
     size: undefined,
   },
   help,
@@ -73,7 +75,13 @@ const InputLabel = ({
       htmlFor={inputId || null}
     >
       <span className={styles.labelText}>{labelText}</span>
-      {helpText && <span className={styles.help}>({helpText})</span>}
+      {helpText && (
+        <span className={styles.help}>
+          <span className={styles.paren}>(</span>
+          {helpText}
+          <span className={styles.paren}>)</span>
+        </span>
+      )}
       {extra && <span className={styles.extra}>{extra}</span>}
     </label>
   );

--- a/src/modules/core/components/Fields/InputLabel/InputLabel.tsx
+++ b/src/modules/core/components/Fields/InputLabel/InputLabel.tsx
@@ -75,13 +75,7 @@ const InputLabel = ({
       htmlFor={inputId || null}
     >
       <span className={styles.labelText}>{labelText}</span>
-      {helpText && (
-        <span className={styles.help}>
-          <span className={styles.paren}>(</span>
-          {helpText}
-          <span className={styles.paren}>)</span>
-        </span>
-      )}
+      {helpText && <span className={styles.help}>{helpText}</span>}
       {extra && <span className={styles.extra}>{extra}</span>}
     </label>
   );

--- a/src/modules/core/components/Fields/InputLabel/__tests__/InputLabel.test.tsx
+++ b/src/modules/core/components/Fields/InputLabel/__tests__/InputLabel.test.tsx
@@ -25,6 +25,6 @@ describe('InputLabel intl={intl} component', () => {
     const wrapper = shallowWithIntl(
       <InputLabel id="foo" help="halp" label="awesome" />,
     );
-    expect(wrapper.html()).toContain('(halp)');
+    expect(wrapper.html()).toContain('<span>(</span>halp<span>)</span>');
   });
 });

--- a/src/modules/core/components/Fields/InputLabel/__tests__/InputLabel.test.tsx
+++ b/src/modules/core/components/Fields/InputLabel/__tests__/InputLabel.test.tsx
@@ -23,8 +23,8 @@ describe('InputLabel intl={intl} component', () => {
 
   test('If error is false, and help is true, returns help field', () => {
     const wrapper = shallowWithIntl(
-      <InputLabel id="foo" help="halp" label="awesome" />,
+      <InputLabel id="foo" help="(halp)" label="awesome" />,
     );
-    expect(wrapper.html()).toContain('<span>(</span>halp<span>)</span>');
+    expect(wrapper.html()).toContain('(halp)');
   });
 });

--- a/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.tsx
@@ -40,11 +40,11 @@ const MSG = defineMessages({
   },
   helpTokenSymbol: {
     id: 'dashboard.CreateColonyWizard.StepCreateToken.helpTokenSymbol',
-    defaultMessage: 'e.g., MAT, AMEX',
+    defaultMessage: '(e.g., MAT, AMEX)',
   },
   helpTokenName: {
     id: 'dashboard.CreateColonyWizard.StepCreateToken.helpTokenName',
-    defaultMessage: 'e.g., My Awesome Token',
+    defaultMessage: '(e.g., My Awesome Token)',
   },
   labelTokenIcon: {
     id: 'dashboard.CreateColonyWizard.StepCreateToken.labelTokenIcon',

--- a/src/modules/dashboard/components/TaskRatingDialogs/ManagerRatingDialog.tsx
+++ b/src/modules/dashboard/components/TaskRatingDialogs/ManagerRatingDialog.tsx
@@ -40,8 +40,9 @@ const MSG = defineMessages({
   },
   workDescriptionHelp: {
     id: 'dashboard.ManagerRatingDialog.workDescriptionHelp',
-    defaultMessage:
-      'Please enter a short description or URL of the work you are submitting',
+    defaultMessage: `
+      (Please enter a short description or URL of the work you are submitting)
+    `,
   },
   workDescriptionError: {
     id: 'dashboard.ManagerRatingDialog.workDescriptionError',

--- a/src/modules/users/components/ConnectWalletWizard/StepJSONUpload/StepJSONUpload.tsx
+++ b/src/modules/users/components/ConnectWalletWizard/StepJSONUpload/StepJSONUpload.tsx
@@ -27,7 +27,7 @@ const MSG = defineMessages({
   },
   fileUploadHelp: {
     id: 'users.ConnectWalletWizard.StepJSONUpload.fileUploadHelp',
-    defaultMessage: '.json',
+    defaultMessage: '(.json)',
   },
   filePasswordLabel: {
     id: 'users.ConnectWalletWizard.StepJSONUpload.filePasswordLabel',
@@ -35,7 +35,7 @@ const MSG = defineMessages({
   },
   filePasswordHelp: {
     id: 'users.ConnectWalletWizard.StepJSONUpload.filePasswordHelp',
-    defaultMessage: 'Optional',
+    defaultMessage: '(Optional)',
   },
   errorKeystore: {
     id: 'users.ConnectWalletWizard.StepJSONUpload.errorKeystore',


### PR DESCRIPTION
## Description

This PR adds some hint text to the "Add domain" input in the colony admin.

**New stuff** ✨

* `helpAlign` appearance prop for `Input`

**Changes** 🏗

* Update unit test `.expect`
* Increase size of `Input` and `Button` to match figma

Resolves #1814 