### PR TITLE
User Wallet proper component import

### DIFF
--- a/src/modules/dashboard/components/Wallet/index.ts
+++ b/src/modules/dashboard/components/Wallet/index.ts
@@ -1,3 +1,4 @@
 // @ts-ignore
-export { default } from './Wallet.tsx';
+export { default } from './Wallet.ts';
+
 export { default as UserTokenEditDialog } from './UserTokenEditDialog';

--- a/src/modules/validations.ts
+++ b/src/modules/validations.ts
@@ -18,11 +18,11 @@ yup.setLocale(en);
  * ^ start match
  * [A-Za-z0-9] allow upper case, lower case, numerals
  * [^.] negate to not allow dots / periods
- * {1,255} match at least 1 and at most 255 chars
+ * {0,255} match at least 1 and at most 255 chars
  * $ end match
  */
 // eslint-disable-next-line import/prefer-default-export
-export const ENS_DOMAIN_REGEX = '^[A-Za-z0-9][^.]{1,255}$';
+export const ENS_DOMAIN_REGEX = '^[A-Za-z0-9][^.]{0,255}$';
 
 /* Custom validators */
 function equalTo(ref, msg) {


### PR DESCRIPTION
## Description

This PR fixes a error reported by a user where the wallet address would not be displayed on the full screen wallet route.

Turns out that was due to the HoC not being imported anymore and as such not providing the `walletAddress` value to the underlying component.

Also, why I was at it, I fixed a error I introduced recently in #1810 that wouldn't allow you create single letter ENS usernames anymore. This was because the regex selector I used expected at least two valid characters before passing. 

I fixed this here as well.

**Changes**

- [x] dashboard `Wallet` import HoC component
- [x] dashboard validations allow single letter ENS name

**Screenshot**

![Screenshot from 2019-09-12 12-32-06](https://user-images.githubusercontent.com/1193222/64773089-6f255000-d55a-11e9-9073-4a951c41d74f.png)

Resolves #1824 