### PR TITLE
Inbox Header Items Count

### DIFF
--- a/src/modules/users/components/Inbox/InboxContainer/InboxContainer.tsx
+++ b/src/modules/users/components/Inbox/InboxContainer/InboxContainer.tsx
@@ -32,7 +32,6 @@ const MSG = defineMessages({
   },
   title: {
     id: 'users.Inbox.InboxContainer.title',
-    // defaultMessage: 'Inbox',
     defaultMessage: `Inbox {hasInboxItems, select,
       true { ({inboxItems})}
       other {}

--- a/src/modules/users/components/Inbox/InboxContainer/InboxContainer.tsx
+++ b/src/modules/users/components/Inbox/InboxContainer/InboxContainer.tsx
@@ -32,7 +32,11 @@ const MSG = defineMessages({
   },
   title: {
     id: 'users.Inbox.InboxContainer.title',
-    defaultMessage: 'Inbox',
+    // defaultMessage: 'Inbox',
+    defaultMessage: `Inbox {hasInboxItems, select,
+      true { ({inboxItems})}
+      other {}
+    }`,
   },
   markAllRead: {
     id: 'users.Inbox.InboxContainer.markAllRead',
@@ -75,6 +79,10 @@ const InboxContainer = ({ full, close }: Props) => {
         <Heading
           appearance={{ size: 'medium', margin: 'small' }}
           text={MSG.title}
+          textValues={{
+            hasInboxItems,
+            inboxItems: hasInboxItems ? inboxItems.length : 0,
+          }}
         />
         <Button
           appearance={{ theme: 'blue' }}


### PR DESCRIPTION
## Description

This is a small feature PR that implements inbox items counter in the header of both the Inbox Popover and the Full-page Inbox.

This feature was initially requested here: https://joincolony.slack.com/archives/C0YNG3M8B/p1569521642123400

**Changes**

- [x] `InboxContainer` display items count in `Header`

**Screenshots**

With inbox items:
![Screenshot from 2019-09-30 09-56-04](https://user-images.githubusercontent.com/1193222/65855957-ffd89a00-e368-11e9-90cd-621d0b9f1f67.png)

Without items:
![Screenshot from 2019-09-30 09-56-23](https://user-images.githubusercontent.com/1193222/65855960-02d38a80-e369-11e9-95e4-e191bef01b91.png)
