### PR TITLE
Fix token resolvers in queries and mutations

### DIFF
--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -1081,7 +1081,7 @@ export type SetTaskPayoutMutationVariables = {
 export type SetTaskPayoutMutation = { setTaskPayout: Maybe<(
     Pick<Task, 'id'>
     & { events: Array<TaskEventFragment>, payouts: Array<(
-      Pick<TaskPayout, 'amount'>
+      Pick<TaskPayout, 'amount' | 'tokenAddress'>
       & { token: Pick<Token, 'id' | 'address'> }
     )> }
   )> };
@@ -1258,7 +1258,7 @@ export type TaskToEditQuery = { task: (
       Pick<User, 'id'>
       & { profile: Pick<UserProfile, 'avatarHash' | 'displayName' | 'username' | 'walletAddress'> }
     )>, colony: (
-      Pick<Colony, 'id' | 'nativeTokenAddress'>
+      Pick<Colony, 'id' | 'nativeTokenAddress' | 'tokenAddresses'>
       & { subscribedUsers: Array<(
         Pick<User, 'id'>
         & { profile: Pick<UserProfile, 'displayName' | 'walletAddress' | 'username' | 'avatarHash'> }
@@ -2048,7 +2048,8 @@ export const SetTaskPayoutDocument = gql`
     }
     payouts {
       amount
-      token {
+      tokenAddress
+      token @client {
         id
         address
       }
@@ -2824,6 +2825,7 @@ export const TaskToEditDocument = gql`
           avatarHash
         }
       }
+      tokenAddresses
       tokens @client {
         id
         address

--- a/src/data/mutations.graphql
+++ b/src/data/mutations.graphql
@@ -143,7 +143,8 @@ mutation SetTaskPayout($input: SetTaskPayoutInput!) {
     }
     payouts {
       amount
-      token {
+      tokenAddress
+      token @client {
         id
         address
       }

--- a/src/data/queries.graphql
+++ b/src/data/queries.graphql
@@ -99,6 +99,7 @@ query TaskToEdit($id: String!) {
           avatarHash
         }
       }
+      tokenAddresses
       tokens @client {
         id
         address

--- a/src/modules/dashboard/sagas/task.ts
+++ b/src/modules/dashboard/sagas/task.ts
@@ -132,10 +132,7 @@ function* taskFinalize({
     if (!payouts.length) throw new Error(`No payout set for task ${draftId}`);
     const {
       amount,
-      token: {
-        address: token,
-        details: { decimals },
-      },
+      token: { address: token, decimals },
     } = payouts[0];
 
     const txChannel = yield call(getTxChannel, meta.id);

--- a/src/utils/external/index.ts
+++ b/src/utils/external/index.ts
@@ -14,13 +14,6 @@ interface EthUsdResponse {
   };
 }
 
-interface TokenDetails {
-  name?: string;
-  symbol?: string;
-  decimals?: number;
-  isVerified?: boolean;
-}
-
 /*
   Request dollar conversion value from etherScan
 */


### PR DESCRIPTION
## Description

This fixes two bugs reported by @rdig in connection with querying and expanding tokens. The issue here in both cases was that the original value was not queried from the server and hence not passed into the resolvers. This is now fixed.

**Changes** 🏗

* Pass `tokenAddress` and `tokenAddresses` to the respective resolvers