### PR TITLE
Fix Automated CI Docker Image Builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,7 +214,7 @@ jobs:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "yarn.lock" }}
-      - run: docker build --build-arg COLONY_NETWORK_ENS_NAME='joincolony.test' --build-arg VERBOSE='true' --build-arg PINNING_ROOM='PINION_DEV_ROOM' --build-arg CHAIN_ID=5 --build-arg INFURA_ID='fe7e19c85e574235a06296de102d16ef' --build-arg NETWORK='goerli' --no-cache -t eu.gcr.io/${PROJECT_NAME}/dapp-goerli:$CIRCLE_SHA1 .
+      - run: docker build --build-arg COLONY_NETWORK_ENS_NAME='joincolony.test' --build-arg VERBOSE='true' --build-arg PINNING_ROOM='PINION_DEV_ROOM' --build-arg CHAIN_ID=5 --build-arg INFURA_ID='fe7e19c85e574235a06296de102d16ef' --build-arg NETWORK='goerli' --build-arg COMMIT_HASH=$CIRCLE_SHA1 --no-cache -t eu.gcr.io/${PROJECT_NAME}/dapp-goerli:$CIRCLE_SHA1 .
       - run: echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
       - run: curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
       - run: sudo apt-get update && sudo apt-get install google-cloud-sdk
@@ -239,7 +239,7 @@ jobs:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "yarn.lock" }}
-      - run: docker build --build-arg COLONY_NETWORK_ENS_NAME='joincolony.eth' --build-arg VERBOSE='true' --build-arg PINNING_ROOM='COLONY' --build-arg CHAIN_ID=1 --build-arg INFURA_ID='fe7e19c85e574235a06296de102d16ef' --build-arg NETWORK='mainnet' --no-cache -t eu.gcr.io/${PROJECT_NAME}/dapp-mainnet:$CIRCLE_SHA1 .
+      - run: docker build --build-arg COLONY_NETWORK_ENS_NAME='joincolony.eth' --build-arg VERBOSE='true' --build-arg PINNING_ROOM='COLONY' --build-arg CHAIN_ID=1 --build-arg INFURA_ID='fe7e19c85e574235a06296de102d16ef' --build-arg NETWORK='mainnet' --build-arg COMMIT_HASH=$CIRCLE_SHA1 --no-cache -t eu.gcr.io/${PROJECT_NAME}/dapp-mainnet:$CIRCLE_SHA1 .
       - run: echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
       - run: curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
       - run: sudo apt-get update && sudo apt-get install google-cloud-sdk

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ ARG GH_PAT
 #
 # Eg: docker build --build-arg INFURA_ID='XXX' .
 ARG INFURA_ID
+# @NOTE Declare the commit hash build variable, so that it gets picked up by the conditional
+ARG COMMIT_HASH
 
 # Make the dapp's ENV values to have the option to be set at build time
 # But fall back to a default
@@ -47,6 +49,7 @@ RUN locale-gen
 # Clone the repo
 RUN git clone "https://$GH_PAT@github.com/JoinColony/colonyDapp.git"
 WORKDIR /colonyDapp
+RUN if [ ! -z "$COMMIT_HASH" ]; then git checkout $COMMIT_HASH; fi
 
 # Install node_modules
 RUN yarn


### PR DESCRIPTION
## Description

This PR fixes the automated CI docker builds, especially relevant for the `goerli` qa builds, by allowing the Docker image to receive an external commit hash, and then, using that build checkout the respective code and build the image _(rather then always pulling the latest master)_

The commit hash is being passed in at builds time using an `--build-arg` variable

**Changes**

- [x] The `Dockerfile` accepts a `COMMIT_HASH` build argument, and uses a bash conditional to checkout the repo's code using that hash value
- [x] CI `build-goerli-image` and `build-mainnet-image` workflow jobs pass along `$CIRCLE_SHA1` to the actual build command, which represents that build's commit hash