### PR TITLE
Fix task attributes cache

### DIFF
--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -996,7 +996,7 @@ export type AssignWorkerMutationVariables = {
 
 
 export type AssignWorkerMutation = { assignWorker: Maybe<(
-    Pick<Task, 'id'>
+    Pick<Task, 'id' | 'assignedWorkerAddress'>
     & { assignedWorker: Maybe<Pick<User, 'id'>>, events: Array<TaskEventFragment> }
   )> };
 
@@ -1023,7 +1023,7 @@ export type CreateWorkRequestMutationVariables = {
 
 
 export type CreateWorkRequestMutation = { createWorkRequest: Maybe<(
-    Pick<Task, 'id'>
+    Pick<Task, 'id' | 'workRequestAddresses'>
     & { events: Array<TaskEventFragment>, workRequests: Array<Pick<User, 'id'>> }
   )> };
 
@@ -1054,7 +1054,7 @@ export type SendWorkInviteMutationVariables = {
 
 
 export type SendWorkInviteMutation = { sendWorkInvite: Maybe<(
-    Pick<Task, 'id'>
+    Pick<Task, 'id' | 'workInviteAddresses'>
     & { events: Array<TaskEventFragment>, workInvites: Array<Pick<User, 'id'>> }
   )> };
 
@@ -1127,7 +1127,7 @@ export type UnassignWorkerMutationVariables = {
 
 
 export type UnassignWorkerMutation = { unassignWorker: Maybe<(
-    Pick<Task, 'id'>
+    Pick<Task, 'id' | 'assignedWorkerAddress'>
     & { assignedWorker: Maybe<Pick<User, 'id'>>, events: Array<TaskEventFragment> }
   )> };
 
@@ -1763,6 +1763,7 @@ export const AssignWorkerDocument = gql`
     mutation AssignWorker($input: AssignWorkerInput!) {
   assignWorker(input: $input) {
     id
+    assignedWorkerAddress
     assignedWorker {
       id
     }
@@ -1872,6 +1873,7 @@ export const CreateWorkRequestDocument = gql`
     events {
       ...TaskEvent
     }
+    workRequestAddresses
     workRequests {
       id
     }
@@ -1991,6 +1993,7 @@ export const SendWorkInviteDocument = gql`
     events {
       ...TaskEvent
     }
+    workInviteAddresses
     workInvites {
       id
     }
@@ -2249,6 +2252,7 @@ export const UnassignWorkerDocument = gql`
     mutation UnassignWorker($input: UnassignWorkerInput!) {
   unassignWorker(input: $input) {
     id
+    assignedWorkerAddress
     assignedWorker {
       id
     }

--- a/src/data/mutations.graphql
+++ b/src/data/mutations.graphql
@@ -4,6 +4,7 @@
 mutation AssignWorker($input: AssignWorkerInput!) {
   assignWorker(input: $input) {
     id
+    assignedWorkerAddress
     assignedWorker {
       id
     }
@@ -35,6 +36,7 @@ mutation CreateWorkRequest($input: CreateWorkRequestInput!) {
     events {
       ...TaskEvent
     }
+    workRequestAddresses
     workRequests {
       id
     }
@@ -75,6 +77,7 @@ mutation SendWorkInvite($input: SendWorkInviteInput!) {
     events {
       ...TaskEvent
     }
+    workInviteAddresses
     workInvites {
       id
     }
@@ -151,6 +154,7 @@ mutation SetTaskTitle($input: SetTaskTitleInput!) {
 mutation UnassignWorker($input: UnassignWorkerInput!) {
   unassignWorker(input: $input) {
     id
+    assignedWorkerAddress
     assignedWorker {
       id
     }


### PR DESCRIPTION
## Description

This PR fixes two particular issues, and likely prevents a couple of related cache bugs from surfacing in the future.

Most notably - in cases where an expanded user and their address are both fields on query types, we now accept both fields in mutation results. This solves some cache issues related to task worker assignment not updating immediately in task lists.

Also, this PR ensures that a task is added or removed from the user task list when they've assigned or unassigned themselves, respectively.

Closes #2012
