### PR TITLE
Don't Display UserInfo on Userlist Avatars

### DIFF
--- a/src/modules/admin/components/Permissions/Permissions.tsx
+++ b/src/modules/admin/components/Permissions/Permissions.tsx
@@ -163,6 +163,7 @@ const Permissions = ({ colonyAddress, domains, openDialog }: Props) => {
                     showDisplayName
                     showMaskedAddress
                     showUsername
+                    showInfo={false}
                   >
                     <TableCell>
                       <UserPermissions

--- a/src/modules/admin/components/Permissions/Permissions.tsx
+++ b/src/modules/admin/components/Permissions/Permissions.tsx
@@ -174,19 +174,21 @@ const Permissions = ({ colonyAddress, domains, openDialog }: Props) => {
                 ))}
               </TableBody>
             </Table>
-            <p className={styles.parentPermissionTip}>
-              <FormattedMessage
-                {...MSG.permissionInParent}
-                values={{
-                  learnMore: (
-                    <ExternalLink
-                      text={MSG.learnMore}
-                      href={DOMAINS_HELP_URL}
-                    />
-                  ),
-                }}
-              />
-            </p>
+            {selectedDomain && selectedDomain.id !== ROOT_DOMAIN && (
+              <p className={styles.parentPermissionTip}>
+                <FormattedMessage
+                  {...MSG.permissionInParent}
+                  values={{
+                    learnMore: (
+                      <ExternalLink
+                        text={MSG.learnMore}
+                        href={DOMAINS_HELP_URL}
+                      />
+                    ),
+                  }}
+                />
+              </p>
+            )}
           </>
         </div>
       </main>

--- a/src/modules/admin/components/UserList/UserList.tsx
+++ b/src/modules/admin/components/UserList/UserList.tsx
@@ -56,6 +56,12 @@ interface Props {
 
   /* Colony address to use when removing the user */
   colonyAddress: Address;
+
+  /*
+   * Whether or not the items that render an avatar should show a UserInfo tooltip upon clicking them
+   * This gets passed down to `UserListItem`
+   */
+  showInfo?: boolean;
 }
 
 const displayName = 'admin.UserList';
@@ -71,6 +77,7 @@ const UserList = ({
   showUsername,
   showMaskedAddress,
   viewOnly = true,
+  showInfo,
 }: Props) => {
   const transform = pipe(
     withKey(colonyAddress),
@@ -110,6 +117,7 @@ const UserList = ({
                 showMaskedAddress={showMaskedAddress}
                 viewOnly={viewOnly}
                 onRemove={() => handleRemove(user)}
+                showInfo={showInfo}
               />
             ))}
           </TableBody>

--- a/src/modules/admin/components/UserListItem/UserListItem.tsx
+++ b/src/modules/admin/components/UserListItem/UserListItem.tsx
@@ -68,6 +68,11 @@ interface Props {
    * Method to call when clicking the remove button
    */
   onRemove?: (evt: MouseEvent) => void;
+
+  /*
+   * Whether or not to display a `UserInfo` tooltip component when clicking on the User's avatar
+   */
+  showInfo?: boolean;
 }
 
 const UserListItem = ({
@@ -79,6 +84,7 @@ const UserListItem = ({
   viewOnly = true,
   onClick: callbackFn,
   onRemove,
+  showInfo = true,
 }: Props) => {
   // @TODO pass down user to UserListItem
   // @body once the roles come through apollo, this can be sync and passed down from the parent as we can get the whole list of users easily
@@ -117,7 +123,12 @@ const UserListItem = ({
       {...rowProps}
     >
       <TableCell className={styles.userAvatar}>
-        <UserAvatar size="xs" address={address} user={user} />
+        <UserAvatar
+          size="xs"
+          address={address}
+          user={user}
+          showInfo={showInfo}
+        />
       </TableCell>
       <TableCell className={styles.userDetails}>
         {showDisplayName && displayName && (

--- a/src/modules/admin/components/UserListItem/UserListItem.tsx
+++ b/src/modules/admin/components/UserListItem/UserListItem.tsx
@@ -117,7 +117,7 @@ const UserListItem = ({
       {...rowProps}
     >
       <TableCell className={styles.userAvatar}>
-        <UserAvatar size="xs" address={address} user={user} showInfo />
+        <UserAvatar size="xs" address={address} user={user} />
       </TableCell>
       <TableCell className={styles.userDetails}>
         {showDisplayName && displayName && (


### PR DESCRIPTION
## Description

This PR disables the `UserInfo` tooltip on items displayed via a `UserList` in the admin panel. This was due to both actions firing at the same time: showing userinfo and opening the permission modal resulting in a broken UI state.

While I was at it, I also added a simple logic check to display the parent (root) inheritance description text, only if a different domain that root is selected.

**Changes**

- `UserListItem` don't show `UserInfo` on avatars
- `Permissions` only show parent inheritance tip on non-root domains

**Screenshots**

_`UserInfo` still available on the permissions edit modal:_
![Screenshot from 2020-01-26 15-57-01](https://user-images.githubusercontent.com/1193222/73136314-0647fb80-4055-11ea-9d47-162ebf95e730.png)

_Parent inheritance tip only shown on non-root domain:_
![Screenshot from 2020-01-26 15-56-53](https://user-images.githubusercontent.com/1193222/73136317-09db8280-4055-11ea-9c73-c540571a23dd.png)
![Screenshot from 2020-01-26 15-57-20](https://user-images.githubusercontent.com/1193222/73136318-09db8280-4055-11ea-91ee-16554eaa731f.png)


Resolves #1913 