### PR TITLE
Fix Task List Filter

### DIFF
--- a/src/modules/dashboard/components/TaskList/TaskList.tsx
+++ b/src/modules/dashboard/components/TaskList/TaskList.tsx
@@ -90,12 +90,14 @@ const TaskList = ({
     ({ creatorAddress, workerAddress, currentState, domainId }: TaskType) => {
       if (filteredDomainId && filteredDomainId !== domainId) return false;
 
+      const taskIsOpen = currentState === TaskStates.ACTIVE;
+
       switch (filterOption) {
         case TasksFilterOptions.CREATED:
-          return creatorAddress === walletAddress;
+          return creatorAddress === walletAddress && taskIsOpen;
 
         case TasksFilterOptions.ASSIGNED:
-          return workerAddress === walletAddress;
+          return workerAddress === walletAddress && taskIsOpen;
 
         case TasksFilterOptions.COMPLETED:
           return currentState === TaskStates.FINALIZED;
@@ -104,7 +106,7 @@ const TaskList = ({
           return currentState === TaskStates.CANCELLED;
 
         case TasksFilterOptions.ALL_OPEN:
-          return currentState === TaskStates.ACTIVE;
+          return taskIsOpen;
 
         default:
           return currentState !== TaskStates.CANCELLED;


### PR DESCRIPTION
## Description

This PR adds in a fix for the `TaskList` filter that prevents showing _assigned to you_ or _created by you_ filtered tasks, if those tasks are **not** in an `OPEN` state. _(Ie: `FINALIZED` or  `CANCELLED`)_

**Changes**

- [x] `TaskList` take into account task state when filtering created / assigned tasks

**Screenshots**

![Screenshot from 2019-11-18 14-08-35](https://user-images.githubusercontent.com/1193222/69051629-8aef1b80-0a0d-11ea-88e8-39aacf98f5cf.png)
![Screenshot from 2019-11-18 14-08-42](https://user-images.githubusercontent.com/1193222/69051630-8aef1b80-0a0d-11ea-96b5-51b7832aaa29.png)
![Screenshot from 2019-11-18 14-08-48](https://user-images.githubusercontent.com/1193222/69051631-8aef1b80-0a0d-11ea-9090-742e72b8aad0.png)

Resolves #1917

Rebased on #1916 branch `fix/more-dlx-fixes`
