### PR TITLE
Checksum the Token addresses added by users

### DIFF
--- a/src/modules/core/components/TokenEditDialog/TokenEditDialog.tsx
+++ b/src/modules/core/components/TokenEditDialog/TokenEditDialog.tsx
@@ -8,7 +8,7 @@ import Dialog, { DialogSection } from '~core/Dialog';
 import { Form, Input } from '~core/Fields';
 import Heading from '~core/Heading';
 import { AnyToken } from '~data/index';
-import { Address } from '~types/strings';
+import { Address, createAddress } from '~types/strings';
 
 import TokenItem from './TokenItem/index';
 
@@ -77,7 +77,7 @@ const TokenEditDialog = ({
       { resetForm, setSubmitting, setFieldError }: FormikHelpers<FormValues>,
     ) => {
       try {
-        await addTokenFn(tokenAddress);
+        await addTokenFn(createAddress(tokenAddress));
         resetForm();
       } catch (e) {
         setFieldError('tokenAddress', MSG.errorAddingToken);


### PR DESCRIPTION
## Description

This PR is here to prevent users adding un-checksummed Token addresses to either a colony's token list, or just their wallets.

While this might seem simple, it's quite a "hairy" issue, since in almost all cases it adds the wrong address.

Let's take for example SAI. If you look up on [etherscan](https://etherscan.io/token/0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359), the address for this token is `0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359`, while our server, dapp, all services we use in the background (ethplorer) expect this address checksummed: `0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359`

So using just Etherscan, other then for some very rare cases where we keep Token records ourselves, we'll get a `???` representing missing token details:

![image](https://user-images.githubusercontent.com/1193222/73465248-c781b080-4388-11ea-8940-39a1485f3a87.png)

This issue was originally reported here: https://joincolony.slack.com/archives/C02R9SP3J/p1580152894091000

_NOTE: An accompanying issue very similar to this goes on the server side as well: JoinColony/colonyServer#42_

**Changes**

- `TokenEditDialog` pass a checksummed token address to `addTokenFn`