### PR TITLE
Restrict token validation to mainnet only

### DIFF
--- a/src/data/token.ts
+++ b/src/data/token.ts
@@ -119,10 +119,13 @@ export const tokenResolvers = ({ colonyManager }: ContextType): Resolvers => ({
 
       let ethplorerData = {} as TokenInfo;
 
-      try {
-        ethplorerData = await getEthplorerTokenData(tokenAddress);
-      } catch (err) {
-        console.warn(`Could not verify token details for ${tokenAddress}`);
+      // Token verification using ethplorer only really works on mainnet
+      if (process.env.NETWORK === 'mainnet') {
+        try {
+          ethplorerData = await getEthplorerTokenData(tokenAddress);
+        } catch (err) {
+          console.warn(`Could not verify token details for ${tokenAddress}`);
+        }
       }
 
       const { data: serverDataResult } = await client.query({


### PR DESCRIPTION
## Description

This PR disables the token validation on `local` and `goerli` networks as there is no use doing that (ethplorer doesn't have this data).

**Changes** 🏗

* Only validate token data if `NETWORK` environment variable is set to `mainnet`