### PR TITLE
Show Server Version in the Colony's Profile Advanced Page

### DIFF
--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -1485,6 +1485,11 @@ export type UserNotificationsQuery = { user: (
     )> }
   ) };
 
+export type SystemInfoQueryVariables = {};
+
+
+export type SystemInfoQuery = { systemInfo: Pick<SystemInfo, 'version'> };
+
 export const PayoutsFragmentDoc = gql`
     fragment Payouts on Task {
   payouts {
@@ -3729,3 +3734,35 @@ export function useUserNotificationsLazyQuery(baseOptions?: ApolloReactHooks.Laz
 export type UserNotificationsQueryHookResult = ReturnType<typeof useUserNotificationsQuery>;
 export type UserNotificationsLazyQueryHookResult = ReturnType<typeof useUserNotificationsLazyQuery>;
 export type UserNotificationsQueryResult = ApolloReactCommon.QueryResult<UserNotificationsQuery, UserNotificationsQueryVariables>;
+export const SystemInfoDocument = gql`
+    query SystemInfo {
+  systemInfo {
+    version
+  }
+}
+    `;
+
+/**
+ * __useSystemInfoQuery__
+ *
+ * To run a query within a React component, call `useSystemInfoQuery` and pass it any options that fit your needs.
+ * When your component renders, `useSystemInfoQuery` returns an object from Apollo Client that contains loading, error, and data properties 
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useSystemInfoQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useSystemInfoQuery(baseOptions?: ApolloReactHooks.QueryHookOptions<SystemInfoQuery, SystemInfoQueryVariables>) {
+        return ApolloReactHooks.useQuery<SystemInfoQuery, SystemInfoQueryVariables>(SystemInfoDocument, baseOptions);
+      }
+export function useSystemInfoLazyQuery(baseOptions?: ApolloReactHooks.LazyQueryHookOptions<SystemInfoQuery, SystemInfoQueryVariables>) {
+          return ApolloReactHooks.useLazyQuery<SystemInfoQuery, SystemInfoQueryVariables>(SystemInfoDocument, baseOptions);
+        }
+export type SystemInfoQueryHookResult = ReturnType<typeof useSystemInfoQuery>;
+export type SystemInfoLazyQueryHookResult = ReturnType<typeof useSystemInfoLazyQuery>;
+export type SystemInfoQueryResult = ApolloReactCommon.QueryResult<SystemInfoQuery, SystemInfoQueryVariables>;

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -596,6 +596,7 @@ export type Query = {
   domain: Domain,
   task: Task,
   tokenInfo: TokenInfo,
+  systemInfo: SystemInfo,
   loggedInUser: LoggedInUser,
   colonyAddress: Scalars['String'],
   colonyName: Scalars['String'],
@@ -799,6 +800,10 @@ export enum SuggestionStatus {
   Accepted = 'Accepted',
   Deleted = 'Deleted'
 }
+
+export type SystemInfo = {
+  version: Scalars['String'],
+};
 
 export type Task = {
   id: Scalars['String'],

--- a/src/data/queries.graphql
+++ b/src/data/queries.graphql
@@ -373,3 +373,9 @@ query UserNotifications($address: String!) {
     }
   }
 }
+
+query SystemInfo {
+  systemInfo {
+    version
+  }
+}

--- a/src/modules/admin/components/Profile/ProfileAdvanced.tsx
+++ b/src/modules/admin/components/Profile/ProfileAdvanced.tsx
@@ -7,7 +7,7 @@ import { ActionTypes } from '~redux/index';
 import { DialogActionButton } from '~core/Button';
 import Heading from '~core/Heading';
 import ExternalLink from '~core/ExternalLink';
-import { FullColonyFragment } from '~data/index';
+import { FullColonyFragment, useSystemInfoQuery } from '~data/index';
 
 import { networkVersionSelector } from '../../../core/selectors';
 import { canEnterRecoveryMode } from '../../../users/checks';
@@ -30,6 +30,10 @@ const MSG = defineMessages({
   labelDappVersion: {
     id: 'admin.Profile.ProfileAdvanced.labelDappVersion',
     defaultMessage: 'Dapp Version',
+  },
+  labelServerVersion: {
+    id: 'admin.Profile.ProfileAdvanced.labelServerVersion',
+    defaultMessage: 'Server Version',
   },
   labelId: {
     id: 'admin.Profile.ProfileAdvanced.labelId',
@@ -97,6 +101,7 @@ const ProfileAdvanced = ({
   rootRoles,
 }: Props) => {
   const networkVersion = useSelector(networkVersionSelector);
+  const { data } = useSystemInfoQuery();
 
   return (
     <div className={styles.main}>
@@ -134,6 +139,17 @@ const ProfileAdvanced = ({
           <p className={styles.bigInfoText}>{dappVersion}</p>
         </div>
       </section>
+      {data && data.systemInfo && (
+        <section className={styles.section}>
+          <div>
+            <Heading
+              appearance={{ size: 'small', margin: 'none' }}
+              text={MSG.labelServerVersion}
+            />
+            <p className={styles.bigInfoText}>{data.systemInfo.version}</p>
+          </div>
+        </section>
+      )}
       <section className={styles.section}>
         <Heading
           appearance={{ size: 'small', margin: 'none' }}


### PR DESCRIPTION
## Description

This is a small PR that exposes the server version, alongside the dapp's version in the colony's profile advanced page.

This is the dapp-side of the JoinColony/colonyServer#39 PR

**Changes**

- Added `serverInfo` gql query
- Re-generated the the graphql helper methods
- Fetch/display the version from the `serverInfo` query in the `ProfileAdvanced`

**Screenshot**

![Screenshot from 2020-01-26 14-36-45](https://user-images.githubusercontent.com/1193222/73135484-51f5a780-404b-11ea-900b-9e3ccef6d9de.png)

