### PR TITLE
Upgrade to @colony/colony-js-client@1.14.0-beta.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "dependencies": {
         "@babel/runtime": "^7.0.0",
         "@colony/colony-js-adapter-ethers": "^1.14.0-beta.2",
-        "@colony/colony-js-client": "^1.14.0-beta.2",
+        "@colony/colony-js-client": "^1.14.0-beta.3",
         "@colony/colony-js-contract-loader-http": "^1.14.0-beta.0",
         "@colony/colony-js-contract-loader-network": "^1.14.0-beta.0",
         "@colony/purser-core": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1157,9 +1157,10 @@
     "@colony/colony-js-contract-loader" "^1.12.0"
     bn.js "^4.11.8"
 
-"@colony/colony-js-client@^1.14.0-beta.2":
-  version "1.14.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@colony/colony-js-client/-/colony-js-client-1.14.0-beta.2.tgz#86b81a65a0963987fa947d0aaff05757a074a53e"
+"@colony/colony-js-client@^1.14.0-beta.3":
+  version "1.14.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@colony/colony-js-client/-/colony-js-client-1.14.0-beta.3.tgz#4383f41891210f94209757b781bb619bdab63fc8"
+  integrity sha512-ICAdmor4WEKo9H9pX7IgY/kV6g7aqr6Xm8Xzk1N1y4tj+SyUvPxJNkxdSNoTi45t+a8QYKqDM9k5PqzkR5qbVQ==
   dependencies:
     "@colony/colony-js-adapter" "^1.14.0-beta.2"
     "@colony/colony-js-adapter-ethers" "^1.14.0-beta.2"


### PR DESCRIPTION
## Description

We were incorrectly checking architecture permissions in colonyJS. With the latest beta we aren't any more, so here's the upgrade 😄 

**Changes** 🏗

* `@colony/colony-js-client` upgraded to `1.14.0-beta.3`

Resolves #1883 
