### PR TITLE
Fix TaskList height on Dashboard and ColonyHome

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyTasks/ColonyTasks.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyTasks/ColonyTasks.css
@@ -29,3 +29,8 @@
 .noTaskAddition {
   margin-top: 20px;
 }
+
+.taskList {
+  display: flex;
+  max-height: calc(100vh - 350px);
+}

--- a/src/modules/dashboard/components/ColonyHome/ColonyTasks/ColonyTasks.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyTasks/ColonyTasks.css
@@ -32,5 +32,6 @@
 
 .taskList {
   display: flex;
+  min-height: 88px;
   max-height: calc(100vh - 350px);
 }

--- a/src/modules/dashboard/components/ColonyHome/ColonyTasks/ColonyTasks.css.d.ts
+++ b/src/modules/dashboard/components/ColonyHome/ColonyTasks/ColonyTasks.css.d.ts
@@ -2,3 +2,4 @@ export const newTaskButtonContainer: string;
 export const newTaskSpinnerContainer: string;
 export const newTaskButton: string;
 export const noTaskAddition: string;
+export const taskList: string;

--- a/src/modules/dashboard/components/ColonyHome/ColonyTasks/ColonyTasks.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyTasks/ColonyTasks.tsx
@@ -180,20 +180,22 @@ const ColonyTasks = ({
    * Let TaskList handle the empty states
    */
   return (
-    <TaskList
-      colonyAddress={colonyAddress}
-      draftIds={draftIds}
-      filteredDomainId={filteredDomainId}
-      filterOption={filterOption}
-      walletAddress={walletAddress}
-      /*
-       * - If we can create tasks, but no tokens are minted,
-       *   don't show the empty state.
-       * - If we can't create tasks, and no tokens are minted,
-       *   show the empty state.
-       */
-      showEmptyState={!canCreateTask}
-    />
+    <div className={styles.taskList}>
+      <TaskList
+        colonyAddress={colonyAddress}
+        draftIds={draftIds}
+        filteredDomainId={filteredDomainId}
+        filterOption={filterOption}
+        walletAddress={walletAddress}
+        /*
+         * - If we can create tasks, but no tokens are minted,
+         *   don't show the empty state.
+         * - If we can't create tasks, and no tokens are minted,
+         *   show the empty state.
+         */
+        showEmptyState={!canCreateTask}
+      />
+    </div>
   );
 };
 

--- a/src/modules/dashboard/components/Dashboard/Dashboard.css
+++ b/src/modules/dashboard/components/Dashboard/Dashboard.css
@@ -18,7 +18,6 @@
   display: inline-block;
   margin: 20px 0 6px;
   width: 105px;
-  float: right;
 }
 
 .sidebar {

--- a/src/modules/dashboard/components/Dashboard/UserTasks.css
+++ b/src/modules/dashboard/components/Dashboard/UserTasks.css
@@ -7,3 +7,13 @@
 .coloniesContainer {
   margin-top: 40px;
 }
+
+.filter {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.taskList {
+  display: flex;
+  max-height: calc(100vh - 450px);
+}

--- a/src/modules/dashboard/components/Dashboard/UserTasks.css
+++ b/src/modules/dashboard/components/Dashboard/UserTasks.css
@@ -15,5 +15,6 @@
 
 .taskList {
   display: flex;
+  min-height: 88px;
   max-height: calc(100vh - 450px);
 }

--- a/src/modules/dashboard/components/Dashboard/UserTasks.css.d.ts
+++ b/src/modules/dashboard/components/Dashboard/UserTasks.css.d.ts
@@ -1,2 +1,4 @@
 export const emptyText: string;
 export const coloniesContainer: string;
+export const filter: string;
+export const taskList: string;

--- a/src/modules/dashboard/components/Dashboard/UserTasks.tsx
+++ b/src/modules/dashboard/components/Dashboard/UserTasks.tsx
@@ -61,12 +61,16 @@ const UserTasks = ({
   }
   return draftIds && draftIds.length ? (
     <>
-      {FilterComponent}
-      <TaskList
-        draftIds={draftIds}
-        filterOption={filterOption}
-        walletAddress={walletAddress}
-      />
+      {!!FilterComponent && (
+        <div className={styles.filter}>{FilterComponent}</div>
+      )}
+      <div className={styles.taskList}>
+        <TaskList
+          draftIds={draftIds}
+          filterOption={filterOption}
+          walletAddress={walletAddress}
+        />
+      </div>
     </>
   ) : (
     <p className={styles.emptyText}>

--- a/src/modules/dashboard/components/TaskList/TaskList.tsx
+++ b/src/modules/dashboard/components/TaskList/TaskList.tsx
@@ -162,106 +162,103 @@ const TaskList = ({
 
   const colonyName = colonyAddress ? data.record : undefined;
 
-  return (
-    <>
-      {/* These empty states are getting a bit out of hand.
-        We have now 4 different empty states for different occurences
-        of the task list and different filter states
-      */}
-      {filteredTasksData.length === 0 && !colonyAddress && (
-        <div className={taskListItemStyles.empty}>
-          {emptyState || (
-            <p>
-              <FormattedMessage {...MSG.noTasks} />
-            </p>
+  /*
+   * These empty states are getting a bit out of hand. We have now 4 different
+   * empty states for different occurences of the task list and different
+   * filter states.
+   */
+  if (filteredTasksData.length === 0 && !colonyAddress) {
+    return (
+      <div className={taskListItemStyles.empty}>
+        {emptyState || (
+          <p>
+            <FormattedMessage {...MSG.noTasks} />
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  return filteredTasksData.length === 0 && colonyAddress ? (
+    <div>
+      {showEmptyState && (
+        <>
+          {filteredDomainId ? (
+            <div>
+              <Icon
+                className={taskListItemStyles.noTask}
+                name="empty-task"
+                title={MSG.noTasks}
+                viewBox="0 0 120 120"
+              />
+              <div className={taskListItemStyles.emptyStateElements}>
+                <FormattedMessage tagName="p" {...MSG.noTaskDescription} />
+              </div>
+              <div className={taskListItemStyles.emptyStateElements}>
+                <FormattedMessage tagName="p" {...MSG.noTaskAddition} />
+              </div>
+            </div>
+          ) : (
+            <div>
+              <Icon
+                className={taskListItemStyles.noTask}
+                name="cup"
+                title={MSG.noTasks}
+                viewBox="0 0 120 120"
+              />
+              <div className={taskListItemStyles.emptyStateElements}>
+                <FormattedMessage
+                  tagName="p"
+                  {...MSG.welcomeToColony}
+                  values={{
+                    colonyNameExists: !!colonyName,
+                    colonyName,
+                  }}
+                />
+              </div>
+              <div className={taskListItemStyles.emptyStateElements}>
+                <FormattedMessage
+                  tagName="p"
+                  {...MSG.subscribeToColony}
+                  values={{
+                    /*
+                     * If the current user hasn't claimed a profile yet, then don't show the
+                     * subscribe to colony call to action
+                     */
+                    isSubscribed: currentUser.profile.username
+                      ? isSubscribed
+                      : true,
+                    myColonies: (
+                      <ActionButton
+                        className={taskListItemStyles.subscribe}
+                        error={ActionTypes.USER_COLONY_SUBSCRIBE_ERROR}
+                        submit={ActionTypes.USER_COLONY_SUBSCRIBE}
+                        success={ActionTypes.USER_COLONY_SUBSCRIBE_SUCCESS}
+                        transform={transform}
+                      >
+                        <FormattedMessage tagName="span" {...MSG.myColonies} />
+                      </ActionButton>
+                    ),
+                  }}
+                />
+              </div>
+            </div>
           )}
-        </div>
+        </>
       )}
-      {filteredTasksData.length === 0 && colonyAddress ? (
-        <div>
-          {showEmptyState && (
-            <>
-              {filteredDomainId ? (
-                <div>
-                  <Icon
-                    className={taskListItemStyles.noTask}
-                    name="empty-task"
-                    title={MSG.noTasks}
-                    viewBox="0 0 120 120"
-                  />
-                  <div className={taskListItemStyles.emptyStateElements}>
-                    <FormattedMessage tagName="p" {...MSG.noTaskDescription} />
-                  </div>
-                  <div className={taskListItemStyles.emptyStateElements}>
-                    <FormattedMessage tagName="p" {...MSG.noTaskAddition} />
-                  </div>
-                </div>
-              ) : (
-                <div>
-                  <Icon
-                    className={taskListItemStyles.noTask}
-                    name="cup"
-                    title={MSG.noTasks}
-                    viewBox="0 0 120 120"
-                  />
-                  <div className={taskListItemStyles.emptyStateElements}>
-                    <FormattedMessage
-                      tagName="p"
-                      {...MSG.welcomeToColony}
-                      values={{
-                        colonyNameExists: !!colonyName,
-                        colonyName,
-                      }}
-                    />
-                  </div>
-                  <div className={taskListItemStyles.emptyStateElements}>
-                    <FormattedMessage
-                      tagName="p"
-                      {...MSG.subscribeToColony}
-                      values={{
-                        /*
-                         * If the current user hasn't claimed a profile yet, then don't show the
-                         * subscribe to colony call to action
-                         */
-                        isSubscribed: currentUser.profile.username
-                          ? isSubscribed
-                          : true,
-                        myColonies: (
-                          <ActionButton
-                            className={taskListItemStyles.subscribe}
-                            error={ActionTypes.USER_COLONY_SUBSCRIBE_ERROR}
-                            submit={ActionTypes.USER_COLONY_SUBSCRIBE}
-                            success={ActionTypes.USER_COLONY_SUBSCRIBE_SUCCESS}
-                            transform={transform}
-                          >
-                            <FormattedMessage
-                              tagName="span"
-                              {...MSG.myColonies}
-                            />
-                          </ActionButton>
-                        ),
-                      }}
-                    />
-                  </div>
-                </div>
-              )}
-            </>
-          )}
-        </div>
-      ) : (
-        <Table
-          data-test="dashboardTaskList"
-          appearance={{ theme: 'rounder' }}
-          scrollable
-        >
-          <TableBody>
-            {filteredTasksData.map((taskData: any) => (
-              <TaskListItem key={taskData.key} data={taskData} />
-            ))}
-          </TableBody>
-        </Table>
-      )}
-    </>
+    </div>
+  ) : (
+    <Table
+      data-test="dashboardTaskList"
+      appearance={{ theme: 'rounder' }}
+      scrollable
+    >
+      <TableBody>
+        {filteredTasksData.map((taskData: any) => (
+          <TaskListItem key={taskData.key} data={taskData} />
+        ))}
+      </TableBody>
+    </Table>
   );
 };
 


### PR DESCRIPTION
## Description

The `TaskList` now scrolls when it would otherwise cause the page to scroll. This is done in `UserTasks` and` ColonyTasks`.

Some of the CSS for these components is quite overwhelming, but I hope I haven't done anything crazy!

**Changes** 🏗

* `UserTasks` has a max height
* `ColonyTasks` has a max height

Resolves #1570 
