### PR TITLE
Remove CI Goerli Build Trigger on Commit 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,14 +286,6 @@ workflows:
           filters:
             branches:
               only: master
-      - build-goerli-image:
-          requires:
-            - build-with-lockfile
-            - integration-testing
-            - e2e-testing
-          filters:
-            branches:
-              ignore: master
       - build-mainnet-image:
           requires:
             - build-with-lockfile


### PR DESCRIPTION
## Description

This PR simply removes the trigger to run the `build-goerli-image` job on a non-`master` branch commit.

This prevents unwanted builds, while allowing chewie to access this job via the API trigger.
