### PR TITLE
Re-Add Inbox Notification Dot Functionality

### DIFF
--- a/src/modules/users/components/Inbox/InboxIcon/InboxIcon.css
+++ b/src/modules/users/components/Inbox/InboxIcon/InboxIcon.css
@@ -1,18 +1,10 @@
-.inboxIcon {
-  composes: navigationItem from '~pages/NavigationWrapper/UserNavigation.css';
-}
-
-.inboxIconWCircle {
-  composes: inboxIcon;
-
-  &::after {
-    display: inline-block;
-    margin-bottom: 8px;
-    margin-left: -5px;
-    height: 8px;
-    width: 8px;
-    border-radius: 50%;
-    background-color: var(--danger);
-    content: '';
-  }
+.inboxNotification::after {
+  display: inline-block;
+  margin-bottom: 8px;
+  margin-left: -5px;
+  height: 8px;
+  width: 8px;
+  border-radius: 50%;
+  background-color: var(--danger);
+  content: '';
 }

--- a/src/modules/users/components/Inbox/InboxIcon/InboxIcon.css.d.ts
+++ b/src/modules/users/components/Inbox/InboxIcon/InboxIcon.css.d.ts
@@ -1,2 +1,1 @@
-export const inboxIcon: string;
-export const inboxIconWCircle: string;
+export const inboxNotification: string;

--- a/src/modules/users/components/Inbox/InboxIcon/InboxIcon.tsx
+++ b/src/modules/users/components/Inbox/InboxIcon/InboxIcon.tsx
@@ -1,7 +1,12 @@
 import { MessageDescriptor, defineMessages } from 'react-intl';
 import React from 'react';
 
+import { useSelector } from '~utils/hooks';
+import { inboxItemsSelector } from '../../../selectors';
+
 import Icon from '~core/Icon';
+
+import styles from './InboxIcon.css';
 
 const MSG = defineMessages({
   fallbackTitle: {
@@ -17,9 +22,17 @@ interface Props {
 
 const displayName = 'users.Inbox.InboxIcon';
 
-const InboxIcon = ({ title = MSG.fallbackTitle }: Props) => (
-  <Icon name="envelope" title={title} />
-);
+const InboxIcon = ({ title = MSG.fallbackTitle }: Props) => {
+  const { record: activities = [] } = useSelector(inboxItemsSelector);
+  const hasUnreadActivities = activities.some(activity => activity.unread);
+  return (
+    <span
+      className={hasUnreadActivities ? styles.inboxNotification : undefined}
+    >
+      <Icon name="envelope" title={title} />
+    </span>
+  );
+};
 
 InboxIcon.displayName = displayName;
 


### PR DESCRIPTION
## Description

This re-adds the functionality that shows a notification dot when the user's inbox has unread items.

This was _(erroneously?)_ removed when the Inbox Popover feature was added in #1739: https://github.com/JoinColony/colonyDapp/commit/970c52c7e26af887c28c92844bd9977c1792c343#diff-c5e58327087a73af346da2d72fb4c91c

**Changes** 

- [x] `InboxIcon` re-add unread activities functionality

**Screenshots**

![Screenshot from 2019-09-23 10-48-38](https://user-images.githubusercontent.com/1193222/65409307-0ce90c80-ddf0-11e9-945a-6fc1d95205d7.png)

Resolves #1841 