### PR TITLE
Whitelist Token Locking address when creating a new Colony

### DIFF
--- a/src/modules/dashboard/sagas/colonyCreate.ts
+++ b/src/modules/dashboard/sagas/colonyCreate.ts
@@ -52,6 +52,8 @@ function* colonyCreate({
     Context.APOLLO_CLIENT,
   );
 
+  const { networkClient } = yield getContext(Context.COLONY_MANAGER);
+
   const TOKEN_DECIMALS = 18;
 
   /*
@@ -153,10 +155,16 @@ function* colonyCreate({
     });
 
     if (createToken) {
+      const { address: tokenLockingAddress } = yield call([
+        networkClient.getTokenLockingAddress,
+        networkClient.getTokenLockingAddress.call,
+      ]);
       yield createGroupedTransaction(deployTokenAuthority, {
         context: ContractContexts.TOKEN_CONTEXT,
         methodName: 'createTokenAuthority',
-        params: { allowedToTransfer: [] },
+        params: {
+          allowedToTransfer: [tokenLockingAddress],
+        },
         ready: false,
       });
 


### PR DESCRIPTION
## Description

This PR adds in the token locking address (fetched from the network) to the `deployTokenAuthority` transaction's `allowToTransfer` argument, when creating a new colony.

This way users will be allowed be allowed to deposit tokens, even while the token is locked.

Original report: https://joincolony.slack.com/archives/C02R9SP3J/p1580399575113400

**Changes** 

- [x] `colonyCreate` saga, import `networkClient`, fetch `tokenLockingAddress`, pass it to the `deployTokenAuthority` tx

