### PR TITLE
Improve Network Health Info

### DIFF
--- a/src/modules/core/components/ExpandedParagraph/ExpandedParagraph.css
+++ b/src/modules/core/components/ExpandedParagraph/ExpandedParagraph.css
@@ -1,8 +1,3 @@
-.moreButtonContainer {
-  margin-left: 5px;
-}
-
-.hideButtonContainer {
-  display: flex;
-  justify-content: flex-end;
+.controlContainer {
+  margin-top: 10px;
 }

--- a/src/modules/core/components/ExpandedParagraph/ExpandedParagraph.css.d.ts
+++ b/src/modules/core/components/ExpandedParagraph/ExpandedParagraph.css.d.ts
@@ -1,2 +1,1 @@
-export const moreButtonContainer: string;
-export const hideButtonContainer: string;
+export const controlContainer: string;

--- a/src/modules/core/components/ExpandedParagraph/ExpandedParagraph.tsx
+++ b/src/modules/core/components/ExpandedParagraph/ExpandedParagraph.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useState } from 'react';
-import { defineMessages } from 'react-intl';
+import { defineMessages, MessageDescriptor, MessageValues } from 'react-intl';
 
 import Button from '~core/Button';
 
@@ -7,17 +7,25 @@ import { multiLineTextEllipsis } from '~utils/strings';
 import styles from './ExpandedParagraph.css';
 
 const MSG = defineMessages({
-  more: {
-    id: 'core.ExpandedParagraph.more',
-    defaultMessage: 'More',
+  expandText: {
+    id: 'core.ExpandedParagraph.expandText',
+    defaultMessage: 'Show more',
   },
-  hide: {
-    id: 'core.ExpandedParagraph.hide',
-    defaultMessage: 'Hide',
+  contractText: {
+    id: 'core.ExpandedParagraph.contractText',
+    defaultMessage: 'Show less',
   },
 });
 
 interface Props {
+  /** A string or a `messageDescriptor` that makes up the "show more" control */
+  expandText?: MessageDescriptor | string;
+  /** Message descriptor Values for the "show more" control text (react-intl interpolation) */
+  expandTextValues?: MessageValues;
+  /** A string or a `messageDescriptor` that makes up the "show less" control */
+  contractText?: MessageDescriptor | string;
+  /** Message descriptor Values for the "show less" control text (react-intl interpolation) */
+  contractTextValues?: MessageValues;
   /*
    * This contains a long text paragraph that initially gets shown
    * in a shortened version that can be extended clicking a more button
@@ -48,6 +56,10 @@ interface Props {
 const displayName = 'core.ExpandedParagraph';
 
 const ExpandedParagraph = ({
+  expandText = MSG.expandText,
+  expandTextValues,
+  contractText = MSG.contractText,
+  contractTextValues,
   paragraph,
   elements,
   expandedElements,
@@ -68,7 +80,8 @@ const ExpandedParagraph = ({
             onClick={() => {
               expandDescription(true);
             }}
-            text={MSG.more}
+            text={expandText}
+            textValues={expandTextValues}
             appearance={{ theme: 'blue' }}
           />
         </span>
@@ -81,7 +94,8 @@ const ExpandedParagraph = ({
               onClick={() => {
                 expandDescription(false);
               }}
-              text={MSG.hide}
+              text={contractText}
+              textValues={contractTextValues}
               appearance={{ theme: 'blue' }}
             />
           </div>

--- a/src/modules/core/components/ExpandedParagraph/ExpandedParagraph.tsx
+++ b/src/modules/core/components/ExpandedParagraph/ExpandedParagraph.tsx
@@ -75,7 +75,7 @@ const ExpandedParagraph = ({
       )}
       {elements && elements}
       {!expanded && (
-        <span className={styles.moreButtonContainer}>
+        <div className={styles.controlContainer}>
           <Button
             onClick={() => {
               expandDescription(true);
@@ -84,12 +84,12 @@ const ExpandedParagraph = ({
             textValues={expandTextValues}
             appearance={{ theme: 'blue' }}
           />
-        </span>
+        </div>
       )}
       {expanded && (
         <>
           {expandedElements}
-          <div className={styles.hideButtonContainer}>
+          <div className={styles.controlContainer}>
             <Button
               onClick={() => {
                 expandDescription(false);

--- a/src/modules/core/components/NetworkHealth/NetworkHealth.css
+++ b/src/modules/core/components/NetworkHealth/NetworkHealth.css
@@ -8,3 +8,12 @@
 .main:focus {
   outline: none;
 }
+
+.busy {
+  display: inline-block;
+  margin: 1px 15px 0 0;
+  vertical-align: top;
+  font-size: var(--size-small);
+  font-weight: var(--weight-medium);
+  color: var(--grey-4);
+}

--- a/src/modules/core/components/NetworkHealth/NetworkHealth.css.d.ts
+++ b/src/modules/core/components/NetworkHealth/NetworkHealth.css.d.ts
@@ -1,1 +1,2 @@
 export const main: string;
+export const busy: string;

--- a/src/modules/core/components/NetworkHealth/NetworkHealth.tsx
+++ b/src/modules/core/components/NetworkHealth/NetworkHealth.tsx
@@ -1,5 +1,10 @@
 import React, { useEffect } from 'react';
-import { injectIntl, defineMessages, IntlShape } from 'react-intl';
+import {
+  injectIntl,
+  defineMessages,
+  IntlShape,
+  FormattedMessage,
+} from 'react-intl';
 import { useDispatch } from 'redux-react-hook';
 
 import { ConnectionType } from '~immutable/index';
@@ -24,6 +29,10 @@ const MSG = defineMessages({
       2 {fair}
       1 {poor}
     }`,
+  },
+  busyLabel: {
+    id: 'core.NetworkHealth.busyLabel',
+    defaultMessage: 'Busy...',
   },
 });
 
@@ -86,6 +95,9 @@ const NetworkHealth = ({
           className={styles.main}
           title={formatMessage(MSG.statusTitle, { health })}
         >
+          <span className={styles.busy}>
+            <FormattedMessage {...MSG.busyLabel} />
+          </span>
           <NetworkHealthIcon health={health} appearance={appearance} />
         </button>
       </Popover>

--- a/src/modules/core/components/NetworkHealth/NetworkHealth.tsx
+++ b/src/modules/core/components/NetworkHealth/NetworkHealth.tsx
@@ -14,6 +14,7 @@ import { useSelector } from '~utils/hooks';
 import { NetworkHealthIconSize } from './types';
 import { connection as connectionSelector } from '../../selectors';
 import getNetworkHealth from './getNetworkHealth';
+import getNetworkBusyState from './getNetworkBusyState';
 import NetworkHealthIcon from './NetworkHealthIcon';
 import NetworkHealthContent from './NetworkHealthContent';
 import styles from './NetworkHealth.css';
@@ -66,6 +67,7 @@ const NetworkHealth = ({
 
   const connection: ConnectionType = useSelector(connectionSelector);
   const networkItems = getNetworkHealth(connection);
+  const busyItems = getNetworkBusyState(connection);
 
   // Errors are important so we set the whole thing to 1 if there are a lot (> 1)
   const health =
@@ -75,6 +77,7 @@ const NetworkHealth = ({
           networkItems.reduce((sum, current) => sum + current.itemHealth, 0) /
             networkItems.length,
         );
+  const isNetworkBusy = busyItems.some(({ busyState }) => busyState === true);
 
   return (
     <div className={className}>
@@ -95,9 +98,11 @@ const NetworkHealth = ({
           className={styles.main}
           title={formatMessage(MSG.statusTitle, { health })}
         >
-          <span className={styles.busy}>
-            <FormattedMessage {...MSG.busyLabel} />
-          </span>
+          {isNetworkBusy && (
+            <span className={styles.busy}>
+              <FormattedMessage {...MSG.busyLabel} />
+            </span>
+          )}
           <NetworkHealthIcon health={health} appearance={appearance} />
         </button>
       </Popover>

--- a/src/modules/core/components/NetworkHealth/NetworkHealth.tsx
+++ b/src/modules/core/components/NetworkHealth/NetworkHealth.tsx
@@ -88,6 +88,7 @@ const NetworkHealth = ({
             close={close}
             health={health}
             networkItems={networkItems}
+            networkBusy={isNetworkBusy}
           />
         )}
         placement="bottom"

--- a/src/modules/core/components/NetworkHealth/NetworkHealthContent/NetworkHealthContent.css
+++ b/src/modules/core/components/NetworkHealth/NetworkHealthContent/NetworkHealthContent.css
@@ -53,5 +53,9 @@
 }
 
 .content {
-  padding: 10px 10px 15px 10px;
+  padding: 10px 10px 0px 10px;
+}
+
+.expandedSectionContainer {
+  padding: 0 0 15px 0;
 }

--- a/src/modules/core/components/NetworkHealth/NetworkHealthContent/NetworkHealthContent.css
+++ b/src/modules/core/components/NetworkHealth/NetworkHealthContent/NetworkHealthContent.css
@@ -39,17 +39,17 @@
   align-self: flex-start;
 }
 
-.actionsContainer button {
-  padding: 0;
-}
-
 .closeButton {
   composes: button from '~styles/reset.css';
   stroke: var(--text);
-}
 
-.closeButton i {
-  padding: 0;
+  &, & i {
+    /*
+    * @NOTE Use of !important to reset values inherited from the user navigation
+    * component, directly passed down through elements
+    */
+    padding: 0 !important;
+  }
 }
 
 .content {

--- a/src/modules/core/components/NetworkHealth/NetworkHealthContent/NetworkHealthContent.css
+++ b/src/modules/core/components/NetworkHealth/NetworkHealthContent/NetworkHealthContent.css
@@ -41,15 +41,21 @@
 
 .closeButton {
   composes: button from '~styles/reset.css';
-  stroke: var(--text);
 
-  &, & i {
-    /*
-    * @NOTE Use of !important to reset values inherited from the user navigation
-    * component, directly passed down through elements
-    */
-    padding: 0 !important;
-  }
+  /*
+  * @NOTE Use of !important to reset values inherited from the user navigation
+  * component, directly passed down through elements
+  */
+  padding: 0 !important;
+  stroke: var(--text);
+}
+
+.closeButton i {
+  /*
+  * @NOTE Use of !important to reset values inherited from the user navigation
+  * component, directly passed down through elements
+  */
+  padding: 0 !important;
 }
 
 .content {

--- a/src/modules/core/components/NetworkHealth/NetworkHealthContent/NetworkHealthContent.css.d.ts
+++ b/src/modules/core/components/NetworkHealth/NetworkHealthContent/NetworkHealthContent.css.d.ts
@@ -7,3 +7,4 @@ export const healthDetails: string;
 export const actionsContainer: string;
 export const closeButton: string;
 export const content: string;
+export const expandedSectionContainer: string;

--- a/src/modules/core/components/NetworkHealth/NetworkHealthContent/NetworkHealthContent.tsx
+++ b/src/modules/core/components/NetworkHealth/NetworkHealthContent/NetworkHealthContent.tsx
@@ -36,7 +36,7 @@ const MSG = defineMessages({
   expandSectionLabel: {
     id: 'core.NetworkHealth.NetworkHealthContent.expandSectionLabel',
     defaultMessage: 'Advanced',
-  }
+  },
 });
 
 interface Props {
@@ -69,7 +69,10 @@ const NetworkHealthContent = ({ close, health, networkItems = [] }: Props) => {
           <div className={styles.healthTitle}>
             <Heading appearance={{ margin: 'none', size: 'normal' }}>
               <span className={styles.healthIconWrapper}>
-                <NetworkHealthIcon health={health} appearance={{ size: 'pea' }} />
+                <NetworkHealthIcon
+                  health={health}
+                  appearance={{ size: 'pea' }}
+                />
               </span>
               <FormattedMessage {...MSG.healthTitle} values={{ health }} />
             </Heading>
@@ -80,7 +83,11 @@ const NetworkHealthContent = ({ close, health, networkItems = [] }: Props) => {
         </div>
         <div className={styles.actionsContainer}>
           {close && (
-            <button className={styles.closeButton} onClick={close} type="button">
+            <button
+              className={styles.closeButton}
+              onClick={close}
+              type="button"
+            >
               <Icon
                 appearance={{ size: 'normal' }}
                 name="close"

--- a/src/modules/core/components/NetworkHealth/NetworkHealthContent/NetworkHealthContent.tsx
+++ b/src/modules/core/components/NetworkHealth/NetworkHealthContent/NetworkHealthContent.tsx
@@ -2,10 +2,13 @@ import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
 import { NetworkHealthItems } from '../types';
+
 import Icon from '~core/Icon';
 import Heading from '~core/Heading';
+import ExpandedParagraph from '~core/ExpandedParagraph';
 import NetworkHealthIcon from '../NetworkHealthIcon';
 import NetworkHealthContentItem from './NetworkHealthContentItem';
+
 import styles from './NetworkHealthContent.css';
 
 const MSG = defineMessages({
@@ -30,6 +33,10 @@ const MSG = defineMessages({
       other {unknown. Hold tight until we check it.}
     }`,
   },
+  expandSectionLabel: {
+    id: 'core.NetworkHealth.NetworkHealthContent.expandSectionLabel',
+    defaultMessage: 'Advanced',
+  }
 });
 
 interface Props {
@@ -40,34 +47,8 @@ interface Props {
 
 const displayName = 'NetworkHealth.NetworkHealthContent';
 
-const NetworkHealthContent = ({ close, health, networkItems = [] }: Props) => (
-  <div className={styles.main}>
-    <div className={styles.header}>
-      <div className={styles.healthDetailsWrapper}>
-        <div className={styles.healthTitle}>
-          <Heading appearance={{ margin: 'none', size: 'normal' }}>
-            <span className={styles.healthIconWrapper}>
-              <NetworkHealthIcon health={health} appearance={{ size: 'pea' }} />
-            </span>
-            <FormattedMessage {...MSG.healthTitle} values={{ health }} />
-          </Heading>
-        </div>
-        <div className={styles.healthDetails}>
-          <FormattedMessage {...MSG.healthDetails} values={{ health }} />
-        </div>
-      </div>
-      <div className={styles.actionsContainer}>
-        {close && (
-          <button className={styles.closeButton} onClick={close} type="button">
-            <Icon
-              appearance={{ size: 'normal' }}
-              name="close"
-              title={{ id: 'button.close' }}
-            />
-          </button>
-        )}
-      </div>
-    </div>
+const NetworkHealthContent = ({ close, health, networkItems = [] }: Props) => {
+  const renderNetworkItems = (
     <ul className={styles.content}>
       {networkItems.map(networkHealthItem => (
         <NetworkHealthContentItem
@@ -80,8 +61,47 @@ const NetworkHealthContent = ({ close, health, networkItems = [] }: Props) => (
         />
       ))}
     </ul>
-  </div>
-);
+  );
+  return (
+    <div className={styles.main}>
+      <div className={styles.header}>
+        <div className={styles.healthDetailsWrapper}>
+          <div className={styles.healthTitle}>
+            <Heading appearance={{ margin: 'none', size: 'normal' }}>
+              <span className={styles.healthIconWrapper}>
+                <NetworkHealthIcon health={health} appearance={{ size: 'pea' }} />
+              </span>
+              <FormattedMessage {...MSG.healthTitle} values={{ health }} />
+            </Heading>
+          </div>
+          <div className={styles.healthDetails}>
+            <FormattedMessage {...MSG.healthDetails} values={{ health }} />
+          </div>
+        </div>
+        <div className={styles.actionsContainer}>
+          {close && (
+            <button className={styles.closeButton} onClick={close} type="button">
+              <Icon
+                appearance={{ size: 'normal' }}
+                name="close"
+                title={{ id: 'button.close' }}
+              />
+            </button>
+          )}
+        </div>
+      </div>
+      <section className={styles.expandedSectionContainer}>
+        <ExpandedParagraph
+          characterLimit={0}
+          maximumCharacters={0}
+          paragraph=""
+          expandedElements={renderNetworkItems}
+          expandText={MSG.expandSectionLabel}
+        />
+      </section>
+    </div>
+  );
+};
 
 NetworkHealthContent.displayName = displayName;
 

--- a/src/modules/core/components/NetworkHealth/NetworkHealthContent/NetworkHealthContent.tsx
+++ b/src/modules/core/components/NetworkHealth/NetworkHealthContent/NetworkHealthContent.tsx
@@ -26,11 +26,18 @@ const MSG = defineMessages({
    */
   healthDetails: {
     id: 'core.NetworkHealth.NetworkHealthContent.healthDetails',
-    defaultMessage: `The network's health is {health, select,
-      3 {good. All systems are operational.}
-      2 {fair. You might experience reduced data loading.}
-      1 {poor. Please keep your browser open until the network health improves.}
-      other {unknown. Hold tight until we check it.}
+    defaultMessage: `{health, select,
+      3 {{networkBusy, select,
+        false {The network's health is good. All systems are operational.}
+        true {Data is currently saving but the network health is good. This
+          should only take a couple of seconds.}
+      }}
+      2 {The network's health is fair. You might experience reduced data
+        loading.}
+      1 {{networkBusy, select,
+        false {The network's health is poor.}
+        true {Data is currently trying to save, but the network health is poor.}
+      } Please keep your browser open until the network health improves.}
     }`,
   },
   expandSectionLabel: {
@@ -43,11 +50,21 @@ interface Props {
   close?: () => void;
   health: number;
   networkItems?: NetworkHealthItems;
+  networkBusy?: boolean;
 }
 
 const displayName = 'NetworkHealth.NetworkHealthContent';
 
-const NetworkHealthContent = ({ close, health, networkItems = [] }: Props) => {
+const NetworkHealthContent = ({
+  close,
+  health,
+  networkItems = [],
+  /*
+   * @NOTE Erring on the side of caution here:
+   * If we (for some reason) can't get the busy state, assume it's busy
+   */
+  networkBusy = true,
+}: Props) => {
   const renderNetworkItems = (
     <ul className={styles.content}>
       {networkItems.map(networkHealthItem => (
@@ -78,7 +95,13 @@ const NetworkHealthContent = ({ close, health, networkItems = [] }: Props) => {
             </Heading>
           </div>
           <div className={styles.healthDetails}>
-            <FormattedMessage {...MSG.healthDetails} values={{ health }} />
+            <FormattedMessage
+              {...MSG.healthDetails}
+              values={{
+                health,
+                networkBusy,
+              }}
+            />
           </div>
         </div>
         <div className={styles.actionsContainer}>

--- a/src/modules/core/components/NetworkHealth/NetworkHealthContent/NetworkHealthContent.tsx
+++ b/src/modules/core/components/NetworkHealth/NetworkHealthContent/NetworkHealthContent.tsx
@@ -26,7 +26,7 @@ const MSG = defineMessages({
     defaultMessage: `The network's health is {health, select,
       3 {good. All systems are operational.}
       2 {fair. You might experience reduced data loading.}
-      1 {poor. Your data will probably fail to load.}
+      1 {poor. Please keep your browser open until the network health improves.}
       other {unknown. Hold tight until we check it.}
     }`,
   },

--- a/src/modules/core/components/NetworkHealth/getNetworkBusyState.ts
+++ b/src/modules/core/components/NetworkHealth/getNetworkBusyState.ts
@@ -1,0 +1,16 @@
+import { ConnectionType } from '~immutable/index';
+
+// true = busy, false = not busy
+
+const storesBusyHealth = busyStores => !!busyStores.length;
+
+const pinnerBusyHealth = pinnerBusy => pinnerBusy;
+
+const calculateNetworkBusyState = ({
+  stats: { busyStores = [], pinnerBusy = false },
+}: ConnectionType) => [
+  { busyState: storesBusyHealth(busyStores) },
+  { busyState: pinnerBusyHealth(pinnerBusy) },
+];
+
+export default calculateNetworkBusyState;

--- a/src/modules/core/components/NetworkHealth/getNetworkHealth.ts
+++ b/src/modules/core/components/NetworkHealth/getNetworkHealth.ts
@@ -3,10 +3,6 @@ import { defineMessages } from 'react-intl';
 import { ConnectionType } from '~immutable/index';
 
 const MSG = defineMessages({
-  busyStores: {
-    id: 'core.NetworkHealth.busyStores',
-    defaultMessage: 'Busy stores: {busyStores}',
-  },
   openStores: {
     id: 'core.NetworkHealth.openStores',
     defaultMessage: 'Open stores: {openStores}',
@@ -23,10 +19,6 @@ const MSG = defineMessages({
     id: 'core.NetworkHealth.pinners',
     defaultMessage: 'Pinners connected to: {pinners}',
   },
-  pinnerBusy: {
-    id: 'core.NetworkHealth.pinnerBusy',
-    defaultMessage: 'Pinner connector is busy: {pinnerBusy}',
-  },
   pubsubPeers: {
     id: 'core.NetworkHealth.pubsubPeers',
     defaultMessage: 'Pubsub peers: {pubsubPeers}',
@@ -39,11 +31,6 @@ const MSG = defineMessages({
 
 // 3 = good, 2 = soso, 1 = poor
 
-const busyStoresHealth = busyStores => {
-  if (busyStores.length > 5) return 1;
-  return busyStores.length ? 2 : 3;
-};
-
 const openStoresHealth = openStores => (openStores ? 3 : 1);
 
 const pingHealth = ping => {
@@ -55,8 +42,6 @@ const pinnersHealth = pinners => {
   if (!pinners.length) return 1;
   return pinners.length === 1 ? 2 : 3;
 };
-
-const pinnerBusyHealth = pinnerBusy => (pinnerBusy ? 2 : 3);
 
 const pubsubPeersHealth = pubsubPeers => {
   if (!pubsubPeers.length) return 1;
@@ -75,32 +60,18 @@ const errorsHealth = errors => {
 
 const calculateNetworkHealth = ({
   stats: {
-    busyStores = [],
     openStores = 0,
     ping = 0,
     pinners = [],
-    pinnerBusy = false,
     pubsubPeers = [],
     swarmPeers = [],
   },
   errors,
 }: ConnectionType) => [
   {
-    itemTitle: MSG.busyStores,
-    itemHealth: busyStoresHealth(busyStores),
-    itemTitleValues: { busyStores: busyStores.length || '0' },
-  },
-  {
     itemTitle: MSG.openStores,
     itemHealth: openStoresHealth(openStores),
     itemTitleValues: { openStores: openStores || '0' },
-  },
-  {
-    itemTitle: MSG.pinnerBusy,
-    itemHealth: pinnerBusyHealth(pinnerBusy),
-    // I know this should be translated but I couldn't figure out how to do it because of the span decoration
-    // Also I don't really care anymore
-    itemTitleValues: { pinnerBusy: pinnerBusy ? 'yes' : 'no' },
   },
   {
     itemTitle: MSG.ipfsPing,

--- a/src/modules/core/sagas/setupOnBeforeUnload.ts
+++ b/src/modules/core/sagas/setupOnBeforeUnload.ts
@@ -1,12 +1,18 @@
 import { getContext } from 'redux-saga/effects';
 
 // Do NOT do this at home! We import the store directly here because we need a sync API (that sagas don't provide)
+import { ConnectionType } from '~immutable/index';
 import store from '~redux/createReduxStore';
 
 import { DDB } from '../../../lib/database';
 import IPFSNode from '../../../lib/ipfs';
 
-import { pendingTransactions } from '../selectors';
+import {
+  pendingTransactions,
+  connection as connectionSelector,
+} from '../selectors';
+
+import getNetworkHealth from '~core/NetworkHealth/getNetworkHealth';
 
 const hasPendingTransactions = () => {
   const transactions = pendingTransactions((store as any).getState());
@@ -18,12 +24,36 @@ const pinnerIsBusy = (ipfsNode: IPFSNode) =>
 
 const ddbIsBusy = (ddb: DDB) => ddb.busy;
 
+const networkHealthIsPoor = () => {
+  const connection: ConnectionType = connectionSelector(
+    (store as any).getState(),
+  );
+  const networkItems = getNetworkHealth(connection);
+  /*
+   * @NOTE This is (currently) exactly the same as the logic inside the `<NetworkHealth />` component
+   * I didn't bother centralizing the source (and reducing code repetition) because my view is that
+   * at some point these two pieces of logic will diverge into they're own separate paths
+   */
+  // Errors are important so we set the whole thing to 1 if there are a lot (> 1)
+  const health =
+    connection.errors.length > 1 || connection.stats.pinners.length < 1
+      ? 1
+      : Math.round(
+          networkItems.reduce((sum, current) => sum + current.itemHealth, 0) /
+            networkItems.length,
+        );
+  return health <= 1;
+};
+
 export default function* setupOnBeforeUnload() {
   const ipfsNode = yield getContext('ipfsNode');
   const ddb = yield getContext('ddb');
   const handleBeforeunload = evt => {
     const disallowUnload =
-      hasPendingTransactions() || pinnerIsBusy(ipfsNode) || ddbIsBusy(ddb);
+      hasPendingTransactions() ||
+      pinnerIsBusy(ipfsNode) ||
+      ddbIsBusy(ddb) ||
+      networkHealthIsPoor();
     if (disallowUnload) {
       evt.preventDefault();
       // eslint-disable-next-line no-param-reassign


### PR DESCRIPTION
## Description

This PR adds a both simple copy changes, but also logic and functionality changes to the `NetworkHealth` information popover.

**New Stuff**

- [x] `getNetworkBusyState` logic

**Changes** 

- [x] `NetworkHealthContent` updated copy
- [x] `ExpandedParagraph` configurable controls labels
- [x] `onBeforeUnload` saga now takes into account network health
- [x] `NetworkContent` show user friendly busy copy

**Screenshots**

![Screenshot from 2019-11-01 12-14-58](https://user-images.githubusercontent.com/1193222/68018323-86063a00-fca1-11e9-8f1f-1dedb19a169e.png)

![Screenshot from 2019-11-01 12-15-21](https://user-images.githubusercontent.com/1193222/68018324-86063a00-fca1-11e9-8bf8-16bf0de86b87.png)

![Screenshot from 2019-11-04 16-55-55](https://user-images.githubusercontent.com/1193222/68135794-e8bf3600-ff2c-11e9-9303-c1883d6ff179.png)

![Screenshot from 2019-11-04 17-19-13](https://user-images.githubusercontent.com/1193222/68135796-e957cc80-ff2c-11e9-9643-4dc531e7b3b7.png)

![Screenshot from 2019-11-04 17-19-26](https://user-images.githubusercontent.com/1193222/68135798-e9f06300-ff2c-11e9-81fe-35e41e852600.png)


Resolves #1861