### PR TITLE
Add "All Domains" option to colony home

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.tsx
@@ -54,13 +54,12 @@ const ColonyFunding = ({
     () =>
       openDialog('TokensMoveDialog', {
         colonyAddress,
-        toDomain: currentDomainId,
+        toDomain: currentDomainId !== 0 ? currentDomainId : undefined,
       }),
     [openDialog, colonyAddress, currentDomainId],
   );
 
-  // hide for root domain
-  return currentDomainId === 0 ? null : (
+  return (
     <div>
       <Heading appearance={{ size: 'normal', weight: 'bold' }}>
         <FormattedMessage {...MSG.title} />

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
@@ -1,5 +1,5 @@
 import { Redirect } from 'react-router';
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import {
   defineMessages,
   FormattedMessage,
@@ -170,19 +170,22 @@ const ColonyHome = ({
     [colonyAddress],
   );
 
-  const crumbs =
-    domains &&
-    domains
-      .sort((a, b) => a.id - b.id)
-      .reduce(
-        (accumulator, domain) => {
-          if (domain && domain.name && domain.id === filteredDomainId) {
-            accumulator.push(domain.name);
-          }
-          return accumulator;
-        },
-        [formatMessage({ id: 'domain.root' })],
-      );
+  const crumbs = useMemo(() => {
+    const selectedDomain =
+      !!domains && domains.find(domain => domain.id === filteredDomainId);
+    switch (filteredDomainId) {
+      case 0:
+        return [formatMessage({ id: 'domain.all' })];
+
+      case 1:
+        return [formatMessage({ id: 'domain.root' })];
+
+      default:
+        return selectedDomain
+          ? [formatMessage({ id: 'domain.root' }), selectedDomain.name]
+          : [formatMessage({ id: 'domain.root' })];
+    }
+  }, [domains, filteredDomainId, formatMessage]);
 
   const nativeTokenRef: ColonyTokenReferenceType | null = useSelector(
     colonyNativeTokenSelector,

--- a/src/modules/dashboard/components/ColonyHome/ColonyMeta/ColonyMeta.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMeta/ColonyMeta.tsx
@@ -138,6 +138,14 @@ const ColonyMeta = ({
               className={getActiveDomainFilterClass(0, filteredDomainId)}
               onClick={() => setFilteredDomainId(0)}
             >
+              <FormattedMessage id="domain.all" />
+            </Button>
+          </li>
+          <li>
+            <Button
+              className={getActiveDomainFilterClass(1, filteredDomainId)}
+              onClick={() => setFilteredDomainId(1)}
+            >
               <FormattedMessage id="domain.root" />
             </Button>
           </li>


### PR DESCRIPTION
## Description

Some tweaks to the way the domain filter affects the colony home page.

**Changes** 🏗

* Root will only show tasks in root, "All Domains" for every domain
* Funding is shown per domain including root, and also the total colony balance if "All Domains" is selected
