### PR TITLE
Colony Home Avatar Size same size as User Avatar

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.css
@@ -3,7 +3,9 @@
 .main {
   composes: stretchVertical stretchHorizontal from '~styles/layout.css';
   display: grid;
-  padding: 16px 18px; /* vertical padding of 16px + nav height (70px) */
+
+  /* vertical padding of 11px + nav height (70px) */
+  padding: 11px 18px 16px 18px;
   overflow: auto;
   overflow: hidden;
   background: var(--gradient-default);

--- a/src/modules/dashboard/components/ColonyHome/ColonyMeta/ColonyMeta.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMeta/ColonyMeta.css
@@ -5,11 +5,13 @@
 }
 
 .main section {
-  margin-left: 52px;
+  margin-left: 63px;
 }
 
 .avatar {
   margin-bottom: 10px;
+  height: 45px;
+  width: 45px;
   border-radius: 50%;
   background-color: white;
   box-shadow: 0 0 20px var(--temp-grey-blue-2);
@@ -41,9 +43,9 @@
 }
 
 .headingAndSettings {
-  margin-top: 3px;
+  margin-top: 10px;
   position: absolute;
-  left: 49px;
+  left: 60px;
 }
 
 .simpleLinkWebsite {

--- a/src/modules/dashboard/components/ColonyHome/ColonyMeta/ColonySubscribe.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMeta/ColonySubscribe.css
@@ -3,8 +3,8 @@
   height: 15px;
   width: 15px;
   position: relative;
-  top: 19px;
-  left: -11px; /* Subscribe icon is overlapping avatar a tiny bit */
+  top: 30px;
+  left: -16px; /* Subscribe icon is overlapping avatar a tiny bit */
   border: none;
   border-radius: 100%;
   font-size: 13px;
@@ -31,6 +31,6 @@
 
 .spinnerContainer {
   position: absolute;
-  top: 19px;
-  left: 21px;
+  top: 30px;
+  left: 31px;
 }


### PR DESCRIPTION
## Description

This is a simple PR that increases the Colony Avatar size _(on Colony Home)_, making it the same size as the User Avatar (from the Nav Bar) and better aligns the two.

**Changes**

- [x] `ColonyMeta` increase colony avatar size
- [x] `ColonySubscribe` re-align subscription button and loading spinner
- [x] `ColonyHome` decrease to margin, to better align user and colony avatars

**Screenshots**

![Screenshot from 2019-10-30 17-53-59](https://user-images.githubusercontent.com/1193222/67876558-c5694500-fb40-11e9-9906-6d6290e0274c.png)

![Screenshot from 2019-10-30 17-59-56](https://user-images.githubusercontent.com/1193222/67876561-c5694500-fb40-11e9-8bf3-24bb10a9ff8b.png)

![Screenshot from 2019-10-30 18-00-14](https://user-images.githubusercontent.com/1193222/67876562-c601db80-fb40-11e9-9088-360417f829d1.png)

![Screenshot from 2019-10-30 18-00-34](https://user-images.githubusercontent.com/1193222/67876563-c69a7200-fb40-11e9-8dfc-37ddab134f28.png)

Resolves #1892 
