### PR TITLE
Adjust transaction sorting

### DIFF
--- a/src/modules/core/selectors/__tests__/transactions.test.ts
+++ b/src/modules/core/selectors/__tests__/transactions.test.ts
@@ -63,20 +63,20 @@ describe('Transaction selectors', () => {
         transactions: {
           list: ImmutableMap({
             // @ts-ignore
-            tx1: TransactionRecord(tx1),
-            // @ts-ignore
-            tx2: TransactionRecord(tx2),
+            tx4: TransactionRecord(tx4),
             // @ts-ignore
             tx3: TransactionRecord(tx3),
             // @ts-ignore
-            tx4: TransactionRecord(tx4),
+            tx2: TransactionRecord(tx2),
+            // @ts-ignore
+            tx1: TransactionRecord(tx1),
           }),
         },
       },
     });
     const grouped = groupedTransactions(state);
     const result = grouped.toList().toJS();
-    expect(result[0][0].createdAt).toEqual(0);
+    expect(result[0][0].createdAt).toEqual(10);
     expect(result[1][0].group).toEqual({
       key: 'taskLifecycle',
       id: 'taskLifecycle-1',

--- a/src/modules/core/selectors/transactions.ts
+++ b/src/modules/core/selectors/transactions.ts
@@ -51,18 +51,26 @@ export const transactionByHash = (state: RootStateRecord, hash: string) =>
 export const groupedTransactions = createSelector(
   allTransactions,
   transactions =>
-    transactions // Create groups of transations which have 'em
-      .groupBy(tx => tx.group && tx.group.id) // Convert groups to lists and sort by no in group
-      .map(txGroup => txGroup.toList().sortBy(tx => tx.group && tx.group.index)) // Merge the ungrouped transactions into the ordered map. It's important that all iterators here have the same type (OrderedMap)
-      // For proper typing we create single value arrays for all of the single transactions
-      // We're using key.toString() here to not confuse flow. The output of allTransactions always has a string id in group
+    transactions
+      // Create groups of transations which have 'em
+      .groupBy(tx => tx.group && tx.group.id)
+      // Convert groups to lists and sort by no in group
+      .map(txGroup => txGroup.toList().sortBy(tx => tx.group && tx.group.index))
+      // Merge the ungrouped transactions into the ordered map.
+      // It's important that all iterators here have the same type (OrderedMap)
+      // For proper typing we create single value arrays for all of the
+      // single transactions.
+      // The output of allTransactions always has a string id in group.
       .flatMap((value, key) =>
-        !key
-          ? value.groupBy(tx => tx.id)
-          : ImmutableMap({ [key.toString()]: value }),
+        !key ? value.groupBy(tx => tx.id) : ImmutableMap({ [key]: value }),
       )
-      .toList() // Finally sort by the createdAt field in the first transaction of the group
-      .sortBy(group => group.first().createdAt),
+      .toList()
+      // Finally sort by the createdAt field in the first transaction of the group
+      .sortBy(
+        group => group.first().createdAt,
+        // Descending createdAt order (most recent groups first)
+        (createdAtA, createdAtB) => createdAtB - createdAtA,
+      ),
 );
 
 export const pendingTransactions = createSelector(
@@ -98,5 +106,9 @@ export const groupedTransactionsAndMessages = createSelector(
        * sorted individually, so without this, the list will just show transactions
        * at the top and messages at the bottom
        */
-      .sortBy(group => group.first().createdAt),
+      .sortBy(
+        group => group.first().createdAt,
+        // Descending createdAt order (most recent groups first)
+        (createdAtA, createdAtB) => createdAtB - createdAtA,
+      ),
 );


### PR DESCRIPTION
## Description

This PR adjusts transaction sorting in the gas station to show the most recent transaction (or message) first.

**Changes** 🏗

* Adjust the sorting of transactions/messages in the gas station, such that transactions are sorted by most-recent-first (descending date order)

Resolves #1666 
