### PR TITLE
Prevent Users w/o a profile from creating new Tasks

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
@@ -114,11 +114,6 @@ const ColonyHome = ({
 
   const { colony } = data;
 
-  /*
-   * Eventually this has to be in the proper domain. There's probably going to be a different UI for that
-   * Also prevent users w/o a claimed profile from creating tasks
-   * (even if the address got administrative permissions in the colony)
-   */
   const canCreateTask = canAdminister(currentDomainUserRoles) && !!username;
 
   const noFilter = (

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
@@ -52,7 +52,7 @@ const ColonyHome = ({
     params: { colonyName },
   },
 }: Props) => {
-  const { walletAddress } = useLoggedInUser();
+  const { walletAddress, username } = useLoggedInUser();
 
   const [filteredDomainId, setFilteredDomainId] = useState(
     COLONY_TOTAL_BALANCE_DOMAIN_ID,
@@ -114,8 +114,12 @@ const ColonyHome = ({
 
   const { colony } = data;
 
-  // Eventually this has to be in the proper domain. There's probably going to be a different UI for that
-  const canCreateTask = canAdminister(currentDomainUserRoles);
+  /*
+   * Eventually this has to be in the proper domain. There's probably going to be a different UI for that
+   * Also prevent users w/o a claimed profile from creating tasks
+   * (even if the address got administrative permissions in the colony)
+   */
+  const canCreateTask = canAdminister(currentDomainUserRoles) && !!username;
 
   const noFilter = (
     <Heading


### PR DESCRIPTION
## Description

This is a simple PR that prevents users that haven't yet claimed a profile from creating new tasks, even if those users were granted admin permissions in the colony.

**Changes**

- `ColonyHome`, `canCreateTask` also check if the user has claimed a profile

**Screenshot**

![Screenshot from 2020-01-26 15-43-10](https://user-images.githubusercontent.com/1193222/73136147-18289f00-4053-11ea-955b-07368c269484.png)

Resolves #1935