### PR TITLE
Add domain funding to colony home

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.css
@@ -1,0 +1,3 @@
+.fundingButton {
+  margin-left: 30px;
+}

--- a/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.css.d.ts
+++ b/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.css.d.ts
@@ -1,0 +1,1 @@
+export const fundingButton: string;

--- a/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.tsx
@@ -9,7 +9,6 @@ import { useSelector, useRoles } from '~utils/hooks';
 import TokenItem from './TokenItem';
 import { useColonyTokens } from '../../../hooks/useColonyTokens';
 import { canMoveTokens as canMoveTokensCheck } from '../../../../admin/checks';
-import { COLONY_TOTAL_BALANCE_DOMAIN_ID } from '../../../../admin/constants';
 import { currentUserSelector } from '../../../../users/selectors';
 
 import styles from './ColonyFunding.css';
@@ -44,7 +43,8 @@ const ColonyFunding = ({ colonyAddress, currentDomainId }: Props) => {
     [currentUserWalletAddress, roles],
   );
 
-  return currentDomainId === COLONY_TOTAL_BALANCE_DOMAIN_ID ? null : (
+  // hide for root domain
+  return currentDomainId === 0 ? null : (
     <div>
       <Heading appearance={{ size: 'normal', weight: 'bold' }}>
         <FormattedMessage {...MSG.title} />

--- a/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.tsx
@@ -1,0 +1,76 @@
+import React, { useMemo } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import Button from '~core/Button';
+import Heading from '~core/Heading';
+import { Address } from '~types/index';
+import { useSelector, useRoles } from '~utils/hooks';
+
+import TokenItem from './TokenItem';
+import { useColonyTokens } from '../../../hooks/useColonyTokens';
+import { canMoveTokens as canMoveTokensCheck } from '../../../../admin/checks';
+import { COLONY_TOTAL_BALANCE_DOMAIN_ID } from '../../../../admin/constants';
+import { currentUserSelector } from '../../../../users/selectors';
+
+import styles from './ColonyFunding.css';
+
+const MSG = defineMessages({
+  buttonFund: {
+    id: 'dashboard.ColonyHome.ColonyFunding.buttonFund',
+    defaultMessage: 'Fund',
+  },
+  title: {
+    id: 'dashboard.ColonyHome.ColonyFunding.title',
+    defaultMessage: 'Available Funding',
+  },
+});
+
+interface Props {
+  colonyAddress: Address;
+  currentDomainId: number;
+}
+
+const displayName = 'dashboard.ColonyHome.ColonyFunding';
+
+const ColonyFunding = ({ colonyAddress, currentDomainId }: Props) => {
+  const [tokenReferences, tokens] = useColonyTokens(colonyAddress);
+
+  const {
+    profile: { walletAddress: currentUserWalletAddress },
+  } = useSelector(currentUserSelector);
+  const { data: roles } = useRoles(colonyAddress);
+  const canMoveTokens = useMemo(
+    () => canMoveTokensCheck(roles, currentUserWalletAddress),
+    [currentUserWalletAddress, roles],
+  );
+
+  return currentDomainId === COLONY_TOTAL_BALANCE_DOMAIN_ID ? null : (
+    <div>
+      <Heading appearance={{ size: 'normal', weight: 'bold' }}>
+        <FormattedMessage {...MSG.title} />
+        {canMoveTokens && (
+          <span className={styles.fundingButton}>
+            <Button appearance={{ theme: 'blue' }} text={MSG.buttonFund} />
+          </span>
+        )}
+      </Heading>
+      <ul>
+        {tokens &&
+          tokenReferences &&
+          tokens.map(token => (
+            <TokenItem
+              currentDomainId={currentDomainId}
+              token={token}
+              tokenReference={tokenReferences.find(
+                ({ address }) => address === token.address,
+              )}
+            />
+          ))}
+      </ul>
+    </div>
+  );
+};
+
+ColonyFunding.displayName = displayName;
+
+export default ColonyFunding;

--- a/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.tsx
@@ -80,6 +80,7 @@ const ColonyFunding = ({
           tokens.map(token => (
             <TokenItem
               currentDomainId={currentDomainId}
+              key={token.address}
               token={token}
               tokenReference={tokenReferences.find(
                 ({ address }) => address === token.address,

--- a/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.tsx
@@ -1,7 +1,9 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
 import Button from '~core/Button';
+import { DialogType } from '~core/Dialog';
+import withDialog from '~core/Dialog/withDialog';
 import Heading from '~core/Heading';
 import { Address } from '~types/index';
 import { useSelector, useRoles } from '~utils/hooks';
@@ -27,11 +29,16 @@ const MSG = defineMessages({
 interface Props {
   colonyAddress: Address;
   currentDomainId: number;
+  openDialog: (dialogName: string, dialogProps?: object) => DialogType;
 }
 
 const displayName = 'dashboard.ColonyHome.ColonyFunding';
 
-const ColonyFunding = ({ colonyAddress, currentDomainId }: Props) => {
+const ColonyFunding = ({
+  colonyAddress,
+  currentDomainId,
+  openDialog,
+}: Props) => {
   const [tokenReferences, tokens] = useColonyTokens(colonyAddress);
 
   const {
@@ -43,6 +50,15 @@ const ColonyFunding = ({ colonyAddress, currentDomainId }: Props) => {
     [currentUserWalletAddress, roles],
   );
 
+  const handleMoveTokens = useCallback(
+    () =>
+      openDialog('TokensMoveDialog', {
+        colonyAddress,
+        toDomain: currentDomainId,
+      }),
+    [openDialog, colonyAddress, currentDomainId],
+  );
+
   // hide for root domain
   return currentDomainId === 0 ? null : (
     <div>
@@ -50,7 +66,11 @@ const ColonyFunding = ({ colonyAddress, currentDomainId }: Props) => {
         <FormattedMessage {...MSG.title} />
         {canMoveTokens && (
           <span className={styles.fundingButton}>
-            <Button appearance={{ theme: 'blue' }} text={MSG.buttonFund} />
+            <Button
+              appearance={{ theme: 'blue' }}
+              onClick={handleMoveTokens}
+              text={MSG.buttonFund}
+            />
           </span>
         )}
       </Heading>
@@ -73,4 +93,4 @@ const ColonyFunding = ({ colonyAddress, currentDomainId }: Props) => {
 
 ColonyFunding.displayName = displayName;
 
-export default ColonyFunding;
+export default (withDialog() as any)(ColonyFunding);

--- a/src/modules/dashboard/components/ColonyHome/ColonyFunding/TokenItem.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyFunding/TokenItem.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import { TokenType, ColonyTokenReferenceType } from '~immutable/index';
+
+import Numeral from '~core/Numeral';
+import { getTokenBalanceFromReference } from '~utils/tokens';
+
+interface Props {
+  currentDomainId: number;
+  token: TokenType;
+  tokenReference?: ColonyTokenReferenceType;
+}
+
+const displayName = 'dashboard.ColonyHome.ColonyFunding.TokenItem';
+
+const TokenItem = ({
+  currentDomainId,
+  token: { decimals, symbol },
+  tokenReference,
+}: Props) => {
+  const balance = tokenReference
+    ? getTokenBalanceFromReference(tokenReference, currentDomainId)
+    : undefined;
+  return typeof balance === 'undefined' ? null : (
+    <li>
+      <Numeral unit={decimals} value={balance} suffix={` ${symbol}`} />
+    </li>
+  );
+};
+
+TokenItem.displayName = displayName;
+
+export default TokenItem;

--- a/src/modules/dashboard/components/ColonyHome/ColonyFunding/index.ts
+++ b/src/modules/dashboard/components/ColonyHome/ColonyFunding/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ColonyFunding';

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.css
@@ -51,7 +51,7 @@
 .sidebar {
   display: flex;
   justify-content: space-between;
-  margin-top: 165px;
+  margin-top: 160px;
   grid-column: 3;
   grid-row: 1;
 }

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.css
@@ -52,7 +52,6 @@
   display: flex;
   justify-content: space-between;
   margin-top: 165px;
-  padding-right: 140px;
   grid-column: 3;
   grid-row: 1;
 }

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
@@ -37,7 +37,6 @@ import {
 import { currentUserColonyPermissionsFetcher } from '../../../users/fetchers';
 import { colonyAddressFetcher, domainsFetcher } from '../../fetchers';
 import { colonySubscriber } from '../../subscribers';
-import { COLONY_TOTAL_BALANCE_DOMAIN_ID } from '../../../admin/constants';
 import {
   canAdminister,
   canCreateTask as canCreateTaskCheck,
@@ -95,10 +94,6 @@ const MSG = defineMessages({
     id: 'dashboard.ColonyHome.recoverColonyCancelButton',
     defaultMessage: 'Nope! Take me back, please',
   },
-  root: {
-    id: 'root',
-    defaultMessage: 'root',
-  },
 });
 
 interface Props {
@@ -118,9 +113,7 @@ const ColonyHome = ({
   intl: { formatMessage },
 }: Props) => {
   const [filterOption, setFilterOption] = useState(TasksFilterOptions.ALL_OPEN);
-  const [filteredDomainId, setFilteredDomainId] = useState(
-    COLONY_TOTAL_BALANCE_DOMAIN_ID,
-  );
+  const [filteredDomainId, setFilteredDomainId] = useState(0);
   const [isTaskBeingCreated, setIsTaskBeingCreated] = useState(false);
   const [showRecoverOption, setRecoverOption] = useState(false);
 
@@ -191,7 +184,7 @@ const ColonyHome = ({
           }
           return accumulator;
         },
-        [formatMessage(MSG.root)],
+        [formatMessage({ id: 'domain.root' })],
       );
 
   const nativeTokenRef: ColonyTokenReferenceType | null = useSelector(

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
@@ -72,14 +72,6 @@ const MSG = defineMessages({
     id: 'dashboard.ColonyHome.newTaskButton',
     defaultMessage: 'New Task',
   },
-  availableFunds: {
-    id: 'dashboard.ColonyHome.availableFunds',
-    defaultMessage: 'Available Funds',
-  },
-  fund: {
-    id: 'dashboard.ColonyHome.fund',
-    defaultMessage: 'Fund',
-  },
   recoverColonyButton: {
     id: 'dashboard.ColonyHome.recoverColonyButton',
     defaultMessage: 'Recover Colony?',

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
@@ -28,7 +28,6 @@ import { Tab, Tabs, TabList, TabPanel } from '~core/Tabs';
 import { Select } from '~core/Fields';
 import Button, { ActionButton, DialogActionButton } from '~core/Button';
 import BreadCrumb from '~core/BreadCrumb';
-import Heading from '~core/Heading';
 import RecoveryModeAlert from '~admin/RecoveryModeAlert';
 import LoadingTemplate from '~pages/LoadingTemplate';
 import {
@@ -38,6 +37,7 @@ import {
 import { currentUserColonyPermissionsFetcher } from '../../../users/fetchers';
 import { colonyAddressFetcher, domainsFetcher } from '../../fetchers';
 import { colonySubscriber } from '../../subscribers';
+import { COLONY_TOTAL_BALANCE_DOMAIN_ID } from '../../../admin/constants';
 import {
   canAdminister,
   canCreateTask as canCreateTaskCheck,
@@ -47,6 +47,7 @@ import {
   canRecoverColony,
 } from '../../checks';
 
+import ColonyFunding from './ColonyFunding';
 import ColonyMeta from './ColonyMeta';
 import TabContribute from './TabContribute';
 import styles from './ColonyHome.css';
@@ -117,7 +118,9 @@ const ColonyHome = ({
   intl: { formatMessage },
 }: Props) => {
   const [filterOption, setFilterOption] = useState(TasksFilterOptions.ALL_OPEN);
-  const [filteredDomainId, setFilteredDomainId] = useState(0);
+  const [filteredDomainId, setFilteredDomainId] = useState(
+    COLONY_TOTAL_BALANCE_DOMAIN_ID,
+  );
   const [isTaskBeingCreated, setIsTaskBeingCreated] = useState(false);
   const [showRecoverOption, setRecoverOption] = useState(false);
 
@@ -319,8 +322,10 @@ const ColonyHome = ({
         </Tabs>
       </main>
       <aside className={styles.sidebar}>
-        <Heading appearance={{ size: 'normal' }} text={MSG.availableFunds} />
-        <Button text={MSG.fund} appearance={{ theme: 'blue' }} />
+        <ColonyFunding
+          colonyAddress={colonyAddress}
+          currentDomainId={filteredDomainId}
+        />
       </aside>
       {isInRecoveryMode && <RecoveryModeAlert />}
     </div>

--- a/src/modules/dashboard/components/ColonyHome/ColonyMeta/ColonyMeta.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMeta/ColonyMeta.tsx
@@ -43,7 +43,7 @@ const ColonyAvatar = HookedColonyAvatar({ fetchColony: false });
 interface Props {
   colony: ColonyType;
   canAdminister: boolean;
-  setFilteredDomainId: Function;
+  setFilteredDomainId: (domainId: number) => void;
   filteredDomainId: number;
 }
 


### PR DESCRIPTION
## Description

This PR adds a domain funding (both balances and "Fund" modal button) widget to the colony home.

**New stuff** ✨

* `ColonyFunding` component

**Changes** 🏗

* Use `ColonyFunding` component in `ColonyHome`

## TODO

- [x] Wire up to the transfer funds between pots dialog once #1858 is complete

Closes #1783 
