### PR TITLE
Permissions Edit Dialog Render Avatar

### DIFF
--- a/src/modules/admin/components/Permissions/ColonyPermissionEditDialog.tsx
+++ b/src/modules/admin/components/Permissions/ColonyPermissionEditDialog.tsx
@@ -17,6 +17,7 @@ import { Address } from '~types/index';
 import { mergePayload, withKey, mapPayload, pipe } from '~utils/actions';
 
 import { DomainType, UserType, User, UserProfile } from '~immutable/index';
+import { ItemDataType } from '~core/OmniPicker';
 import { ActionTypeString, ActionTypes } from '~redux/index';
 import {
   useSelector,
@@ -34,6 +35,7 @@ import Heading from '~core/Heading';
 import Button from '~core/Button';
 import Dialog, { DialogSection } from '~core/Dialog';
 import { ActionForm, InputLabel, Checkbox } from '~core/Fields';
+import HookedUserAvatar from '~users/HookedUserAvatar';
 
 import {
   allUsersAddressesSelector,
@@ -144,6 +146,14 @@ const validationSchema = yup.object({
   user: yup.object().required(),
   roles: yup.array().of(yup.string().required()),
 });
+
+const UserAvatar = HookedUserAvatar({ fetchUser: false });
+
+const supRenderAvatar = (address: string, item: ItemDataType<UserType>) => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { id, ...user } = item;
+  return <UserAvatar address={address} user={user} size="xs" />;
+};
 
 const ColonyPermissionEditDialog = ({
   domain,
@@ -309,6 +319,7 @@ const ColonyPermissionEditDialog = ({
                   placeholder={MSG.search}
                   filter={filterUserSelection}
                   onSelected={user => updateSelectedUser(user)}
+                  renderAvatar={supRenderAvatar}
                 />
               </div>
               <InputLabel label={MSG.permissionsLabel} />


### PR DESCRIPTION
## Description

This PR fixes a "bug" the Colony Permissions Dialog that didn't render the user's Avatar. 

This was due to the fact that `SingleUserPicker` doesn't know how to render the avatar itself, and needs to be passes a function that returns an `Avatar` component. This is done via the `renderAvatar` prop.

**Changes**

- [x] `ColonyPermissionsEditDialog` pass `renderAvatar` to `SingleUserPicker`

**Screenshots** 

![Screenshot from 2019-09-24 14-56-55](https://user-images.githubusercontent.com/1193222/65510147-e654cf80-dedc-11e9-9156-7c5ff942e0bb.png)

Resolves #1851