### PR TITLE
Add `IconButton` component

### DIFF
--- a/src/modules/core/components/Button/Button.tsx
+++ b/src/modules/core/components/Button/Button.tsx
@@ -14,7 +14,7 @@ import styles from './Button.css';
 
 const displayName = 'Button';
 
-interface Appearance {
+export interface Appearance {
   theme?:
     | 'primary'
     | 'secondary'
@@ -25,7 +25,7 @@ interface Appearance {
   size?: 'small' | 'medium' | 'large';
 }
 
-interface Props {
+export interface Props {
   /** Appearance object */
   appearance?: Appearance;
 

--- a/src/modules/core/components/Button/IconButton.css
+++ b/src/modules/core/components/Button/IconButton.css
@@ -1,0 +1,3 @@
+.main {
+  display: block;
+}

--- a/src/modules/core/components/Button/IconButton.css
+++ b/src/modules/core/components/Button/IconButton.css
@@ -1,3 +1,62 @@
-.main {
-  display: block;
+.main i {
+  margin-right: 5px;
+}
+
+.themePrimary, .themeDanger {
+  composes: main;
+
+  & svg {
+    fill: var(--colony-white);
+    stroke: var(--colony-white);
+  }
+}
+
+.themeSecondary {
+  composes: main;
+
+  & svg {
+    fill: var(--text);
+    stroke: var(--text);
+  }
+
+  &:hover {
+    & svg {
+      fill: color-mod(var(--text) shade(30%));
+      stroke: color-mod(var(--text) shade(30%));
+    }
+  }
+}
+
+.themeGhost {
+  composes: main;
+
+  & svg {
+    fill: var(--black);
+    stroke: var(--black);
+  }
+
+  &:hover {
+    & svg {
+      fill: color-mod(var(--colony-black) tint(15%));
+      stroke: color-mod(var(--colony-black) tint(15%));
+    }
+  }
+}
+
+.themeUnderlineBold {
+  composes: main;
+
+  & svg {
+    fill: var(--black);
+    stroke: var(--black);
+  }
+}
+
+.themeBlue {
+  composes: main;
+
+  & svg {
+    fill: var(--sky-blue);
+    stroke: var(--sky-blue);
+  }
 }

--- a/src/modules/core/components/Button/IconButton.css
+++ b/src/modules/core/components/Button/IconButton.css
@@ -2,6 +2,9 @@
   margin-right: 5px;
 }
 
+/*
+ * Themes
+ */
 .themePrimary, .themeDanger {
   composes: main;
 
@@ -58,5 +61,30 @@
   & svg {
     fill: var(--sky-blue);
     stroke: var(--sky-blue);
+  }
+}
+
+/*
+ * Sizes
+ */
+.sizeSmall {
+  & i {
+    height: 12px;
+    width: 12px;
+  }
+}
+
+.sizeMedium {
+  & i {
+    height: 16px;
+    width: 16px;
+  }
+}
+
+.sizeLarge {
+  & i {
+    height: 18px;
+    width: 18px;
+    vertical-align: bottom;
   }
 }

--- a/src/modules/core/components/Button/IconButton.css.d.ts
+++ b/src/modules/core/components/Button/IconButton.css.d.ts
@@ -1,0 +1,1 @@
+export const main: string;

--- a/src/modules/core/components/Button/IconButton.css.d.ts
+++ b/src/modules/core/components/Button/IconButton.css.d.ts
@@ -5,3 +5,6 @@ export const themeSecondary: string;
 export const themeGhost: string;
 export const themeUnderlineBold: string;
 export const themeBlue: string;
+export const sizeSmall: string;
+export const sizeMedium: string;
+export const sizeLarge: string;

--- a/src/modules/core/components/Button/IconButton.css.d.ts
+++ b/src/modules/core/components/Button/IconButton.css.d.ts
@@ -1,1 +1,7 @@
 export const main: string;
+export const themePrimary: string;
+export const themeDanger: string;
+export const themeSecondary: string;
+export const themeGhost: string;
+export const themeUnderlineBold: string;
+export const themeBlue: string;

--- a/src/modules/core/components/Button/IconButton.md
+++ b/src/modules/core/components/Button/IconButton.md
@@ -1,0 +1,60 @@
+
+The icon(ed) button is a twist on the _classic_ `<Button>` where in front of the button's normal text you can now render an icon from the available icons library.
+
+The use case this was created for was to provide the user with a UX confirmation that the action that's about to be done requires a contract interaction / signing.
+
+```js
+import { defineMessages } from 'react-intl';
+
+const MSG = defineMessages({
+  buttonText: {
+    id: 'styleguide.buttonText',
+    defaultMessage: 'Click Me',
+  },
+});
+```
+
+```js
+<IconButton text={buttonText} />
+```
+
+### Icons
+
+All icons available to the `<Icon />` component are also supported here.
+
+```js
+<IconButton text={buttonText} icon="circle-plus" />
+```
+
+### Themes
+
+This component supports all the themes the `<Button />` component, on which is based on, supports.
+
+```js
+<IconButton appearance={{ theme: 'primary', size: 'medium' }} text={buttonText} />
+<IconButton appearance={{ theme: 'secondary', size: 'medium' }} text={buttonText} />
+<IconButton appearance={{ theme: 'danger', size: 'medium' }} text={buttonText} />
+<IconButton appearance={{ theme: 'ghost', size: 'medium' }} text={buttonText} />
+<IconButton appearance={{ theme: 'underlinedBold', size: 'medium' }} text={buttonText} />
+<IconButton appearance={{ theme: 'blue', size: 'medium' }} text={buttonText} />
+```
+
+### Sizes
+
+As with themes, this component supports all 3 sizes the base component has: `small`, `medium`, `large`.
+
+```js
+<IconButton appearance={{ theme: 'primary', size: 'small' }} text={buttonText} />
+<IconButton appearance={{ theme: 'primary', size: 'medium' }} text={buttonText} />
+<IconButton appearance={{ theme: 'primary', size: 'large' }} text={buttonText} />
+```
+
+### Limitations
+
+#### Does not support passing the `children` prop
+
+Since that kinda defeats it's purpouse. If you need to pass `children`, you can just use `<Button />` directly.
+
+#### Only supports button text as a Message Descriptor
+
+We don't really use hard-coded text strings anymore, and especially this component doesn't benefit from that legacy feature.

--- a/src/modules/core/components/Button/IconButton.tsx
+++ b/src/modules/core/components/Button/IconButton.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const displayName = 'IconButton';
+
+const IconButton = () => <div />;
+
+IconButton.displayName = displayName;
+
+export default IconButton;

--- a/src/modules/core/components/Button/IconButton.tsx
+++ b/src/modules/core/components/Button/IconButton.tsx
@@ -1,8 +1,42 @@
 import React from 'react';
+import {
+  MessageDescriptor,
+  MessageValues,
+  FormattedMessage,
+} from 'react-intl';
+
+import Button from './Button';
+import Icon from '~core/Icon';
+
+import styles from './IconButton.css';
 
 const displayName = 'IconButton';
 
-const IconButton = () => <div />;
+interface Props {
+  /** Name of the icon to display */
+  icon?: string;
+  /** A string or a `messageDescriptor` that make up the button's text label */
+  text?: MessageDescriptor;
+  /** Values for loading text (react-intl interpolation) */
+  textValues?: MessageValues;
+}
+
+const IconButton = ({
+  icon = 'wallet',
+  text,
+  textValues,
+  ...props
+}: Props) => (
+  <Button {...props}>
+    <div className={styles.main}>
+      <Icon
+        role="button"
+          name={icon}
+      />
+      <FormattedMessage {...text} values={textValues} />
+    </div>
+  </Button>
+);
 
 IconButton.displayName = displayName;
 

--- a/src/modules/core/components/Button/IconButton.tsx
+++ b/src/modules/core/components/Button/IconButton.tsx
@@ -3,35 +3,42 @@ import {
   MessageDescriptor,
   MessageValues,
   FormattedMessage,
+  injectIntl,
 } from 'react-intl';
 
-import Button from './Button';
+import Button, { Props as DefaultButtonProps } from './Button';
 import Icon from '~core/Icon';
+import { useMainClasses } from '~utils/hooks';
 
 import styles from './IconButton.css';
 
 const displayName = 'IconButton';
 
-interface Props {
+interface Props extends DefaultButtonProps {
   /** Name of the icon to display */
   icon?: string;
   /** A string or a `messageDescriptor` that make up the button's text label */
-  text?: MessageDescriptor;
-  /** Values for loading text (react-intl interpolation) */
+  text: MessageDescriptor;
+  /** Values for message descriptors */
   textValues?: MessageValues;
 }
 
 const IconButton = ({
+  appearance = { theme: 'primary' },
   icon = 'wallet',
   text,
   textValues,
+  children,
   ...props
 }: Props) => (
-  <Button {...props}>
-    <div className={styles.main}>
+  <Button
+    appearance={appearance}
+    {...props}
+  >
+    <div className={useMainClasses(appearance, styles)}>
       <Icon
-        role="button"
-          name={icon}
+        appearance={{ size: 'small' }}
+        name={icon}
       />
       <FormattedMessage {...text} values={textValues} />
     </div>
@@ -40,4 +47,4 @@ const IconButton = ({
 
 IconButton.displayName = displayName;
 
-export default IconButton;
+export default injectIntl(IconButton);

--- a/src/modules/core/components/Button/IconButton.tsx
+++ b/src/modules/core/components/Button/IconButton.tsx
@@ -28,13 +28,15 @@ const IconButton = ({
   icon = 'wallet',
   text,
   textValues,
+  /*
+   * @NOTE Prevent children from being passed both to this component, or to
+   * the underlying `<Button />
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   children,
   ...props
 }: Props) => (
-  <Button
-    appearance={appearance}
-    {...props}
-  >
+  <Button appearance={appearance} {...props}>
     <div className={useMainClasses(appearance, styles)}>
       <Icon name={icon} />
       <FormattedMessage {...text} values={textValues} />

--- a/src/modules/core/components/Button/IconButton.tsx
+++ b/src/modules/core/components/Button/IconButton.tsx
@@ -24,7 +24,7 @@ interface Props extends DefaultButtonProps {
 }
 
 const IconButton = ({
-  appearance = { theme: 'primary' },
+  appearance = { theme: 'primary', size: 'medium' },
   icon = 'wallet',
   text,
   textValues,
@@ -36,10 +36,7 @@ const IconButton = ({
     {...props}
   >
     <div className={useMainClasses(appearance, styles)}>
-      <Icon
-        appearance={{ size: 'small' }}
-        name={icon}
-      />
+      <Icon name={icon} />
       <FormattedMessage {...text} values={textValues} />
     </div>
   </Button>

--- a/src/modules/core/components/Button/index.ts
+++ b/src/modules/core/components/Button/index.ts
@@ -2,3 +2,4 @@ export { default } from './Button';
 export { default as ActionButton } from './ActionButton';
 export { default as ConfirmButton } from './ConfirmButton';
 export { default as DialogActionButton } from './DialogActionButton';
+export { default as IconButton } from './IconButton';

--- a/src/modules/users/components/GasStation/GasStationPrice/GasStationPrice.tsx
+++ b/src/modules/users/components/GasStation/GasStationPrice/GasStationPrice.tsx
@@ -27,7 +27,7 @@ import {
 } from '../../../selectors';
 
 import Alert from '~core/Alert';
-import Button from '~core/Button';
+import { IconButton } from '~core/Button';
 import EthUsd from '~core/EthUsd';
 import { ActionForm, RadioGroup } from '~core/Fields';
 import Icon from '~core/Icon';
@@ -246,9 +246,9 @@ const GasStationPrice = ({ transaction: { id, gasLimit, error } }: Props) => {
                   </div>
                   <div>
                     {error ? (
-                      <Button type="submit" text={{ id: 'button.retry' }} />
+                      <IconButton type="submit" text={{ id: 'button.retry' }} />
                     ) : (
-                      <Button
+                      <IconButton
                         disabled={!isValid}
                         loading={!transactionFee || isSubmitting}
                         text={{ id: 'button.confirm' }}

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -82,6 +82,7 @@ module.exports = {
         './src/modules/core/components/Fields/Select/Select.tsx',
         './src/modules/core/components/Fields/FormStatus/FormStatus.tsx',
         './src/modules/core/components/Button/Button.tsx',
+        './src/modules/core/components/Button/IconButton.tsx',
         './src/modules/core/components/FileUpload/FileUpload.tsx',
         './src/modules/core/components/MnemonicGenerator/MnemonicGenerator.tsx',
         './src/modules/core/components/MnemonicDnDSorter/MnemonicDnDSorter.tsx',


### PR DESCRIPTION
## Description

This PR adds in a new core button component, `IconButton` that is to be used when a user needs to sign any transaction that requires actual wallet interaction.

**New stuff** 

- [x] Added core `IconButton` component
- [x] Added `IconButton` style guide entry

**Changes**

- [x] `GasStationPrice` now uses `IconButton` for confirmations

**Screenshot**

![Screenshot from 2019-10-30 17-09-13](https://user-images.githubusercontent.com/1193222/67872431-98199880-fb3a-11e9-97d7-344fcf053db5.png)

Resolves #1795 
