### PR TITLE
Reset task comment field on success

### DIFF
--- a/src/modules/core/components/Fields/Form/ActionForm.tsx
+++ b/src/modules/core/components/Fields/Form/ActionForm.tsx
@@ -19,8 +19,16 @@ const MSG = defineMessages({
 
 const displayName = 'Form.ActionForm';
 
-type OnError = (error: any, bag: FormikBag<any, any>, values?: any) => void;
-type OnSuccess = (result: any, bag: FormikBag<any, any>, values: any) => void;
+export type OnError = (
+  error: any,
+  bag: FormikBag<any, any>,
+  values?: any,
+) => void;
+export type OnSuccess = (
+  result: any,
+  bag: FormikBag<any, any>,
+  values: any,
+) => void;
 
 interface ExtendedFormikConfig {
   validateOnChange?: boolean;

--- a/src/modules/dashboard/components/TaskComments/TaskComments.tsx
+++ b/src/modules/dashboard/components/TaskComments/TaskComments.tsx
@@ -10,6 +10,7 @@ import { Address, ENTER } from '~types/index';
 import { ActionTypes } from '~redux/index';
 import withDialog from '~core/Dialog/withDialog';
 import { ActionForm, TextareaAutoresize } from '~core/Fields';
+import { OnSuccess } from '~core/Fields/Form/ActionForm';
 import Button from '~core/Button';
 import unfinishedProfileOpener from '~users/UnfinishedProfile';
 
@@ -86,6 +87,14 @@ const TaskComments = ({
 }: Props) => {
   const didClaimProfile = userDidClaimProfile(currentUser);
 
+  const onSuccess: OnSuccess = useCallback(
+    (result, { resetForm, setStatus }) => {
+      setStatus({});
+      resetForm({ comment: '' });
+    },
+    [],
+  );
+
   const transform = useCallback(
     mergePayload({ colonyAddress, author: walletAddress, draftId, taskTitle }),
     [colonyAddress, draftId],
@@ -122,6 +131,7 @@ const TaskComments = ({
         error={ActionTypes.TASK_COMMENT_ADD_ERROR}
         initialValues={{ comment: '' }}
         validationSchema={validationSchema}
+        onSuccess={onSuccess}
         transform={transform}
       >
         {({


### PR DESCRIPTION
## Description

This PR uses the `onSuccess` prop to reset the comment form. It's not clear how this behaviour was originally working, because other fields (e.g. task title, task description) operate on the basis of the form not being reset on success, so that the value is always visible.

**Changes** 🏗

* Reset the task comment field on success with the `onSuccess` prop
* Export the `OnSuccess` and `OnError` types from `ActionForm`

Resolves #1822 
