### PR TITLE
Display correct ETH amount in User Wallet

### DIFF
--- a/src/data/token.ts
+++ b/src/data/token.ts
@@ -133,7 +133,7 @@ export const tokenResolvers = ({ colonyManager }: ContextType): Resolvers => ({
         },
       } = colonyManager;
       if (address === ZERO_ADDRESS) {
-        const balance = provider.getBalance(walletAddress);
+        const balance = await provider.getBalance(walletAddress);
         return balance.toString();
       }
 


### PR DESCRIPTION
## Description

This PR adds in a simple fix in order to display to correct ETH amount in the user wallet's cards list.

What is happening in the background is that for ETH, we're using the provider to make a `getBalance` call to the network and fetch that address's current balance.

For other tokens, we just use the our contracts' internal book-keeping to get the balance.

Now, that get balance call is async, as it should be, but we we're waiting for it resolve, and just returned the unresolved promise, as a string:

![Screenshot from 2020-01-31 14-20-16](https://user-images.githubusercontent.com/1193222/73539423-07eb3800-4436-11ea-8839-9eff148ef969.png)

Our `<Numeral />` component either did some clever converting, or fell back to a default value to produce that `0.00385....` value you see in the _before_ screenshot.

The fix for this, was just to wait for that promise to finish, which returns a BigNumber, and that, converted to a string, gets us the actual value in wei:

![Screenshot from 2020-01-31 14-20-48](https://user-images.githubusercontent.com/1193222/73539534-408b1180-4436-11ea-8009-2cc6868ca075.png)

**Changes**

- [x] `token` gql resolver, wait for `getBalance` call to resolve

**Screenshots**

Before:
![Screenshot from 2020-01-31 14-16-39](https://user-images.githubusercontent.com/1193222/73539175-77145c80-4435-11ea-88bd-262a64f89317.png)

After:
![Screenshot from 2020-01-31 14-23-04](https://user-images.githubusercontent.com/1193222/73539187-7b407a00-4435-11ea-8a16-a614a77f946c.png)

Resolves #2011 
