### PR TITLE
Add Suggestions graphql, wire form and list components

### DIFF
--- a/src/data/fragments.graphql
+++ b/src/data/fragments.graphql
@@ -13,6 +13,34 @@ fragment Payouts on Task {
   }
 }
 
+fragment CreateTaskFields on Task {
+  id
+  ...Payouts
+  assignedWorker {
+    id
+    profile {
+      avatarHash
+    }
+  }
+  assignedWorkerAddress
+  cancelledAt
+  colony {
+    id
+    colonyName
+    displayName
+    nativeTokenAddress
+  }
+  colonyAddress
+  createdAt
+  creatorAddress
+  dueDate
+  ethDomainId
+  ethSkillId
+  finalizedAt
+  title
+  workRequestAddresses
+}
+
 fragment Tokens on Colony {
   nativeTokenAddress
   tokens {
@@ -52,6 +80,19 @@ fragment FullColony on Colony {
   isInRecoveryMode(address: $address) @client
   isNativeTokenLocked(address: $address) @client
 }
+
+fragment SuggestionFields on Suggestion {
+  id
+  createdAt
+  colonyAddress
+  creatorAddress
+  ethDomainId
+  status
+  title
+  taskId
+  upvotes
+}
+
 fragment EventFields on Event {
   createdAt
   initiator {

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -157,6 +157,10 @@ export type Scalars = {
 };
 
 
+export type AddUpvoteToSuggestionInput = {
+  id: Scalars['String'],
+};
+
 export type AssignWorkerEvent = TaskEvent & {
   type: EventType,
   taskId: Scalars['String'],
@@ -197,6 +201,7 @@ export type Colony = {
   isNativeTokenExternal: Scalars['Boolean'],
   nativeTokenAddress: Scalars['String'],
   subscribedUsers: Array<User>,
+  suggestions: Array<Suggestion>,
   tokens: Array<Token>,
   tokenAddresses: Array<Scalars['String']>,
   canMintNativeToken: Scalars['Boolean'],
@@ -266,11 +271,21 @@ export type CreateDomainInput = {
   name: Scalars['String'],
 };
 
+export type CreateSuggestionInput = {
+  colonyAddress: Scalars['String'],
+  ethDomainId: Scalars['Int'],
+  title: Scalars['String'],
+};
+
 export type CreateTaskEvent = TaskEvent & {
   type: EventType,
   taskId: Scalars['String'],
   ethDomainId: Scalars['Int'],
   colonyAddress: Scalars['String'],
+};
+
+export type CreateTaskFromSuggestionInput = {
+  id: Scalars['String'],
 };
 
 export type CreateTaskInput = {
@@ -342,6 +357,7 @@ export type EditUserInput = {
 };
 
 export type Event = {
+  id: Scalars['String'],
   type: EventType,
   createdAt: Scalars['DateTime'],
   initiator?: Maybe<User>,
@@ -401,19 +417,22 @@ export type MarkNotificationAsReadInput = {
 };
 
 export type Mutation = {
-  createUser?: Maybe<User>,
-  editUser?: Maybe<User>,
-  subscribeToColony?: Maybe<User>,
-  unsubscribeFromColony?: Maybe<User>,
-  setUserTokens?: Maybe<User>,
   createColony?: Maybe<Colony>,
   editColonyProfile?: Maybe<Colony>,
   setColonyTokens?: Maybe<Colony>,
   createDomain?: Maybe<Domain>,
   editDomainName?: Maybe<Domain>,
+  sendTaskMessage: Scalars['Boolean'],
+  markAllNotificationsAsRead: Scalars['Boolean'],
+  markNotificationAsRead: Scalars['Boolean'],
+  createSuggestion?: Maybe<Suggestion>,
+  setSuggestionStatus?: Maybe<Suggestion>,
+  addUpvoteToSuggestion?: Maybe<Suggestion>,
+  removeUpvoteFromSuggestion?: Maybe<Suggestion>,
   assignWorker?: Maybe<Task>,
   cancelTask?: Maybe<Task>,
   createTask?: Maybe<Task>,
+  createTaskFromSuggestion?: Maybe<Task>,
   createWorkRequest?: Maybe<Task>,
   finalizeTask?: Maybe<Task>,
   removeTaskPayout?: Maybe<Task>,
@@ -427,36 +446,13 @@ export type Mutation = {
   unassignWorker?: Maybe<Task>,
   createToken?: Maybe<Token>,
   setTokenIcon?: Maybe<Token>,
-  markAllNotificationsAsRead: Scalars['Boolean'],
-  markNotificationAsRead: Scalars['Boolean'],
-  sendTaskMessage: Scalars['Boolean'],
+  createUser?: Maybe<User>,
+  editUser?: Maybe<User>,
+  subscribeToColony?: Maybe<User>,
+  unsubscribeFromColony?: Maybe<User>,
+  setUserTokens?: Maybe<User>,
   setLoggedInUser: LoggedInUser,
   clearLoggedInUser: LoggedInUser,
-};
-
-
-export type MutationCreateUserArgs = {
-  input: CreateUserInput
-};
-
-
-export type MutationEditUserArgs = {
-  input: EditUserInput
-};
-
-
-export type MutationSubscribeToColonyArgs = {
-  input: SubscribeToColonyInput
-};
-
-
-export type MutationUnsubscribeFromColonyArgs = {
-  input: UnsubscribeFromColonyInput
-};
-
-
-export type MutationSetUserTokensArgs = {
-  input: SetUserTokensInput
 };
 
 
@@ -485,6 +481,36 @@ export type MutationEditDomainNameArgs = {
 };
 
 
+export type MutationSendTaskMessageArgs = {
+  input: SendTaskMessageInput
+};
+
+
+export type MutationMarkNotificationAsReadArgs = {
+  input: MarkNotificationAsReadInput
+};
+
+
+export type MutationCreateSuggestionArgs = {
+  input: CreateSuggestionInput
+};
+
+
+export type MutationSetSuggestionStatusArgs = {
+  input: SetSuggestionStatusInput
+};
+
+
+export type MutationAddUpvoteToSuggestionArgs = {
+  input: AddUpvoteToSuggestionInput
+};
+
+
+export type MutationRemoveUpvoteFromSuggestionArgs = {
+  input: RemoveUpvoteFromSuggestionInput
+};
+
+
 export type MutationAssignWorkerArgs = {
   input: AssignWorkerInput
 };
@@ -497,6 +523,11 @@ export type MutationCancelTaskArgs = {
 
 export type MutationCreateTaskArgs = {
   input: CreateTaskInput
+};
+
+
+export type MutationCreateTaskFromSuggestionArgs = {
+  input: CreateTaskFromSuggestionInput
 };
 
 
@@ -565,13 +596,28 @@ export type MutationSetTokenIconArgs = {
 };
 
 
-export type MutationMarkNotificationAsReadArgs = {
-  input: MarkNotificationAsReadInput
+export type MutationCreateUserArgs = {
+  input: CreateUserInput
 };
 
 
-export type MutationSendTaskMessageArgs = {
-  input: SendTaskMessageInput
+export type MutationEditUserArgs = {
+  input: EditUserInput
+};
+
+
+export type MutationSubscribeToColonyArgs = {
+  input: SubscribeToColonyInput
+};
+
+
+export type MutationUnsubscribeFromColonyArgs = {
+  input: UnsubscribeFromColonyInput
+};
+
+
+export type MutationSetUserTokensArgs = {
+  input: SetUserTokensInput
 };
 
 
@@ -662,6 +708,10 @@ export type RemoveTaskPayoutInput = {
   tokenAddress: Scalars['String'],
 };
 
+export type RemoveUpvoteFromSuggestionInput = {
+  id: Scalars['String'],
+};
+
 export type SendTaskMessageInput = {
   id: Scalars['String'],
   message: Scalars['String'],
@@ -681,6 +731,11 @@ export type SendWorkInviteInput = {
 export type SetColonyTokensInput = {
   tokenAddresses: Array<Maybe<Scalars['String']>>,
   colonyAddress: Scalars['String'],
+};
+
+export type SetSuggestionStatusInput = {
+  id: Scalars['String'],
+  status: SuggestionStatus,
 };
 
 export type SetTaskDescriptionEvent = TaskEvent & {
@@ -763,6 +818,26 @@ export type SetUserTokensInput = {
 export type SubscribeToColonyInput = {
   colonyAddress: Scalars['String'],
 };
+
+export type Suggestion = {
+  id: Scalars['String'],
+  createdAt: Scalars['DateTime'],
+  colonyAddress: Scalars['String'],
+  creatorAddress: Scalars['String'],
+  creator: User,
+  ethDomainId: Scalars['Int'],
+  status: SuggestionStatus,
+  title: Scalars['String'],
+  taskId?: Maybe<Scalars['String']>,
+  upvotes: Array<Scalars['String']>,
+};
+
+export enum SuggestionStatus {
+  Open = 'Open',
+  NotPlanned = 'NotPlanned',
+  Accepted = 'Accepted',
+  Deleted = 'Deleted'
+}
 
 export type Task = {
   id: Scalars['String'],
@@ -905,6 +980,15 @@ export type PayoutsFragment = { payouts: Array<(
     ) }
   )> };
 
+export type CreateTaskFieldsFragment = (
+  Pick<Task, 'id' | 'assignedWorkerAddress' | 'cancelledAt' | 'colonyAddress' | 'createdAt' | 'creatorAddress' | 'dueDate' | 'ethDomainId' | 'ethSkillId' | 'finalizedAt' | 'title' | 'workRequestAddresses'>
+  & { assignedWorker: Maybe<(
+    Pick<User, 'id'>
+    & { profile: Pick<UserProfile, 'avatarHash'> }
+  )>, colony: Pick<Colony, 'id' | 'colonyName' | 'displayName' | 'nativeTokenAddress'> }
+  & PayoutsFragment
+);
+
 export type TokensFragment = (
   Pick<Colony, 'nativeTokenAddress'>
   & { tokens: Array<(
@@ -920,6 +1004,8 @@ export type FullColonyFragment = (
   & ColonyProfileFragment
   & TokensFragment
 );
+
+export type SuggestionFieldsFragment = Pick<Suggestion, 'id' | 'createdAt' | 'colonyAddress' | 'creatorAddress' | 'ethDomainId' | 'status' | 'title' | 'taskId' | 'upvotes'>;
 
 export type EventFieldsFragment = (
   Pick<Event, 'createdAt' | 'initiatorAddress' | 'sourceId' | 'sourceType' | 'type'>
@@ -961,14 +1047,7 @@ export type CreateTaskMutationVariables = {
 };
 
 
-export type CreateTaskMutation = { createTask: Maybe<(
-    Pick<Task, 'id' | 'assignedWorkerAddress' | 'cancelledAt' | 'colonyAddress' | 'createdAt' | 'creatorAddress' | 'dueDate' | 'ethDomainId' | 'ethSkillId' | 'finalizedAt' | 'title' | 'workRequestAddresses'>
-    & { assignedWorker: Maybe<(
-      Pick<User, 'id'>
-      & { profile: Pick<UserProfile, 'avatarHash'> }
-    )>, colony: Pick<Colony, 'id' | 'colonyName' | 'displayName' | 'nativeTokenAddress'> }
-    & PayoutsFragment
-  )> };
+export type CreateTaskMutation = { createTask: Maybe<CreateTaskFieldsFragment> };
 
 export type CreateWorkRequestMutationVariables = {
   input: CreateWorkRequestInput
@@ -1188,6 +1267,41 @@ export type EditDomainMutationVariables = {
 
 
 export type EditDomainMutation = { editDomainName: Maybe<Pick<Domain, 'id' | 'ethDomainId' | 'ethParentDomainId' | 'name'>> };
+
+export type CreateSuggestionMutationVariables = {
+  input: CreateSuggestionInput
+};
+
+
+export type CreateSuggestionMutation = { createSuggestion: Maybe<SuggestionFieldsFragment> };
+
+export type SetSuggestionStatusMutationVariables = {
+  input: SetSuggestionStatusInput
+};
+
+
+export type SetSuggestionStatusMutation = { setSuggestionStatus: Maybe<Pick<Suggestion, 'id' | 'status' | 'taskId'>> };
+
+export type AddUpvoteToSuggestionMutationVariables = {
+  input: AddUpvoteToSuggestionInput
+};
+
+
+export type AddUpvoteToSuggestionMutation = { addUpvoteToSuggestion: Maybe<Pick<Suggestion, 'id' | 'upvotes'>> };
+
+export type RemoveUpvoteFromSuggestionMutationVariables = {
+  input: RemoveUpvoteFromSuggestionInput
+};
+
+
+export type RemoveUpvoteFromSuggestionMutation = { removeUpvoteFromSuggestion: Maybe<Pick<Suggestion, 'id' | 'upvotes'>> };
+
+export type CreateTaskFromSuggestionMutationVariables = {
+  input: CreateTaskFromSuggestionInput
+};
+
+
+export type CreateTaskFromSuggestionMutation = { createTaskFromSuggestion: Maybe<CreateTaskFieldsFragment> };
 
 export type TaskQueryVariables = {
   id: Scalars['String']
@@ -1444,6 +1558,16 @@ export type ColonyDomainsQuery = { colony: (
     & { domains: Array<Pick<Domain, 'id' | 'ethDomainId' | 'name' | 'ethParentDomainId'>> }
   ) };
 
+export type ColonySuggestionsQueryVariables = {
+  colonyAddress: Scalars['String']
+};
+
+
+export type ColonySuggestionsQuery = { colony: (
+    Pick<Colony, 'id'>
+    & { suggestions: Array<SuggestionFieldsFragment> }
+  ) };
+
 export type AllTokensQueryVariables = {};
 
 
@@ -1484,6 +1608,35 @@ export const PayoutsFragmentDoc = gql`
   }
 }
     `;
+export const CreateTaskFieldsFragmentDoc = gql`
+    fragment CreateTaskFields on Task {
+  id
+  ...Payouts
+  assignedWorker {
+    id
+    profile {
+      avatarHash
+    }
+  }
+  assignedWorkerAddress
+  cancelledAt
+  colony {
+    id
+    colonyName
+    displayName
+    nativeTokenAddress
+  }
+  colonyAddress
+  createdAt
+  creatorAddress
+  dueDate
+  ethDomainId
+  ethSkillId
+  finalizedAt
+  title
+  workRequestAddresses
+}
+    ${PayoutsFragmentDoc}`;
 export const ColonyProfileFragmentDoc = gql`
     fragment ColonyProfile on Colony {
   id
@@ -1528,6 +1681,19 @@ export const FullColonyFragmentDoc = gql`
 }
     ${ColonyProfileFragmentDoc}
 ${TokensFragmentDoc}`;
+export const SuggestionFieldsFragmentDoc = gql`
+    fragment SuggestionFields on Suggestion {
+  id
+  createdAt
+  colonyAddress
+  creatorAddress
+  ethDomainId
+  status
+  title
+  taskId
+  upvotes
+}
+    `;
 export const EventFieldsFragmentDoc = gql`
     fragment EventFields on Event {
   createdAt
@@ -1711,34 +1877,10 @@ export type CancelTaskMutationOptions = ApolloReactCommon.BaseMutationOptions<Ca
 export const CreateTaskDocument = gql`
     mutation CreateTask($input: CreateTaskInput!) {
   createTask(input: $input) {
-    id
-    ...Payouts
-    assignedWorker {
-      id
-      profile {
-        avatarHash
-      }
-    }
-    assignedWorkerAddress
-    cancelledAt
-    colony {
-      id
-      colonyName
-      displayName
-      nativeTokenAddress
-    }
-    colonyAddress
-    createdAt
-    creatorAddress
-    dueDate
-    ethDomainId
-    ethSkillId
-    finalizedAt
-    title
-    workRequestAddresses
+    ...CreateTaskFields
   }
 }
-    ${PayoutsFragmentDoc}`;
+    ${CreateTaskFieldsFragmentDoc}`;
 export type CreateTaskMutationFn = ApolloReactCommon.MutationFunction<CreateTaskMutation, CreateTaskMutationVariables>;
 
 /**
@@ -2687,6 +2829,170 @@ export function useEditDomainMutation(baseOptions?: ApolloReactHooks.MutationHoo
 export type EditDomainMutationHookResult = ReturnType<typeof useEditDomainMutation>;
 export type EditDomainMutationResult = ApolloReactCommon.MutationResult<EditDomainMutation>;
 export type EditDomainMutationOptions = ApolloReactCommon.BaseMutationOptions<EditDomainMutation, EditDomainMutationVariables>;
+export const CreateSuggestionDocument = gql`
+    mutation CreateSuggestion($input: CreateSuggestionInput!) {
+  createSuggestion(input: $input) {
+    ...SuggestionFields
+  }
+}
+    ${SuggestionFieldsFragmentDoc}`;
+export type CreateSuggestionMutationFn = ApolloReactCommon.MutationFunction<CreateSuggestionMutation, CreateSuggestionMutationVariables>;
+
+/**
+ * __useCreateSuggestionMutation__
+ *
+ * To run a mutation, you first call `useCreateSuggestionMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateSuggestionMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createSuggestionMutation, { data, loading, error }] = useCreateSuggestionMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useCreateSuggestionMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<CreateSuggestionMutation, CreateSuggestionMutationVariables>) {
+        return ApolloReactHooks.useMutation<CreateSuggestionMutation, CreateSuggestionMutationVariables>(CreateSuggestionDocument, baseOptions);
+      }
+export type CreateSuggestionMutationHookResult = ReturnType<typeof useCreateSuggestionMutation>;
+export type CreateSuggestionMutationResult = ApolloReactCommon.MutationResult<CreateSuggestionMutation>;
+export type CreateSuggestionMutationOptions = ApolloReactCommon.BaseMutationOptions<CreateSuggestionMutation, CreateSuggestionMutationVariables>;
+export const SetSuggestionStatusDocument = gql`
+    mutation SetSuggestionStatus($input: SetSuggestionStatusInput!) {
+  setSuggestionStatus(input: $input) {
+    id
+    status
+    taskId
+  }
+}
+    `;
+export type SetSuggestionStatusMutationFn = ApolloReactCommon.MutationFunction<SetSuggestionStatusMutation, SetSuggestionStatusMutationVariables>;
+
+/**
+ * __useSetSuggestionStatusMutation__
+ *
+ * To run a mutation, you first call `useSetSuggestionStatusMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useSetSuggestionStatusMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [setSuggestionStatusMutation, { data, loading, error }] = useSetSuggestionStatusMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useSetSuggestionStatusMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<SetSuggestionStatusMutation, SetSuggestionStatusMutationVariables>) {
+        return ApolloReactHooks.useMutation<SetSuggestionStatusMutation, SetSuggestionStatusMutationVariables>(SetSuggestionStatusDocument, baseOptions);
+      }
+export type SetSuggestionStatusMutationHookResult = ReturnType<typeof useSetSuggestionStatusMutation>;
+export type SetSuggestionStatusMutationResult = ApolloReactCommon.MutationResult<SetSuggestionStatusMutation>;
+export type SetSuggestionStatusMutationOptions = ApolloReactCommon.BaseMutationOptions<SetSuggestionStatusMutation, SetSuggestionStatusMutationVariables>;
+export const AddUpvoteToSuggestionDocument = gql`
+    mutation AddUpvoteToSuggestion($input: AddUpvoteToSuggestionInput!) {
+  addUpvoteToSuggestion(input: $input) {
+    id
+    upvotes
+  }
+}
+    `;
+export type AddUpvoteToSuggestionMutationFn = ApolloReactCommon.MutationFunction<AddUpvoteToSuggestionMutation, AddUpvoteToSuggestionMutationVariables>;
+
+/**
+ * __useAddUpvoteToSuggestionMutation__
+ *
+ * To run a mutation, you first call `useAddUpvoteToSuggestionMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useAddUpvoteToSuggestionMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [addUpvoteToSuggestionMutation, { data, loading, error }] = useAddUpvoteToSuggestionMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useAddUpvoteToSuggestionMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<AddUpvoteToSuggestionMutation, AddUpvoteToSuggestionMutationVariables>) {
+        return ApolloReactHooks.useMutation<AddUpvoteToSuggestionMutation, AddUpvoteToSuggestionMutationVariables>(AddUpvoteToSuggestionDocument, baseOptions);
+      }
+export type AddUpvoteToSuggestionMutationHookResult = ReturnType<typeof useAddUpvoteToSuggestionMutation>;
+export type AddUpvoteToSuggestionMutationResult = ApolloReactCommon.MutationResult<AddUpvoteToSuggestionMutation>;
+export type AddUpvoteToSuggestionMutationOptions = ApolloReactCommon.BaseMutationOptions<AddUpvoteToSuggestionMutation, AddUpvoteToSuggestionMutationVariables>;
+export const RemoveUpvoteFromSuggestionDocument = gql`
+    mutation RemoveUpvoteFromSuggestion($input: RemoveUpvoteFromSuggestionInput!) {
+  removeUpvoteFromSuggestion(input: $input) {
+    id
+    upvotes
+  }
+}
+    `;
+export type RemoveUpvoteFromSuggestionMutationFn = ApolloReactCommon.MutationFunction<RemoveUpvoteFromSuggestionMutation, RemoveUpvoteFromSuggestionMutationVariables>;
+
+/**
+ * __useRemoveUpvoteFromSuggestionMutation__
+ *
+ * To run a mutation, you first call `useRemoveUpvoteFromSuggestionMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useRemoveUpvoteFromSuggestionMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [removeUpvoteFromSuggestionMutation, { data, loading, error }] = useRemoveUpvoteFromSuggestionMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useRemoveUpvoteFromSuggestionMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<RemoveUpvoteFromSuggestionMutation, RemoveUpvoteFromSuggestionMutationVariables>) {
+        return ApolloReactHooks.useMutation<RemoveUpvoteFromSuggestionMutation, RemoveUpvoteFromSuggestionMutationVariables>(RemoveUpvoteFromSuggestionDocument, baseOptions);
+      }
+export type RemoveUpvoteFromSuggestionMutationHookResult = ReturnType<typeof useRemoveUpvoteFromSuggestionMutation>;
+export type RemoveUpvoteFromSuggestionMutationResult = ApolloReactCommon.MutationResult<RemoveUpvoteFromSuggestionMutation>;
+export type RemoveUpvoteFromSuggestionMutationOptions = ApolloReactCommon.BaseMutationOptions<RemoveUpvoteFromSuggestionMutation, RemoveUpvoteFromSuggestionMutationVariables>;
+export const CreateTaskFromSuggestionDocument = gql`
+    mutation CreateTaskFromSuggestion($input: CreateTaskFromSuggestionInput!) {
+  createTaskFromSuggestion(input: $input) {
+    ...CreateTaskFields
+  }
+}
+    ${CreateTaskFieldsFragmentDoc}`;
+export type CreateTaskFromSuggestionMutationFn = ApolloReactCommon.MutationFunction<CreateTaskFromSuggestionMutation, CreateTaskFromSuggestionMutationVariables>;
+
+/**
+ * __useCreateTaskFromSuggestionMutation__
+ *
+ * To run a mutation, you first call `useCreateTaskFromSuggestionMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateTaskFromSuggestionMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createTaskFromSuggestionMutation, { data, loading, error }] = useCreateTaskFromSuggestionMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useCreateTaskFromSuggestionMutation(baseOptions?: ApolloReactHooks.MutationHookOptions<CreateTaskFromSuggestionMutation, CreateTaskFromSuggestionMutationVariables>) {
+        return ApolloReactHooks.useMutation<CreateTaskFromSuggestionMutation, CreateTaskFromSuggestionMutationVariables>(CreateTaskFromSuggestionDocument, baseOptions);
+      }
+export type CreateTaskFromSuggestionMutationHookResult = ReturnType<typeof useCreateTaskFromSuggestionMutation>;
+export type CreateTaskFromSuggestionMutationResult = ApolloReactCommon.MutationResult<CreateTaskFromSuggestionMutation>;
+export type CreateTaskFromSuggestionMutationOptions = ApolloReactCommon.BaseMutationOptions<CreateTaskFromSuggestionMutation, CreateTaskFromSuggestionMutationVariables>;
 export const TaskDocument = gql`
     query Task($id: String!) {
   task(id: $id) {
@@ -3678,6 +3984,42 @@ export function useColonyDomainsLazyQuery(baseOptions?: ApolloReactHooks.LazyQue
 export type ColonyDomainsQueryHookResult = ReturnType<typeof useColonyDomainsQuery>;
 export type ColonyDomainsLazyQueryHookResult = ReturnType<typeof useColonyDomainsLazyQuery>;
 export type ColonyDomainsQueryResult = ApolloReactCommon.QueryResult<ColonyDomainsQuery, ColonyDomainsQueryVariables>;
+export const ColonySuggestionsDocument = gql`
+    query ColonySuggestions($colonyAddress: String!) {
+  colony(address: $colonyAddress) {
+    id
+    suggestions {
+      ...SuggestionFields
+    }
+  }
+}
+    ${SuggestionFieldsFragmentDoc}`;
+
+/**
+ * __useColonySuggestionsQuery__
+ *
+ * To run a query within a React component, call `useColonySuggestionsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useColonySuggestionsQuery` returns an object from Apollo Client that contains loading, error, and data properties 
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useColonySuggestionsQuery({
+ *   variables: {
+ *      colonyAddress: // value for 'colonyAddress'
+ *   },
+ * });
+ */
+export function useColonySuggestionsQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<ColonySuggestionsQuery, ColonySuggestionsQueryVariables>) {
+        return ApolloReactHooks.useQuery<ColonySuggestionsQuery, ColonySuggestionsQueryVariables>(ColonySuggestionsDocument, baseOptions);
+      }
+export function useColonySuggestionsLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<ColonySuggestionsQuery, ColonySuggestionsQueryVariables>) {
+          return ApolloReactHooks.useLazyQuery<ColonySuggestionsQuery, ColonySuggestionsQueryVariables>(ColonySuggestionsDocument, baseOptions);
+        }
+export type ColonySuggestionsQueryHookResult = ReturnType<typeof useColonySuggestionsQuery>;
+export type ColonySuggestionsLazyQueryHookResult = ReturnType<typeof useColonySuggestionsLazyQuery>;
+export type ColonySuggestionsQueryResult = ApolloReactCommon.QueryResult<ColonySuggestionsQuery, ColonySuggestionsQueryVariables>;
 export const AllTokensDocument = gql`
     query AllTokens {
   allTokens {

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -16,6 +16,7 @@ import {
   UserQuery,
   UserTasksQuery,
   UserTokensQuery,
+  ColonySuggestionsQuery,
 } from './generated';
 import {
   loggedInUserResolvers,
@@ -61,6 +62,8 @@ export type Payouts = PayoutsFragment['payouts'];
 export type Notifications = UserNotificationsQuery['user']['notifications'];
 
 export type AnyColonyProfile = FullColonyFragment | ColonyProfileFragment;
+
+export type OneSuggestion = ColonySuggestionsQuery['colony']['suggestions'][number];
 
 export type OneToken = TokenQuery['token'];
 export type TokenList = AllTokensQuery['allTokens'];

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -60,6 +60,7 @@ export type AnyTask =
 export type Payouts = PayoutsFragment['payouts'];
 
 export type Notifications = UserNotificationsQuery['user']['notifications'];
+export type OneNotification = Notifications[number];
 
 export type AnyColonyProfile = FullColonyFragment | ColonyProfileFragment;
 

--- a/src/data/mutations.graphql
+++ b/src/data/mutations.graphql
@@ -25,31 +25,7 @@ mutation CancelTask($input: TaskIdInput!) {
 
 mutation CreateTask($input: CreateTaskInput!) {
   createTask(input: $input) {
-    id
-    ...Payouts
-    assignedWorker {
-      id
-      profile {
-        avatarHash
-      }
-    }
-    assignedWorkerAddress
-    cancelledAt
-    colony {
-      id
-      colonyName
-      displayName
-      nativeTokenAddress
-    }
-    colonyAddress
-    createdAt
-    creatorAddress
-    dueDate
-    ethDomainId
-    ethSkillId
-    finalizedAt
-    title
-    workRequestAddresses
+    ...CreateTaskFields
   }
 }
 
@@ -306,5 +282,39 @@ mutation EditDomain($input: EditDomainNameInput!) {
     ethDomainId
     ethParentDomainId
     name
+  }
+}
+
+mutation CreateSuggestion($input: CreateSuggestionInput!) {
+  createSuggestion(input: $input) {
+    ...SuggestionFields
+  }
+}
+
+mutation SetSuggestionStatus($input: SetSuggestionStatusInput!) {
+  setSuggestionStatus(input: $input) {
+    id
+    status
+    taskId
+  }
+}
+
+mutation AddUpvoteToSuggestion($input: AddUpvoteToSuggestionInput!) {
+  addUpvoteToSuggestion(input: $input) {
+    id
+    upvotes
+  }
+}
+
+mutation RemoveUpvoteFromSuggestion($input: RemoveUpvoteFromSuggestionInput!) {
+  removeUpvoteFromSuggestion(input: $input) {
+    id
+    upvotes
+  }
+}
+
+mutation CreateTaskFromSuggestion($input: CreateTaskFromSuggestionInput!) {
+  createTaskFromSuggestion(input: $input) {
+    ...CreateTaskFields
   }
 }

--- a/src/data/queries.graphql
+++ b/src/data/queries.graphql
@@ -367,6 +367,15 @@ query ColonyDomains($colonyAddress: String!) {
   }
 }
 
+query ColonySuggestions($colonyAddress: String!) {
+  colony(address: $colonyAddress) {
+    id
+    suggestions {
+      ...SuggestionFields
+    }
+  }
+}
+
 query AllTokens {
   allTokens {
     id

--- a/src/modules/dashboard/components/SuggestionCreate/SuggestionCreate.tsx
+++ b/src/modules/dashboard/components/SuggestionCreate/SuggestionCreate.tsx
@@ -7,7 +7,12 @@ import { Address } from '~types/index';
 import { Form, Input } from '~core/Fields';
 import { withDialog } from '~core/Dialog';
 import { OpenDialog } from '~core/Dialog/types';
-import { Domain } from '~data/index';
+import {
+  Domain,
+  useCreateSuggestionMutation,
+  ColonySuggestionsDocument,
+  ColonySuggestionsQueryVariables,
+} from '~data/index';
 import { COLONY_TOTAL_BALANCE_DOMAIN_ID, ROOT_DOMAIN } from '~constants';
 
 const MSG = defineMessages({
@@ -38,6 +43,8 @@ const validationSchema = yup.object({
 const displayName = 'Dashboard.SuggestionCreate';
 
 const SuggestionCreate = ({ colonyAddress, domainId, openDialog }: Props) => {
+  const [createSuggestion] = useCreateSuggestionMutation();
+
   const handleSubmit = useCallback(
     ({ title }: FormValues, { resetForm }: FormikHelpers<FormValues>) => {
       openDialog('ConfirmDialog')
@@ -48,13 +55,18 @@ const SuggestionCreate = ({ colonyAddress, domainId, openDialog }: Props) => {
             domainId === COLONY_TOTAL_BALANCE_DOMAIN_ID
               ? ROOT_DOMAIN
               : domainId;
-          // @todo Use createSuggestionMutation
-          // eslint-disable-next-line no-console
-          console.log(title, colonyAddress, ethDomainId);
-          resetForm();
+          createSuggestion({
+            variables: { input: { colonyAddress, ethDomainId, title } },
+            refetchQueries: [
+              {
+                query: ColonySuggestionsDocument,
+                variables: { colonyAddress } as ColonySuggestionsQueryVariables,
+              },
+            ],
+          }).then(() => resetForm());
         });
     },
-    [colonyAddress, openDialog, domainId],
+    [openDialog, domainId, createSuggestion, colonyAddress],
   );
   return (
     <Form

--- a/src/modules/dashboard/components/Suggestions/Suggestions.tsx
+++ b/src/modules/dashboard/components/Suggestions/Suggestions.tsx
@@ -15,7 +15,7 @@ const displayName = 'dashboard.Suggestions';
 const Suggestions = ({ colonyAddress, domainId }: Props) => (
   <div>
     <SuggestionCreate colonyAddress={colonyAddress} domainId={domainId} />
-    <SuggestionsList colonyAddress={colonyAddress} domainId={domainId} />
+    <SuggestionsList colonyAddress={colonyAddress} />
   </div>
 );
 

--- a/src/modules/dashboard/components/SuggestionsList/SuggestionsList.css
+++ b/src/modules/dashboard/components/SuggestionsList/SuggestionsList.css
@@ -1,0 +1,11 @@
+
+.main {
+  display: flex;
+}
+
+.main.stateIsEmpty {
+  justify-content: center;
+  align-items: center;
+  height: 200px;
+  text-align: center;
+}

--- a/src/modules/dashboard/components/SuggestionsList/SuggestionsList.css.d.ts
+++ b/src/modules/dashboard/components/SuggestionsList/SuggestionsList.css.d.ts
@@ -1,0 +1,2 @@
+export const main: string;
+export const stateIsEmpty: string;

--- a/src/modules/dashboard/components/SuggestionsList/SuggestionsList.tsx
+++ b/src/modules/dashboard/components/SuggestionsList/SuggestionsList.tsx
@@ -1,26 +1,66 @@
 import React from 'react';
+import { defineMessages } from 'react-intl';
 
-import { Domain } from '~data/index';
+import { SpinnerLoader } from '~core/Preloaders';
+import { useColonySuggestionsQuery } from '~data/index';
 import { Address } from '~types/index';
+import Heading from '~core/Heading';
+import { getMainClasses } from '~utils/css';
+
+import styles from './SuggestionsList.css';
+
+const MSG = defineMessages({
+  emptyStateTitle: {
+    id: 'Dashboard.SuggestionsList.emptyStateTitle',
+    defaultMessage: 'There are no suggestions here.',
+  },
+  emptyStateSubTitle: {
+    id: 'Dashboard.SuggestionsList.emptyStateSubTitle',
+    defaultMessage:
+      'Create a new suggestion, or switch domains to change the filter.',
+  },
+});
 
 interface Props {
   colonyAddress: Address;
-  domainId: Domain['ethDomainId'];
 }
 
 const displayName = 'Dashboard.SuggestionsList';
 
-const SuggestionsList = ({ colonyAddress, domainId }: Props) => {
-  // @todo use suggestions query here
-  const suggestions = ['okay', 'alright'];
+const SuggestionsList = ({ colonyAddress }: Props) => {
+  const { data, loading } = useColonySuggestionsQuery({
+    variables: { colonyAddress },
+  });
+  if (loading) {
+    return <SpinnerLoader size="medium" />;
+  }
+
+  const suggestions = (data && data.colony.suggestions) || [];
+
   return (
-    <div>
-      {colonyAddress} {domainId}
-      <ul>
-        {suggestions.map(suggestion => (
-          <li key={suggestion}>{suggestion}</li>
-        ))}
-      </ul>
+    <div
+      className={getMainClasses({}, styles, {
+        isEmpty: suggestions.length === 0,
+      })}
+    >
+      {suggestions.length > 0 ? (
+        <ul>
+          {suggestions.map(suggestion => (
+            <li key={suggestion.id}>{suggestion.title}</li>
+          ))}
+        </ul>
+      ) : (
+        <div>
+          <Heading
+            appearance={{ size: 'medium', weight: 'bold' }}
+            text={MSG.emptyStateTitle}
+          />
+          <Heading
+            appearance={{ size: 'small' }}
+            text={MSG.emptyStateSubTitle}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/modules/users/components/Inbox/InboxIcon/InboxIcon.tsx
+++ b/src/modules/users/components/Inbox/InboxIcon/InboxIcon.tsx
@@ -2,7 +2,7 @@ import { MessageDescriptor, defineMessages } from 'react-intl';
 import React from 'react';
 
 import Icon from '~core/Icon';
-import { Notification } from '~data/index';
+import { Notifications } from '~data/index';
 
 import styles from './InboxIcon.css';
 
@@ -14,7 +14,7 @@ const MSG = defineMessages({
 });
 
 interface Props {
-  notifications: Notification[];
+  notifications: Notifications;
   activeClassName?: string;
   title?: MessageDescriptor;
 }

--- a/src/modules/users/components/Inbox/InboxItem/InboxItem.tsx
+++ b/src/modules/users/components/Inbox/InboxItem/InboxItem.tsx
@@ -18,7 +18,7 @@ import {
   useUserQuery,
   useUserLazyQuery,
   useTaskLazyQuery,
-  Notification,
+  OneNotification,
   UserNotificationsDocument,
 } from '~data/index';
 
@@ -42,7 +42,7 @@ const LOCAL_MSG = defineMessages({
 const displayName = 'users.Inbox.InboxItem';
 
 export interface Props {
-  item: Notification;
+  item: OneNotification;
   full?: boolean;
 }
 


### PR DESCRIPTION
## Description

This PR aims to add graphql support for Suggestions, and wire the existing components.

**New stuff** ✨

* `ColonySuggestions` Query
* All suggestion-related mutations

**Changes** 🏗

* Regenerated graphql
* Fixed notification types after regenerating graphql
* Add suggestions list empty state, styled
* Use create suggestion mutation to create a new suggestion
* Update `colonyServer` submodule

## TODO

- [x] Update `colonyServer` submodule once https://github.com/JoinColony/colonyServer/pull/33 has been merged

Closes #1919 
Closes #1920 
Closes #1963 
Closes #1964 