### PR TITLE
Notifications cleanup and fixes

### DIFF
--- a/src/modules/users/components/Inbox/InboxItem/InboxItem.tsx
+++ b/src/modules/users/components/Inbox/InboxItem/InboxItem.tsx
@@ -176,13 +176,8 @@ const InboxItem = ({
       <TableCell
         className={full ? styles.inboxRowCellFull : styles.inboxRowCellPopover}
       >
-        {/*
-         * @FIXME The first ever notification for every user (user profile claimed)
-         * does not have a colony name or a token, so in that case the spinner
-         * will always render even though it shouldn't at that point
-         */
-        // !colonyName ||
-        // !token ||
+        {(colonyAddress && !colonyName) ||
+        (tokenAddress && !token) ||
         isFetchingDomains ? (
           <div className={styles.spinnerWrapper}>
             <SpinnerLoader
@@ -205,11 +200,6 @@ const InboxItem = ({
             )}
             <span className={styles.inboxAction}>
               <FormattedMessage
-                /*
-                 * @todo switch between notificationAdminOtherAdded v. notificationUserMadeAdmin notifications
-                 * depending if the otherUser address is the same as the sourceUserAddress
-                 * This is preffered as opposed to adding two notifications to the stores
-                 */
                 {...MSG[transformNotificationEventNames(eventType)]}
                 values={{
                   amount: makeInboxDetail(amount, value => (

--- a/src/modules/users/components/Inbox/InboxItem/InboxItem.tsx
+++ b/src/modules/users/components/Inbox/InboxItem/InboxItem.tsx
@@ -155,7 +155,7 @@ const InboxItem = ({
     [colonyAddress],
   );
 
-  const currentDomain: DomainType | undefined = domains[domainId];
+  const currentDomain: DomainType | undefined = domains && domains[domainId];
 
   const [markAsReadMutation] = useMarkNotificationAsReadMutation({
     variables: { input: { id } },

--- a/src/modules/users/components/Inbox/InboxItem/InboxItem.tsx
+++ b/src/modules/users/components/Inbox/InboxItem/InboxItem.tsx
@@ -87,14 +87,16 @@ const InboxItem = ({
       context,
       createdAt,
       type: eventType,
-      /* onClickRoute, */
+      /*
+       * @TODO Disabled notification click for initial deployment
+       *
+       * onClickRoute,
+       */
       initiatorAddress,
     },
   },
   full,
 }: Props) => {
-  // FIXME Get these from somewhere if applicable
-  const onClickRoute = 'xxx';
   const setTo = true;
   // Let's see what event type context props we have
 
@@ -189,7 +191,7 @@ const InboxItem = ({
             />
           </div>
         ) : (
-          <WithLink to={onClickRoute}>
+          <WithLink>
             {!read && <UnreadIndicator type={getType(eventType)} />}
             {initiatorUser && initiatorUser.user && (
               <div className={styles.avatarWrapper}>

--- a/src/modules/users/data/utils.ts
+++ b/src/modules/users/data/utils.ts
@@ -38,37 +38,3 @@ export const getExtensionAddresses = async (
 
   return [createAddress(oldRolesAddress), createAddress(oneTxAddress)];
 };
-
-/*
- * @REMOVE Most likely this can be removed as well
- */
-export const decorateColonyEventPayload = ({ payload, ...event }: any) => ({
-  ...event,
-  payload: {
-    ...payload,
-    ...(() => {
-      switch (event.type) {
-        case 'ColonyRoleSet':
-          return {
-            colonyAddress: event.meta.sourceId,
-            targetUser: payload.address,
-          };
-        case 'DomainAdded':
-          return {
-            colonyAddress: event.meta.sourceId,
-          };
-        case 'Mint':
-          return {
-            colonyAddress: payload.address,
-            tokenAddress: payload.tokenAddress,
-          };
-        case 'ColonyLabelRegistered':
-          return {
-            colonyAddress: payload.colony,
-          };
-        default:
-          return {};
-      }
-    })(),
-  },
-});


### PR DESCRIPTION
This PR adds in a couple of fixes, removes a `@FIXME` and some unused code from the server based notifications logic.

The gist of it:
- Disable on-click route for notifications _(for the initial launch. This also fixes a React DOM nesting violation)_
- Check if colony and tokens are in context before loading that data _(inside `InboxItem`)_
- Remove unused `decorateColonyEventPayload`
- Add a check for the domains array before attempting to load data from it _(inside `InboxItem`)_
