### PR TITLE
Redirect nonexistent Colonies, Users, Tasks to the 404 route

### DIFF
--- a/src/data/colony.ts
+++ b/src/data/colony.ts
@@ -22,7 +22,7 @@ export const colonyResolvers = ({
         return address;
       } catch (error) {
         /*
-         * @NOTE This makes the server query fail in case of an unexistent error
+         * @NOTE This makes the server query fail in case of an unexistent/unregistered colony ENS name
          *
          * Otherwise, the ENS resolution will fail, but not this query.
          * This will then not proceed further to the server query and the data

--- a/src/data/colony.ts
+++ b/src/data/colony.ts
@@ -14,11 +14,22 @@ export const colonyResolvers = ({
 }: ContextType): Resolvers => ({
   Query: {
     async colonyAddress(_, { name }) {
-      const address = await ens.getAddress(
-        ENS.getFullDomain('colony', name),
-        networkClient,
-      );
-      return address;
+      try {
+        const address = await ens.getAddress(
+          ENS.getFullDomain('colony', name),
+          networkClient,
+        );
+        return address;
+      } catch (error) {
+        /*
+         * @NOTE This makes the server query fail in case of an unexistent error
+         *
+         * Otherwise, the ENS resolution will fail, but not this query.
+         * This will then not proceed further to the server query and the data
+         * will try to load indefinitely w/o an error
+         */
+        return undefined;
+      }
     },
     async colonyName(_, { address }) {
       const domain = await ens.getDomain(address, networkClient);

--- a/src/modules/admin/components/AdminDashboard/AdminDashboard.tsx
+++ b/src/modules/admin/components/AdminDashboard/AdminDashboard.tsx
@@ -145,7 +145,7 @@ const AdminDashboard = ({
   const CURRENT_COLONY_ROUTE = colonyName ? `/colony/${colonyName}` : '';
 
   // @TODO: Try to get proper error handling going in resolvers (for colonies that don't exist)
-  const { data } = useColonyFromNameQuery({
+  const { data, error: colonyFetchError } = useColonyFromNameQuery({
     // We have to define an empty address here for type safety, will be replaced by the query
     variables: { name: colonyName, address: '' },
   });
@@ -177,7 +177,7 @@ const AdminDashboard = ({
     walletAddress,
   ]);
 
-  if (!colonyName) {
+  if (!colonyName || colonyFetchError) {
     return <Redirect to="/404" />;
   }
 

--- a/src/modules/admin/components/AdminDashboard/AdminDashboard.tsx
+++ b/src/modules/admin/components/AdminDashboard/AdminDashboard.tsx
@@ -21,6 +21,7 @@ import {
   useColonyFromNameQuery,
   useLoggedInUser,
 } from '~data/index';
+import { NOT_FOUND_ROUTE } from '~routes/index';
 
 import {
   TEMP_getUserRolesWithRecovery,
@@ -178,7 +179,7 @@ const AdminDashboard = ({
   ]);
 
   if (!colonyName || colonyFetchError) {
-    return <Redirect to="/404" />;
+    return <Redirect to={NOT_FOUND_ROUTE} />;
   }
 
   if (!data || !domains || isFetchingDomains) {

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
@@ -71,7 +71,7 @@ const ColonyHome = ({
   const [activeTab, setActiveTab] = useState<TabName>(TabName.TasksTab);
 
   // @TODO: Try to get proper error handling going in resolvers (for colonies that don't exist)
-  const { data } = useColonyFromNameQuery({
+  const { data, error: colonyFetchError } = useColonyFromNameQuery({
     // We have to define an empty address here for type safety, will be replaced by the query
     variables: { name: colonyName, address: '' },
   });
@@ -109,7 +109,7 @@ const ColonyHome = ({
     }
   }, [domains, filteredDomainId]);
 
-  if (!colonyName) {
+  if (!colonyName || colonyFetchError) {
     return <Redirect to="/404" />;
   }
 

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
@@ -17,6 +17,7 @@ import { useDataFetcher, useTransformer } from '~utils/hooks';
 import { getUserRoles } from '../../../transformers';
 import { canAdminister, hasRoot } from '../../../users/checks';
 import { domainsAndRolesFetcher } from '../../fetchers';
+import { NOT_FOUND_ROUTE } from '~routes/index';
 
 import ColonyFunding from './ColonyFunding';
 import styles from './ColonyHome.css';
@@ -110,7 +111,7 @@ const ColonyHome = ({
   }, [domains, filteredDomainId]);
 
   if (!colonyName || colonyFetchError) {
-    return <Redirect to="/404" />;
+    return <Redirect to={NOT_FOUND_ROUTE} />;
   }
 
   if (

--- a/src/modules/dashboard/components/Task/Task.tsx
+++ b/src/modules/dashboard/components/Task/Task.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useCallback, useState } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
-import { useHistory, useParams } from 'react-router-dom';
+import { useHistory, useParams, Redirect } from 'react-router-dom';
 
 import Button, { ActionButton } from '~core/Button';
 import { OpenDialog } from '~core/Dialog/types';
@@ -122,13 +122,13 @@ const Task = ({ openDialog }: Props) => {
 
   const { walletAddress } = useLoggedInUser();
 
-  const { data } = useTaskQuery({
+  const { data, error: taskFetchError } = useTaskQuery({
     // @todo use subscription for `Task` instead of `pollInterval` (once supported by server)
     pollInterval: 5000,
     variables: { id: draftId },
   });
 
-  const { data: colonyData } = useColonyFromNameQuery({
+  const { data: colonyData, error: colonyFetchError } = useColonyFromNameQuery({
     variables: { address: '', name: colonyName },
   });
 
@@ -182,6 +182,10 @@ const Task = ({ openDialog }: Props) => {
   const [handleCancelTask] = useCancelTaskMutation({
     variables: { input: { id: draftId } },
   });
+
+  if (!colonyName || colonyFetchError || taskFetchError) {
+    return <Redirect to="/404" />;
+  }
 
   if (isFetchingDomains || !task || !colonyData || !domains || !walletAddress) {
     return <LoadingTemplate loadingText={MSG.loadingText} />;

--- a/src/modules/dashboard/components/Task/Task.tsx
+++ b/src/modules/dashboard/components/Task/Task.tsx
@@ -27,6 +27,7 @@ import LoadingTemplate from '~pages/LoadingTemplate';
 import { ActionTypes } from '~redux/index';
 import { mergePayload } from '~utils/actions';
 import { useDataFetcher, useTransformer } from '~utils/hooks';
+import { NOT_FOUND_ROUTE } from '~routes/index';
 
 import { getUserRoles } from '../../../transformers';
 import {
@@ -184,7 +185,7 @@ const Task = ({ openDialog }: Props) => {
   });
 
   if (!colonyName || colonyFetchError || taskFetchError) {
-    return <Redirect to="/404" />;
+    return <Redirect to={NOT_FOUND_ROUTE} />;
   }
 
   if (isFetchingDomains || !task || !colonyData || !domains || !walletAddress) {

--- a/src/modules/users/components/UserProfile/UserProfile.tsx
+++ b/src/modules/users/components/UserProfile/UserProfile.tsx
@@ -34,13 +34,14 @@ const UserProfile = ({
     }
   }, [loadUser, userAddress]);
 
+  if (userAddressError) {
+    return <Redirect to={NOT_FOUND_ROUTE} />;
+  }
+
   if (!data || !data.user) {
     return <UserProfileSpinner />;
   }
 
-  if (userAddressError) {
-    return <Redirect to={NOT_FOUND_ROUTE} />;
-  }
   const { user } = data;
 
   return (


### PR DESCRIPTION
## Description

This PR started as way to fix the issue of an indefinitely loading colony page, when accessing a colony name that was not yet registered on ENS.

This was happening because the `@client` query which was responsible for fetching the colony address from the ENS name would fail, but wouldn't actually fail the whole server query, it would just stop executing from that point on, meaning the app would consider the query in still a loading state.

This was fixed by wrapping the client query in a try/catch block, and returning `undefined` as the colony address in case of an error. This in turn, makes the server query fail, which puts the query result in an error state. Based on that, we can now redirect the app to the "not found" route.

While I was at it, I implemented the same logic for loading task data _(that's actually colony + task data, since we check for either of those element's existence)_, as well as for the user _(the user one was easy, since it was just faulty logic, as everything was already there, it just needed to be ordered differently)_

I've also changed all instances where we hardcoded the `"/404"` route redirect to now use the `NOT_FOUND_ROUTE` constant.

**Changes**

- [x] `colonyAddress` client query return `undefined` if the ENS resolution fails
- [x] `ColonyHome` redirect to "not found" if the colony query is in an error state
- [x] `Task` redirect to "not found" if either the colony or the task query is in an error state
- [x] `UserProfile` redirect directive moved in front of the loading directive

**Demos**

Colony:
![not-found-colony](https://user-images.githubusercontent.com/1193222/73362803-2fb09380-42b0-11ea-87b4-9a1400f0dfd8.gif)

Task:
![not-found-task](https://user-images.githubusercontent.com/1193222/73362804-2fb09380-42b0-11ea-867d-03d699f7b0eb.gif)

User:
![not-found-user](https://user-images.githubusercontent.com/1193222/73362806-2fb09380-42b0-11ea-8aca-1e66e406632f.gif)

Resolves #2004 