### PR TITLE
Add parent role indicator to Permissions

### DIFF
--- a/src/modules/admin/components/Permissions/ColonyPermissionEditDialog.css
+++ b/src/modules/admin/components/Permissions/ColonyPermissionEditDialog.css
@@ -19,3 +19,9 @@
   margin-top: 35px;
   margin-bottom: 32px;
 }
+
+.parentPermissionTip {
+  margin: 10px 0;
+  font-size: var(--size-small);
+  font-weight: var(--weight-medium);
+}

--- a/src/modules/admin/components/Permissions/ColonyPermissionEditDialog.css.d.ts
+++ b/src/modules/admin/components/Permissions/ColonyPermissionEditDialog.css.d.ts
@@ -2,3 +2,4 @@ export const borderColor: string;
 export const dialogContainer: string;
 export const permissionChoiceContainer: string;
 export const titleContainer: string;
+export const parentPermissionTip: string;

--- a/src/modules/admin/components/Permissions/ColonyPermissionEditDialog.tsx
+++ b/src/modules/admin/components/Permissions/ColonyPermissionEditDialog.tsx
@@ -51,27 +51,27 @@ const DOMAINS_HELP_URL = 'https://help.colony.io/';
 
 const MSG = defineMessages({
   title: {
-    id: 'core.ColonyPermissionEditDialog.title',
+    id: 'admin.ColonyPermissionEditDialog.title',
     defaultMessage: 'Add New Role in {domain}',
   },
   selectUser: {
-    id: 'core.ColonyPermissionEditDialog.selectUser',
+    id: 'admin.ColonyPermissionEditDialog.selectUser',
     defaultMessage: 'Select Member',
   },
   permissionsLabel: {
-    id: 'core.ColonyPermissionEditDialog.permissionsLabel',
+    id: 'admin.ColonyPermissionEditDialog.permissionsLabel',
     defaultMessage: 'Permissions',
   },
   search: {
-    id: 'core.ColonyPermissionEditDialog.search',
+    id: 'admin.ColonyPermissionEditDialog.search',
     defaultMessage: 'Search for a user or paste a wallet address',
   },
   permissionInParent: {
-    id: 'dashboard.Permissions.permissionInParent',
+    id: 'admin.ColonyPermissionEditDialog.permissionInParent',
     defaultMessage: '*Permission granted via parent domain. {learnMore}',
   },
   learnMore: {
-    id: 'dashboard.Permissions.learnMore',
+    id: 'admin.ColonyPermissionEditDialog.learnMore',
     defaultMessage: 'Learn more',
   },
 });
@@ -351,6 +351,6 @@ const ColonyPermissionEditDialog = ({
   );
 };
 
-ColonyPermissionEditDialog.displayName = 'core.ColonyPermissionEditDialog';
+ColonyPermissionEditDialog.displayName = 'admin.ColonyPermissionEditDialog';
 
 export default ColonyPermissionEditDialog;

