### PR TITLE
TransactionDetails defaults for not-yet-loaded data

### DIFF
--- a/src/modules/core/components/TransactionList/TransactionDetails.tsx
+++ b/src/modules/core/components/TransactionList/TransactionDetails.tsx
@@ -1,17 +1,21 @@
 import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
-import { useDataSubscriber } from '~utils/hooks';
-import { colonySubscriber } from '../../../dashboard/subscribers';
-import MaskedAddress from '~core/MaskedAddress';
-import Link from '~core/Link';
-import { Address, ENSName } from '~types/index';
 import {
+  UserRecord,
+  ColonyRecord,
+  TaskRecord,
   ColonyType,
   ContractTransactionType,
   TaskType,
   UserProfileType,
 } from '~immutable/index';
+import { useDataSubscriber } from '~utils/hooks';
+import { colonySubscriber } from '../../../dashboard/subscribers';
+import MaskedAddress from '~core/MaskedAddress';
+import Link from '~core/Link';
+import { Address, ENSName } from '~types/index';
+
 import styles from './TransactionDetails.css';
 
 const MSG = defineMessages({
@@ -48,7 +52,11 @@ interface HookedProps extends Props {
 }
 
 const UserDetails = ({
-  user: { displayName: userDisplayName = '', username = '', walletAddress },
+  user: {
+    displayName: userDisplayName = '',
+    username = '',
+    walletAddress,
+  } = UserRecord().profile,
   address = walletAddress,
   showMaskedAddress,
 }: {
@@ -68,7 +76,10 @@ const UserDetails = ({
 );
 
 const ColonyDetails = ({
-  colony: { displayName: colonyDisplayName, colonyAddress },
+  colony: {
+    displayName: colonyDisplayName,
+    colonyAddress,
+  } = ColonyRecord().toJS(),
   address = colonyAddress,
   showMaskedAddress,
 }: {
@@ -88,7 +99,7 @@ const ColonyDetails = ({
 
 const TaskDetails = ({
   colonyName,
-  task: { draftId, title },
+  task: { draftId, title } = TaskRecord().toJS(),
 }: {
   task: TaskType;
   colonyName: ENSName;


### PR DESCRIPTION
## Description

This PR is a simple fix for instances where the Transactions Lists wants to render, but the data for either a user, a colony or a task hasn't loaded yet from the store.

To fix it, we're just defaulting the destructuring assignment to it's respective immutable record:
- `UserRecord`
- `ColonyRecord`
- `TaskRecord`

**Changes**

- [x] `TransactionDetails` default colony, user, task to they're respective immutable records

Resolves #1812 