### PR TITLE
Automatically build and push dapp images on successful builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,7 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install google-cloud-sdk
       - run: bash ./scripts/authGoogle.sh
       - run: gcloud docker -- push eu.gcr.io/${PROJECT_NAME}/dapp-goerli:$CIRCLE_SHA1
-  build-deploy-mainnet-image:
+  build-mainnet-image:
     docker:
       - image: circleci/node:10.16.3
     working_directory: ~/repo
@@ -245,7 +245,6 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install google-cloud-sdk
       - run: bash ./scripts/authGoogle.sh
       - run: gcloud docker -- push eu.gcr.io/${PROJECT_NAME}/dapp-mainnet:$CIRCLE_SHA1
-      - run: kubectl patch deployment dapp-red -p '{"spec":{"template":{"spec":{"containers":[{"name":"dapp","image":"eu.gcr.io/${PROJECT_NAME}/dapp-mainnet:${CIRCLE_SHA1}"}]}}}}'
   deploy-styleguide:
     docker:
       - image: circleci/node:10.16.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,6 +195,57 @@ jobs:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "yarn.lock" }}
+  build-goerli-image:
+    docker:
+      - image: circleci/node:10.16.3
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - setup_remote_docker
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "yarn.lock" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+      - run: yarn install
+      - attach_workspace:
+          at: .
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "yarn.lock" }}
+      - run: docker build --build-arg COLONY_NETWORK_ENS_NAME='joincolony.test' --build-arg VERBOSE='true' --build-arg PINNING_ROOM='PINION_DEV_ROOM' --build-arg CHAIN_ID=5 --build-arg INFURA_ID='fe7e19c85e574235a06296de102d16ef' --build-arg NETWORK='goerli' --no-cache -t eu.gcr.io/${PROJECT_NAME}/dapp-goerli:$CIRCLE_SHA1 .
+      - run: echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+      - run: curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+      - run: sudo apt-get update && sudo apt-get install google-cloud-sdk
+      - run: bash ./scripts/authGoogle.sh
+      - run: gcloud docker -- push eu.gcr.io/${PROJECT_NAME}/dapp-goerli:$CIRCLE_SHA1
+  build-deploy-mainnet-image:
+    docker:
+      - image: circleci/node:10.16.3
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - setup_remote_docker
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "yarn.lock" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+      - run: yarn install
+      - attach_workspace:
+          at: .
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "yarn.lock" }}
+      - run: docker build --build-arg COLONY_NETWORK_ENS_NAME='joincolony.eth' --build-arg VERBOSE='true' --build-arg PINNING_ROOM='COLONY' --build-arg CHAIN_ID=1 --build-arg INFURA_ID='fe7e19c85e574235a06296de102d16ef' --build-arg NETWORK='mainnet' --no-cache -t eu.gcr.io/${PROJECT_NAME}/dapp-mainnet:$CIRCLE_SHA1 .
+      - run: echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+      - run: curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+      - run: sudo apt-get update && sudo apt-get install google-cloud-sdk
+      - run: bash ./scripts/authGoogle.sh
+      - run: gcloud docker -- push eu.gcr.io/${PROJECT_NAME}/dapp-mainnet:$CIRCLE_SHA1
+      - run: kubectl patch deployment dapp-red -p '{"spec":{"template":{"spec":{"containers":[{"name":"dapp","image":"eu.gcr.io/${PROJECT_NAME}/dapp-mainnet:${CIRCLE_SHA1}"}]}}}}'
   deploy-styleguide:
     docker:
       - image: circleci/node:10.16.3
@@ -236,6 +287,23 @@ workflows:
           filters:
             branches:
               only: master
+      - build-goerli-image:
+          requires:
+            - build-with-lockfile
+            - integration-testing
+            - e2e-testing
+          filters:
+            branches:
+              ignore: master
+      - build-deploy-mainnet-image:
+          requires:
+            - build-with-lockfile
+            - integration-testing
+            - e2e-testing
+          filters:
+            branches:
+              only: master
+
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,7 +294,7 @@ workflows:
           filters:
             branches:
               ignore: master
-      - build-deploy-mainnet-image:
+      - build-mainnet-image:
           requires:
             - build-with-lockfile
             - integration-testing

--- a/scripts/authGoogle.sh
+++ b/scripts/authGoogle.sh
@@ -1,0 +1,10 @@
+echo $GCLOUD_SERVICE_KEY | base64 --decode > ${HOME}/gcloud-service-key.json
+sudo apt-get install kubectl
+gcloud auth activate-service-account --key-file ${HOME}/gcloud-service-key.json
+ gcloud config set project $PROJECT_NAME
+gcloud --quiet config set container/cluster $CLUSTER_NAME
+gcloud config set compute/zone ${CLOUDSDK_COMPUTE_ZONE}
+gcloud --quiet container clusters get-credentials $CLUSTER_NAME
+cat ~/gcloud-service-key.json | jq -r .private_key > ~/.ssh/google_compute_engine
+chmod 0600 ~/.ssh/google_compute_engine
+ssh-keygen -y -f ~/.ssh/google_compute_engine > ~/.ssh/google_compute_engine.pub


### PR DESCRIPTION
Builds on all branches except master generate a build of a docker image targeted at goerli, and push it to GCR.

Builds on master generate a build of a docker image targeted at mainnet and push it to GCR.

Unfortunately, this build seems a bit spotty ([green](https://circleci.com/gh/JoinColony/colonyDapp/20232), [red](https://circleci.com/gh/JoinColony/colonyDapp/20231) on the same commit hash), and I'm not sure  why...