### PR TITLE
Fix ColonyMeta selected domain

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyMeta/ColonyMeta.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMeta/ColonyMeta.tsx
@@ -34,14 +34,6 @@ const MSG = defineMessages({
     id: 'dashboard.ColonyHome.ColonyMeta.editColonyTitle',
     defaultMessage: 'Edit Colony',
   },
-  allDomains: {
-    id: 'dashboard.ColonyHome.ColonyMeta.allDomains',
-    defaultMessage: 'root',
-  },
-  title: {
-    id: 'dashboard.ColonyHome.ColonyMeta.title',
-    defaultMessage: 'All Domains',
-  },
 });
 
 const ColonyAvatar = HookedColonyAvatar({ fetchColony: false });
@@ -139,16 +131,12 @@ const ColonyMeta = ({
       )}
       <div className={styles.domainContainer}>
         <ul>
-          <Heading
-            appearance={{ size: 'normal', weight: 'thin' }}
-            text={MSG.title}
-          />
           <li>
             <Button
               className={getActiveDomainFilterClass(0, filteredDomainId)}
-              onClick={() => setFilteredDomainId()}
+              onClick={() => setFilteredDomainId(0)}
             >
-              <FormattedMessage {...MSG.allDomains} />
+              <FormattedMessage id="domain.root" />
             </Button>
           </li>
           {(domains || []).map(({ name, id }) => (


### PR DESCRIPTION
## Description

Selecting the root domain wouldn't correctly highlight it in the domain list. We also didn't need the "All Domains" header.

**Changes** 🏗

* Clicking root will now set the filter to domain `0` (all domains)
* Use global intl message for root domain in `ColonyMeta`

**Deletions** ⚰️

* Removed "All Domains" heading
