### PR TITLE
Task Tooltips and Copy

### DIFF
--- a/src/modules/dashboard/components/Task/Task.css
+++ b/src/modules/dashboard/components/Task/Task.css
@@ -61,7 +61,6 @@
 .headerAside {
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
   height: 25px;
 }
 
@@ -112,4 +111,13 @@
 .trustInfoTooltipHeading {
   margin-bottom: 5px;
   font-weight: 500;
+}
+
+.helpButton {
+  composes: button from '~styles/reset.css';
+  margin-left: 5px;
+}
+
+.tooltipText {
+  max-width: 180px;
 }

--- a/src/modules/dashboard/components/Task/Task.css.d.ts
+++ b/src/modules/dashboard/components/Task/Task.css.d.ts
@@ -17,3 +17,5 @@ export const completedDescription: string;
 export const trustInfoIcon: string;
 export const trustInfoTooltip: string;
 export const trustInfoTooltipHeading: string;
+export const helpButton: string;
+export const tooltipText: string;

--- a/src/modules/dashboard/components/Task/Task.tsx
+++ b/src/modules/dashboard/components/Task/Task.tsx
@@ -90,6 +90,16 @@ const MSG = defineMessages({
       // eslint-disable-next-line max-len
       'Admins can edit the task and remove the assignee without consent. Protect your work and ensure you trust whom you are working with.',
   },
+  payoutInfo: {
+    id: 'dashboard.Task.payoutInfo',
+    defaultMessage:
+      // eslint-disable-next-line max-len
+      "Each task has its own funding pot which allows you to set aside funds for payouts. The payouts for each role will be taken from the task's funding pot. The Colony fee will be deducted from each payout once the task is completed.",
+  },
+  helpIconTitle: {
+    id: 'dashboard.Task.helpIconTitle',
+    defaultMessage: 'Help',
+  },
 });
 
 interface Props {
@@ -179,6 +189,25 @@ const Task = ({
               appearance={{ size: 'normal' }}
               text={MSG.assignmentFunding}
             />
+            <Tooltip
+              placement="right"
+              content={
+                <div className={styles.tooltipText}>
+                  <FormattedMessage {...MSG.payoutInfo} />
+                </div>
+              }
+            >
+              <button className={styles.helpButton} type="button">
+                <Icon
+                  appearance={{
+                    size: 'small',
+                    theme: 'invert',
+                  }}
+                  name="question-mark"
+                  title={MSG.helpIconTitle}
+                />
+              </button>
+            </Tooltip>
           </header>
           <div className={styles.assignment}>
             <div>

--- a/src/modules/dashboard/components/Task/Task.tsx
+++ b/src/modules/dashboard/components/Task/Task.tsx
@@ -46,7 +46,7 @@ import styles from './Task.css';
 const MSG = defineMessages({
   assignmentFunding: {
     id: 'dashboard.Task.assignmentFunding',
-    defaultMessage: 'Assignee and Funding',
+    defaultMessage: 'Assignee and Payout',
   },
   details: {
     id: 'dashboard.Task.details',

--- a/src/modules/dashboard/components/TaskEditDialog/TaskEditDialog.css
+++ b/src/modules/dashboard/components/TaskEditDialog/TaskEditDialog.css
@@ -19,3 +19,12 @@
   border-radius: var(--radius-large);
   background-color: var(--colony-white);
 }
+
+.helpButton {
+  composes: button from '~styles/reset.css';
+  margin-right: 5px;
+}
+
+.tooltipText {
+  max-width: 180px;
+}

--- a/src/modules/dashboard/components/TaskEditDialog/TaskEditDialog.css.d.ts
+++ b/src/modules/dashboard/components/TaskEditDialog/TaskEditDialog.css.d.ts
@@ -1,3 +1,5 @@
 export const buttonContainer: string;
 export const editor: string;
 export const taskDialog: string;
+export const helpButton: string;
+export const tooltipText: string;

--- a/src/modules/dashboard/components/TaskEditDialog/TaskEditDialog.tsx
+++ b/src/modules/dashboard/components/TaskEditDialog/TaskEditDialog.tsx
@@ -94,6 +94,13 @@ const MSG = defineMessages({
     id: 'dashboard.TaskEditDialog.unknownToken',
     defaultMessage: 'Unknown Token',
   },
+  fundingInfo: {
+    id: 'dashboard.TaskEditDialog.fundingInfo',
+    defaultMessage: `Each task has its own funding pot which allows you to set
+    aside funds for payouts. The payouts for each role will be taken from the
+    task's funding pot.The Colony fee will be deducted from each payout once
+    the task is completed.`,
+  },
 });
 
 interface Props {

--- a/src/modules/dashboard/components/TaskEditDialog/TaskEditDialog.tsx
+++ b/src/modules/dashboard/components/TaskEditDialog/TaskEditDialog.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useEffect } from 'react';
-import { defineMessages } from 'react-intl';
+import { defineMessages, FormattedMessage } from 'react-intl';
 import * as yup from 'yup';
 import { FieldArray } from 'formik';
 import nanoid from 'nanoid';
@@ -26,6 +26,8 @@ import DialogSection from '~core/Dialog/DialogSection';
 import Heading from '~core/Heading';
 import DialogBox from '~core/Dialog/DialogBox';
 import { SpinnerLoader } from '~core/Preloaders';
+import Icon from '~core/Icon';
+import { Tooltip } from '~core/Popover';
 import { ActionTypes } from '~redux/index';
 import HookedUserAvatar from '~users/HookedUserAvatar';
 import { mapPayload, mergePayload, pipe } from '~utils/actions';
@@ -43,6 +45,7 @@ import { usersByAddressFetcher } from '../../../users/fetchers';
 import { userSubscriber } from '../../../users/subscribers';
 import { allUsersAddressesSelector } from '../../../users/selectors';
 import { createAddress } from '../../../../types';
+
 import styles from './TaskEditDialog.css';
 
 const MSG = defineMessages({
@@ -52,7 +55,7 @@ const MSG = defineMessages({
   },
   titleFunding: {
     id: 'dashboard.TaskEditDialog.titleFunding',
-    defaultMessage: 'Funding',
+    defaultMessage: 'Payout',
   },
   add: {
     id: 'dashboard.TaskEditDialog.add',
@@ -94,12 +97,14 @@ const MSG = defineMessages({
     id: 'dashboard.TaskEditDialog.unknownToken',
     defaultMessage: 'Unknown Token',
   },
-  fundingInfo: {
-    id: 'dashboard.TaskEditDialog.fundingInfo',
-    defaultMessage: `Each task has its own funding pot which allows you to set
-    aside funds for payouts. The payouts for each role will be taken from the
-    task's funding pot.The Colony fee will be deducted from each payout once
-    the task is completed.`,
+  payoutInfo: {
+    id: 'dashboard.TaskEditDialog.payoutInfo',
+    defaultMessage: `The worker will receive their payout at the end of the
+    task. Make sure you have enough funds in the task to match the payout`,
+  },
+  helpIconTitle: {
+    id: 'dashboard.TaskEditDialog.helpIconTitle',
+    defaultMessage: 'Help',
   },
 });
 
@@ -384,6 +389,28 @@ const TaskEditDialog = ({
                               appearance={{ size: 'medium' }}
                               text={MSG.titleFunding}
                             />
+                            <Tooltip
+                              placement="right"
+                              content={
+                                <div className={styles.tooltipText}>
+                                  <FormattedMessage {...MSG.payoutInfo} />
+                                </div>
+                              }
+                            >
+                              <button
+                                className={styles.helpButton}
+                                type="button"
+                              >
+                                <Icon
+                                  appearance={{
+                                    size: 'small',
+                                    theme: 'invert',
+                                  }}
+                                  name="question-mark"
+                                  title={MSG.helpIconTitle}
+                                />
+                              </button>
+                            </Tooltip>
                             {canAddTokens(values, maxTokens) && (
                               <Button
                                 appearance={{ theme: 'blue', size: 'small' }}

--- a/src/modules/dashboard/components/TaskEditDialog/TaskEditDialog.tsx
+++ b/src/modules/dashboard/components/TaskEditDialog/TaskEditDialog.tsx
@@ -99,8 +99,9 @@ const MSG = defineMessages({
   },
   payoutInfo: {
     id: 'dashboard.TaskEditDialog.payoutInfo',
-    defaultMessage: `The worker will receive their payout at the end of the
-    task. Make sure you have enough funds in the task to match the payout`,
+    defaultMessage:
+      // eslint-disable-next-line max-len
+      'The worker will receive their payout at the end of the task. Make sure you have enough funds in the task to match the payout',
   },
   helpIconTitle: {
     id: 'dashboard.TaskEditDialog.helpIconTitle',


### PR DESCRIPTION
## Description

This PR adds a couple of Tooltips the the task and task edit dialog, in order to better provide context for the user on what's happening with the funds / payouts.

**Changes** 
- [x] Added info icon and tooltip to `TaskEditDialog`
- [x] Added info icon and tooltip to `Task`

**Screenshots** 

![Screenshot from 2019-10-23 19-39-31](https://user-images.githubusercontent.com/1193222/67417071-aa428680-f5d0-11e9-9e68-7e77fe3be980.png)

![Screenshot from 2019-10-23 19-39-39](https://user-images.githubusercontent.com/1193222/67417072-aadb1d00-f5d0-11e9-86f9-16ebcfd44486.png)

![Screenshot from 2019-10-23 19-39-56](https://user-images.githubusercontent.com/1193222/67417073-aadb1d00-f5d0-11e9-8726-85b2b6680c69.png)

![Screenshot from 2019-10-23 19-59-46](https://user-images.githubusercontent.com/1193222/67417078-ab73b380-f5d0-11e9-820e-a9eec3f78d55.png)

![Screenshot from 2019-10-23 20-00-16](https://user-images.githubusercontent.com/1193222/67417079-ab73b380-f5d0-11e9-8408-2b62c76d3404.png)


Resolves #1809