### PR TITLE
Display Notifications in reverse chronological order

### DIFF
--- a/src/modules/pages/components/NavigationWrapper/UserNavigation.tsx
+++ b/src/modules/pages/components/NavigationWrapper/UserNavigation.tsx
@@ -37,7 +37,8 @@ const UserNavigation = () => {
     variables: { address: walletAddress },
   });
 
-  const notifications = (data && data.user && data.user.notifications) || [];
+  const notifications =
+    (data && data.user && data.user.notifications.reverse()) || [];
 
   return (
     <div className={styles.main}>

--- a/src/modules/users/components/Inbox/InboxFullscreen/InboxFullscreen.tsx
+++ b/src/modules/users/components/Inbox/InboxFullscreen/InboxFullscreen.tsx
@@ -14,7 +14,8 @@ const InboxFullscreen = () => {
     variables: { address: walletAddress },
   });
 
-  const notifications = (data && data.user && data.user.notifications) || [];
+  const notifications =
+    (data && data.user && data.user.notifications.reverse()) || [];
 
   return (
     <CenteredTemplate appearance={{ theme: 'alt' }}>


### PR DESCRIPTION
## Description

This is a very simple PR that reverses the order in which notifications are displayed.

This will make new notifications show at the top of the inbox list(s).

**Changes**

- [x] Sort notifications data in `UserNavigation` in reverse
- [x] Sort notifications data in `InboxFullScreen` in reverse

**Screenshots**

![Screenshot from 2020-01-26 00-20-37](https://user-images.githubusercontent.com/1193222/73128035-05ba5100-3fd2-11ea-8c40-d4efff4969c9.png)
![Screenshot from 2020-01-26 00-20-57](https://user-images.githubusercontent.com/1193222/73128036-05ba5100-3fd2-11ea-9b9f-5bead8cae505.png)

Resolves #1995 