### PR TITLE
Add root to domains list

### DIFF
--- a/src/modules/admin/components/Domains/DomainList.tsx
+++ b/src/modules/admin/components/Domains/DomainList.tsx
@@ -46,7 +46,7 @@ const DomainList = ({
     <div className={styles.listWrapper}>
       <Table scrollable>
         <TableBody>
-          {domains && (
+          {domains &&
             Object.keys(domains).map(domainId => (
               <DomainListItem
                 key={domainId}
@@ -54,7 +54,7 @@ const DomainList = ({
                 viewOnly={viewOnly}
                 colonyAddress={colonyAddress}
               />
-            )))}
+            ))}
         </TableBody>
       </Table>
     </div>

--- a/src/modules/admin/components/Domains/DomainList.tsx
+++ b/src/modules/admin/components/Domains/DomainList.tsx
@@ -46,7 +46,7 @@ const DomainList = ({
     <div className={styles.listWrapper}>
       <Table scrollable>
         <TableBody>
-          {domains ? (
+          {domains && (
             Object.keys(domains).map(domainId => (
               <DomainListItem
                 key={domainId}
@@ -54,12 +54,7 @@ const DomainList = ({
                 viewOnly={viewOnly}
                 colonyAddress={colonyAddress}
               />
-            ))
-          ) : (
-            <div>
-              {/* //TODO: Add empty state here once we have it designed */}
-            </div>
-          )}
+            )))}
         </TableBody>
       </Table>
     </div>

--- a/src/modules/admin/components/Domains/OrganizationAddDomains.tsx
+++ b/src/modules/admin/components/Domains/OrganizationAddDomains.tsx
@@ -65,6 +65,7 @@ const OrganizationAddDomains = ({ colonyAddress }: Props) => {
                 help={MSG.helpText}
                 label={MSG.labelAddDomain}
                 name="domainName"
+                formattingOptions={{ lowercase: true }}
               />
             </div>
             <div className={styles.submitButton}>

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
@@ -105,7 +105,7 @@ interface MatchParams {
   colonyName: string;
 }
 
-interface Props extends RouteComponentProps<MatchParams> {}
+type Props = RouteComponentProps<MatchParams>;
 
 const COLONY_DB_RECOVER_BUTTON_TIMEOUT = 20 * 1000;
 

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
@@ -1,5 +1,5 @@
-import { Redirect } from 'react-router';
 import React, { useState, useCallback, useEffect, useMemo } from 'react';
+import { Redirect, RouteComponentProps } from 'react-router';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { subscribeActions as subscribeToReduxActions } from 'redux-action-watch/lib/actionCreators';
 import { useDispatch } from 'redux-react-hook';
@@ -101,9 +101,11 @@ const MSG = defineMessages({
   },
 });
 
-interface Props {
-  match: any;
+interface MatchParams {
+  colonyName: string;
 }
+
+interface Props extends RouteComponentProps<MatchParams> {}
 
 const COLONY_DB_RECOVER_BUTTON_TIMEOUT = 20 * 1000;
 

--- a/src/modules/dashboard/components/TaskDomains/TaskDomains.tsx
+++ b/src/modules/dashboard/components/TaskDomains/TaskDomains.tsx
@@ -1,5 +1,5 @@
-import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import React, { useCallback, useMemo, useState } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
 
 import { COLONY_TOTAL_BALANCE_DOMAIN_ID } from '~constants';
 import Heading from '~core/Heading';
@@ -106,6 +106,9 @@ const TaskDomains = ({ colonyAddress, domainId, draftId, disabled }: Props) => {
         .map(id => ({
           ...(domains || {})[id],
           disabled: !domainHasEnoughFunds(id),
+          disabledText: !domainHasEnoughFunds(id)
+            ? MSG.insufficientFundsInDomain
+            : undefined,
           id: parseInt(id, 10),
         })),
     [domainHasEnoughFunds, domains],
@@ -147,4 +150,4 @@ const TaskDomains = ({ colonyAddress, domainId, draftId, disabled }: Props) => {
 
 TaskDomains.displayName = displayName;
 
-export default injectIntl(TaskDomains);
+export default TaskDomains;

--- a/src/modules/dashboard/data/queries/colonies.ts
+++ b/src/modules/dashboard/data/queries/colonies.ts
@@ -442,7 +442,7 @@ export const getColonyDomains: Query<
 
           return [...difference, event];
         },
-        [],
+        [{ payload: { domainId: 0, name: 'root' } }],
       )
       .map(
         ({ payload: { domainId, name } }): DomainType => ({

--- a/src/modules/dashboard/data/queries/colonies.ts
+++ b/src/modules/dashboard/data/queries/colonies.ts
@@ -442,7 +442,7 @@ export const getColonyDomains: Query<
 
           return [...difference, event];
         },
-        [{ payload: { domainId: 0, name: 'root' } }],
+        [{ payload: { domainId: 1, name: 'root' } }],
       )
       .map(
         ({ payload: { domainId, name } }): DomainType => ({

--- a/src/modules/dashboard/reducers/allDomains.ts
+++ b/src/modules/dashboard/reducers/allDomains.ts
@@ -84,10 +84,6 @@ const allDomainsReducer: ReducerType<AllDomainsMap> = (
         meta: { key },
         payload: { domains },
       } = action;
-      /* Add root domain to response which is the parent of all domains  */
-      if (domains.find(domain => domain.name !== 'root')) {
-        domains.push({ name: 'root', id: 0 });
-      }
       return state.set(
         key,
         FetchableData({

--- a/src/modules/dashboard/reducers/allDomains.ts
+++ b/src/modules/dashboard/reducers/allDomains.ts
@@ -84,6 +84,10 @@ const allDomainsReducer: ReducerType<AllDomainsMap> = (
         meta: { key },
         payload: { domains },
       } = action;
+      /* Add root domain to response which is the parent of all domains  */
+      if (domains.find(domain => domain.name !== 'root')) {
+        domains.push({ name: 'root', id: 0 });
+      }
       return state.set(
         key,
         FetchableData({


### PR DESCRIPTION
## Description

This PR is rebased on top of the #1785, that's why it seems a bit bigger then it actually is.

The changes are adding the "root" domain to the DomainList by default, while making sure the root domain can not be edit, because it wouldn't make sense to edit it. Also all newly added domains are now all underscore. 
<img width="650" alt="Screen Shot 2019-09-20 at 18 47 29" src="https://user-images.githubusercontent.com/6294044/65344129-23684b80-dbd7-11e9-829c-fb709248c5fa.png">

To achieve this I changed the `allDomains.ts` reducer by adding a root domain if there's none, so that it gets fetched with the domainsFetcher.

Consequently, it also shows on Colony Home. 
<img width="779" alt="Screen Shot 2019-09-20 at 18 50 58" src="https://user-images.githubusercontent.com/6294044/65344307-a1c4ed80-dbd7-11e9-8fd9-d9bc92c95bc6.png">


Resolves  #1700
