### PR TITLE
Allow JPEG mime types uploads

### DIFF
--- a/src/modules/core/components/AvatarUploader/AvatarUploader.tsx
+++ b/src/modules/core/components/AvatarUploader/AvatarUploader.tsx
@@ -27,13 +27,9 @@ const MSG = defineMessages({
   },
 });
 
-export const ACCEPTED_MIME_TYPES: string[] = [
-  'image/png',
-  'image/jpeg',
-];
+export const ACCEPTED_MIME_TYPES: string[] = ['image/png', 'image/jpeg'];
 
 export const ACCEPTED_MAX_FILE_SIZE = 2097152; // 2MB
-
 
 interface Props {
   /** Only render the Uploader, no label */

--- a/src/modules/core/components/AvatarUploader/AvatarUploader.tsx
+++ b/src/modules/core/components/AvatarUploader/AvatarUploader.tsx
@@ -27,6 +27,14 @@ const MSG = defineMessages({
   },
 });
 
+export const ACCEPTED_MIME_TYPES: string[] = [
+  'image/png',
+  'image/jpeg',
+];
+
+export const ACCEPTED_MAX_FILE_SIZE = 2097152; // 2MB
+
+
 interface Props {
   /** Only render the Uploader, no label */
   elementOnly?: boolean;
@@ -88,11 +96,11 @@ class AvatarUploader extends Component<Props> {
             dropzoneRef={this.registerDropzone}
             elementOnly={elementOnly}
             classNames={styles}
-            accept={['image/jpeg', 'image/png']}
+            accept={ACCEPTED_MIME_TYPES}
             label={label}
             help={help}
             maxFilesLimit={1}
-            maxFileSize={2097152} // 2MB
+            maxFileSize={ACCEPTED_MAX_FILE_SIZE}
             name="avatarUploader"
             renderPlaceholder={placeholder}
             itemComponent={AvatarUploadItem}

--- a/src/modules/core/components/FileUpload/ActionFileUpload.tsx
+++ b/src/modules/core/components/FileUpload/ActionFileUpload.tsx
@@ -15,6 +15,7 @@ interface Props {
   maxFileSize?: number;
   name?: string;
   label?: any;
+  status?: any;
 }
 
 const ActionFileUpload = ({

--- a/src/modules/core/components/FileUpload/FileUpload.tsx
+++ b/src/modules/core/components/FileUpload/FileUpload.tsx
@@ -8,12 +8,15 @@ import {
 import Dropzone from 'react-dropzone';
 import { getIn } from 'formik';
 
-import styles from './FileUpload.css';
+import { FileReaderFile, UploadFile } from './types';
+import { DEFAULT_MIME_TYPES, DEFAULT_MAX_FILE_SIZE } from './limits';
+
 import { asFieldArray } from '../Fields';
 import InputLabel from '../Fields/InputLabel';
 import InputStatus from '../Fields/InputStatus';
-import { FileReaderFile, UploadFile } from './types';
 import UploadItem from './UploadItem';
+
+import styles from './FileUpload.css';
 
 const MSG = defineMessages({
   dropzoneText: {
@@ -107,11 +110,12 @@ class FileUpload extends Component<Props> {
   static displayName = 'FileUpload';
 
   static defaultProps = {
+    accept: DEFAULT_MIME_TYPES,
     classNames: styles,
     disableClick: false,
     itemComponent: UploadItem,
     maxFilesLimit: 1,
-    maxFileSize: 1024 * 1024,
+    maxFileSize: DEFAULT_MAX_FILE_SIZE,
     renderPlaceholder: <Placeholder />,
   };
 

--- a/src/modules/core/components/FileUpload/limits.ts
+++ b/src/modules/core/components/FileUpload/limits.ts
@@ -1,0 +1,7 @@
+export const DEFAULT_MIME_TYPES: string[] = [
+  'image/svg+xml',
+  'image/png',
+  'image/jpeg',
+];
+
+export const DEFAULT_MAX_FILE_SIZE = 1048576; // 1MB

--- a/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.tsx
@@ -48,7 +48,7 @@ const MSG = defineMessages({
   },
   labelTokenIcon: {
     id: 'dashboard.CreateColonyWizard.StepCreateToken.labelTokenIcon',
-    defaultMessage: 'Token Logo (optional)',
+    defaultMessage: 'Token Icon (Optional)',
   },
   tokenIconHint: {
     id: 'dashboard.CreateColonyWizard.StepCreateToken.tokenIconHint',

--- a/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.tsx
@@ -50,6 +50,10 @@ const MSG = defineMessages({
     id: 'dashboard.CreateColonyWizard.StepCreateToken.labelTokenIcon',
     defaultMessage: 'Token Logo (optional)',
   },
+  tokenIconHint: {
+    id: 'dashboard.CreateColonyWizard.StepCreateToken.tokenIconHint',
+    defaultMessage: 'Recommended format: .png or .svg',
+  },
   link: {
     id: 'dashboard.CreateColonyWizard.StepCreateToken.link',
     defaultMessage: 'I want to use an existing token',
@@ -191,6 +195,7 @@ const StepCreateToken = ({
                 success={ActionTypes.IPFS_DATA_UPLOAD_SUCCESS}
                 error={ActionTypes.IPFS_DATA_UPLOAD_ERROR}
                 transform={transform}
+                status={MSG.tokenIconHint}
               />
             </div>
           </section>

--- a/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.tsx
@@ -70,7 +70,12 @@ const MSG = defineMessages({
   },
 });
 
-const ACCEPTED_MIME_TYPES: string[] = ['image/svg+xml', 'image/png'];
+const ACCEPTED_MIME_TYPES: string[] = [
+  'image/svg+xml',
+  'image/png',
+  'image/jpeg',
+];
+
 const ACCEPTED_MAX_FILE_SIZE = 1000000;
 
 const validationSchema = yup.object({

--- a/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.tsx
@@ -70,14 +70,6 @@ const MSG = defineMessages({
   },
 });
 
-const ACCEPTED_MIME_TYPES: string[] = [
-  'image/svg+xml',
-  'image/png',
-  'image/jpeg',
-];
-
-const ACCEPTED_MAX_FILE_SIZE = 1000000;
-
 const validationSchema = yup.object({
   tokenName: yup.string().required(),
   tokenSymbol: yup
@@ -193,8 +185,6 @@ const StepCreateToken = ({
             </div>
             <div className={styles.inputFieldWrapper}>
               <ActionFileUpload
-                accept={ACCEPTED_MIME_TYPES}
-                maxFileSize={ACCEPTED_MAX_FILE_SIZE}
                 name="tokenIcon"
                 label={MSG.labelTokenIcon}
                 submit={ActionTypes.IPFS_DATA_UPLOAD}

--- a/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.tsx
@@ -4,14 +4,17 @@ import React, { useCallback, useState } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import * as yup from 'yup';
 
+import { ActionTypes } from '~redux/index';
 import { WizardProps } from '~core/Wizard';
 import { Form, Input } from '~core/Fields';
 import Heading from '~core/Heading';
 import Button from '~core/Button';
-import FileUpload from '~core/FileUpload';
+import { ActionFileUpload } from '~core/FileUpload';
 import { multiLineTextEllipsis } from '~utils/strings';
+import { mapPayload } from '~utils/actions';
 import ENS from '~lib/ENS';
 import TokenSelector from './TokenSelector';
+
 import styles from './StepSelectToken.css';
 
 type TokenData = {
@@ -24,7 +27,7 @@ interface FormValues {
   tokenChoice: 'create' | 'select';
   tokenSymbol?: string;
   tokenName?: string;
-  iconUpload?: string;
+  tokenIcon?: string;
   tokenData: TokenData | null;
   colonyName: string;
 }
@@ -98,6 +101,11 @@ const StepSelectToken = ({
       setFieldValue('tokenSymbol', data.symbol);
     }
   };
+
+  const transform = useCallback(
+    mapPayload(({ data }) => ({ ipfsData: data })),
+    [],
+  );
 
   const goToTokenCreate = useCallback(() => {
     /* This is a custom link since it goes to a sibling step that appears
@@ -179,9 +187,13 @@ const StepSelectToken = ({
                   />
                 </div>
                 <div className={styles.tokenDetails}>
-                  <FileUpload
+                  <ActionFileUpload
+                    name="tokenIcon"
+                    submit={ActionTypes.IPFS_DATA_UPLOAD}
+                    success={ActionTypes.IPFS_DATA_UPLOAD_SUCCESS}
+                    error={ActionTypes.IPFS_DATA_UPLOAD_ERROR}
+                    transform={transform}
                     label={MSG.fileUploadTitle}
-                    name="iconUpload"
                     status={MSG.fileUploadHint}
                   />
                 </div>

--- a/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.tsx
@@ -180,11 +180,9 @@ const StepSelectToken = ({
                 </div>
                 <div className={styles.tokenDetails}>
                   <FileUpload
-                    accept={['svg', 'png']}
                     label={MSG.fileUploadTitle}
                     name="iconUpload"
                     status={MSG.fileUploadHint}
-                    maxFilesLimit={1}
                   />
                 </div>
               </>

--- a/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.tsx
@@ -69,7 +69,7 @@ const MSG = defineMessages({
   },
   fileUploadTitle: {
     id: 'dashboard.CreateColonyWizard.StepSelectToken.fileUpload',
-    defaultMessage: 'Token Icon (.svg or .png)',
+    defaultMessage: 'Token Icon (optional)',
   },
   fileUploadHint: {
     id: 'dashboard.CreateColonyWizard.StepSelectToken.fileUploadHint',

--- a/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.tsx
@@ -70,7 +70,7 @@ const MSG = defineMessages({
   },
   fileUploadHint: {
     id: 'dashboard.CreateColonyWizard.StepSelectToken.fileUploadHint',
-    defaultMessage: 'Recommended size for .png file is 60px by 60px, up to 1MB',
+    defaultMessage: 'Recommended format: .png or .svg',
   },
 });
 

--- a/src/modules/users/components/ConnectWalletWizard/StepJSONUpload/StepJSONUpload.tsx
+++ b/src/modules/users/components/ConnectWalletWizard/StepJSONUpload/StepJSONUpload.tsx
@@ -56,9 +56,7 @@ const MSG = defineMessages({
   },
 });
 
-export const ACCEPTED_MIME_TYPES: string[] = [
-  'application/json',
-];
+export const ACCEPTED_MIME_TYPES: string[] = ['application/json'];
 
 type FormValues = {
   method: WALLET_SPECIFICS;

--- a/src/modules/users/components/ConnectWalletWizard/StepJSONUpload/StepJSONUpload.tsx
+++ b/src/modules/users/components/ConnectWalletWizard/StepJSONUpload/StepJSONUpload.tsx
@@ -56,6 +56,10 @@ const MSG = defineMessages({
   },
 });
 
+export const ACCEPTED_MIME_TYPES: string[] = [
+  'application/json',
+];
+
 type FormValues = {
   method: WALLET_SPECIFICS;
   walletJsonFileUpload: UploadFile[];
@@ -126,7 +130,7 @@ const StepJSONUpload = ({
             <Heading text={MSG.heading} appearance={{ size: 'medium' }} />
             <div className={styles.uploadArea}>
               <FileUpload
-                accept={['application/json']}
+                accept={ACCEPTED_MIME_TYPES}
                 name="walletJsonFileUpload"
                 label={MSG.fileUploadLabel}
                 help={MSG.fileUploadHelp}


### PR DESCRIPTION
## Description

This PR adds in supports for allowing a user to upload `jpeg` image files while creating or using an already-existing token.

While at it, make sure all file uploaders allow this mime type and refactor it to all pull from a single source in order to make changing it at a later date easier.

Along with allowing `jpeg` files, we're also updating the copy to inform the user of this fact.

LE: Turns out the file upload in `StepSelectToken` **was broken** and no-one noticed. I fixed that as well here.

**Changes**

- [x] `FileUpload` now has defaults that accept `svg`,`jpeg` and `png`
- [x] `AvatarUploader` better accepted file size and mime types
- [x] `StepJSONUpload` better accepted file size and mime types
- [x] `StepCreateToken`, `StepSelectToken` unify label copy
- [x] `StepCreateToken`, `StepSelectToken` add file type hint
- [x] `StepSelectToken` fix actual file upload! _(by using the `ActionFileUpload` component)_

**Screenshots**

![Screenshot from 2019-10-03 16-05-28](https://user-images.githubusercontent.com/1193222/66128991-ae920a00-e5f7-11e9-9af2-80788bc174a9.png)

![Screenshot from 2019-10-03 16-05-42](https://user-images.githubusercontent.com/1193222/66128992-ae920a00-e5f7-11e9-9581-b4ab5b365ece.png)

Resolves #1796 