### PR TITLE
Show Edit Profile Icon for the Current User Only

### DIFF
--- a/src/modules/users/components/UserProfile/UserMeta.tsx
+++ b/src/modules/users/components/UserProfile/UserMeta.tsx
@@ -11,6 +11,7 @@ import Link from '~core/Link';
 import UserMention from '~core/UserMention';
 import HookedUserAvatar from '~users/HookedUserAvatar';
 import { stripProtocol } from '~utils/strings';
+import { useLoggedInUser } from '~data/index';
 
 import styles from './UserMeta.css';
 
@@ -34,53 +35,58 @@ const UserMeta = ({
     profile: { username, displayName, bio, website, location, walletAddress },
   },
   user,
-}: Props) => (
-  <div className={styles.main}>
-    <div data-test="userProfileAvatar">
-      <UserAvatar
-        className={styles.avatar}
-        address={walletAddress}
-        size="xl"
-        user={user}
-      />
-    </div>
-    <div className={styles.headingContainer}>
-      {displayName && (
-        <Heading
-          appearance={{ margin: 'none', size: 'medium', theme: 'dark' }}
-          text={displayName}
-          data-test="userProfileName"
+}: Props) => {
+  const { walletAddress: currentUserWalletAddress } = useLoggedInUser();
+  return (
+    <div className={styles.main}>
+      <div data-test="userProfileAvatar">
+        <UserAvatar
+          className={styles.avatar}
+          address={walletAddress}
+          size="xl"
+          user={user}
         />
+      </div>
+      <div className={styles.headingContainer}>
+        {displayName && (
+          <Heading
+            appearance={{ margin: 'none', size: 'medium', theme: 'dark' }}
+            text={displayName}
+            data-test="userProfileName"
+          />
+        )}
+        {currentUserWalletAddress === walletAddress && (
+          <Link className={styles.profileLink} to="/edit-profile">
+            <Icon name="settings" title={MSG.editProfileTitle} />
+          </Link>
+        )}
+      </div>
+      <div className={styles.usernameContainer}>
+        <UserMention username={username || walletAddress} hasLink={false} />
+      </div>
+      <CopyableAddress>{walletAddress}</CopyableAddress>
+      {bio && (
+        <div className={styles.bioContainer}>
+          <p data-test="userProfileBio">{bio}</p>
+        </div>
       )}
-      <Link className={styles.profileLink} to="/edit-profile">
-        <Icon name="settings" title={MSG.editProfileTitle} />
-      </Link>
+      {website && (
+        <div className={styles.websiteContainer} title={stripProtocol(website)}>
+          <ExternalLink href={website} text={stripProtocol(website)} />
+        </div>
+      )}
+      {location && (
+        <div className={styles.locationContainer}>
+          <Heading
+            appearance={{ size: 'normal', weight: 'thin' }}
+            text={location}
+            data-test="userProfileLocation"
+          />
+        </div>
+      )}
     </div>
-    <div className={styles.usernameContainer}>
-      <UserMention username={username || walletAddress} hasLink={false} />
-    </div>
-    <CopyableAddress>{walletAddress}</CopyableAddress>
-    {bio && (
-      <div className={styles.bioContainer}>
-        <p data-test="userProfileBio">{bio}</p>
-      </div>
-    )}
-    {website && (
-      <div className={styles.websiteContainer} title={stripProtocol(website)}>
-        <ExternalLink href={website} text={stripProtocol(website)} />
-      </div>
-    )}
-    {location && (
-      <div className={styles.locationContainer}>
-        <Heading
-          appearance={{ size: 'normal', weight: 'thin' }}
-          text={location}
-          data-test="userProfileLocation"
-        />
-      </div>
-    )}
-  </div>
-);
+  );
+};
 
 UserMeta.displayName = componentDisplayName;
 

--- a/src/modules/users/components/UserProfile/UserMeta.tsx
+++ b/src/modules/users/components/UserProfile/UserMeta.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { defineMessages } from 'react-intl';
 
-import { AnyUser } from '~data/index';
+import { AnyUser, useLoggedInUser } from '~data/index';
 
 import CopyableAddress from '~core/CopyableAddress';
 import ExternalLink from '~core/ExternalLink';
@@ -11,7 +11,6 @@ import Link from '~core/Link';
 import UserMention from '~core/UserMention';
 import HookedUserAvatar from '~users/HookedUserAvatar';
 import { stripProtocol } from '~utils/strings';
-import { useLoggedInUser } from '~data/index';
 
 import styles from './UserMeta.css';
 


### PR DESCRIPTION
## Description

This PR fixes a bug where the user profile would render a profile edit icon (cog wheel) for all users, didn't matter if it was the current user, or someone else.

Granted, the bug was not that severe given that upon clicking it, it would redirect you to your own user profile edit page.

**Changes**

- [x] User profile `UserMeta` now checks if the rendered user is the currently logged in one

**Screenshots**

Current user:
![Screenshot from 2020-01-20 16-23-54](https://user-images.githubusercontent.com/1193222/72733882-73651800-3ba1-11ea-8932-f3150e7469ee.png)

Another user:
![Screenshot from 2020-01-20 16-24-08](https://user-images.githubusercontent.com/1193222/72733890-7829cc00-3ba1-11ea-9a90-853a215fc38d.png)


Resolves #1972 