### PR TITLE
Prevent finalizing a Task with insufficient domain pot balance

### DIFF
--- a/src/dialogComponents.ts
+++ b/src/dialogComponents.ts
@@ -26,6 +26,7 @@ import {
 import RecoveryModeDialog from '~admin/RecoveryModeDialog';
 import UnlockTokenDialog from '~admin/Profile/UnlockTokenDialog';
 import UpgradeContractDialog from '~admin/UpgradeContractDialog';
+import { TaskFinalizeDialog } from '~dashboard/TaskFinalize';
 
 const dialogComponents: Record<string, DialogComponent> = {
   ActivityBarExample,
@@ -45,6 +46,7 @@ const dialogComponents: Record<string, DialogComponent> = {
   UpgradeContractDialog,
   UserTokenEditDialog,
   WorkerRatingDialog,
+  TaskFinalizeDialog,
 };
 
 export default dialogComponents;

--- a/src/modules/dashboard/components/Task/Task.tsx
+++ b/src/modules/dashboard/components/Task/Task.tsx
@@ -2,7 +2,7 @@ import React, { FC, useCallback, useState } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { useHistory, useParams, Redirect } from 'react-router-dom';
 
-import Button, { ActionButton } from '~core/Button';
+import Button from '~core/Button';
 import { OpenDialog } from '~core/Dialog/types';
 import withDialog from '~core/Dialog/withDialog';
 import Heading from '~core/Heading';
@@ -17,6 +17,7 @@ import TaskFeed from '~dashboard/TaskFeed';
 import TaskRequestWork from '~dashboard/TaskRequestWork';
 import TaskSkills from '~dashboard/TaskSkills';
 import TaskTitle from '~dashboard/TaskTitle';
+import TaskFinalize from '~dashboard/TaskFinalize';
 import {
   useCancelTaskMutation,
   useColonyFromNameQuery,
@@ -24,8 +25,6 @@ import {
   useTaskQuery,
 } from '~data/index';
 import LoadingTemplate from '~pages/LoadingTemplate';
-import { ActionTypes } from '~redux/index';
-import { mergePayload } from '~utils/actions';
 import { useDataFetcher, useTransformer } from '~utils/hooks';
 import { NOT_FOUND_ROUTE } from '~routes/index';
 
@@ -62,10 +61,6 @@ const MSG = defineMessages({
   discarded: {
     id: 'dashboard.Task.discarded',
     defaultMessage: 'Task discarded',
-  },
-  finalizeTask: {
-    id: 'dashboard.Task.finalizeTask',
-    defaultMessage: 'Finalize task',
   },
   discardTask: {
     id: 'dashboard.Task.discardTask',
@@ -171,14 +166,6 @@ const Task = ({ openDialog }: Props) => {
       minTokens: 0,
     });
   }, [colonyData, draftId, openDialog, task]);
-
-  const transform = useCallback(
-    mergePayload({
-      colonyAddress: colonyData && colonyData.colonyAddress,
-      draftId,
-    }),
-    [colonyData, draftId],
-  );
 
   const [handleCancelTask] = useCancelTaskMutation({
     variables: { input: { id: draftId } },
@@ -332,12 +319,9 @@ const Task = ({ openDialog }: Props) => {
           {!isDiscardConfirmDisplayed && (
             <>
               {canFinalizeTask(task, userRoles) && (
-                <ActionButton
-                  text={MSG.finalizeTask}
-                  submit={ActionTypes.TASK_FINALIZE}
-                  error={ActionTypes.TASK_FINALIZE_ERROR}
-                  success={ActionTypes.TASK_FINALIZE_SUCCESS}
-                  transform={transform}
+                <TaskFinalize
+                  draftId={draftId}
+                  colonyAddress={colonyData.colonyAddress}
                 />
               )}
               {isFinalized(task) && (

--- a/src/modules/dashboard/components/Task/Task.tsx
+++ b/src/modules/dashboard/components/Task/Task.tsx
@@ -27,6 +27,7 @@ import {
 import LoadingTemplate from '~pages/LoadingTemplate';
 import { useDataFetcher, useTransformer } from '~utils/hooks';
 import { NOT_FOUND_ROUTE } from '~routes/index';
+import { ROOT_DOMAIN } from '~constants';
 
 import { getUserRoles } from '../../../transformers';
 import {
@@ -249,7 +250,7 @@ const Task = ({ openDialog }: Props) => {
                 colonyAddress={colony.colonyAddress}
                 // Disable the change of domain for now
                 disabled
-                ethDomainId={ethDomainId || 1}
+                ethDomainId={ethDomainId || ROOT_DOMAIN}
                 draftId={draftId}
                 payouts={payouts}
               />
@@ -322,6 +323,8 @@ const Task = ({ openDialog }: Props) => {
                 <TaskFinalize
                   draftId={draftId}
                   colonyAddress={colonyData.colonyAddress}
+                  ethDomainId={ethDomainId || ROOT_DOMAIN}
+                  payouts={payouts}
                 />
               )}
               {isFinalized(task) && (

--- a/src/modules/dashboard/components/TaskFinalize/TaskFinalize.tsx
+++ b/src/modules/dashboard/components/TaskFinalize/TaskFinalize.tsx
@@ -1,12 +1,20 @@
 import React, { useCallback, useState } from 'react';
 import { defineMessages } from 'react-intl';
+import moveDecimal from 'move-decimal-point';
 
 import Button from '~core/Button';
-import { ActionTypes } from '~redux/index';
-import { mergePayload } from '~utils/actions';
-import { AnyTask } from '~data/index';
+
 import { Address } from '~types/index';
+import {
+  AnyTask,
+  Payouts,
+  TokenWithBalances,
+  useTokenBalancesForDomainsQuery,
+} from '~data/index';
+import { ActionTypes } from '~redux/index';
 import { useAsyncFunction } from '~utils/hooks';
+import { mergePayload } from '~utils/actions';
+import { bnLessThan } from '~utils/numbers';
 
 const MSG = defineMessages({
   finalizeTask: {
@@ -20,10 +28,46 @@ const displayName = 'dashboard.TaskFinalize';
 interface Props {
   draftId: AnyTask['id'];
   colonyAddress: Address;
+  ethDomainId: number,
+  payouts: Payouts,
 }
 
-const TaskFinalize = ({ draftId, colonyAddress }: Props) => {
+const TaskFinalize = ({
+  draftId,
+  colonyAddress,
+  ethDomainId,
+  payouts,
+}: Props) => {
   const [isLoading, setIsLoading] = useState(false);
+
+  const tokenAddresses = payouts.map(({ token }) => token.address);
+  const { data: tokenBalances } = useTokenBalancesForDomainsQuery({
+    variables: {
+      colonyAddress,
+      tokenAddresses,
+      domainIds: [ethDomainId],
+    },
+  });
+  const enoughFundsAvailable = payouts.every(({ amount, tokenAddress }) => {
+    if (!tokenBalances) {
+      return false;
+    }
+    /*
+     * @NOTE About the types ignore
+     *
+     * For some reason I get a TS error about balances prop not existing, even though
+     * it's available on the union type. I must be missing something...
+     */
+    // @ts-ignore
+    const { balances: domainBalances, decimals } = tokenBalances.tokens.find(
+      ({ address: domainTokenAddress }) => domainTokenAddress === tokenAddress,
+    ) as TokenWithBalances;
+    return domainBalances.every(
+      ({ amount: availableDomainAmount }) =>
+        !bnLessThan(availableDomainAmount, moveDecimal(amount, decimals || 18)),
+    );
+  });
+
   const transform = useCallback(
     mergePayload({
       colonyAddress,
@@ -37,6 +81,7 @@ const TaskFinalize = ({ draftId, colonyAddress }: Props) => {
     success: ActionTypes.TASK_FINALIZE_SUCCESS,
     transform,
   });
+
   const handleOnClick = async () => {
     setIsLoading(true);
     try {
@@ -46,11 +91,13 @@ const TaskFinalize = ({ draftId, colonyAddress }: Props) => {
       setIsLoading(false);
     }
   };
+
   return (
     <Button
       text={MSG.finalizeTask}
       onClick={handleOnClick}
       loading={isLoading}
+      disabled={!enoughFundsAvailable}
     />
   );
 };

--- a/src/modules/dashboard/components/TaskFinalize/TaskFinalize.tsx
+++ b/src/modules/dashboard/components/TaskFinalize/TaskFinalize.tsx
@@ -1,0 +1,45 @@
+import React, { useCallback } from 'react';
+import { defineMessages } from 'react-intl';
+
+import { ActionButton } from '~core/Button';
+import { ActionTypes } from '~redux/index';
+import { mergePayload } from '~utils/actions';
+import { AnyTask } from '~data/index';
+import { Address } from '~types/index';
+
+const MSG = defineMessages({
+  finalizeTask: {
+    id: 'dashboard.Task.finalizeTask',
+    defaultMessage: 'Finalize task',
+  },
+});
+
+const displayName = 'dashboard.TaskFinalize';
+
+interface Props {
+  draftId: AnyTask['id'];
+  colonyAddress: Address;
+}
+
+const TaskFinalize = ({ draftId, colonyAddress }: Props) => {
+  const transform = useCallback(
+    mergePayload({
+      colonyAddress,
+      draftId,
+    }),
+    [colonyAddress, draftId],
+  );
+  return (
+    <ActionButton
+      text={MSG.finalizeTask}
+      submit={ActionTypes.TASK_FINALIZE}
+      error={ActionTypes.TASK_FINALIZE_ERROR}
+      success={ActionTypes.TASK_FINALIZE_SUCCESS}
+      transform={transform}
+    />
+  );
+};
+
+TaskFinalize.displayName = displayName;
+
+export default TaskFinalize;

--- a/src/modules/dashboard/components/TaskFinalize/TaskFinalize.tsx
+++ b/src/modules/dashboard/components/TaskFinalize/TaskFinalize.tsx
@@ -1,11 +1,12 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { defineMessages } from 'react-intl';
 
-import { ActionButton } from '~core/Button';
+import Button from '~core/Button';
 import { ActionTypes } from '~redux/index';
 import { mergePayload } from '~utils/actions';
 import { AnyTask } from '~data/index';
 import { Address } from '~types/index';
+import { useAsyncFunction } from '~utils/hooks';
 
 const MSG = defineMessages({
   finalizeTask: {
@@ -22,6 +23,7 @@ interface Props {
 }
 
 const TaskFinalize = ({ draftId, colonyAddress }: Props) => {
+  const [isLoading, setIsLoading] = useState(false);
   const transform = useCallback(
     mergePayload({
       colonyAddress,
@@ -29,13 +31,26 @@ const TaskFinalize = ({ draftId, colonyAddress }: Props) => {
     }),
     [colonyAddress, draftId],
   );
+  const finalizeTask = useAsyncFunction({
+    submit: ActionTypes.TASK_FINALIZE,
+    error: ActionTypes.TASK_FINALIZE_ERROR,
+    success: ActionTypes.TASK_FINALIZE_SUCCESS,
+    transform,
+  });
+  const handleOnClick = async () => {
+    setIsLoading(true);
+    try {
+      await finalizeTask({});
+      setIsLoading(false);
+    } catch (error) {
+      setIsLoading(false);
+    }
+  };
   return (
-    <ActionButton
+    <Button
       text={MSG.finalizeTask}
-      submit={ActionTypes.TASK_FINALIZE}
-      error={ActionTypes.TASK_FINALIZE_ERROR}
-      success={ActionTypes.TASK_FINALIZE_SUCCESS}
-      transform={transform}
+      onClick={handleOnClick}
+      loading={isLoading}
     />
   );
 };

--- a/src/modules/dashboard/components/TaskFinalize/TaskFinalizeDialog.tsx
+++ b/src/modules/dashboard/components/TaskFinalize/TaskFinalizeDialog.tsx
@@ -1,0 +1,50 @@
+import React, { FC } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import Button from '~core/Button';
+import Heading from '~core/Heading';
+import Dialog, { DialogSection } from '~core/Dialog';
+
+const MSG = defineMessages({
+  heading: {
+    id: 'dashboard.TaskFinalizeDialog.heading',
+    defaultMessage: 'Insufficient Domain Funds',
+  },
+  description: {
+    id: 'dashboard.TaskFinalizeDialog.description',
+    defaultMessage: `The current domain does not have enough funds in it's pot,
+      in order to cover this task's payout`,
+  },
+});
+
+interface Props {
+  cancel: () => void;
+  close: () => void;
+}
+
+const TaskFinalizeDialog = ({ cancel, close }: Props) => (
+  <Dialog cancel={cancel}>
+    <DialogSection appearance={{ border: 'bottom' }}>
+      <Heading
+        appearance={{ size: 'medium', margin: 'none' }}
+        text={MSG.heading}
+      />
+    </DialogSection>
+    <DialogSection appearance={{ border: 'bottom' }}>
+      <FormattedMessage {...MSG.defaultText} />
+    </DialogSection>
+    <DialogSection appearance={{ align: 'right' }}>
+      <Button
+        appearance={{
+          theme: 'primary',
+          size: 'large',
+        }}
+        autoFocus
+        onClick={() => close()}
+        text={{ id: 'button.ok' }}
+      />
+    </DialogSection>
+  </Dialog>
+);
+
+export default TaskFinalizeDialog as FC<Props>;

--- a/src/modules/dashboard/components/TaskFinalize/TaskFinalizeDialog.tsx
+++ b/src/modules/dashboard/components/TaskFinalize/TaskFinalizeDialog.tsx
@@ -31,7 +31,7 @@ const TaskFinalizeDialog = ({ cancel, close }: Props) => (
       />
     </DialogSection>
     <DialogSection appearance={{ border: 'bottom' }}>
-      <FormattedMessage {...MSG.defaultText} />
+      <FormattedMessage {...MSG.description} />
     </DialogSection>
     <DialogSection appearance={{ align: 'right' }}>
       <Button

--- a/src/modules/dashboard/components/TaskFinalize/index.ts
+++ b/src/modules/dashboard/components/TaskFinalize/index.ts
@@ -1,1 +1,3 @@
 export { default } from './TaskFinalize';
+
+export { default as TaskFinalizeDialog } from './TaskFinalizeDialog';

--- a/src/modules/dashboard/components/TaskFinalize/index.ts
+++ b/src/modules/dashboard/components/TaskFinalize/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TaskFinalize';


### PR DESCRIPTION
## Description

This PR fixes the bad UX pattern where a task can be _finalized_ with a payout larger then available funds in the domain pot.

The user would be allowed to press _Finalize Task_, generate the transaction, sign it, but as expected, the transaction would fail _(with a rather cryptic error message)_

The fix for this implies calculating the that task payout relative to the domain pot balance, and in the funds are not sufficient, show a dialog informing the user of that fact, otherwise proceed as nromal.

**New stuff** 

- [x] `TaskFinalize` component
- [x] `TaskFinalizeDialog` dialog component

**Changes** 

- [x] Refactor `Task` to extract the finalize button into it's own component (`TaskFinalize`)
- [x] Fix `Task` to use the `ROOT_DOMAIN` constant, rather then the number `1`

**Demo**

![demo-prevent-insufficient-funds-payouts](https://user-images.githubusercontent.com/1193222/73943906-51d29300-48fa-11ea-9a25-2efb11f999af.gif)

Resolves #1952
Resolves #1997