### PR TITLE
Fix: `SuggestionsList` fix duplicate messageDescriptor ids

### DIFF
--- a/src/modules/dashboard/components/SuggestionsList/SuggestionsList.tsx
+++ b/src/modules/dashboard/components/SuggestionsList/SuggestionsList.tsx
@@ -49,7 +49,7 @@ const MSG = defineMessages({
     defaultMessage: 'Accept suggestion and create a new task?',
   },
   confirmCreateTaskText: {
-    id: 'Dashboard.SuggestionsList.confirmCreateTaskHeading',
+    id: 'Dashboard.SuggestionsList.confirmCreateTaskText',
     defaultMessage: `Would you like to mark this suggestion as Accepted and create a new task in your Colony?`,
   },
   confirmCreateTaskButton: {


### PR DESCRIPTION
## Description

This is quick fix that removes the duplicated message descriptor id in the `SuggestionsList` component
