### PR TITLE
Fix select dropdown placement when input status is provided

### DIFF
--- a/src/modules/core/components/Fields/Select/Select.css
+++ b/src/modules/core/components/Fields/Select/Select.css
@@ -15,13 +15,16 @@
 
 .main {
   composes: field from '~styles/fields.css';
-  position: relative;
 }
 
 .selectInner {
   display: flex;
   justify-content: space-between;
   align-items: center;
+}
+
+.inputWrapper {
+  position: relative;
 }
 
 .select[aria-disabled="true"], .select[aria-busy="true"] {

--- a/src/modules/core/components/Fields/Select/Select.css.d.ts
+++ b/src/modules/core/components/Fields/Select/Select.css.d.ts
@@ -1,6 +1,7 @@
 export const baseSelect: string;
 export const main: string;
 export const selectInner: string;
+export const inputWrapper: string;
 export const select: string;
 export const selectExpandContainer: string;
 export const activeOption: string;

--- a/src/modules/core/components/Fields/Select/Select.tsx
+++ b/src/modules/core/components/Fields/Select/Select.tsx
@@ -325,52 +325,54 @@ class Select extends Component<Props, State> {
         {!elementOnly && label ? (
           <InputLabel inputId={$id} label={label} help={help} />
         ) : null}
-        <button
-          className={`${styles.select} ${getMainClasses(appearance, styles)}`}
-          aria-haspopup="listbox"
-          aria-controls={listboxId}
-          aria-expanded={isOpen}
-          aria-label={label}
-          aria-labelledby={ariaLabelledby}
-          aria-disabled={disabled}
-          tabIndex={0}
-          ref={this.registerComboboxNode}
-          onClick={this.toggle}
-          onKeyUp={this.handleKeyUp}
-          onKeyDown={this.handleKeyDown}
-          type="button"
-          name={name}
-          {...props}
-        >
-          <div className={styles.selectInner}>
-            <div className={styles.activeOption}>
-              <span>{activeOptionLabel || placeholder}</span>
+        <div className={styles.inputWrapper}>
+          <button
+            className={`${styles.select} ${getMainClasses(appearance, styles)}`}
+            aria-haspopup="listbox"
+            aria-controls={listboxId}
+            aria-expanded={isOpen}
+            aria-label={label}
+            aria-labelledby={ariaLabelledby}
+            aria-disabled={disabled}
+            tabIndex={0}
+            ref={this.registerComboboxNode}
+            onClick={this.toggle}
+            onKeyUp={this.handleKeyUp}
+            onKeyDown={this.handleKeyDown}
+            type="button"
+            name={name}
+            {...props}
+          >
+            <div className={styles.selectInner}>
+              <div className={styles.activeOption}>
+                <span>{activeOptionLabel || placeholder}</span>
+              </div>
+              <span className={styles.selectExpandContainer}>
+                <Icon name="caret-down-small" title={MSG.expandIconHTMLTitle} />
+              </span>
             </div>
-            <span className={styles.selectExpandContainer}>
-              <Icon name="caret-down-small" title={MSG.expandIconHTMLTitle} />
-            </span>
-          </div>
-        </button>
+          </button>
+          {isOpen && !!options.length && (
+            <SelectListBox
+              checkedOption={checkedOption}
+              selectedOption={selectedOption}
+              listboxId={listboxId}
+              options={options}
+              onSelect={this.selectOption}
+              onClick={this.checkOption}
+              formatIntl={formatIntl}
+              appearance={appearance}
+              ariaLabelledby={ariaLabelledby}
+              name={name}
+            />
+          )}
+        </div>
         {!elementOnly && (
           <InputStatus
             appearance={{ theme: 'minimal' }}
             status={status}
             statusValues={statusValues}
             error={$error}
-          />
-        )}
-        {isOpen && !!options.length && (
-          <SelectListBox
-            checkedOption={checkedOption}
-            selectedOption={selectedOption}
-            listboxId={listboxId}
-            options={options}
-            onSelect={this.selectOption}
-            onClick={this.checkOption}
-            formatIntl={formatIntl}
-            appearance={appearance}
-            ariaLabelledby={ariaLabelledby}
-            name={name}
           />
         )}
       </div>


### PR DESCRIPTION
## Description

This PR reorganizes the `Select` component a bit, adjusting the vertical placement of the list box to be closer to the button when an input status is provided.


Here's how it looked before:

![image](https://user-images.githubusercontent.com/3052635/67782791-49cfa100-fa37-11e9-9f70-fe1a145cb963.png)
