### PR TITLE
Pass colonyAddress into PayoutClaimed event

### DIFF
--- a/src/utils/web3/eventLogs/eventParsers.ts
+++ b/src/utils/web3/eventLogs/eventParsers.ts
@@ -111,10 +111,12 @@ export const parsePayoutClaimedEvent = async ({
   log: { transactionHash: hash },
   log,
   colonyClient,
+  colonyAddress,
 }: {
   colonyClient: ColonyClientType;
   event: any;
   log: any;
+  colonyAddress: string;
 }): Promise<ContractTransactionType | null> => {
   const date = await getLogDate(colonyClient.adapter.provider, log);
   const { typeId: paymentId, type } = await colonyClient.getFundingPot.call({
@@ -124,6 +126,7 @@ export const parsePayoutClaimedEvent = async ({
   const { recipient: to } = await colonyClient.getPayment.call({ paymentId });
   return createContractTxObj({
     amount,
+    colonyAddress,
     date,
     hash,
     incoming: false,


### PR DESCRIPTION
## Description

Hurray, I fixed a bug we didn't even know existed.

**Changes** 🏗

* The colony address is now properly passed into the parsed `PayoutClaimed` event and will not trigger a server error anymore. Also you can now see that the colony sent the funds in the transaction.
