### PR TITLE
Fix admin permissions hover

### DIFF
--- a/src/modules/admin/components/Permissions/ColonyPermissionEditDialog.css
+++ b/src/modules/admin/components/Permissions/ColonyPermissionEditDialog.css
@@ -1,10 +1,5 @@
 @value borderColor: var(--grey-blue-0);
 
-.permissionChoice {
-  display: flex;
-  align-items: center;
-}
-
 .dialogContainer {
   padding: 27px 19px 17px 19px;
 }
@@ -18,10 +13,6 @@
 .permissionChoiceContainer {
   padding: 15px 0px;
   border-bottom: 1px solid borderColor;
-}
-
-.permissionChoiceDescription {
-  padding-left: 14px;
 }
 
 .titleContainer {

--- a/src/modules/admin/components/Permissions/ColonyPermissionEditDialog.css.d.ts
+++ b/src/modules/admin/components/Permissions/ColonyPermissionEditDialog.css.d.ts
@@ -1,6 +1,4 @@
 export const borderColor: string;
-export const permissionChoice: string;
 export const dialogContainer: string;
 export const permissionChoiceContainer: string;
-export const permissionChoiceDescription: string;
 export const titleContainer: string;

--- a/src/modules/admin/components/Permissions/ColonyPermissionEditDialog.tsx
+++ b/src/modules/admin/components/Permissions/ColonyPermissionEditDialog.tsx
@@ -267,9 +267,9 @@ const ColonyPermissionEditDialog = ({
 
   // When selected user gets updates get that user's roles
   // to populate the checkboxes
-  const useSelectedUserForRoles = (): Array<string> => {
-    const { data } = useUserDomainRoles(colonyAddress, domain.id, selectedUser);
+  const { data } = useUserDomainRoles(colonyAddress, domain.id, selectedUser);
 
+  useEffect(() => {
     // Avoid too many rerenders when no new data has loaded with the following condition
     if (
       selectedRoles &&
@@ -280,9 +280,7 @@ const ColonyPermissionEditDialog = ({
 
       setUserRoles(getRoles(data));
     }
-    return [];
-  };
-  useSelectedUserForRoles();
+  }, [data, selectedRoles, selectedUser]);
 
   // Set user whose roles should be edited
   const {

--- a/src/modules/admin/components/Permissions/ColonyPermissionEditDialog.tsx
+++ b/src/modules/admin/components/Permissions/ColonyPermissionEditDialog.tsx
@@ -59,33 +59,6 @@ const MSG = defineMessages({
     id: 'core.ColonyPermissionEditDialog.permissionsLabel',
     defaultMessage: 'Permissions',
   },
-  roleDescription0: {
-    id: 'core.ColonyPermissionEditDialog.roleDescription0',
-    defaultMessage:
-      'The highest permission, control all aspects of running a colony.',
-  },
-  roleDescription1: {
-    id: 'core.ColonyPermissionEditDialog.roleDescription1',
-    defaultMessage: 'Create and manage new tasks.',
-  },
-  roleDescription2: {
-    id: 'core.ColonyPermissionEditDialog.roleDescription2',
-    defaultMessage:
-      // eslint-disable-next-line max-len
-      'Set the administration, funding, and architecture roles in any subdomain.',
-  },
-  roleDescription3: {
-    id: 'core.ColonyPermissionEditDialog.roleDescription3',
-    defaultMessage: 'Fund tasks and transfer funds between domains.',
-  },
-  roleDescription4: {
-    id: 'core.ColonyPermissionEditDialog.roleDescription4',
-    defaultMessage: 'Put the Colony into recovery mode.',
-  },
-  roleDescription5: {
-    id: 'core.ColonyPermissionEditDialog.roleDescription5',
-    defaultMessage: 'Coming soon...',
-  },
   search: {
     id: 'core.ColonyPermissionEditDialog.search',
     defaultMessage: 'Search for a user or paste a wallet address',
@@ -307,12 +280,11 @@ const ColonyPermissionEditDialog = ({
                 />
               </div>
               <InputLabel label={MSG.permissionsLabel} />
-              {availableRoles.map((role, idx) => (
+              {availableRoles.map(role => (
                 <div key={role} className={styles.permissionChoiceContainer}>
                   <PermissionCheckbox
                     disabled={!checkIfCanBeSet(role)}
                     role={role}
-                    roleDescription={MSG[`roleDescription${idx}`]}
                   />
                 </div>
               ))}

--- a/src/modules/admin/components/Permissions/ColonyPermissionEditDialog.tsx
+++ b/src/modules/admin/components/Permissions/ColonyPermissionEditDialog.tsx
@@ -1,7 +1,7 @@
 import { FormikProps } from 'formik';
 
 import React, { useCallback, useMemo, useState, useEffect } from 'react';
-import { defineMessages, FormattedMessage } from 'react-intl';
+import { defineMessages } from 'react-intl';
 import * as yup from 'yup';
 
 import {
@@ -28,6 +28,7 @@ import {
 } from '~utils/hooks';
 import { filterUserSelection } from '~utils/arrays';
 
+import PermissionCheckbox from './PermissionCheckbox';
 import { userSubscriber } from '../../../users/subscribers';
 import { usersByAddressFetcher } from '../../../users/fetchers';
 
@@ -35,7 +36,7 @@ import SingleUserPicker from '~core/SingleUserPicker';
 import Heading from '~core/Heading';
 import Button from '~core/Button';
 import Dialog, { DialogSection } from '~core/Dialog';
-import { ActionForm, InputLabel, Checkbox } from '~core/Fields';
+import { ActionForm, InputLabel } from '~core/Fields';
 import HookedUserAvatar from '~users/HookedUserAvatar';
 
 import {
@@ -58,26 +59,14 @@ const MSG = defineMessages({
     id: 'core.ColonyPermissionEditDialog.permissionsLabel',
     defaultMessage: 'Permissions',
   },
-  role0: {
-    id: 'core.ColonyPermissionEditDialog.role0',
-    defaultMessage: 'Root',
-  },
   roleDescription0: {
     id: 'core.ColonyPermissionEditDialog.roleDescription0',
     defaultMessage:
       'The highest permission, control all aspects of running a colony.',
   },
-  role1: {
-    id: 'core.ColonyPermissionEditDialog.role1',
-    defaultMessage: 'Administration',
-  },
   roleDescription1: {
     id: 'core.ColonyPermissionEditDialog.roleDescription1',
     defaultMessage: 'Create and manage new tasks.',
-  },
-  role2: {
-    id: 'core.ColonyPermissionEditDialog.role2',
-    defaultMessage: 'Architecture',
   },
   roleDescription2: {
     id: 'core.ColonyPermissionEditDialog.roleDescription2',
@@ -85,25 +74,13 @@ const MSG = defineMessages({
       // eslint-disable-next-line max-len
       'Set the administration, funding, and architecture roles in any subdomain.',
   },
-  role3: {
-    id: 'core.ColonyPermissionEditDialog.role3',
-    defaultMessage: 'Funding',
-  },
   roleDescription3: {
     id: 'core.ColonyPermissionEditDialog.roleDescription3',
     defaultMessage: 'Fund tasks and transfer funds between domains.',
   },
-  role4: {
-    id: 'core.ColonyPermissionEditDialog.role4',
-    defaultMessage: 'Recovery',
-  },
   roleDescription4: {
     id: 'core.ColonyPermissionEditDialog.roleDescription4',
     defaultMessage: 'Put the Colony into recovery mode.',
-  },
-  role5: {
-    id: 'core.ColonyPermissionEditDialog.role5',
-    defaultMessage: 'Arbitration',
   },
   roleDescription5: {
     id: 'core.ColonyPermissionEditDialog.roleDescription5',
@@ -112,14 +89,6 @@ const MSG = defineMessages({
   search: {
     id: 'core.ColonyPermissionEditDialog.search',
     defaultMessage: 'Search for a user or paste a wallet address',
-  },
-  buttonCancel: {
-    id: 'core.ColonyPermissionEditDialog.buttonCancel',
-    defaultMessage: 'Cancel',
-  },
-  buttonConfirm: {
-    id: 'core.ColonyPermissionEditDialog.buttonConfirm',
-    defaultMessage: 'Confirm',
   },
 });
 
@@ -338,34 +307,25 @@ const ColonyPermissionEditDialog = ({
                 />
               </div>
               <InputLabel label={MSG.permissionsLabel} />
-              {availableRoles.map((role, id) => (
+              {availableRoles.map((role, idx) => (
                 <div key={role} className={styles.permissionChoiceContainer}>
-                  <Checkbox
-                    className={styles.permissionChoice}
-                    value={role}
-                    name="roles"
+                  <PermissionCheckbox
                     disabled={!checkIfCanBeSet(role)}
-                  >
-                    <span className={styles.permissionChoiceDescription}>
-                      <Heading
-                        text={MSG[`role${id}`]}
-                        appearance={{ size: 'small', margin: 'none' }}
-                      />
-                      <FormattedMessage {...MSG[`roleDescription${id}`]} />
-                    </span>
-                  </Checkbox>
+                    role={role}
+                    roleDescription={MSG[`roleDescription${idx}`]}
+                  />
                 </div>
               ))}
               <DialogSection appearance={{ align: 'right' }}>
                 <Button
                   appearance={{ theme: 'secondary', size: 'large' }}
                   onClick={cancel}
-                  text={MSG.buttonCancel}
+                  text={{ id: 'button.cancel' }}
                 />
                 <Button
                   appearance={{ theme: 'primary', size: 'large' }}
                   loading={isSubmitting}
-                  text={MSG.buttonConfirm}
+                  text={{ id: 'button.confirm' }}
                   disabled={!isValid}
                   type="submit"
                 />

--- a/src/modules/admin/components/Permissions/PermissionCheckbox.css
+++ b/src/modules/admin/components/Permissions/PermissionCheckbox.css
@@ -1,0 +1,12 @@
+.permissionChoice {
+  display: flex;
+  align-items: center;
+}
+
+.permissionChoiceDescription {
+  padding-left: 14px;
+}
+
+.popoverContent {
+  padding: 10px;
+}

--- a/src/modules/admin/components/Permissions/PermissionCheckbox.css.d.ts
+++ b/src/modules/admin/components/Permissions/PermissionCheckbox.css.d.ts
@@ -1,0 +1,3 @@
+export const permissionChoice: string;
+export const permissionChoiceDescription: string;
+export const popoverContent: string;

--- a/src/modules/admin/components/Permissions/PermissionCheckbox.tsx
+++ b/src/modules/admin/components/Permissions/PermissionCheckbox.tsx
@@ -1,0 +1,87 @@
+import React, { useMemo } from 'react';
+import {
+  defineMessages,
+  FormattedMessage,
+  injectIntl,
+  IntlShape,
+  MessageDescriptor,
+} from 'react-intl';
+
+import { Checkbox } from '~core/Fields';
+import Heading from '~core/Heading';
+import Popover from '~core/Popover';
+
+import styles from './PermissionCheckbox.css';
+
+const MSG = defineMessages({
+  tooltipNoPermissionsText: {
+    id: 'core.Permissions.PermissionCheckbox.tooltipNoPermissionsText',
+    defaultMessage: 'You do not have permission to set the {roleName} role.',
+  },
+});
+
+interface Props {
+  disabled: boolean;
+  intl: IntlShape;
+  role: string;
+  roleDescription: MessageDescriptor;
+}
+
+const displayName = 'admin.Permissions.PermissionCheckbox';
+
+const PermissionCheckbox = ({
+  disabled,
+  intl: { formatMessage },
+  role,
+  roleDescription,
+}: Props) => {
+  const roleNameMessage = { id: `role.${role.toLowerCase()}` };
+  const checkboxContent = useMemo(
+    () => (
+      <Checkbox
+        className={styles.permissionChoice}
+        value={role}
+        name="roles"
+        disabled={disabled}
+      >
+        <span className={styles.permissionChoiceDescription}>
+          <Heading
+            text={roleNameMessage}
+            appearance={{ size: 'small', margin: 'none' }}
+          />
+          <FormattedMessage {...roleDescription} />
+        </span>
+      </Checkbox>
+    ),
+    [disabled, role, roleDescription, roleNameMessage],
+  );
+  return disabled ? (
+    <Popover
+      // Note: `placement` must be set in both `appearance` & `placement` prop
+      // @todo Cleanup `Popover` placement styles
+      // @body `react-popper` uses the `placement` prop, while our styles uses `appearance.placement`. Let's consolidate this into one or the other.
+      appearance={{ placement: 'bottom', theme: 'dark' }}
+      content={() => (
+        <div className={styles.popoverContent}>
+          <FormattedMessage
+            {...MSG.tooltipNoPermissionsText}
+            values={{ roleName: formatMessage(roleNameMessage).toLowerCase() }}
+          />
+        </div>
+      )}
+      placement="bottom"
+    >
+      {({ close, open, ref }) => (
+        <div ref={ref} onMouseEnter={open} onMouseLeave={close}>
+          {checkboxContent}
+        </div>
+      )}
+    </Popover>
+  ) : (
+    <>{checkboxContent}</>
+  );
+};
+
+PermissionCheckbox.displayName = displayName;
+
+export default injectIntl(PermissionCheckbox);

--- a/src/modules/admin/components/Permissions/PermissionCheckbox.tsx
+++ b/src/modules/admin/components/Permissions/PermissionCheckbox.tsx
@@ -4,16 +4,44 @@ import {
   FormattedMessage,
   injectIntl,
   IntlShape,
-  MessageDescriptor,
 } from 'react-intl';
+import camelcase from 'camelcase';
 
 import { Checkbox } from '~core/Fields';
 import Heading from '~core/Heading';
 import Popover from '~core/Popover';
+import { capitalize } from '~utils/strings';
 
 import styles from './PermissionCheckbox.css';
 
 const MSG = defineMessages({
+  roleDescriptionRoot: {
+    id: 'core.ColonyPermissionEditDialog.roleDescriptionRoot',
+    defaultMessage:
+      'The highest permission, control all aspects of running a colony.',
+  },
+  roleDescriptionAdministration: {
+    id: 'core.ColonyPermissionEditDialog.roleDescriptionAdministration',
+    defaultMessage: 'Create and manage new tasks.',
+  },
+  roleDescriptionArchitecture: {
+    id: 'core.ColonyPermissionEditDialog.roleDescriptionArchitecture',
+    defaultMessage:
+      // eslint-disable-next-line max-len
+      'Set the administration, funding, and architecture roles in any subdomain.',
+  },
+  roleDescriptionFunding: {
+    id: 'core.ColonyPermissionEditDialog.roleDescriptionFunding',
+    defaultMessage: 'Fund tasks and transfer funds between domains.',
+  },
+  roleDescriptionRecovery: {
+    id: 'core.ColonyPermissionEditDialog.roleDescriptionRecovery',
+    defaultMessage: 'Put the Colony into recovery mode.',
+  },
+  roleDescriptionArbitration: {
+    id: 'core.ColonyPermissionEditDialog.roleDescriptionArbitration',
+    defaultMessage: 'Coming soon...',
+  },
   tooltipNoPermissionsText: {
     id: 'core.Permissions.PermissionCheckbox.tooltipNoPermissionsText',
     defaultMessage: 'You do not have permission to set the {roleName} role.',
@@ -24,7 +52,6 @@ interface Props {
   disabled: boolean;
   intl: IntlShape;
   role: string;
-  roleDescription: MessageDescriptor;
 }
 
 const displayName = 'admin.Permissions.PermissionCheckbox';
@@ -33,9 +60,11 @@ const PermissionCheckbox = ({
   disabled,
   intl: { formatMessage },
   role,
-  roleDescription,
 }: Props) => {
   const roleNameMessage = { id: `role.${role.toLowerCase()}` };
+  const roleDescriptionMessage = MSG[
+    `roleDescription${capitalize(camelcase(role))}`
+  ] || { id: '', defaultMessage: '' };
   const checkboxContent = useMemo(
     () => (
       <Checkbox
@@ -49,11 +78,11 @@ const PermissionCheckbox = ({
             text={roleNameMessage}
             appearance={{ size: 'small', margin: 'none' }}
           />
-          <FormattedMessage {...roleDescription} />
+          <FormattedMessage {...roleDescriptionMessage} />
         </span>
       </Checkbox>
     ),
-    [disabled, role, roleDescription, roleNameMessage],
+    [disabled, role, roleDescriptionMessage, roleNameMessage],
   );
   return disabled ? (
     <Popover

--- a/src/modules/admin/components/Permissions/PermissionCheckbox.tsx
+++ b/src/modules/admin/components/Permissions/PermissionCheckbox.tsx
@@ -62,9 +62,14 @@ const PermissionCheckbox = ({
   role,
 }: Props) => {
   const roleNameMessage = { id: `role.${role.toLowerCase()}` };
-  const roleDescriptionMessage = MSG[
-    `roleDescription${capitalize(camelcase(role))}`
-  ] || { id: '', defaultMessage: '' };
+  const roleDescriptionMessage = useMemo(
+    () =>
+      MSG[`roleDescription${capitalize(camelcase(role))}`] || {
+        id: '',
+        defaultMessage: '',
+      },
+    [role],
+  );
   const checkboxContent = useMemo(
     () => (
       <Checkbox

--- a/src/modules/core/components/Fields/Checkbox/Checkbox.css
+++ b/src/modules/core/components/Fields/Checkbox/Checkbox.css
@@ -1,5 +1,6 @@
 .main {
   display: block;
+  cursor: pointer;
 }
 
 .delegate {
@@ -70,6 +71,10 @@
   bottom: 0;
   background-color: var(--primary);
   content: '';
+}
+
+.stateDisabled {
+  cursor: default;
 }
 
 .stateDisabled .checkbox {


### PR DESCRIPTION
## Description

This PR adds a tooltip (er... `Popover`, to be technical) when a user hovers over a disabled permission in the colony permissions edit dialog.

**New stuff** ✨

* `PermissionCheckbox` component

**Changes** 🏗

* Use `PermissionCheckbox` component in `ColonyPermissionsEditDialog`
* Improve clarity of some logic regarding state updates
* Use global i18n messages for buttons and some roles.

**Demo** 🎥 

![Permissions Hover](https://user-images.githubusercontent.com/3052635/65792609-bd754a00-e129-11e9-90b3-4ed2cfc55fc2.gif)


Closes #1852 
