### PR TITLE
Fix webpack dev server bundle

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -14,6 +14,11 @@ module.exports = () => ({
     contentBase: [path.resolve(__dirname, '..', 'colonyNetwork', 'build')],
     hotOnly: true,
   },
+  output: {
+    filename: 'dev-[name].js',
+    path: path.resolve(__dirname, 'dist'),
+    publicPath: '/',
+  },
   module: {
     rules: [
       ...webpackBaseConfig.module.rules,


### PR DESCRIPTION
This PR comes to fix the issue introduced by #1983 where the dev server bundle would be server from an absolute location, rather then relative.

This would screw with the router, and every request to a subdomain, would have failed. Ie: `/user/abc`.

The fix required adding an `output` instruction to the dev config, so that the bundle can be served from a relative path:

![Screenshot from 2020-01-22 19-41-15](https://user-images.githubusercontent.com/1193222/72919355-fdeb7a00-3d4f-11ea-965c-1a19c39502c3.png)
