### PR TITLE
Hide ARCHITECTURE_SUBDOMAIN, allow setting of RECOVERY

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -101,8 +101,10 @@
     "transaction.colony.setArchitectureRole.description": "{setTo, select, true { Give role to ({ address }) } false { Remove role from ({ address }) } }",
     "transaction.colony.setFundingRole.title": "{setTo, select, true { Add funding role } false { Remove funding role } }",
     "transaction.colony.setFundingRole.description": "{setTo, select, true { Give role to ({ address }) } false { Remove role from ({ address }) } }",
-    "transaction.colony.setRecoveryRole.title": "{setTo, select, true { Add recovery role } false { Remove recovery role } }",
-    "transaction.colony.setRecoveryRole.description": "{setTo, select, true { Give role to ({ address }) } false { Remove role from ({ address }) } }",
+    "transaction.colony.setRecoveryRole.title": "Add recovery role",
+    "transaction.colony.setRecoveryRole.description": "Give role to ({ address })",
+    "transaction.colony.removeRecoveryRole.title": "Remove recovery role",
+    "transaction.colony.removeRecoveryRole.description": "Remove role from ({ address })",
     "transaction.colony.setRootRole.title": "{setTo, select, true { Add root role } false { Remove root role } }",
     "transaction.colony.setRootRole.description": "{setTo, select, true { Give role to ({ address }) } false { Remove role from ({ address }) } }",
 

--- a/src/modules/admin/components/Permissions/ColonyPermissionEditDialog.tsx
+++ b/src/modules/admin/components/Permissions/ColonyPermissionEditDialog.tsx
@@ -9,6 +9,7 @@ import {
   COLONY_ROLE_ADMINISTRATION,
   COLONY_ROLE_ARCHITECTURE,
   COLONY_ROLE_FUNDING,
+  COLONY_ROLE_RECOVERY,
   COLONY_ROLE_ARBITRATION,
 } from '@colony/colony-js-client';
 
@@ -80,7 +81,9 @@ const MSG = defineMessages({
   },
   roleDescription2: {
     id: 'core.ColonyPermissionEditDialog.roleDescription2',
-    defaultMessage: 'Set the administration, funding, and architecture roles.',
+    defaultMessage:
+      // eslint-disable-next-line max-len
+      'Set the administration, funding, and architecture roles in any subdomain.',
   },
   role3: {
     id: 'core.ColonyPermissionEditDialog.role3',
@@ -92,10 +95,18 @@ const MSG = defineMessages({
   },
   role4: {
     id: 'core.ColonyPermissionEditDialog.role4',
-    defaultMessage: 'Arbitration',
+    defaultMessage: 'Recovery',
   },
   roleDescription4: {
     id: 'core.ColonyPermissionEditDialog.roleDescription4',
+    defaultMessage: 'Put the Colony into recovery mode.',
+  },
+  role5: {
+    id: 'core.ColonyPermissionEditDialog.role5',
+    defaultMessage: 'Arbitration',
+  },
+  roleDescription5: {
+    id: 'core.ColonyPermissionEditDialog.roleDescription5',
     defaultMessage: 'Coming soon...',
   },
   search: {
@@ -126,10 +137,11 @@ interface Props {
 // Ideally these types would come from colonyJS but can't get it to work
 enum Roles {
   ADMINISTRATION = 'ADMINISTRATION',
-  ARCHITECTURE = 'ARCHITECTURE',
   ARBITRATION = 'ARBITRATION',
-  ROOT = 'ROOT',
+  ARCHITECTURE = 'ARCHITECTURE',
   FUNDING = 'FUNDING',
+  RECOVERY = 'RECOVERY',
+  ROOT = 'ROOT',
 }
 type Role = keyof typeof Roles;
 type SelectedRoles = Partial<Record<Role, boolean>>;
@@ -139,6 +151,7 @@ const availableRoles: Role[] = [
   COLONY_ROLE_ADMINISTRATION,
   COLONY_ROLE_ARCHITECTURE,
   COLONY_ROLE_FUNDING,
+  COLONY_ROLE_RECOVERY,
   COLONY_ROLE_ARBITRATION,
 ];
 
@@ -198,8 +211,12 @@ const ColonyPermissionEditDialog = ({
         case COLONY_ROLE_ARBITRATION:
           return false;
 
-        // Must be root for these
+        // Can only be set by root and in root domain
         case COLONY_ROLE_ROOT:
+        case COLONY_ROLE_RECOVERY:
+          return domain.id === 1 && !!currentUserDomainRoles[COLONY_ROLE_ROOT];
+
+        // Must be root for these
         case COLONY_ROLE_ADMINISTRATION:
         case COLONY_ROLE_FUNDING:
         case COLONY_ROLE_ARCHITECTURE:
@@ -209,7 +226,7 @@ const ColonyPermissionEditDialog = ({
           return false;
       }
     },
-    [currentUserDomainRoles],
+    [currentUserDomainRoles, domain.id],
   );
 
   const transform = useCallback(

--- a/src/modules/admin/components/Permissions/UserPermissions.tsx
+++ b/src/modules/admin/components/Permissions/UserPermissions.tsx
@@ -1,6 +1,9 @@
 import React, { useMemo } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { COLONY_ROLE_ROOT } from '@colony/colony-js-client';
+import {
+  COLONY_ROLE_ROOT,
+  COLONY_ROLE_ARCHITECTURE_SUBDOMAIN,
+} from '@colony/colony-js-client';
 
 import { Address } from '~types/strings';
 import { useUserDomainRoles } from '~utils/hooks';
@@ -27,7 +30,12 @@ const UserPermissions = ({ colonyAddress, domainId, userAddress }: Props) => {
   const sortedUserPermissionlabels = useMemo(
     () =>
       Object.keys(userPermissions)
-        .filter(key => !!userPermissions[key])
+        .filter(
+          key =>
+            !!userPermissions[key] &&
+            // Don't display ARCHITECTURE_SUBDOMAIN in listed roles
+            key !== COLONY_ROLE_ARCHITECTURE_SUBDOMAIN,
+        )
         .sort((a, b) => {
           if (a === COLONY_ROLE_ROOT || b === COLONY_ROLE_ROOT) {
             return a === COLONY_ROLE_ROOT ? 1 : -1;


### PR DESCRIPTION
## Description

Some tweaks to what roles are displayed in the permissions list, and which roles can be set (and under which circumstances) in the set roles dialog.

**Changes** 🏗

* `ARCHITECTURE_SUBDOMAIN` is not shown 
* Set roles dialog now only allows setting of `ROOT` role in root domain
* Fix to `colonyDomainUserRolesSet` to use correct methods for recovery role

Resolves #1842 