--- a/src/modules/admin/components/Permissions/PermissionCheckbox.tsx
+++ b/src/modules/admin/components/Permissions/PermissionCheckbox.tsx
@@ -15,6 +15,10 @@ import { capitalize } from '~utils/strings';
 import styles from './PermissionCheckbox.css';
 
 const MSG = defineMessages({
+  roleWithAsterisk: {
+    id: 'core.ColonyPermissionEditDialog.roleWithAsterisk',
+    defaultMessage: '{role}{asterisk, select, true {*} false {} }',
+  },
   roleDescriptionRoot: {
     id: 'core.ColonyPermissionEditDialog.roleDescriptionRoot',
     defaultMessage:
@@ -49,6 +53,7 @@ const MSG = defineMessages({
 });
 
 interface Props {
+  asterisk: boolean;
   disabled: boolean;
   intl: IntlShape;
   role: string;
@@ -57,6 +62,7 @@ interface Props {
 const displayName = 'admin.Permissions.PermissionCheckbox';
 
 const PermissionCheckbox = ({
+  asterisk,
   disabled,
   intl: { formatMessage },
   role,
@@ -80,14 +86,25 @@ const PermissionCheckbox = ({
       >
         <span className={styles.permissionChoiceDescription}>
           <Heading
-            text={roleNameMessage}
+            text={MSG.roleWithAsterisk}
+            textValues={{
+              role: formatMessage(roleNameMessage),
+              asterisk: !!asterisk,
+            }}
             appearance={{ size: 'small', margin: 'none' }}
           />
           <FormattedMessage {...roleDescriptionMessage} />
         </span>
       </Checkbox>
     ),
-    [disabled, role, roleDescriptionMessage, roleNameMessage],
+    [
+      asterisk,
+      disabled,
+      formatMessage,
+      role,
+      roleDescriptionMessage,
+      roleNameMessage,
+    ],
   );
   return disabled ? (
     <Popover

--- a/src/modules/admin/components/Permissions/PermissionCheckbox.tsx
+++ b/src/modules/admin/components/Permissions/PermissionCheckbox.tsx
@@ -16,38 +16,38 @@ import styles from './PermissionCheckbox.css';
 
 const MSG = defineMessages({
   roleWithAsterisk: {
-    id: 'core.ColonyPermissionEditDialog.roleWithAsterisk',
+    id: 'admin.ColonyPermissionEditDialog.roleWithAsterisk',
     defaultMessage: '{role}{asterisk, select, true {*} false {} }',
   },
   roleDescriptionRoot: {
-    id: 'core.ColonyPermissionEditDialog.roleDescriptionRoot',
+    id: 'admin.ColonyPermissionEditDialog.roleDescriptionRoot',
     defaultMessage:
       'The highest permission, control all aspects of running a colony.',
   },
   roleDescriptionAdministration: {
-    id: 'core.ColonyPermissionEditDialog.roleDescriptionAdministration',
+    id: 'admin.ColonyPermissionEditDialog.roleDescriptionAdministration',
     defaultMessage: 'Create and manage new tasks.',
   },
   roleDescriptionArchitecture: {
-    id: 'core.ColonyPermissionEditDialog.roleDescriptionArchitecture',
+    id: 'admin.ColonyPermissionEditDialog.roleDescriptionArchitecture',
     defaultMessage:
       // eslint-disable-next-line max-len
       'Set the administration, funding, and architecture roles in any subdomain.',
   },
   roleDescriptionFunding: {
-    id: 'core.ColonyPermissionEditDialog.roleDescriptionFunding',
+    id: 'admin.ColonyPermissionEditDialog.roleDescriptionFunding',
     defaultMessage: 'Fund tasks and transfer funds between domains.',
   },
   roleDescriptionRecovery: {
-    id: 'core.ColonyPermissionEditDialog.roleDescriptionRecovery',
+    id: 'admin.ColonyPermissionEditDialog.roleDescriptionRecovery',
     defaultMessage: 'Put the Colony into recovery mode.',
   },
   roleDescriptionArbitration: {
-    id: 'core.ColonyPermissionEditDialog.roleDescriptionArbitration',
+    id: 'admin.ColonyPermissionEditDialog.roleDescriptionArbitration',
     defaultMessage: 'Coming soon...',
   },
   tooltipNoPermissionsText: {
-    id: 'core.Permissions.PermissionCheckbox.tooltipNoPermissionsText',
+    id: 'admin.Permissions.PermissionCheckbox.tooltipNoPermissionsText',
     defaultMessage: 'You do not have permission to set the {roleName} role.',
   },
 });

--- a/src/modules/admin/components/Permissions/Permissions.css
+++ b/src/modules/admin/components/Permissions/Permissions.css
@@ -31,3 +31,9 @@
 .main table .tableBody tr {
   overflow-x: auto;
 }
+
+.parentPermissionTip {
+  margin: 10px;
+  font-size: var(--size-small);
+  font-weight: var(--weight-medium);
+}

--- a/src/modules/admin/components/Permissions/Permissions.css.d.ts
+++ b/src/modules/admin/components/Permissions/Permissions.css.d.ts
@@ -3,3 +3,4 @@ export const titleContainer: string;
 export const tableWrapper: string;
 export const sidebar: string;
 export const tableBody: string;
+export const parentPermissionTip: string;

--- a/src/modules/admin/components/Permissions/Permissions.tsx
+++ b/src/modules/admin/components/Permissions/Permissions.tsx
@@ -31,26 +31,26 @@ const DOMAINS_HELP_URL = 'https://help.colony.io/';
 
 const MSG = defineMessages({
   title: {
-    id: 'dashboard.Permissions.title',
+    id: 'admin.Permissions.title',
     defaultMessage: `Permissions{domainLabel, select,
       root {}
       other {: {domainLabel}}
     }`,
   },
   labelFilter: {
-    id: 'dashboard.Permissions.labelFilter',
+    id: 'admin.Permissions.labelFilter',
     defaultMessage: 'Filter',
   },
   addRole: {
-    id: 'dashboard.Permissions.addRole',
+    id: 'admin.Permissions.addRole',
     defaultMessage: 'Add Role',
   },
   permissionInParent: {
-    id: 'dashboard.Permissions.permissionInParent',
+    id: 'admin.Permissions.permissionInParent',
     defaultMessage: '*Permission granted via parent domain. {learnMore}',
   },
   learnMore: {
-    id: 'dashboard.Permissions.learnMore',
+    id: 'admin.Permissions.learnMore',
     defaultMessage: 'Learn more',
   },
 });

--- a/src/modules/admin/components/Permissions/Permissions.tsx
+++ b/src/modules/admin/components/Permissions/Permissions.tsx
@@ -1,6 +1,11 @@
 import React, { useCallback, useMemo, useState } from 'react';
 
-import { defineMessages, injectIntl, IntlShape } from 'react-intl';
+import {
+  defineMessages,
+  injectIntl,
+  IntlShape,
+  FormattedMessage,
+} from 'react-intl';
 import { compose } from 'recompose';
 
 import { Address, createAddress } from '~types/index';
@@ -12,6 +17,7 @@ import { Table, TableBody, TableCell } from '~core/Table';
 import Button from '~core/Button';
 import withDialog from '~core/Dialog/withDialog';
 import { DialogType } from '~core/Dialog';
+import ExternalLink from '~core/ExternalLink';
 import { useDataFetcher, useRoles } from '~utils/hooks';
 
 import UserListItem from '../UserListItem';
@@ -20,6 +26,8 @@ import { domainsFetcher } from '../../../dashboard/fetchers';
 import UserPermissions from './UserPermissions';
 
 import styles from './Permissions.css';
+
+const DOMAINS_HELP_URL = 'https://help.colony.io/';
 
 const MSG = defineMessages({
   title: {
@@ -36,6 +44,14 @@ const MSG = defineMessages({
   addRole: {
     id: 'dashboard.Permissions.addRole',
     defaultMessage: 'Add Role',
+  },
+  permissionInParent: {
+    id: 'dashboard.Permissions.permissionInParent',
+    defaultMessage: '*Permission granted via parent domain. {learnMore}',
+  },
+  learnMore: {
+    id: 'dashboard.Permissions.learnMore',
+    defaultMessage: 'Learn more',
   },
 });
 
@@ -71,7 +87,10 @@ const Permissions = ({
     [domainsData],
   );
 
-  const { data: roles, isFetching: isFetchingRoles } = useRoles(colonyAddress);
+  const { data: roles, isFetching: isFetchingRoles } = useRoles(
+    colonyAddress,
+    true,
+  );
 
   const setFieldValue = useCallback((_, value) => setSelectedDomain(value), [
     setSelectedDomain,
@@ -152,28 +171,43 @@ const Permissions = ({
           {isFetchingRoles || isFetchingDomains ? (
             <SpinnerLoader />
           ) : (
-            <Table scrollable>
-              <TableBody className={styles.tableBody}>
-                {users.map(user => (
-                  <UserListItem
-                    address={user}
-                    key={user}
-                    onClick={handleOnClick}
-                    showDisplayName
-                    showMaskedAddress
-                    showUsername
-                  >
-                    <TableCell>
-                      <UserPermissions
-                        colonyAddress={colonyAddress}
-                        domainId={selectedDomain}
-                        userAddress={user}
+            <>
+              <Table scrollable>
+                <TableBody className={styles.tableBody}>
+                  {users.map(user => (
+                    <UserListItem
+                      address={user}
+                      key={user}
+                      onClick={handleOnClick}
+                      showDisplayName
+                      showMaskedAddress
+                      showUsername
+                    >
+                      <TableCell>
+                        <UserPermissions
+                          colonyAddress={colonyAddress}
+                          domainId={selectedDomain}
+                          userAddress={user}
+                        />
+                      </TableCell>
+                    </UserListItem>
+                  ))}
+                </TableBody>
+              </Table>
+              <p className={styles.parentPermissionTip}>
+                <FormattedMessage
+                  {...MSG.permissionInParent}
+                  values={{
+                    learnMore: (
+                      <ExternalLink
+                        text={MSG.learnMore}
+                        href={DOMAINS_HELP_URL}
                       />
-                    </TableCell>
-                  </UserListItem>
-                ))}
-              </TableBody>
-            </Table>
+                    ),
+                  }}
+                />
+              </p>
+            </>
           )}
         </div>
       </main>

--- a/src/modules/admin/components/Permissions/UserPermissions.tsx
+++ b/src/modules/admin/components/Permissions/UserPermissions.tsx
@@ -27,12 +27,19 @@ const UserPermissions = ({ colonyAddress, domainId, userAddress }: Props) => {
     userAddress,
   );
 
+  const { data: userPermissionsWithParents } = useUserDomainRoles(
+    colonyAddress,
+    domainId,
+    userAddress,
+    true,
+  );
+
   const sortedUserPermissionlabels = useMemo(
     () =>
-      Object.keys(userPermissions)
+      Object.keys(userPermissionsWithParents)
         .filter(
           key =>
-            !!userPermissions[key] &&
+            !!userPermissionsWithParents[key] &&
             // Don't display ARCHITECTURE_SUBDOMAIN in listed roles
             key !== COLONY_ROLE_ARCHITECTURE_SUBDOMAIN,
         )
@@ -42,7 +49,7 @@ const UserPermissions = ({ colonyAddress, domainId, userAddress }: Props) => {
           }
           return 0;
         }),
-    [userPermissions],
+    [userPermissionsWithParents],
   );
 
   return (
@@ -54,6 +61,7 @@ const UserPermissions = ({ colonyAddress, domainId, userAddress }: Props) => {
           {sortedUserPermissionlabels.map(userPermission => (
             <span className={styles.permission} key={userPermission}>
               <FormattedMessage id={ROLE_MESSAGES[userPermission]} />
+              {!userPermissions[userPermission] && <span>*</span>}
             </span>
           ))}
         </>


### PR DESCRIPTION
## Description

Now it's clear when a user has a role in a parent domain in the colony admin permissions list and edit dialog.

![image](https://user-images.githubusercontent.com/7497084/66051419-98bd1000-e537-11e9-85c2-71db7c93eabb.png)

![image](https://user-images.githubusercontent.com/7497084/66051482-ab374980-e537-11e9-9660-21b195ed4032.png)

**New stuff** ✨

* `UserPermissions` now shows asterisk if role is set in parent domain
* `ColonyPermissionEditDialog` shows asterisk if role is set in parent

Resolves #1848 
