### PR TITLE
Fix: Permissions Dialog help article link

### DIFF
--- a/src/modules/admin/components/Permissions/ColonyPermissionEditDialog.tsx
+++ b/src/modules/admin/components/Permissions/ColonyPermissionEditDialog.tsx
@@ -239,7 +239,7 @@ const ColonyPermissionEditDialog = ({
     if (
       selectedRoles &&
       Object.keys(selectedRoles).length !==
-      Object.keys(userPermissions).length &&
+        Object.keys(userPermissions).length &&
       selectedUser
     ) {
       setSelectedRoles(userPermissions);
@@ -260,10 +260,10 @@ const ColonyPermissionEditDialog = ({
   const selectedUserData =
     !!selectedUser && !selectedUserObj
       ? User({
-        profile: UserProfile({
-          walletAddress: selectedUser,
-        }),
-      }).toJS()
+          profile: UserProfile({
+            walletAddress: selectedUser,
+          }),
+        }).toJS()
       : selectedUserObj;
 
   return (

--- a/src/modules/admin/components/Permissions/ColonyPermissionEditDialog.tsx
+++ b/src/modules/admin/components/Permissions/ColonyPermissionEditDialog.tsx
@@ -47,7 +47,9 @@ import {
 
 import styles from './ColonyPermissionEditDialog.css';
 
-const DOMAINS_HELP_URL = 'https://help.colony.io/';
+const DOMAINS_HELP_URL =
+  // eslint-disable-next-line max-len
+  'https://help.colony.io/hc/en-us/articles/360024588993-What-are-the-permissions-in-a-colony-';
 
 const MSG = defineMessages({
   title: {
@@ -237,7 +239,7 @@ const ColonyPermissionEditDialog = ({
     if (
       selectedRoles &&
       Object.keys(selectedRoles).length !==
-        Object.keys(userPermissions).length &&
+      Object.keys(userPermissions).length &&
       selectedUser
     ) {
       setSelectedRoles(userPermissions);
@@ -258,10 +260,10 @@ const ColonyPermissionEditDialog = ({
   const selectedUserData =
     !!selectedUser && !selectedUserObj
       ? User({
-          profile: UserProfile({
-            walletAddress: selectedUser,
-          }),
-        }).toJS()
+        profile: UserProfile({
+          walletAddress: selectedUser,
+        }),
+      }).toJS()
       : selectedUserObj;
 
   return (


### PR DESCRIPTION
## Description

This PR adds in the correct url for the help article describing Colony Permissions.

This article is linked to from the _Colony's Permission Edit Dialog_ Learn more link.
