### PR TITLE
Fix colony admin permissions dialog

### DIFF
--- a/src/modules/admin/components/Permissions/Permissions.tsx
+++ b/src/modules/admin/components/Permissions/Permissions.tsx
@@ -108,11 +108,9 @@ const Permissions = ({ colonyAddress, openDialog }: Props) => {
 
   const handleOnClick = useCallback(
     (userAddress: Address) => {
-      // eslint-disable-next-line no-console
-      console.log(userAddress, colonyAddress, selectedDomain);
       handleEditPermissions(userAddress);
     },
-    [colonyAddress, handleEditPermissions, selectedDomain],
+    [handleEditPermissions],
   );
 
   const users = useMemo(


### PR DESCRIPTION
## Description

Various fixes for DLP phase 1.

**Changes** 🏗

* It wasn't possible to unset roles
* It wasn't possible to set admin role
* Role names are now from `react-intl` messages

**Deletions** ⚰️

* Removed an unwanted console.log
