### PR TITLE
TransactionLink account for both mainnet and homestead network names

### DIFF
--- a/src/modules/core/components/TransactionLink/TransactionLink.tsx
+++ b/src/modules/core/components/TransactionLink/TransactionLink.tsx
@@ -35,7 +35,8 @@ const TransactionLink = ({
 }: Props) => {
   const linkText = text || hash;
   const tld = network === 'tobalaba' ? 'com' : 'io';
-  const networkSubdomain = network === 'homestead' ? '' : `${network}.`;
+  const networkSubdomain =
+    network === 'homestead' || network === 'mainnet' ? '' : `${network}.`;
   const href = `https://${networkSubdomain}etherscan.${tld}/tx/${hash}`;
   return (
     <ExternalLink


### PR DESCRIPTION
## Description

This PR fixes the wrong link that would show up in the completed transaction info card.

This happened because one of our core components, `TransactionLink` would only expect main net to be referred to as `homestead`, and would only strip the sub-domain for that. _(since Etherscan uses the root domain for this case)_

But the way we're deploying the dApp, we're referring to it as plain `mainnet`, and since that wasn't accounted for, it would get appended as a sub-domain.

The fix here is just to account for both versions.

**Changes** 

- [x] `TransactionLink` take into account both `homestead` and `mainnet` when generating the network subdomain

Resolves #1802 