### PR TITLE
More DLx Fixes!

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "dependencies": {
         "@babel/runtime": "^7.0.0",
         "@colony/colony-js-adapter-ethers": "^1.14.0-beta.2",
-        "@colony/colony-js-client": "^1.14.0",
+        "@colony/colony-js-client": "^1.14.1",
         "@colony/colony-js-contract-loader-http": "^1.14.0-beta.0",
         "@colony/colony-js-contract-loader-network": "^1.14.0-beta.0",
         "@colony/purser-core": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "dependencies": {
         "@babel/runtime": "^7.0.0",
         "@colony/colony-js-adapter-ethers": "^1.14.0-beta.2",
-        "@colony/colony-js-client": "^1.14.0-beta.3",
+        "@colony/colony-js-client": "^1.14.0",
         "@colony/colony-js-contract-loader-http": "^1.14.0-beta.0",
         "@colony/colony-js-contract-loader-network": "^1.14.0-beta.0",
         "@colony/purser-core": "^2.2.1",

--- a/src/data/accessControllers/ColonyAccessController.ts
+++ b/src/data/accessControllers/ColonyAccessController.ts
@@ -61,7 +61,7 @@ class ColonyAccessController extends AbstractAccessController<
 
   async save({ onlyDetermineAddress }: { onlyDetermineAddress: boolean }) {
     if (!onlyDetermineAddress) {
-      const isAllowed = await this.can('is-founder', this.walletAddress, {});
+      const isAllowed = await this.can('is-root', this.walletAddress, {});
       if (!isAllowed) {
         throw new Error('Cannot create colony database, user not allowed');
       }

--- a/src/data/accessControllers/ColonyAccessController.ts
+++ b/src/data/accessControllers/ColonyAccessController.ts
@@ -1,7 +1,14 @@
 import { WalletObjectType } from '@colony/purser-core';
 
 import { transformEntry } from '~data/utils';
-import { Entry, PermissionsManifest, createAddress } from '../../types/index';
+import { TaskEvents } from '~data/types/TaskEvents';
+
+import {
+  Address,
+  Entry,
+  PermissionsManifest,
+  createAddress,
+} from '../../types/index';
 import { log } from '../../utils/debug';
 import { PermissionManager } from '../permissions';
 import AbstractAccessController from './AbstractAccessController';
@@ -50,8 +57,23 @@ class ColonyAccessController extends AbstractAccessController<
     return createAddress(this.wallet.address);
   }
 
-  private extendVerifyContext<C extends object | void>(context: C) {
-    return { ...context, colonyAddress: this.colonyAddress };
+  private extendVerifyContext<C extends object | void>(
+    context: C & { event?: TaskEvents },
+  ): C & { colonyAddress: Address; domainId: number } {
+    let domainId;
+    if (
+      context &&
+      context.event &&
+      context.event.payload &&
+      'domainId' in context.event.payload
+    ) {
+      domainId = context.event.payload.domainId;
+    }
+    return {
+      ...context,
+      colonyAddress: this.colonyAddress,
+      domainId,
+    };
   }
 
   private checkWalletAddress() {
@@ -83,14 +105,14 @@ class ColonyAccessController extends AbstractAccessController<
     const isAuthorized = await super.canAppend(entry, provider);
     if (!isAuthorized) return false;
 
-    const event = transformEntry(entry);
+    const event = transformEntry(entry) as TaskEvents;
     return this.can(event.type, event.meta.userAddress, { event });
   }
 
   async can<C extends object | void>(
     actionId: string,
     user: string,
-    context: C,
+    context: C & { event?: TaskEvents },
   ): Promise<boolean> {
     log.verbose('Checking permission for action', actionId, user, context);
     return this.manager.can(

--- a/src/data/migrations/v2.ts
+++ b/src/data/migrations/v2.ts
@@ -2,7 +2,9 @@ import { EventTypes, Versions } from '~data/constants';
 import { ROOT_DOMAIN } from '~constants';
 import { EventMigrationFunction } from './types';
 
-const taskCreated: EventMigrationFunction<
+const addRootDomain: EventMigrationFunction<
+  // @todo Improve Event typing in migrations
+  // @body I'm just using this event as I have no idea how to define all that are valid
   EventTypes.TASK_CREATED,
   Versions.V2
 > = ({ payload, meta, ...event }) => ({
@@ -23,6 +25,19 @@ export const V2Migrations: [
 ] = [
   Versions.V2,
   {
-    [EventTypes.TASK_CREATED]: taskCreated,
+    [EventTypes.COMMENT_STORE_CREATED]: addRootDomain,
+    [EventTypes.DUE_DATE_SET]: addRootDomain,
+    [EventTypes.PAYOUT_SET]: addRootDomain,
+    [EventTypes.PAYOUT_REMOVED]: addRootDomain,
+    [EventTypes.SKILL_SET]: addRootDomain,
+    [EventTypes.TASK_CREATED]: addRootDomain,
+    [EventTypes.TASK_CANCELLED]: addRootDomain,
+    [EventTypes.TASK_CLOSED]: addRootDomain,
+    [EventTypes.TASK_DESCRIPTION_SET]: addRootDomain,
+    [EventTypes.TASK_FINALIZED]: addRootDomain,
+    [EventTypes.TASK_TITLE_SET]: addRootDomain,
+    [EventTypes.WORK_INVITE_SENT]: addRootDomain,
+    [EventTypes.WORKER_ASSIGNED]: addRootDomain,
+    [EventTypes.WORKER_UNASSIGNED]: addRootDomain,
   },
 ];

--- a/src/data/migrations/v2.ts
+++ b/src/data/migrations/v2.ts
@@ -35,6 +35,7 @@ export const V2Migrations: [
     [EventTypes.TASK_CLOSED]: addRootDomain,
     [EventTypes.TASK_DESCRIPTION_SET]: addRootDomain,
     [EventTypes.TASK_FINALIZED]: addRootDomain,
+    [EventTypes.TASK_STORE_REGISTERED]: addRootDomain,
     [EventTypes.TASK_TITLE_SET]: addRootDomain,
     [EventTypes.WORK_INVITE_SENT]: addRootDomain,
     [EventTypes.WORKER_ASSIGNED]: addRootDomain,

--- a/src/data/permissions/colony.ts
+++ b/src/data/permissions/colony.ts
@@ -18,12 +18,14 @@ export default function loadModule(): PermissionsManifest<{
     TASK_STORE_UNREGISTERED: { inherits: 'register-task-store' },
     TOKEN_INFO_ADDED: { inherits: 'add-token' },
     TOKEN_INFO_REMOVED: { inherits: 'add-token' },
-    'add-domain': { inherits: 'is-founder-or-admin' },
-    'edit-domain': { inherits: 'is-founder-or-admin' },
-    'add-token': { inherits: 'is-founder' },
-    'create-colony-profile': { inherits: 'is-founder' },
-    'register-task-store': { inherits: 'is-founder-or-admin' },
-    'set-colony-avatar': { inherits: 'is-founder-or-admin' },
-    'update-colony-profile': { inherits: 'is-founder-or-admin' },
+    // @todo Fix domain permissions
+    // @body For now that's OK because we only allow 1 level depth of domains. As soon as that changes, we have to find a solution for this
+    'add-domain': { inherits: 'has-root-architecture' },
+    'edit-domain': { inherits: 'has-root-architecture' },
+    'add-token': { inherits: 'is-root' },
+    'create-colony-profile': { inherits: 'is-root' },
+    'register-task-store': { inherits: 'is-root' },
+    'set-colony-avatar': { inherits: 'is-root' },
+    'update-colony-profile': { inherits: 'is-root' },
   };
 }

--- a/src/data/permissions/colony.ts
+++ b/src/data/permissions/colony.ts
@@ -24,7 +24,7 @@ export default function loadModule(): PermissionsManifest<{
     'edit-domain': { inherits: 'has-root-architecture' },
     'add-token': { inherits: 'is-root' },
     'create-colony-profile': { inherits: 'is-root' },
-    'register-task-store': { inherits: 'is-root' },
+    'register-task-store': { inherits: 'is-admin' },
     'set-colony-avatar': { inherits: 'is-root' },
     'update-colony-profile': { inherits: 'is-root' },
   };

--- a/src/data/permissions/common.ts
+++ b/src/data/permissions/common.ts
@@ -1,10 +1,6 @@
-import {
-  ColonyClient,
-  COLONY_ROLE_ROOT,
-  COLONY_ROLE_ADMINISTRATION,
-} from '@colony/colony-js-client';
+import { ColonyClient } from '@colony/colony-js-client';
 
-import { ROOT_DOMAIN } from '~constants';
+import { ROLES, ROOT_DOMAIN } from '~constants';
 import { Address } from '~types/strings';
 import { PermissionsManifest } from '../types';
 import { makeUserHasRoleFn } from './utils';
@@ -12,19 +8,17 @@ import { makeUserHasRoleFn } from './utils';
 export default function loadModule(
   colonyClient: ColonyClient,
 ): PermissionsManifest<any> {
-  const isFounder = makeUserHasRoleFn(colonyClient, COLONY_ROLE_ROOT);
-  const isAdmin = makeUserHasRoleFn(colonyClient, COLONY_ROLE_ADMINISTRATION);
+  const isRoot = makeUserHasRoleFn(colonyClient, ROLES.ROOT);
+  const isAdmin = makeUserHasRoleFn(colonyClient, ROLES.ADMINISTRATION);
+  const hasArchitecture = makeUserHasRoleFn(colonyClient, ROLES.ARCHITECTURE);
 
   return {
-    'is-founder': async (address: Address) => isFounder(address, ROOT_DOMAIN),
-    'is-founder-or-admin': async (
+    'is-admin': async (
       address: Address,
       { domainId = ROOT_DOMAIN }: { domainId: number },
-    ) => {
-      const hasAdminRole = await isAdmin(address, domainId);
-      if (hasAdminRole) return hasAdminRole;
-
-      return isFounder(address, ROOT_DOMAIN);
-    },
+    ) => isAdmin(address, domainId),
+    'is-root': async (address: Address) => isRoot(address, ROOT_DOMAIN),
+    'has-root-architecture': async (address: Address) =>
+      hasArchitecture(address, ROOT_DOMAIN),
   };
 }

--- a/src/data/permissions/task.ts
+++ b/src/data/permissions/task.ts
@@ -1,37 +1,12 @@
-import {
-  COLONY_ROLE_ADMINISTRATION,
-  COLONY_ROLE_ROOT,
-} from '@colony/colony-js-client';
-
-import { ROOT_DOMAIN } from '~constants';
-import { EventTypes } from '~data/constants';
 import { TaskEvents } from '~data/types/TaskEvents';
-import { Address, ColonyClient, PermissionsManifest } from '~types/index';
-import { makeUserHasRoleFn } from './utils';
+import { Address, PermissionsManifest } from '~types/index';
 
-export default function loadModule(
-  colonyClient: ColonyClient,
-): PermissionsManifest<{
+export default function loadModule(): PermissionsManifest<{
   domainId?: number;
   colonyAddress?: Address;
   event?: TaskEvents;
   heads?: object[];
 }> {
-  const isAdmin = makeUserHasRoleFn(colonyClient, COLONY_ROLE_ADMINISTRATION);
-  const isFounder = makeUserHasRoleFn(colonyClient, COLONY_ROLE_ROOT);
-
-  const isAdminOrFounder = async (
-    userAddress: Address,
-    domainId: number,
-  ): Promise<boolean> => {
-    // I don't know why this can be string or number? Maybe because we're dealing with the raw (not migrated) event here.
-    // Should we apply migrations here as well?
-    const hasAdminRole = await isAdmin(userAddress, domainId);
-    if (hasAdminRole) return hasAdminRole;
-
-    return isFounder(userAddress, ROOT_DOMAIN);
-  };
-
   return {
     COMMENT_STORE_CREATED: { inherits: 'create-task' },
     DUE_DATE_SET: { inherits: 'set-task-due-date' },
@@ -49,24 +24,26 @@ export default function loadModule(
     WORK_REQUEST_CREATED: { inherits: 'send-task-work-request' },
     WORKER_ASSIGNED: { inherits: 'set-task-assignee' },
     WORKER_UNASSIGNED: { inherits: 'remove-task-assignee' },
-    'cancel-task': { inherits: 'is-founder-or-admin' },
-    'create-task': { inherits: 'is-founder-or-admin' },
-    'finalize-task': { inherits: 'is-founder-or-admin' },
-    'remove-task-assignee': { inherits: 'is-founder-or-admin' },
-    'send-task-work-invite': { inherits: 'is-founder-or-admin' },
+    'cancel-task': { inherits: 'is-admin' },
+    'create-task': { inherits: 'is-admin' },
+    'finalize-task': { inherits: 'is-admin' },
+    'remove-task-assignee': { inherits: 'is-admin' },
+    'send-task-work-invite': { inherits: 'is-admin' },
     'send-task-work-request': async () => true,
-    'set-task-assignee': { inherits: 'is-founder-or-admin' },
-    'set-task-domain': async (userAddress, { event }) => {
-      // Ideally, this would also check the current domainId; this has to
-      // be done outside of the action controller, because Orbit only passes
-      // the current entry to the `canAppend` method.
-      return event && event.type === EventTypes.DOMAIN_SET
-        ? isAdminOrFounder(userAddress, event.payload.domainId)
-        : false;
-    },
-    'set-task-due-date': { inherits: 'is-founder-or-admin' },
-    'set-task-payout': { inherits: 'is-founder-or-admin' },
-    'set-task-skill': { inherits: 'is-founder-or-admin' },
-    'update-task': { inherits: 'is-founder-or-admin' },
+    'set-task-assignee': { inherits: 'is-admin' },
+    // disallow changing of the domain for now
+    'set-task-domain': async () => false,
+    // 'set-task-domain': async (userAddress, { event }) => {
+    //   // Ideally, this would also check the current domainId; this has to
+    //   // be done outside of the action controller, because Orbit only passes
+    //   // the current entry to the `canAppend` method.
+    //   return event && event.type === EventTypes.DOMAIN_SET
+    //     ? isAdminOrFounder(userAddress, event.payload.domainId)
+    //     : false;
+    // },
+    'set-task-due-date': { inherits: 'is-admin' },
+    'set-task-payout': { inherits: 'is-admin' },
+    'set-task-skill': { inherits: 'is-admin' },
+    'update-task': { inherits: 'is-admin' },
   };
 }

--- a/src/data/permissions/utils.ts
+++ b/src/data/permissions/utils.ts
@@ -1,6 +1,6 @@
 import { ColonyClient } from '@colony/colony-js-client';
 
-import { ROLES } from '~constants';
+import { ROOT_DOMAIN, ROLES } from '~constants';
 import { Address } from '~types/index';
 
 import { PermissionModuleLoader } from '../types';
@@ -18,10 +18,18 @@ export const makeUserHasRoleFn = (
   colonyClient: ColonyClient,
   role: ROLES,
 ) => async (address: Address, domainId: number): Promise<boolean> => {
+  // This won't work anymore once we have a domain depth of > 1. This should probably go into ColonyJS then
+  // But everything we built in the dapp (and even in ColonyJS) is making that assumption so I guess we're ok for now
   const { hasRole } = await colonyClient.hasColonyRole.call({
     address,
     role,
     domainId,
   });
-  return hasRole;
+  if (hasRole) return hasRole;
+  const { hasRole: hasRoleInRoot } = await colonyClient.hasColonyRole.call({
+    address,
+    role,
+    ROOT_DOMAIN,
+  });
+  return hasRoleInRoot;
 };

--- a/src/data/permissions/utils.ts
+++ b/src/data/permissions/utils.ts
@@ -29,7 +29,7 @@ export const makeUserHasRoleFn = (
   const { hasRole: hasRoleInRoot } = await colonyClient.hasColonyRole.call({
     address,
     role,
-    ROOT_DOMAIN,
+    domainId: ROOT_DOMAIN,
   });
   return hasRoleInRoot;
 };

--- a/src/data/types/TaskEvents.ts
+++ b/src/data/types/TaskEvents.ts
@@ -8,6 +8,14 @@ export type TaskEvents =
       {
         commentsStoreAddress: Address;
       },
+      Versions.V1
+    >
+  | EventDefinition<
+      EventTypes.COMMENT_STORE_CREATED,
+      {
+        commentsStoreAddress: Address;
+        domainId: number;
+      },
       Versions.CURRENT
     >
   | EventDefinition<
@@ -22,6 +30,14 @@ export type TaskEvents =
       {
         dueDate?: number;
       },
+      Versions.V1
+    >
+  | EventDefinition<
+      EventTypes.DUE_DATE_SET,
+      {
+        dueDate?: number;
+        domainId: number;
+      },
       Versions.CURRENT
     >
   | EventDefinition<
@@ -30,18 +46,41 @@ export type TaskEvents =
         amount: string;
         token: string;
       },
+      Versions.V1
+    >
+  | EventDefinition<
+      EventTypes.PAYOUT_SET,
+      {
+        amount: string;
+        token: string;
+        domainId: number;
+      },
       Versions.CURRENT
     >
   | EventDefinition<
       // forcing a line break for visual consistency
       EventTypes.PAYOUT_REMOVED,
       null,
+      Versions.V1
+    >
+  | EventDefinition<
+      // forcing a line break for visual consistency
+      EventTypes.PAYOUT_REMOVED,
+      { domainId: number },
       Versions.CURRENT
     >
   | EventDefinition<
       EventTypes.SKILL_SET,
       {
         skillId?: number;
+      },
+      Versions.V1
+    >
+  | EventDefinition<
+      EventTypes.SKILL_SET,
+      {
+        skillId?: number;
+        domainId: number;
       },
       Versions.CURRENT
     >
@@ -50,12 +89,28 @@ export type TaskEvents =
       {
         status: TaskStates.CANCELLED;
       },
+      Versions.V1
+    >
+  | EventDefinition<
+      EventTypes.TASK_CANCELLED,
+      {
+        status: TaskStates.CANCELLED;
+        domainId: number;
+      },
       Versions.CURRENT
     >
   | EventDefinition<
       EventTypes.TASK_CLOSED,
       {
         status: TaskStates.CLOSED;
+      },
+      Versions.V1
+    >
+  | EventDefinition<
+      EventTypes.TASK_CLOSED,
+      {
+        status: TaskStates.CLOSED;
+        domainId: number;
       },
       Versions.CURRENT
     >
@@ -81,6 +136,14 @@ export type TaskEvents =
       {
         description: string;
       },
+      Versions.V1
+    >
+  | EventDefinition<
+      EventTypes.TASK_DESCRIPTION_SET,
+      {
+        description: string;
+        domainId: number;
+      },
       Versions.CURRENT
     >
   | EventDefinition<
@@ -91,6 +154,17 @@ export type TaskEvents =
         workerAddress: Address;
         transactionHash: string;
       },
+      Versions.V1
+    >
+  | EventDefinition<
+      EventTypes.TASK_FINALIZED,
+      {
+        amountPaid: string;
+        paymentTokenAddress?: Address;
+        workerAddress: Address;
+        transactionHash: string;
+        domainId: number;
+      },
       Versions.CURRENT
     >
   | EventDefinition<
@@ -98,12 +172,28 @@ export type TaskEvents =
       {
         title: string;
       },
+      Versions.V1
+    >
+  | EventDefinition<
+      EventTypes.TASK_TITLE_SET,
+      {
+        title: string;
+        domainId: number;
+      },
       Versions.CURRENT
     >
   | EventDefinition<
       EventTypes.WORK_INVITE_SENT,
       {
         workerAddress: Address;
+      },
+      Versions.V1
+    >
+  | EventDefinition<
+      EventTypes.WORK_INVITE_SENT,
+      {
+        workerAddress: Address;
+        domainId: number;
       },
       Versions.CURRENT
     >
@@ -119,6 +209,14 @@ export type TaskEvents =
       {
         workerAddress: Address;
       },
+      Versions.V1
+    >
+  | EventDefinition<
+      EventTypes.WORKER_ASSIGNED,
+      {
+        workerAddress: Address;
+        domainId: number;
+      },
       Versions.CURRENT
     >
   | EventDefinition<
@@ -126,6 +224,15 @@ export type TaskEvents =
       {
         workerAddress: Address;
         userAddress: Address;
+      },
+      Versions.V1
+    >
+  | EventDefinition<
+      EventTypes.WORKER_UNASSIGNED,
+      {
+        workerAddress: Address;
+        userAddress: Address;
+        domainId: number;
       },
       Versions.CURRENT
     >;

--- a/src/data/types/TaskIndexEvents.ts
+++ b/src/data/types/TaskIndexEvents.ts
@@ -9,6 +9,24 @@ export type TaskIndexEvents =
         draftId: string;
         taskStoreAddress: string;
       },
+      Versions.V1
+    >
+  | EventDefinition<
+      EventTypes.TASK_STORE_UNREGISTERED,
+      {
+        draftId: string;
+        taskStoreAddress: string;
+      },
+      Versions.V1
+    >
+  | EventDefinition<
+      EventTypes.TASK_STORE_REGISTERED,
+      {
+        commentsStoreAddress: string;
+        draftId: string;
+        taskStoreAddress: string;
+        domainId: number;
+      },
       Versions.CURRENT
     >
   | EventDefinition<
@@ -16,6 +34,7 @@ export type TaskIndexEvents =
       {
         draftId: string;
         taskStoreAddress: string;
+        domainId: number;
       },
       Versions.CURRENT
     >;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -75,6 +75,8 @@
 
     "transaction.colony.makePayment.title": "Make payment",
     "transaction.colony.makePayment.description": "Make payment",
+    "transaction.colony.makePaymentFundedFromDomain.title": "Make payment",
+    "transaction.colony.makePaymentFundedFromDomain.description": "Make payment",
 
     "transaction.colony.upgrade.title": "Update Colony",
     "transaction.colony.upgrade.description": "Update Colony",

--- a/src/modules/admin/components/Permissions/ColonyPermissionsAddDialog.tsx
+++ b/src/modules/admin/components/Permissions/ColonyPermissionsAddDialog.tsx
@@ -5,7 +5,7 @@ import { defineMessages } from 'react-intl';
 import { ROLES } from '~constants';
 import { Address } from '~types/index';
 import { mergePayload, withKey, mapPayload, pipe } from '~utils/actions';
-import { UserType } from '~immutable/index';
+import { UserType, UserProfile, User } from '~immutable/index';
 import { ItemDataType } from '~core/OmniPicker';
 import { ActionTypeString, ActionTypes } from '~redux/index';
 import { useSelector, useDataFetcher, useTransformer } from '~utils/hooks';
@@ -136,13 +136,20 @@ const ColonyPermissionsAddDialog = ({
     [colonyAddress, domainId],
   );
 
-  const user = useMemo(
-    () =>
-      selectedUserAddress
-        ? users.find(({ id }) => id === selectedUserAddress)
-        : null,
-    [selectedUserAddress, users],
-  );
+  const user = useMemo(() => {
+    if (!selectedUserAddress) {
+      return null;
+    }
+    const userInStore = users.find(({ id }) => id === selectedUserAddress);
+    if (userInStore) {
+      return userInStore;
+    }
+    return User({
+      profile: UserProfile({
+        walletAddress: selectedUserAddress,
+      }),
+    }).toJS();
+  }, [selectedUserAddress, users]);
 
   return (
     <Dialog cancel={cancel}>
@@ -200,7 +207,7 @@ const ColonyPermissionsAddDialog = ({
                     appearance={{ theme: 'primary', size: 'large' }}
                     loading={isSubmitting}
                     text={{ id: 'button.confirm' }}
-                    disabled={!user}
+                    disabled={!selectedUserAddress}
                     type="submit"
                   />
                 </DialogSection>

--- a/src/modules/admin/components/Permissions/ColonyPermissionsEditDialog.tsx
+++ b/src/modules/admin/components/Permissions/ColonyPermissionsEditDialog.tsx
@@ -99,7 +99,7 @@ const ColonyPermissionsEditDialog = ({
 
   return (
     <Dialog cancel={cancel}>
-      {!user || !domains ? (
+      {!userAddress || !domains ? (
         <SpinnerLoader />
       ) : (
         <ActionForm
@@ -131,7 +131,9 @@ const ColonyPermissionsEditDialog = ({
                     user={user}
                     placeholder={MSG.placeholder}
                   >
-                    {user.profile.displayName || user.profile.username}
+                    {user && user.profile
+                      ? user.profile.displayName || user.profile.username
+                      : userAddress}
                   </UserInfo>
                 </div>
                 <PermissionForm

--- a/src/modules/admin/components/Permissions/ColonyPermissionsEditDialog.tsx
+++ b/src/modules/admin/components/Permissions/ColonyPermissionsEditDialog.tsx
@@ -2,7 +2,6 @@ import { FormikProps } from 'formik';
 import React, { useCallback } from 'react';
 import { defineMessages } from 'react-intl';
 
-import { ROOT_DOMAIN } from '~constants';
 import { Address } from '~types/index';
 import { mergePayload, withKey, mapPayload, pipe } from '~utils/actions';
 import { ActionTypeString, ActionTypes } from '~redux/index';
@@ -75,8 +74,9 @@ const ColonyPermissionsEditDialog = ({
   const userRoles = useTransformer(TEMP_getUserRolesWithRecovery, [
     domains,
     colonyRecoveryRoles,
-    ROOT_DOMAIN,
+    domainId,
     userAddress,
+    true,
   ]);
 
   const transform = useCallback(

--- a/src/modules/admin/components/Permissions/PermissionForm.tsx
+++ b/src/modules/admin/components/Permissions/PermissionForm.tsx
@@ -60,12 +60,11 @@ const PermissionForm = ({
     currentUserAddress,
   ]);
 
-  const userDirectRoles = useTransformer(TEMP_getUserRolesWithRecovery, [
+  const userInheritedRoles = useTransformer(TEMP_getUserRolesWithRecovery, [
     domains,
     colonyRecoveryRoles,
     domainId,
     userAddress,
-    true,
   ]);
 
   // Check which roles the current user is allowed to set in this domain
@@ -101,7 +100,7 @@ const PermissionForm = ({
       <InputLabel label={MSG.permissionsLabel} />
       {availableRoles.map(role => {
         const roleIsInherited =
-          !userDirectRoles.includes(role) && userRoles.includes(role);
+          !userRoles.includes(role) && userInheritedRoles.includes(role);
         return (
           <div key={role} className={styles.permissionChoiceContainer}>
             <PermissionCheckbox

--- a/src/modules/admin/components/Permissions/Permissions.tsx
+++ b/src/modules/admin/components/Permissions/Permissions.tsx
@@ -110,11 +110,11 @@ const Permissions = ({ colonyAddress, domains, openDialog }: Props) => {
     [openDialog, colonyAddress, selectedDomainId],
   );
 
-  // Convert to array and sort the users for the selected role such that those with root are first
   const domainRolesArray = useMemo(
     () =>
       Object.entries(domainRoles)
         .sort(([, roles]) => (roles.includes(ROLES.ROOT) ? -1 : 1))
+        .filter(([, roles]) => !!roles.length)
         .map(([userAddress, roles]) => ({
           userAddress,
           roles,

--- a/src/modules/admin/components/Permissions/Permissions.tsx
+++ b/src/modules/admin/components/Permissions/Permissions.tsx
@@ -75,6 +75,12 @@ const Permissions = ({ colonyAddress, domains, openDialog }: Props) => {
     selectedDomainId,
   ]);
 
+  const directDomainRoles = useTransformer(getDomainRoles, [
+    domains,
+    selectedDomainId,
+    true,
+  ]);
+
   const domainSelectOptions = sortBy(
     (Object.values(domains) as DomainType[]).map(({ id, name }) => ({
       value: id,
@@ -109,8 +115,12 @@ const Permissions = ({ colonyAddress, domains, openDialog }: Props) => {
     () =>
       Object.entries(domainRoles)
         .sort(([, roles]) => (roles.includes(ROLES.ROOT) ? -1 : 1))
-        .map(([userAddress, roles]) => ({ userAddress, roles })),
-    [domainRoles],
+        .map(([userAddress, roles]) => ({
+          userAddress,
+          roles,
+          directRoles: directDomainRoles[userAddress] || [],
+        })),
+    [directDomainRoles, domainRoles],
   );
 
   const selectedDomain = domains[selectedDomainId];
@@ -141,7 +151,7 @@ const Permissions = ({ colonyAddress, domains, openDialog }: Props) => {
           <>
             <Table scrollable>
               <TableBody className={styles.tableBody}>
-                {domainRolesArray.map(({ userAddress }) => (
+                {domainRolesArray.map(({ userAddress, roles, directRoles }) => (
                   <UserListItem
                     address={userAddress}
                     key={userAddress}
@@ -152,9 +162,8 @@ const Permissions = ({ colonyAddress, domains, openDialog }: Props) => {
                   >
                     <TableCell>
                       <UserPermissions
-                        userAddress={userAddress}
-                        domains={domains}
-                        domainId={selectedDomainId}
+                        roles={roles}
+                        directRoles={directRoles}
                       />
                     </TableCell>
                   </UserListItem>

--- a/src/modules/admin/components/Permissions/UserPermissions.tsx
+++ b/src/modules/admin/components/Permissions/UserPermissions.tsx
@@ -2,30 +2,20 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import { ROLES } from '~constants';
-import { Address, DomainsMapType } from '~types/index';
-import { useTransformer } from '~utils/hooks';
 
-import { getUserRoles } from '../../../transformers';
 import { ROLE_MESSAGES } from '../../constants';
 
 import styles from './UserPermissions.css';
 
 interface Props {
-  userAddress: Address;
-  domains: DomainsMapType;
-  domainId: number;
+  roles: ROLES[];
+  directRoles: ROLES[];
 }
 
 const displayName = 'admin.Permissions.UserPermissions';
 
-const UserPermissions = ({ userAddress, domains, domainId }: Props) => {
-  const inheritedUserRoles = useTransformer(getUserRoles, [
-    domains,
-    domainId,
-    userAddress,
-  ]);
-
-  const sortedRoles = inheritedUserRoles
+const UserPermissions = ({ roles, directRoles }: Props) => {
+  const sortedRoles = roles
     .filter(
       role =>
         // Don't display ARCHITECTURE_SUBDOMAIN in listed roles
@@ -40,12 +30,10 @@ const UserPermissions = ({ userAddress, domains, domainId }: Props) => {
 
   return (
     <div className={styles.main}>
-      {/* @TODO restore pending role indicator */}
-      {/* {userPermissions.pending ? ( */}
-      {/*  <div className={styles.pendingDot} /> */}
       {sortedRoles.map(role => (
         <span className={styles.permission} key={role}>
           <FormattedMessage id={ROLE_MESSAGES[role]} />
+          {!directRoles.includes(role) ? '*' : null}
         </span>
       ))}
     </div>

--- a/src/modules/core/components/SingleUserPicker/ItemDefault.tsx
+++ b/src/modules/core/components/SingleUserPicker/ItemDefault.tsx
@@ -28,11 +28,18 @@ interface Props {
    */
   showMaskedAddress?: boolean;
 }
-
 const ItemDefault = ({
   walletAddress,
   itemData: {
-    profile: { walletAddress: userAddress, displayName, username },
+    profile: { walletAddress: userAddress, displayName, username } = {
+      /*
+       * @NOTE This is a last resort default!
+       *
+       * If the app ever gets to use this value, the SingleUserPickerItem
+       * compontn will display: _Address format is wrong!_
+       */
+      walletAddress: '',
+    },
   },
   itemData,
   renderAvatar,

--- a/src/modules/core/components/UserAvatar/UserAvatar.tsx
+++ b/src/modules/core/components/UserAvatar/UserAvatar.tsx
@@ -44,7 +44,7 @@ const UserAvatar = ({
   size,
   user,
 }: Props) => {
-  const username = user && (user as UserType).profile.username;
+  const username = user && user.profile && (user as UserType).profile.username;
   const avatar = (
     <InfoPopover trigger={showInfo ? 'click' : 'disabled'} address={address}>
       <div>

--- a/src/modules/dashboard/checks.ts
+++ b/src/modules/dashboard/checks.ts
@@ -2,7 +2,7 @@ import { ROLES } from '~constants';
 import { TaskStates } from '~data/constants';
 import { ColonyType, TaskType, TaskUserType } from '~immutable/index';
 import { Address } from '~types/index';
-import { isFounder, canAdminister, canFund } from '../users/checks';
+import { hasRoot, canAdminister, canFund } from '../users/checks';
 
 /*
  * Colony
@@ -119,4 +119,4 @@ export const canFinalizeTask = (task: TaskType, roles: ROLES[]) =>
   canAdminister(roles) &&
   canFund(roles);
 
-export const canRecoverColony = isFounder;
+export const canRecoverColony = hasRoot;

--- a/src/modules/dashboard/checks.ts
+++ b/src/modules/dashboard/checks.ts
@@ -108,7 +108,7 @@ export const canRequestToWork = (task: TaskType, userAddress: Address) =>
     task.workerAddress ||
     isCreator(task, userAddress) ||
     hasRequestedToWork(task, userAddress)
-  );
+  ) && isActive(task);
 
 export const canFinalizeTask = (task: TaskType, roles: ROLES[]) =>
   task &&

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
@@ -30,7 +30,7 @@ import RecoveryModeAlert from '~admin/RecoveryModeAlert';
 import LoadingTemplate from '~pages/LoadingTemplate';
 
 import { walletAddressSelector } from '../../../users/selectors';
-import { canAdminister, isFounder } from '../../../users/checks';
+import { canAdminister, hasRoot } from '../../../users/checks';
 import { colonyAddressFetcher, domainsAndRolesFetcher } from '../../fetchers';
 import {
   colonyNativeTokenSelector,
@@ -328,7 +328,7 @@ const ColonyHome = ({
               filterOption={filterOption}
               ethTokenRef={ethTokenRef}
               nativeTokenRef={nativeTokenRef}
-              showQrCode={isFounder(rootUserRoles)}
+              showQrCode={hasRoot(rootUserRoles)}
             />
           </TabPanel>
           <TabPanel>

--- a/src/modules/dashboard/components/Task/Task.tsx
+++ b/src/modules/dashboard/components/Task/Task.tsx
@@ -264,6 +264,7 @@ const Task = ({
                 disabled={!canEdit}
                 draftId={draftId}
                 skillId={skillId}
+                domainId={domainId}
               />
             </div>
             <div className={styles.editor}>
@@ -272,6 +273,7 @@ const Task = ({
                 disabled={!canEdit}
                 draftId={draftId}
                 dueDate={dueDate}
+                domainId={domainId}
               />
             </div>
           </section>

--- a/src/modules/dashboard/components/TaskDate/TaskDate.tsx
+++ b/src/modules/dashboard/components/TaskDate/TaskDate.tsx
@@ -28,22 +28,30 @@ const MSG = defineMessages({
   },
 });
 
-interface Props extends TaskProps<'colonyAddress' | 'draftId' | 'dueDate'> {
+interface Props
+  extends TaskProps<'colonyAddress' | 'draftId' | 'dueDate' | 'domainId'> {
   disabled?: boolean;
 }
 
 const displayName = 'dashboard.TaskDate';
 
-const TaskDate = ({ colonyAddress, draftId, dueDate, disabled }: Props) => {
+const TaskDate = ({
+  colonyAddress,
+  draftId,
+  dueDate,
+  disabled,
+  domainId,
+}: Props) => {
   const transform = useCallback(
     pipe(
       mapPayload(({ taskDueDate }) => ({ dueDate: taskDueDate })),
       mergePayload({
         colonyAddress,
         draftId,
+        domainId,
       }),
     ),
-    [colonyAddress, draftId],
+    [colonyAddress, draftId, domainId],
   );
 
   return (

--- a/src/modules/dashboard/components/TaskList/TaskList.tsx
+++ b/src/modules/dashboard/components/TaskList/TaskList.tsx
@@ -90,12 +90,14 @@ const TaskList = ({
     ({ creatorAddress, workerAddress, currentState, domainId }: TaskType) => {
       if (filteredDomainId && filteredDomainId !== domainId) return false;
 
+      const taskIsOpen = currentState === TaskStates.ACTIVE;
+
       switch (filterOption) {
         case TasksFilterOptions.CREATED:
-          return creatorAddress === walletAddress;
+          return creatorAddress === walletAddress && taskIsOpen;
 
         case TasksFilterOptions.ASSIGNED:
-          return workerAddress === walletAddress;
+          return workerAddress === walletAddress && taskIsOpen;
 
         case TasksFilterOptions.COMPLETED:
           return currentState === TaskStates.FINALIZED;
@@ -104,7 +106,7 @@ const TaskList = ({
           return currentState === TaskStates.CANCELLED;
 
         case TasksFilterOptions.ALL_OPEN:
-          return currentState === TaskStates.ACTIVE;
+          return taskIsOpen;
 
         default:
           return currentState !== TaskStates.CANCELLED;

--- a/src/modules/dashboard/components/TaskSkills/TaskSkills.tsx
+++ b/src/modules/dashboard/components/TaskSkills/TaskSkills.tsx
@@ -29,13 +29,20 @@ const MSG = defineMessages({
   },
 });
 
-interface Props extends TaskProps<'draftId' | 'colonyAddress' | 'skillId'> {
+interface Props
+  extends TaskProps<'draftId' | 'colonyAddress' | 'skillId' | 'domainId'> {
   disabled?: boolean;
 }
 
 const displayName = 'daskboard.TaskSKills';
 
-const TaskSkills = ({ colonyAddress, draftId, disabled, skillId }: Props) => {
+const TaskSkills = ({
+  colonyAddress,
+  draftId,
+  disabled,
+  skillId,
+  domainId,
+}: Props) => {
   const setSkill = useAsyncFunction({
     submit: ActionTypes.TASK_SET_SKILL,
     success: ActionTypes.TASK_SET_SKILL_SUCCESS,
@@ -48,6 +55,7 @@ const TaskSkills = ({ colonyAddress, draftId, disabled, skillId }: Props) => {
         await setSkill({
           colonyAddress,
           draftId,
+          domainId,
           skillId: skillValue ? skillValue.id : undefined,
         });
       } catch (caughtError) {
@@ -57,7 +65,7 @@ const TaskSkills = ({ colonyAddress, draftId, disabled, skillId }: Props) => {
         log.error(caughtError);
       }
     },
-    [colonyAddress, draftId, setSkill],
+    [colonyAddress, domainId, draftId, setSkill],
   );
 
   return (

--- a/src/modules/dashboard/data/commands/task.ts
+++ b/src/modules/dashboard/data/commands/task.ts
@@ -155,6 +155,7 @@ export const createTask: Command<
     await taskStore.append(
       createEvent(EventTypes.COMMENT_STORE_CREATED, {
         commentsStoreAddress,
+        domainId,
       }),
     );
 
@@ -190,6 +191,7 @@ export const setTaskTitle: Command<
   {
     currentTitle: string | void;
     title: string;
+    domainId: number;
   },
   {
     event: Event<EventTypes.TASK_TITLE_SET>;
@@ -200,11 +202,12 @@ export const setTaskTitle: Command<
   context: [Context.COLONY_MANAGER, Context.DDB_INSTANCE, Context.WALLET],
   prepare: prepareTaskStoreCommand,
   schema: SetTaskTitleCommandArgsSchema,
-  async execute(taskStore, { currentTitle, title }) {
+  async execute(taskStore, { currentTitle, title, domainId }) {
     if (title === currentTitle) return null;
     const eventHash = await taskStore.append(
       createEvent(EventTypes.TASK_TITLE_SET, {
         title,
+        domainId,
       }),
     );
     return {
@@ -220,6 +223,7 @@ export const setTaskDescription: Command<
   {
     currentDescription: string | void;
     description: string;
+    domainId: number;
   },
   {
     event: Event<EventTypes.TASK_DESCRIPTION_SET>;
@@ -230,13 +234,14 @@ export const setTaskDescription: Command<
   context: [Context.COLONY_MANAGER, Context.DDB_INSTANCE, Context.WALLET],
   prepare: prepareTaskStoreCommand,
   schema: SetTaskDescriptionCommandArgsSchema,
-  async execute(taskStore, { currentDescription, description }) {
+  async execute(taskStore, { currentDescription, description, domainId }) {
     if (description === currentDescription) {
       return null;
     }
     const eventHash = await taskStore.append(
       createEvent(EventTypes.TASK_DESCRIPTION_SET, {
         description,
+        domainId,
       }),
     );
     return {
@@ -253,6 +258,7 @@ export const setTaskDueDate: Command<
   TaskStoreMetadata,
   {
     dueDate?: number;
+    domainId: number;
   },
   {
     event: Event<EventTypes.DUE_DATE_SET>;
@@ -263,10 +269,11 @@ export const setTaskDueDate: Command<
   context: [Context.COLONY_MANAGER, Context.DDB_INSTANCE, Context.WALLET],
   prepare: prepareTaskStoreCommand,
   schema: SetTaskDueDateCommandArgsSchema,
-  async execute(taskStore, { dueDate }) {
+  async execute(taskStore, { dueDate, domainId }) {
     const eventHash = await taskStore.append(
       createEvent(EventTypes.DUE_DATE_SET, {
         dueDate,
+        domainId,
       }),
     );
     return {
@@ -281,6 +288,7 @@ export const setTaskSkill: Command<
   TaskStoreMetadata,
   {
     skillId?: number;
+    domainId: number;
   },
   {
     event: Event<EventTypes.SKILL_SET>;
@@ -291,10 +299,11 @@ export const setTaskSkill: Command<
   context: [Context.COLONY_MANAGER, Context.DDB_INSTANCE, Context.WALLET],
   prepare: prepareTaskStoreCommand,
   schema: SetTaskSkillCommandArgsSchema,
-  async execute(taskStore, { skillId }) {
+  async execute(taskStore, { skillId, domainId }) {
     const eventHash = await taskStore.append(
       createEvent(EventTypes.SKILL_SET, {
         skillId,
+        domainId,
       }),
     );
     return {
@@ -338,6 +347,7 @@ export const sendWorkInvite: Command<
   TaskStoreMetadata,
   {
     workerAddress: Address;
+    domainId: number;
   },
   {
     event: Event<EventTypes.WORK_INVITE_SENT>;
@@ -348,10 +358,11 @@ export const sendWorkInvite: Command<
   context: [Context.COLONY_MANAGER, Context.DDB_INSTANCE, Context.WALLET],
   prepare: prepareTaskStoreCommand,
   schema: SendWorkInviteCommandArgsSchema,
-  async execute(taskStore, { workerAddress }) {
+  async execute(taskStore, { workerAddress, domainId }) {
     const eventHash = await taskStore.append(
       createEvent(EventTypes.WORK_INVITE_SENT, {
         workerAddress,
+        domainId,
       }),
     );
     return {
@@ -408,6 +419,7 @@ export const setTaskPayout: Command<
   {
     amount: BigNumber;
     token: string;
+    domainId: number;
   },
   {
     event: Event<EventTypes.PAYOUT_SET>;
@@ -418,11 +430,12 @@ export const setTaskPayout: Command<
   context: [Context.COLONY_MANAGER, Context.DDB_INSTANCE, Context.WALLET],
   prepare: prepareTaskStoreCommand,
   schema: SetTaskPayoutCommandArgsSchema,
-  async execute(taskStore, { amount, token }) {
+  async execute(taskStore, { amount, token, domainId }) {
     const eventHash = await taskStore.append(
       createEvent(EventTypes.PAYOUT_SET, {
         amount: amount.toString(10),
         token,
+        domainId,
       }),
     );
     return {
@@ -461,6 +474,7 @@ export const assignWorker: Command<
   {
     workerAddress: Address;
     currentWorkerAddress: Address | null;
+    domainId: number;
   },
   {
     event: Event<EventTypes.WORKER_ASSIGNED>;
@@ -470,13 +484,14 @@ export const assignWorker: Command<
   name: 'assignWorker',
   context: [Context.COLONY_MANAGER, Context.DDB_INSTANCE, Context.WALLET],
   prepare: prepareTaskStoreCommand,
-  async execute(taskStore, { workerAddress, currentWorkerAddress }) {
+  async execute(taskStore, { workerAddress, currentWorkerAddress, domainId }) {
     if (workerAddress === currentWorkerAddress) {
       return null;
     }
     const eventHash = await taskStore.append(
       createEvent(EventTypes.WORKER_ASSIGNED, {
         workerAddress,
+        domainId,
       }),
     );
     return {
@@ -492,6 +507,7 @@ export const unassignWorker: Command<
   {
     workerAddress: Address;
     userAddress: Address;
+    domainId: number;
   },
   {
     event: Event<EventTypes.WORKER_UNASSIGNED>;
@@ -501,11 +517,12 @@ export const unassignWorker: Command<
   name: 'unassignWorker',
   context: [Context.COLONY_MANAGER, Context.DDB_INSTANCE, Context.WALLET],
   prepare: prepareTaskStoreCommand,
-  async execute(taskStore, { workerAddress, userAddress }) {
+  async execute(taskStore, { workerAddress, userAddress, domainId }) {
     const eventHash = await taskStore.append(
       createEvent(EventTypes.WORKER_UNASSIGNED, {
         workerAddress,
         userAddress,
+        domainId,
       }),
     );
     return {
@@ -525,6 +542,7 @@ export const finalizeTask: Command<
     paymentTokenAddress?: Address;
     workerAddress: Address;
     transactionHash: string;
+    domainId: number;
   },
   {
     event: Event<EventTypes.TASK_FINALIZED>;
@@ -555,6 +573,7 @@ export const cancelTask: Command<
   TaskStoreMetadata,
   {
     draftId: TaskDraftId;
+    domainId: number;
   },
   {
     event: Event<EventTypes.TASK_CANCELLED>;
@@ -600,7 +619,10 @@ export const cancelTask: Command<
     };
   },
   schema: CancelTaskCommandArgsSchema,
-  async execute({ colonyStore, colonyTaskIndexStore, taskStore }, { draftId }) {
+  async execute(
+    { colonyStore, colonyTaskIndexStore, taskStore },
+    { draftId, domainId },
+  ) {
     // backwards-compatibility Colony task index store
     const store = colonyTaskIndexStore || colonyStore;
     if (!store) {
@@ -611,6 +633,7 @@ export const cancelTask: Command<
     const eventHash = await taskStore.append(
       createEvent(EventTypes.TASK_CANCELLED, {
         status: TaskStates.CANCELLED,
+        domainId,
       }),
     );
     await store.append(
@@ -629,7 +652,7 @@ export const cancelTask: Command<
 export const closeTask: Command<
   TaskStore,
   TaskStoreMetadata,
-  void,
+  { domainId: number },
   {
     event: Event<EventTypes.TASK_CLOSED>;
     taskStore: TaskStore;
@@ -639,10 +662,11 @@ export const closeTask: Command<
   context: [Context.COLONY_MANAGER, Context.DDB_INSTANCE, Context.WALLET],
   prepare: prepareTaskStoreCommand,
   schema: FinalizeTaskCommandArgsSchema,
-  async execute(taskStore) {
+  async execute(taskStore, { domainId }) {
     const eventHash = await taskStore.append(
       createEvent(EventTypes.TASK_CLOSED, {
         status: TaskStates.CLOSED,
+        domainId,
       }),
     );
     return {

--- a/src/modules/dashboard/data/commands/task.ts
+++ b/src/modules/dashboard/data/commands/task.ts
@@ -1,10 +1,6 @@
 import BigNumber from 'bn.js';
-import {
-  COLONY_ROLE_ROOT,
-  COLONY_ROLE_ADMINISTRATION,
-} from '@colony/colony-js-client';
 
-import { ROOT_DOMAIN } from '~constants';
+import { ROLES } from '~constants';
 import { Context } from '~context/index';
 import { EventTypes, TaskStates, Versions } from '~data/constants';
 import {
@@ -727,21 +723,22 @@ export const setTaskDomain: Command<
         EventTypes.TASK_CREATED | EventTypes.DOMAIN_SET
       >;
 
-      const { hasRole: isFounder } = await colonyClient.hasColonyRole.call({
-        address: walletAddress,
-        role: COLONY_ROLE_ROOT,
-        domainId: ROOT_DOMAIN,
-      });
-      if (isFounder) return true;
-
       const {
         hasRole: isAdminOfCurrentDomain,
       } = await colonyClient.hasColonyRole.call({
         address: walletAddress,
-        role: COLONY_ROLE_ADMINISTRATION,
+        role: ROLES.ADMINISTRATION,
         domainId: currentDomainId,
       });
-      return isAdminOfCurrentDomain;
+
+      const {
+        hasRole: isAdminOfNextDomain,
+      } = await colonyClient.hasColonyRole.call({
+        address: walletAddress,
+        role: ROLES.ADMINISTRATION,
+        domainId,
+      });
+      return isAdminOfCurrentDomain && isAdminOfNextDomain;
     })();
 
     if (!canAppend) {

--- a/src/modules/dashboard/data/commands/task.ts
+++ b/src/modules/dashboard/data/commands/task.ts
@@ -167,6 +167,7 @@ export const createTask: Command<
       commentsStoreAddress,
       draftId,
       taskStoreAddress: taskStore.address.toString(),
+      domainId,
     });
 
     await taskIndexStore.append(event);
@@ -636,6 +637,7 @@ export const cancelTask: Command<
       createEvent(EventTypes.TASK_STORE_UNREGISTERED, {
         draftId,
         taskStoreAddress: taskStore.address.toString(),
+        domainId,
       }),
     );
     return {

--- a/src/modules/dashboard/sagas/task.ts
+++ b/src/modules/dashboard/sagas/task.ts
@@ -238,12 +238,13 @@ function* taskSetDescription({
 }: Action<ActionTypes.TASK_SET_DESCRIPTION>) {
   try {
     const {
-      record: { description: currentDescription },
+      record: { description: currentDescription, domainId },
     } = yield selectAsJS(taskSelector, draftId);
     const eventData = yield executeCommand(setTaskDescription, {
       args: {
         currentDescription,
         description,
+        domainId,
       },
       metadata: { colonyAddress, draftId },
     });
@@ -271,10 +272,10 @@ function* taskSetTitle({
 }: Action<ActionTypes.TASK_SET_TITLE>) {
   try {
     const {
-      record: { title: currentTitle },
+      record: { title: currentTitle, domainId },
     }: { record: TaskType } = yield selectAsJS(taskSelector, draftId);
     const eventData = yield executeCommand(setTaskTitle, {
-      args: { currentTitle, title },
+      args: { currentTitle, title, domainId },
       metadata: { colonyAddress, draftId },
     });
     if (eventData) {
@@ -326,11 +327,11 @@ function* taskSetDomain({
  */
 function* taskCancel({
   meta,
-  payload: { colonyAddress, draftId },
+  payload: { colonyAddress, draftId, domainId },
 }: Action<ActionTypes.TASK_CANCEL>) {
   try {
     const { event } = yield executeCommand(cancelTask, {
-      args: { draftId },
+      args: { draftId, domainId },
       metadata: { colonyAddress, draftId },
     });
 
@@ -356,10 +357,11 @@ function* taskCancel({
  */
 function* taskClose({
   meta,
-  payload: { colonyAddress, draftId },
+  payload: { colonyAddress, draftId, domainId },
 }: Action<ActionTypes.TASK_CLOSE>) {
   try {
     const { event } = yield executeCommand(closeTask, {
+      args: { domainId },
       metadata: { colonyAddress, draftId },
     });
 
@@ -382,12 +384,12 @@ function* taskClose({
  * As worker or manager, I want to be able to set a skill
  */
 function* taskSetSkill({
-  payload: { colonyAddress, draftId, skillId },
+  payload: { colonyAddress, draftId, skillId, domainId },
   meta,
 }: Action<ActionTypes.TASK_SET_SKILL>) {
   try {
     const { event } = yield executeCommand(setTaskSkill, {
-      args: { skillId },
+      args: { skillId, domainId },
       metadata: { colonyAddress, draftId },
     });
 
@@ -425,7 +427,7 @@ function* taskSetPayout({
 }: Action<ActionTypes.TASK_SET_PAYOUT>) {
   try {
     const {
-      record: { payouts },
+      record: { payouts, domainId },
     }: { record: TaskType } = yield selectAsJS(taskSelector, draftId);
 
     /*
@@ -438,7 +440,7 @@ function* taskSetPayout({
       !amount.eq(new BigNumber(payouts[0].amount))
     ) {
       const { event } = yield executeCommand(setTaskPayout, {
-        args: { token, amount },
+        args: { token, amount, domainId },
         metadata: { colonyAddress, draftId },
       });
 
@@ -499,12 +501,12 @@ function* taskRemovePayout({
  * As worker or manager, I want to be able to set a date
  */
 function* taskSetDueDate({
-  payload: { colonyAddress, draftId, dueDate },
+  payload: { colonyAddress, draftId, dueDate, domainId },
   meta,
 }: Action<ActionTypes.TASK_SET_DUE_DATE>) {
   try {
     const { event } = yield executeCommand(setTaskDueDate, {
-      args: { dueDate: dueDate ? dueDate.getTime() : undefined },
+      args: { dueDate: dueDate ? dueDate.getTime() : undefined, domainId },
       metadata: { colonyAddress, draftId },
     });
     yield put<AllActions>({
@@ -565,6 +567,7 @@ function* taskFinalize({
     // add finalize task event to task store
     const { event } = yield executeCommand(finalizeTask, {
       args: {
+        domainId,
         paymentTokenAddress: token,
         amountPaid: amount.toString(),
         workerAddress,
@@ -604,9 +607,9 @@ function* taskSendWorkInvite({
   meta,
 }: Action<ActionTypes.TASK_SEND_WORK_INVITE>) {
   try {
-    const { workerAddress } = yield select(taskSelector, draftId);
+    const { workerAddress, domainId } = yield select(taskSelector, draftId);
     const { event } = yield executeCommand(sendWorkInvite, {
-      args: { workerAddress },
+      args: { workerAddress, domainId },
       metadata: { colonyAddress, draftId },
     });
     yield put<AllActions>({
@@ -684,10 +687,14 @@ function* taskWorkerAssign({
   try {
     const walletAddress = yield select(walletAddressSelector);
     const {
-      record: { workerAddress: currentWorkerAddress, title: taskTitle },
+      record: {
+        workerAddress: currentWorkerAddress,
+        title: taskTitle,
+        domainId,
+      },
     } = yield select(taskSelector, draftId);
     const eventData = yield executeCommand(assignWorker, {
-      args: { workerAddress, currentWorkerAddress },
+      args: { workerAddress, currentWorkerAddress, domainId },
       metadata: { colonyAddress, draftId },
     });
     if (eventData) {
@@ -731,10 +738,10 @@ function* taskWorkerUnassign({
     if (workerAddress) {
       const userAddress = yield select(walletAddressSelector);
       const {
-        record: { title: taskTitle },
+        record: { title: taskTitle, domainId },
       } = yield select(taskSelector, draftId);
       const eventData = yield executeCommand(unassignWorker, {
-        args: { workerAddress, userAddress },
+        args: { workerAddress, userAddress, domainId },
         metadata: { colonyAddress, draftId },
       });
 

--- a/src/modules/dashboard/sagas/task.ts
+++ b/src/modules/dashboard/sagas/task.ts
@@ -546,7 +546,7 @@ function* taskFinalize({
     const txChannel = yield call(getTxChannel, meta.id);
     yield fork(createTransaction, meta.id, {
       context: ContractContexts.COLONY_CONTEXT,
-      methodName: 'makePayment',
+      methodName: 'makePaymentFundedFromDomain',
       identifier: colonyAddress,
       params: {
         recipient: workerAddress,

--- a/src/modules/transformers.ts
+++ b/src/modules/transformers.ts
@@ -74,6 +74,25 @@ export const TEMP_getUserRolesWithRecovery = (
   return roles[userAddress];
 };
 
+export const getAllUserRoles = (
+  domains: DomainsMapType | null,
+  userAddress: Address | null,
+): ROLES[] => {
+  if (!domains) return [] as ROLES[];
+  return Array.from(
+    Object.values(domains).reduce(
+      (allUserRoles: Set<ROLES>, domain: DomainType) => {
+        if (!userAddress) return allUserRoles;
+        if (domain.roles[userAddress]) {
+          domain.roles[userAddress].forEach(role => allUserRoles.add(role));
+        }
+        return allUserRoles;
+      },
+      new Set(),
+    ),
+  );
+};
+
 /*
  * Eventually we'll switch all of the dApp to using new roles, but until then
  * we still need to be able to get the old roles `admins` and `founder`. This

--- a/src/modules/transformers.ts
+++ b/src/modules/transformers.ts
@@ -18,7 +18,8 @@ export const getDomainRoles = (
     return domain.roles;
   }
 
-  let parent = domains[domain.parentId] as DomainType | null;
+  // Start with the current domain to accumulate roles
+  let parent = domains[domainId] as DomainType | null;
   const roleSets = {};
   while (parent) {
     Object.entries(parent.roles).forEach(([userAddress, roles]) => {

--- a/src/modules/users/checks.ts
+++ b/src/modules/users/checks.ts
@@ -13,8 +13,11 @@ export const canAdminister = (userRoles: ROLES[]) =>
 export const canFund = (userRoles: ROLES[]) =>
   userHasRole(userRoles, ROLES.FUNDING);
 
-export const isFounder = (userRoles: ROLES[]) =>
+export const hasRoot = (userRoles: ROLES[]) =>
   userHasRole(userRoles, ROLES.ROOT);
+
+export const canArchitect = (userRoles: ROLES[]) =>
+  userHasRole(userRoles, ROLES.ARCHITECTURE);
 
 export const userDidClaimProfile = ({ profile: { username } }: UserType) =>
   !!username;

--- a/src/modules/users/components/HookedUserAvatar/HookedUserAvatar.ts
+++ b/src/modules/users/components/HookedUserAvatar/HookedUserAvatar.ts
@@ -23,7 +23,10 @@ export default withHooks<
     );
     result.user = fetchedUser as UserType;
   }
-  const avatarHash = result.user ? result.user.profile.avatarHash : undefined;
+  const avatarHash =
+    result.user && result.user.profile
+      ? result.user.profile.avatarHash
+      : undefined;
   const { data: avatarURL } = useDataFetcher(
     ipfsDataFetcher,
     [avatarHash as string], // Technically a bug

--- a/src/redux/types/actions/task.ts
+++ b/src/redux/types/actions/task.ts
@@ -63,13 +63,13 @@ interface TaskErrorActionType<T extends string>
  * TASK_WORKER_REVEAL_MANAGER_RATING_SUCCESS
  */
 export type TaskActionTypes =
-  | TaskActionType<ActionTypes.TASK_CANCEL, object>
+  | TaskActionType<ActionTypes.TASK_CANCEL, { domainId: number }>
   | TaskErrorActionType<ActionTypes.TASK_CANCEL_ERROR>
   | TaskActionType<
       ActionTypes.TASK_CANCEL_SUCCESS,
       { event: Event<EventTypes.TASK_CANCELLED> }
     >
-  | TaskActionType<ActionTypes.TASK_CLOSE, object>
+  | TaskActionType<ActionTypes.TASK_CLOSE, { domainId: number }>
   | TaskErrorActionType<ActionTypes.TASK_CLOSE_ERROR>
   | TaskActionType<
       ActionTypes.TASK_CLOSE_SUCCESS,
@@ -175,7 +175,10 @@ export type TaskActionTypes =
       ActionTypes.TASK_SEND_WORK_REQUEST_SUCCESS,
       { event: Event<EventTypes.WORK_REQUEST_CREATED> }
     >
-  | TaskActionType<ActionTypes.TASK_SET_DUE_DATE, TaskProps<'dueDate'>>
+  | TaskActionType<
+      ActionTypes.TASK_SET_DUE_DATE,
+      TaskProps<'dueDate' | 'domainId'>
+    >
   | TaskErrorActionType<ActionTypes.TASK_SET_DUE_DATE_ERROR>
   | TaskActionType<
       ActionTypes.TASK_SET_DUE_DATE_SUCCESS,
@@ -205,7 +208,10 @@ export type TaskActionTypes =
       ActionTypes.TASK_SET_PAYOUT_SUCCESS,
       { event: Event<EventTypes.PAYOUT_SET> }
     >
-  | TaskActionType<ActionTypes.TASK_SET_SKILL, TaskProps<'skillId'>>
+  | TaskActionType<
+      ActionTypes.TASK_SET_SKILL,
+      TaskProps<'skillId' | 'domainId'>
+    >
   | TaskErrorActionType<ActionTypes.TASK_SET_SKILL_ERROR>
   | TaskActionType<
       ActionTypes.TASK_SET_SKILL_SUCCESS,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1157,10 +1157,10 @@
     "@colony/colony-js-contract-loader" "^1.12.0"
     bn.js "^4.11.8"
 
-"@colony/colony-js-client@^1.14.0-beta.3":
-  version "1.14.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@colony/colony-js-client/-/colony-js-client-1.14.0-beta.3.tgz#4383f41891210f94209757b781bb619bdab63fc8"
-  integrity sha512-ICAdmor4WEKo9H9pX7IgY/kV6g7aqr6Xm8Xzk1N1y4tj+SyUvPxJNkxdSNoTi45t+a8QYKqDM9k5PqzkR5qbVQ==
+"@colony/colony-js-client@^1.14.0":
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/@colony/colony-js-client/-/colony-js-client-1.14.0.tgz#6c3eec085af574b0d1cd77842829044615266dce"
+  integrity sha512-g+rAQrgTIDxWt/KTK8yx/59LEhlrqKfBlVcFnigKnZswuUWikbDvzu1NQp+ewkz6rv0Ga7yjggdA88fBDFfgGQ==
   dependencies:
     "@colony/colony-js-adapter" "^1.14.0-beta.2"
     "@colony/colony-js-adapter-ethers" "^1.14.0-beta.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1157,10 +1157,10 @@
     "@colony/colony-js-contract-loader" "^1.12.0"
     bn.js "^4.11.8"
 
-"@colony/colony-js-client@^1.14.0":
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/@colony/colony-js-client/-/colony-js-client-1.14.0.tgz#6c3eec085af574b0d1cd77842829044615266dce"
-  integrity sha512-g+rAQrgTIDxWt/KTK8yx/59LEhlrqKfBlVcFnigKnZswuUWikbDvzu1NQp+ewkz6rv0Ga7yjggdA88fBDFfgGQ==
+"@colony/colony-js-client@^1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@colony/colony-js-client/-/colony-js-client-1.14.1.tgz#57ad35c7a2e07bcd8b1e610ecdfb927e4f3db7a8"
+  integrity sha512-CRMIvgoQwE0XChKu50l5ULj2/N9RdF0xekfCTLfBjQxFk0uz/mQS/fPpU1ev96FHOVoKXSErT1aTK2Yh/aarUw==
   dependencies:
     "@colony/colony-js-adapter" "^1.14.0-beta.2"
     "@colony/colony-js-adapter-ethers" "^1.14.0-beta.2"


### PR DESCRIPTION
## Description

This PR fixes more DLx issues discovered following deployment of #1907 to QA, including broader improvements to domain-level permissions.

**New stuff** ✨

* Migrations for task events to add root domain
* `getAllUserRoles` transformer
* `canArchitect` check

**Changes** 🏗

* Adjust task permissions to allow admins
* Use `domainId`s everywhere in commands & sagas
* Use current `domainId` in task access controller

## TODO

Colony Admin Permissions
- [x] Fix asterisks for inherited roles OR remove asterisk text at bottom of list / @rdig 
- [x] ~SingleUserPicker only works (on first click) if the selected user is already in the redux store. Doesn’t work when pasting an (unloaded) user’s address and selecting it. Even still, the form won’t pass validation, thus can’t submit~ / @rdig 
- [x] Add user permissions on a subdomain does nothing after signing TXs / @chmanie 
- [x] User with only the architecture domain cannot see the admin panel, and thus cannot modify domains. We may have to rethink the architecture of the colony admin area because of the large number of user role permutations @chmanie 


Tasks
- [x] ~Finalizing a task in a subdomain pays with funds from the root domain~ This should be an own issue as it requires colonyJS to be altered as well, while probably fixing a whole bunch of permissioning issues on the way
- [x] Can request to work on a task that's been discarded
- [x] Actually use `makePaymentFundedFromDomain`
- [x] Use inherited roles to check task permissions in access controller