### PR TITLE
Suggestion post-QA fixes

### DIFF
--- a/src/modules/dashboard/components/SuggestionCreate/SuggestionCreate.tsx
+++ b/src/modules/dashboard/components/SuggestionCreate/SuggestionCreate.tsx
@@ -30,7 +30,7 @@ const MSG = defineMessages({
   },
   inputLabelTitle: {
     id: 'Dashboard.SuggestionCreate.inputLabelTitle',
-    defaultMessage: 'Suggest features, report bugs, or propose tasks',
+    defaultMessage: 'Suggest a task',
   },
 });
 

--- a/src/modules/dashboard/components/SuggestionsList/SuggestionsList.tsx
+++ b/src/modules/dashboard/components/SuggestionsList/SuggestionsList.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useCallback, useMemo, useState } from 'react';
-import { defineMessages } from 'react-intl';
+import { defineMessages, FormattedMessage } from 'react-intl';
 import { useHistory } from 'react-router-dom';
 
 import { COLONY_TOTAL_BALANCE_DOMAIN_ID } from '~constants';
@@ -152,7 +152,7 @@ const SuggestionsList = ({
     async (id: string) => {
       await openDialog('ConfirmDialog', {
         heading: MSG.confirmDeleteHeading,
-        children: MSG.confirmDeleteText,
+        children: <FormattedMessage {...MSG.confirmDeleteText} />,
         confirmButtonText: MSG.confirmDeleteButton,
       }).afterClosed();
       return setSuggestionStatus({
@@ -165,7 +165,7 @@ const SuggestionsList = ({
     async (id: string) => {
       await openDialog('ConfirmDialog', {
         heading: MSG.confirmCreateTaskHeading,
-        children: MSG.confirmCreateTaskText,
+        children: <FormattedMessage {...MSG.confirmCreateTaskText} />,
         confirmButtonText: MSG.confirmCreateTaskButton,
       }).afterClosed();
       const { data: createTaskData } = await createTaskFromSuggestion({

--- a/src/modules/dashboard/components/SuggestionsList/SuggestionsList.tsx
+++ b/src/modules/dashboard/components/SuggestionsList/SuggestionsList.tsx
@@ -118,13 +118,11 @@ const SuggestionsList = ({
   });
   const [createTaskFromSuggestion] = useCreateTaskFromSuggestionMutation();
   const handleNotPlanned = useCallback(
-    async (id: string) => {
-      await openDialog('ConfirmDialog').afterClosed();
-      return setSuggestionStatus({
+    (id: string) =>
+      setSuggestionStatus({
         variables: { input: { id, status: SuggestionStatus.NotPlanned } },
-      });
-    },
-    [openDialog, setSuggestionStatus],
+      }),
+    [setSuggestionStatus],
   );
   const handleDeleted = useCallback(
     async (id: string) => {

--- a/src/modules/dashboard/components/SuggestionsList/SuggestionsList.tsx
+++ b/src/modules/dashboard/components/SuggestionsList/SuggestionsList.tsx
@@ -44,6 +44,30 @@ const MSG = defineMessages({
     defaultMessage:
       'Create a new suggestion, or switch domains to change the filter.',
   },
+  confirmCreateTaskHeading: {
+    id: 'Dashboard.SuggestionsList.confirmCreateTaskHeading',
+    defaultMessage: 'Accept suggestion and create a new task?',
+  },
+  confirmCreateTaskText: {
+    id: 'Dashboard.SuggestionsList.confirmCreateTaskHeading',
+    defaultMessage: `Would you like to mark this suggestion as Accepted and create a new task in your Colony?`,
+  },
+  confirmCreateTaskButton: {
+    id: 'Dashboard.SuggestionsList.confirmCreateTaskButton',
+    defaultMessage: 'Accept and Create',
+  },
+  confirmDeleteHeading: {
+    id: 'Dashboard.SuggestionsList.confirmDeleteHeading',
+    defaultMessage: 'Are you sure you would like to delete this suggestion?',
+  },
+  confirmDeleteText: {
+    id: 'Dashboard.SuggestionsList.confirmDeleteText',
+    defaultMessage: 'It is not possible to undo this action',
+  },
+  confirmDeleteButton: {
+    id: 'Dashboard.SuggestionsList.confirmDeleteButton',
+    defaultMessage: 'Yes, delete',
+  },
 });
 
 interface InProps {
@@ -126,7 +150,11 @@ const SuggestionsList = ({
   );
   const handleDeleted = useCallback(
     async (id: string) => {
-      await openDialog('ConfirmDialog').afterClosed();
+      await openDialog('ConfirmDialog', {
+        heading: MSG.confirmDeleteHeading,
+        children: MSG.confirmDeleteText,
+        confirmButtonText: MSG.confirmDeleteButton,
+      }).afterClosed();
       return setSuggestionStatus({
         variables: { input: { id, status: SuggestionStatus.Deleted } },
       });
@@ -135,7 +163,11 @@ const SuggestionsList = ({
   );
   const handleCreateTask = useCallback(
     async (id: string) => {
-      await openDialog('ConfirmDialog').afterClosed();
+      await openDialog('ConfirmDialog', {
+        heading: MSG.confirmCreateTaskHeading,
+        children: MSG.confirmCreateTaskText,
+        confirmButtonText: MSG.confirmCreateTaskButton,
+      }).afterClosed();
       const { data: createTaskData } = await createTaskFromSuggestion({
         update: cacheUpdates.createTaskFromSuggestion(colonyAddress, id),
         variables: { input: { id } },

--- a/src/modules/dashboard/components/SuggestionsListItem/SuggestionsListItem.css
+++ b/src/modules/dashboard/components/SuggestionsListItem/SuggestionsListItem.css
@@ -50,6 +50,10 @@
   color: var(--grey-3);
 }
 
+.authorText a:hover {
+  color: var(--sky-blue);
+}
+
 .titleContentContainer,
 .badgeContainer {
   margin-right: 10px;

--- a/src/modules/dashboard/components/SuggestionsListItem/SuggestionsListItem.tsx
+++ b/src/modules/dashboard/components/SuggestionsListItem/SuggestionsListItem.tsx
@@ -177,7 +177,16 @@ const SuggestionsListItem = ({
         <p className={styles.authorText}>
           <FormattedMessage
             {...MSG.byAuthorText}
-            values={{ creator: getFriendlyName(creator) }}
+            values={{
+              creator:
+                creator && creator.profile && creator.profile.username ? (
+                  <Link to={`/user/${creator.profile.username}`}>
+                    {getFriendlyName(creator)}
+                  </Link>
+                ) : (
+                  getFriendlyName(creator)
+                ),
+            }}
           />
         </p>
       </div>


### PR DESCRIPTION
## Description

This PR serves as a catch all for post-QA fixes of the suggestions feature.

**Changes** 🏗

* Do not show confirm dialog when setting a suggestion to `not planned`
* Changed copy above input field to "Suggest a task"
* Fixed broken ConfirmDialog modals in the SuggestionsList.
* Suggestion list item link to author's profile.