### PR TITLE
Transaction List long values wrapping cell

### DIFF
--- a/src/modules/core/components/TransactionList/TransactionListItem.css
+++ b/src/modules/core/components/TransactionList/TransactionListItem.css
@@ -2,6 +2,9 @@
 
 tr.main:hover .etherscanButtonWrapper {
   display: block;
+  position: absolute;
+  background-color: var(--colony-white);
+  padding: 10px 15px 10px 20px;
 }
 
 .main td {
@@ -48,7 +51,7 @@ td.transactionDetails {
 td.transactionAmountActions {
   flex-direction: row-reverse;
   padding-right: 30px;
-  width: 50%;
+  width: 60%;
 }
 
 .customButton {

--- a/src/modules/core/components/TransactionList/TransactionListItem.css
+++ b/src/modules/core/components/TransactionList/TransactionListItem.css
@@ -2,9 +2,9 @@
 
 tr.main:hover .etherscanButtonWrapper {
   display: block;
+  padding: 10px 15px 10px 20px;
   position: absolute;
   background-color: var(--colony-white);
-  padding: 10px 15px 10px 20px;
 }
 
 .main td {


### PR DESCRIPTION
## Description

This PR attempts a fix for a issue with the Colony's Transaction table, where, if a transaction amount was very long, when hovering _(and the etherscan button would render)_ it would be to much for the width of that cell and wrap the contents onto a second line.

The only _"sane"_ way to fix this that I found was to make the Etherscan button `absolute` as to render above the value itself _(as that can grow indefinitely)_

As I've mentioned above, this value can grow indefinitely, so while my attempt fixes this table for the vast amount of cases, it will still break in edge cases.

But I guess that's what we have to live with for now.

Ie: 
```
123(...)n.123123123123123123
```

**Changes** 
- [x] `TransactionListItem` render etherscan button above transaction value

**Screenshot**:

Before:
![Screenshot from 2019-09-26 15-37-46](https://user-images.githubusercontent.com/1193222/65690051-e25cb500-e076-11e9-93ae-4bce1d46217c.png)

After:
![Screenshot from 2019-09-26 15-53-13](https://user-images.githubusercontent.com/1193222/65690057-e7216900-e076-11e9-847f-cfa390322541.png)

Resolves #1741 