### PR TITLE
Fix Long Domain Names breaking UI

### DIFF
--- a/src/modules/admin/components/Permissions/ColonyPermissionsDialog.css
+++ b/src/modules/admin/components/Permissions/ColonyPermissionsDialog.css
@@ -1,5 +1,15 @@
 .dialogContainer {
   padding: 27px 19px 17px 19px;
+
+  & h3 {
+    /*
+     * @NOTE We can't compose from `inlineEllipsis` here since we're inside an
+     * element, not a component :(
+     */
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }
 
 .titleContainer {

--- a/src/modules/admin/components/Permissions/Permissions.css
+++ b/src/modules/admin/components/Permissions/Permissions.css
@@ -10,6 +10,17 @@
   justify-content: space-between;
   align-items: baseline;
   border-bottom: 1px solid var(--temp-grey-5);
+
+  & h3 {
+    /*
+     * @NOTE We can't compose from `inlineEllipsis` here since we're inside an
+     * element, not a component :(
+     */
+    width: calc(100% - 150px);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }
 
 .tableWrapper {

--- a/src/modules/admin/components/Permissions/Permissions.tsx
+++ b/src/modules/admin/components/Permissions/Permissions.tsx
@@ -137,7 +137,11 @@ const Permissions = ({ colonyAddress, domains, openDialog }: Props) => {
             appearance={{ size: 'medium', theme: 'dark' }}
           />
           <Select
-            appearance={{ alignOptions: 'right', theme: 'alt' }}
+            appearance={{
+              alignOptions: 'right',
+              theme: 'alt',
+              width: 'strict',
+            }}
             connect={false}
             elementOnly
             label={MSG.labelFilter}

--- a/src/modules/admin/components/Tokens/Tokens.css
+++ b/src/modules/admin/components/Tokens/Tokens.css
@@ -17,6 +17,17 @@
   justify-content: space-between;
   align-items: baseline;
   border-bottom: 1px solid var(--temp-grey-5);
+
+  & h3 {
+    /*
+     * @NOTE We can't compose from `inlineEllipsis` here since we're inside an
+     * element, not a component :(
+     */
+    width: calc(100% - 150px);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }
 
 .sidebar {

--- a/src/modules/admin/components/Tokens/Tokens.tsx
+++ b/src/modules/admin/components/Tokens/Tokens.tsx
@@ -150,7 +150,11 @@ const Tokens = ({
               appearance={{ size: 'medium', theme: 'dark' }}
             />
             <Select
-              appearance={{ alignOptions: 'right', theme: 'alt' }}
+              appearance={{
+                alignOptions: 'right',
+                width: 'strict',
+                theme: 'alt',
+              }}
               connect={false}
               elementOnly
               label={MSG.labelSelectDomain}

--- a/src/modules/core/components/BreadCrumb/BreadCrumb.css
+++ b/src/modules/core/components/BreadCrumb/BreadCrumb.css
@@ -3,11 +3,17 @@
 }
 
 .element {
-  flex-shrink: 0;
+  flex: 0 0 auto;
+}
+
+.elementLast {
+  composes: inlineEllipsis from '~styles/text.css';
+  flex: 1 1 auto;
 }
 
 .crumbContainer {
   display: flex;
+  overflow: hidden;
 }
 
 .arrow {

--- a/src/modules/core/components/BreadCrumb/BreadCrumb.css.d.ts
+++ b/src/modules/core/components/BreadCrumb/BreadCrumb.css.d.ts
@@ -1,4 +1,5 @@
 export const breadCrumble: string;
 export const element: string;
+export const elementLast: string;
 export const crumbContainer: string;
 export const arrow: string;

--- a/src/modules/core/components/BreadCrumb/BreadCrumb.tsx
+++ b/src/modules/core/components/BreadCrumb/BreadCrumb.tsx
@@ -22,21 +22,19 @@ const BreadCrumb = ({ elements, intl: { formatMessage } }: Props) => {
         const crumbText =
           typeof crumb == 'string' ? crumb : formatMessage(crumb);
         return (
-          <div className={styles.element} key={`breadCrumb_${crumbText}`}>
-            <>
-              {elements.length > 1 && i < elements.length - 1 ? (
-                <>
-                  <span className={styles.breadCrumble}>{crumbText}</span>
-                  <span className={styles.arrow}>&gt;</span>
-                </>
-              ) : null}
-            </>
-            <>
-              {i === elements.length - 1 || elements.length === 1 ? (
+          <>
+            {elements.length > 1 && i < elements.length - 1 ? (
+              <div className={styles.element} key={`breadCrumb_${crumbText}`}>
+                <span className={styles.breadCrumble}>{crumbText}</span>
+                <span className={styles.arrow}>&gt;</span>
+              </div>
+            ) : null}
+            {i === elements.length - 1 || elements.length === 1 ? (
+              <div className={styles.elementLast}>
                 <b className={styles.breadCrumble}>{crumbText}</b>
-              ) : null}
-            </>
-          </div>
+              </div>
+            ) : null}
+          </>
         );
       })}
     </div>

--- a/src/modules/core/components/BreadCrumb/BreadCrumb.tsx
+++ b/src/modules/core/components/BreadCrumb/BreadCrumb.tsx
@@ -24,13 +24,17 @@ const BreadCrumb = ({ elements, intl: { formatMessage } }: Props) => {
         return (
           <>
             {elements.length > 1 && i < elements.length - 1 ? (
-              <div className={styles.element} key={`breadCrumb_${crumbText}`}>
+              <div
+                className={styles.element}
+                key={`breadCrumb_${crumbText}`}
+                title={crumbText}
+              >
                 <span className={styles.breadCrumble}>{crumbText}</span>
                 <span className={styles.arrow}>&gt;</span>
               </div>
             ) : null}
             {i === elements.length - 1 || elements.length === 1 ? (
-              <div className={styles.elementLast}>
+              <div className={styles.elementLast} title={crumbText}>
                 <b className={styles.breadCrumble}>{crumbText}</b>
               </div>
             ) : null}

--- a/src/modules/core/components/Fields/Select/Select.css
+++ b/src/modules/core/components/Fields/Select/Select.css
@@ -85,3 +85,11 @@
 .themeAlt.select[aria-expanded="true"], .themeAlt:focus {
   background-color: var(--temp-grey-5);
 }
+
+.widthFluid {
+  width: 100%;
+}
+
+.widthStrict {
+  width: 100px;
+}

--- a/src/modules/core/components/Fields/Select/Select.css.d.ts
+++ b/src/modules/core/components/Fields/Select/Select.css.d.ts
@@ -7,3 +7,5 @@ export const selectExpandContainer: string;
 export const activeOption: string;
 export const themeDefault: string;
 export const themeAlt: string;
+export const widthFluid: string;
+export const widthStrict: string;

--- a/src/modules/core/components/Fields/Select/Select.md
+++ b/src/modules/core/components/Fields/Select/Select.md
@@ -21,7 +21,7 @@ const options = [
         name="basicSelect"
       />
       <Select
-        appearance={{ alignOptions: 'left', theme: 'alt' }}
+        appearance={{ alignOptions: 'left', theme: 'alt', width: 'fluid' }}
         label="I'm an alt Select"
         options={options}
         placeholder="Select an alt option"
@@ -50,7 +50,7 @@ initialState = { $value: ''};
     // with connect={false}, `$value` and `setValue` are required
     $value={state.$value}
     setValue={val => setState({ $value: val })}
-    appearance={{ alignOptions: 'right', theme: 'alt' }}
+    appearance={{ alignOptions: 'right', theme: 'alt', width: 'strict' }}
     elementOnly={true}
     label="I'm an unconnected Select"
     options={options}

--- a/src/modules/core/components/Fields/Select/SelectListBox.css
+++ b/src/modules/core/components/Fields/Select/SelectListBox.css
@@ -39,3 +39,13 @@
   left: 50%;
   transform: translate(-50%);
 }
+
+.widthFluid {
+  width: auto;
+  min-width: 100%;
+}
+
+.widthStrict {
+  width: 300px;
+  min-width: auto;
+}

--- a/src/modules/core/components/Fields/Select/SelectListBox.css.d.ts
+++ b/src/modules/core/components/Fields/Select/SelectListBox.css.d.ts
@@ -4,3 +4,5 @@ export const themeAlt: string;
 export const alignOptionsLeft: string;
 export const alignOptionsRight: string;
 export const alignOptionsCenter: string;
+export const widthFluid: string;
+export const widthStrict: string;

--- a/src/modules/core/components/Fields/Select/types.ts
+++ b/src/modules/core/components/Fields/Select/types.ts
@@ -1,4 +1,5 @@
 export type Appearance = {
   alignOptions?: 'left' | 'center' | 'right';
   theme?: 'default' | 'alt';
+  width?: 'fluid' | 'strict';
 };

--- a/src/modules/dashboard/components/ColonyHome/ColonyMeta/ColonyMeta.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMeta/ColonyMeta.tsx
@@ -152,7 +152,7 @@ const ColonyMeta = ({
             </Button>
           </li>
           {sortedDomains.map(({ name, id }) => (
-            <li key={`domain_${id}`}>
+            <li key={`domain_${id}`} title={name}>
               <Button
                 className={getActiveDomainFilterClass(id, filteredDomainId)}
                 onClick={() => setFilteredDomainId(id)}


### PR DESCRIPTION
## Description

This PR fixes all the remaining instances were a long domain would break our UI _(due to that long domain spanning over other elements)_

**New stuff** 

- [x] `Select` appearance prop: `width`,  either `static` or `fluid` _(`fluid` by default)_

**Changes** 

- [x] Last `BreadCrumb` in a set, no will truncate longer text
- [x] `ColonyMeta` domains now show a title attribute on hover
- [x] `Permissions` and `Tokens` pages now use `strict` `Select` component width
- [x] `Permissions` and `Tokens` page title _(width domain)_ ellipsis
- [x] `ColonyPermissionsDialog` ellipsis for long domain names _(both edit and add)_

**Screenshots**

![Screenshot from 2019-11-21 16-29-11](https://user-images.githubusercontent.com/1193222/69350570-7bc4d380-0c82-11ea-864f-6c352ecfdb1c.png)
![Screenshot from 2019-11-21 16-45-01](https://user-images.githubusercontent.com/1193222/69350571-7bc4d380-0c82-11ea-8aac-f57d2927d8c1.png)
![Screenshot from 2019-11-21 16-45-07](https://user-images.githubusercontent.com/1193222/69350572-7c5d6a00-0c82-11ea-8d60-b05ba3c8a401.png)
![Screenshot from 2019-11-21 16-59-42](https://user-images.githubusercontent.com/1193222/69350573-7c5d6a00-0c82-11ea-80d7-dce4be9c2b52.png)
![Screenshot from 2019-11-21 17-01-34](https://user-images.githubusercontent.com/1193222/69350574-7cf60080-0c82-11ea-8f8d-bb98166f72fe.png)
![Screenshot from 2019-11-21 17-08-23](https://user-images.githubusercontent.com/1193222/69350576-7cf60080-0c82-11ea-8508-8b2ddebb302b.png)
![Screenshot from 2019-11-21 17-09-11](https://user-images.githubusercontent.com/1193222/69350577-7cf60080-0c82-11ea-8414-c80de020aa11.png)

Resolves #1915 

Rebased on #1907 branch `feature/fix-dlx`