### PR TITLE
Make SingleUserPicker fill available width

### DIFF
--- a/src/modules/core/components/SingleUserPicker/SingleUserPicker.css
+++ b/src/modules/core/components/SingleUserPicker/SingleUserPicker.css
@@ -1,5 +1,6 @@
 .main {
   composes: field from '~styles/fields.css';
+  width: 100%;
 }
 
 .directionHorizontal {
@@ -101,7 +102,7 @@
 
 .omniPickerContainer {
   width: 100%;
-  max-width: 450px;
+  max-width: 330px;
   position: absolute;
   top: 35px;
   left: 10px;


### PR DESCRIPTION
## Description

The `SingleUserPicker` now doesn't look weird after selecting a short username!

![image](https://user-images.githubusercontent.com/7497084/65599879-88d98500-dfa7-11e9-8972-d5b20a75113f.png)
![image](https://user-images.githubusercontent.com/7497084/65599889-8e36cf80-dfa7-11e9-8e2f-64f1f6d2d696.png)

**Changes** 🏗

*`SingleUserPicker` `.main` class fills all available width
* The `max-width` of the dropdown matches that of the input element

Resolves #1853 
