### PR TITLE
Replace the use of blocksBack with fromBlock=1

### DIFF
--- a/src/modules/admin/data/queries.ts
+++ b/src/modules/admin/data/queries.ts
@@ -51,9 +51,9 @@ export const getColonyTransactions: ContractEventQuery<
       colonyClient,
       {
         address: colonyAddress,
+        fromBlock: 1,
       },
       {
-        blocksBack: 400000,
         events: [
           ColonyFundsClaimed,
           /*
@@ -98,23 +98,21 @@ export const getColonyUnclaimedTransactions: ContractEventQuery<
       events: { Transfer },
     } = tokenClient;
 
-    const blocksBack = 400000;
-
     // Get logs & events for token transfer to this colony
     const {
       logs: transferLogs,
       events: transferEvents,
     } = await getLogsAndEvents(
       tokenClient,
-      {},
-      { blocksBack, events: [Transfer], to: colonyAddress },
+      { fromBlock: 1 },
+      { events: [Transfer], to: colonyAddress },
     );
 
     // Get logs & events for token claims by this colony
     const { logs: claimLogs, events: claimEvents } = await getLogsAndEvents(
       colonyClient,
-      { address: colonyAddress },
-      { blocksBack, events: [ColonyFundsClaimed] },
+      { address: colonyAddress, fromBlock: 1 },
+      { events: [ColonyFundsClaimed] },
     );
 
     const unclaimedTransfers = await Promise.all(

--- a/src/modules/dashboard/data/queries/colonies.ts
+++ b/src/modules/dashboard/data/queries/colonies.ts
@@ -112,9 +112,9 @@ export const getColonyRoles: ContractEventQuery<
       colonyClient,
       {
         address: colonyAddress,
+        fromBlock: 1,
       },
       {
-        blocksBack: 400000,
         events: [ColonyRoleSet],
       },
     );

--- a/src/modules/users/data/queries.ts
+++ b/src/modules/users/data/queries.ts
@@ -305,7 +305,6 @@ export const getUsername: Query<
 
 /**
  * This query gets all tokens sent from or received to this wallet since a certain block time
- * @todo Use a meaningful value for `blocksBack` when getting past transactions.
  */
 export const getUserColonyTransactions: Query<
   ColonyClient,
@@ -325,13 +324,12 @@ export const getUserColonyTransactions: Query<
       events: { Transfer },
     } = tokenClient;
     const logFilterOptions = {
-      blocksBack: 400000,
       events: [Transfer],
     };
 
     const transferToEventLogs = await getEventLogs(
       tokenClient,
-      {},
+      { fromBlock: 1 },
       {
         ...logFilterOptions,
         to: walletAddress,
@@ -340,7 +338,7 @@ export const getUserColonyTransactions: Query<
 
     const transferFromEventLogs = await getEventLogs(
       tokenClient,
-      {},
+      { fromBlock: 1 },
       {
         ...logFilterOptions,
         from: walletAddress,
@@ -415,9 +413,11 @@ const getColonyEventsForUserInbox = async (
     { colony: string; label: string; tokenAddress: string }
   >(
     networkClient,
-    mapTopics(ColonyLabelRegistered.interface.topics[0], colonyAddress),
     {
-      blocksBack: 400000,
+      ...mapTopics(ColonyLabelRegistered.interface.topics[0], colonyAddress),
+      fromBlock: 1,
+    },
+    {
       events: [ColonyLabelRegistered],
     },
   );
@@ -442,9 +442,9 @@ const getColonyEventsForUserInbox = async (
         formatFilterTopic(COLONY_ROLES[COLONY_ROLE_ADMINISTRATION]),
       ),
       address: colonyAddress,
+      fromBlock: 1,
     },
     {
-      blocksBack: 400000,
       events: [ColonyRoleSet],
     },
   );
@@ -458,9 +458,9 @@ const getColonyEventsForUserInbox = async (
     colonyClient,
     {
       address: colonyAddress,
+      fromBlock: 1,
     },
     {
-      blocksBack: 400000,
       events: [DomainAdded],
     },
   );
@@ -472,9 +472,9 @@ const getColonyEventsForUserInbox = async (
     tokenClient,
     {
       address: tokenAddress,
+      fromBlock: 1,
     },
     {
-      blocksBack: 400000,
       events: [Mint],
     },
   );


### PR DESCRIPTION
## Description

We were previously only fetching event logs up to a certain number of blocks ago. This was due to performance reasons and nodes taking a long time to respond if we include all blocks.

The way in which nodes index events has apparently been improved now (at least for Infura), and so we can query for all blocks! This fixed weird things happening for colonies older than the blocksBack value.

Probably best to test this on goerli or mainnet (otherwise you won't see any potential performance hits).

**Changes** 🏗

* Any instance of `blocksBack` replaced with `fromBlock: 1` in the raw log filter

Resolves #1893
