### PR TITLE
BYOT Display proper Token preview values

### DIFF
--- a/src/modules/dashboard/components/CreateColonyWizard/TokenSelector.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/TokenSelector.tsx
@@ -59,8 +59,8 @@ const getStatusText = (tokenData, isLoading) => {
   if (tokenData === null) {
     return { status: MSG.statusNotFound };
   }
-  return tokenData
-    ? { status: MSG.preview, statusValues: tokenData }
+  return tokenData && tokenData.details
+    ? { status: MSG.preview, statusValues: tokenData.details }
     : { status: MSG.hint };
 };
 


### PR DESCRIPTION
## Description

This PR fixes a small issue with the "user external" create colony wizard path, where the Token's preview values would not be displayed.

This was due to the fact that the return object changed after refactoring the metadata storage, so this needed to be adjusted as well.

**Changes**

- [x] `TokenSelector` use the proper object for diplay Token details

**Demo**

![Screenshot from 2020-01-20 17-00-10](https://user-images.githubusercontent.com/1193222/72736620-b4abf680-3ba6-11ea-916f-cc2db9a40bcf.png)

Resolves #1971 
