### PR TITLE
Colony Community Tab

### DIFF
--- a/src/data/cacheUpdates.ts
+++ b/src/data/cacheUpdates.ts
@@ -259,7 +259,6 @@ const cacheUpdates = {
               address: subscribedUserWalletAddress,
             },
           });
-          // console.log(subscribedUserProfileFromCache);
           if (
             subscribedUserProfileFromCache &&
             subscribedUserProfileFromCache.user

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -6,7 +6,7 @@
     "role.disabled": "Disabled",
     "role.member": "Member",
     "role.admin": "Admin",
-    "role.owner": "Owner",
+    "role.founder": "Founder",
     "role.administration": "Administration",
     "role.arbitration": "Arbitration",
     "role.architecture": "Architecture",

--- a/src/modules/constants.ts
+++ b/src/modules/constants.ts
@@ -13,3 +13,9 @@ export enum ROLES {
   FUNDING = 'FUNDING',
   ADMINISTRATION = 'ADMINISTRATION',
 }
+
+export enum ROLES_COMMUNITY {
+  founder = 'role.founder',
+  admin = 'role.admin',
+  member = 'role.member',
+}

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
@@ -9,6 +9,7 @@ import BreadCrumb from '~core/BreadCrumb';
 import Heading from '~core/Heading';
 import { Tab, TabList, TabPanel, Tabs } from '~core/Tabs';
 import Suggestions from '~dashboard/Suggestions';
+import Community from '~dashboard/Community';
 import { useLoggedInUser } from '~data/helpers';
 import { useColonyFromNameQuery } from '~data/index';
 import LoadingTemplate from '~pages/LoadingTemplate';
@@ -41,6 +42,10 @@ const MSG = defineMessages({
     id: 'dashboard.ColonyHome.tabTransactions',
     defaultMessage: 'Transactions',
   },
+  tabCommunity: {
+    id: 'dashboard.ColonyHome.tabCommunity',
+    defaultMessage: 'Community',
+  },
   noFilter: {
     id: 'dashboard.ColonyHome.noFilter',
     defaultMessage: 'All Transactions in Colony',
@@ -50,6 +55,7 @@ const MSG = defineMessages({
 enum TabName {
   SuggestionsTab = 'suggestions',
   TasksTab = 'tasks',
+  CommunityTab = 'community',
   TransactionsTab = 'transactions',
 }
 
@@ -164,6 +170,9 @@ const ColonyHome = ({
             <Tab onClick={() => setActiveTab(TabName.SuggestionsTab)}>
               <FormattedMessage {...MSG.tabSuggestions} />
             </Tab>
+            <Tab onClick={() => setActiveTab(TabName.CommunityTab)}>
+              <FormattedMessage {...MSG.tabCommunity} />
+            </Tab>
             <Tab onClick={() => setActiveTab(TabName.TransactionsTab)}>
               <FormattedMessage {...MSG.tabTransactions} />
             </Tab>
@@ -182,6 +191,9 @@ const ColonyHome = ({
               colonyName={colony.colonyName}
               domainId={filteredDomainId}
             />
+          </TabPanel>
+          <TabPanel>
+            <Community colonyAddress={colony.colonyAddress} />
           </TabPanel>
           <TabPanel>
             <Transactions colonyAddress={colony.colonyAddress} />

--- a/src/modules/dashboard/components/ColonyHome/ColonyMeta/ColonySubscribe.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMeta/ColonySubscribe.tsx
@@ -11,6 +11,7 @@ import {
   useUnsubscribeFromColonyMutation,
   useUserColonyAddressesQuery,
   ColonySubscribedUsersDocument,
+  cacheUpdates,
 } from '~data/index';
 
 import styles from './ColonySubscribe.css';
@@ -57,12 +58,7 @@ const ColonySubscribe = ({ colonyAddress }: Props) => {
     { loading: loadingUnsubscribe },
   ] = useUnsubscribeFromColonyMutation({
     variables: { input: { colonyAddress } },
-    refetchQueries: [
-      {
-        query: ColonySubscribedUsersDocument,
-        variables: { colonyAddress },
-      },
-    ],
+    update: cacheUpdates.unsubscribeFromColony(colonyAddress),
   });
 
   if (!username || !data) return null;

--- a/src/modules/dashboard/components/ColonyHome/ColonyMeta/ColonySubscribe.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMeta/ColonySubscribe.tsx
@@ -10,6 +10,7 @@ import {
   useSubscribeToColonyMutation,
   useUnsubscribeFromColonyMutation,
   useUserColonyAddressesQuery,
+  ColonySubscribedUsersDocument,
 } from '~data/index';
 
 import styles from './ColonySubscribe.css';
@@ -44,12 +45,24 @@ const ColonySubscribe = ({ colonyAddress }: Props) => {
     { loading: loadingSubscribe },
   ] = useSubscribeToColonyMutation({
     variables: { input: { colonyAddress } },
+    refetchQueries: [
+      {
+        query: ColonySubscribedUsersDocument,
+        variables: { colonyAddress },
+      },
+    ],
   });
   const [
     unsubscribe,
     { loading: loadingUnsubscribe },
   ] = useUnsubscribeFromColonyMutation({
     variables: { input: { colonyAddress } },
+    refetchQueries: [
+      {
+        query: ColonySubscribedUsersDocument,
+        variables: { colonyAddress },
+      },
+    ],
   });
 
   if (!username || !data) return null;

--- a/src/modules/dashboard/components/ColonyHome/ColonyMeta/ColonySubscribe.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMeta/ColonySubscribe.tsx
@@ -10,7 +10,6 @@ import {
   useSubscribeToColonyMutation,
   useUnsubscribeFromColonyMutation,
   useUserColonyAddressesQuery,
-  ColonySubscribedUsersDocument,
   cacheUpdates,
 } from '~data/index';
 
@@ -46,12 +45,7 @@ const ColonySubscribe = ({ colonyAddress }: Props) => {
     { loading: loadingSubscribe },
   ] = useSubscribeToColonyMutation({
     variables: { input: { colonyAddress } },
-    refetchQueries: [
-      {
-        query: ColonySubscribedUsersDocument,
-        variables: { colonyAddress },
-      },
-    ],
+    update: cacheUpdates.subscribeToColony(colonyAddress),
   });
   const [
     unsubscribe,

--- a/src/modules/dashboard/components/Community/Community.css
+++ b/src/modules/dashboard/components/Community/Community.css
@@ -1,0 +1,12 @@
+.main {
+  margin-top: 20px;
+}
+
+.main table .tableBody {
+  overflow-y: auto;
+  overflow-x: none;
+}
+
+.main table .tableBody tr {
+  overflow-x: auto;
+}

--- a/src/modules/dashboard/components/Community/Community.css
+++ b/src/modules/dashboard/components/Community/Community.css
@@ -18,3 +18,54 @@
   font-weight: var(--weight-semi);
   white-space: nowrap;
 }
+
+.subscribeCallToAction {
+  margin-bottom: 20px;
+  color: var(--text-dark);
+}
+
+.subscribeButton {
+  padding: 0px;
+  border: none;
+  background-color: rgb(0, 0, 0, 0);
+  color: var(--sky-blue);
+  cursor: pointer;
+}
+
+.subscribedIcon, .unsubscribedIcon {
+  display: inline-block;
+  margin-right: 5px;
+
+  /*
+   * @NOTE Negative margins
+   * Better align subscription icon with the text
+   */
+  margin-bottom: -1px;
+  padding: 0;
+  height: 18px;
+  width: 18px;
+  position: relative;
+  vertical-align: bottom;
+  border: none;
+  border-radius: 100%;
+  font-size: 13px;
+  line-height: 100%;
+  color: white;
+  cursor: pointer;
+}
+
+.subscribedIcon::before, .unsubscribedIcon::before {
+  width: 100%;
+  position: absolute;
+  top: 2px;
+  left: 0;
+  content: '\2605';
+}
+
+.subscribedIcon {
+  background: var(--golden);
+}
+
+.unsubscribedIcon {
+  background-color: var(--grey-4);
+}

--- a/src/modules/dashboard/components/Community/Community.css
+++ b/src/modules/dashboard/components/Community/Community.css
@@ -54,7 +54,21 @@
   cursor: pointer;
 }
 
-.subscribedIcon::before, .unsubscribedIcon::before {
+.subscribedIcon::before {
+  width: 100%;
+  position: absolute;
+  top: 2px;
+  left: 3px;
+  content: '\2605';
+}
+
+.subscribedIcon {
+  margin-right: 2px;
+  margin-bottom: 2px;
+  background: var(--golden);
+}
+
+.unsubscribedIcon::before {
   width: 100%;
   position: absolute;
   top: 2px;
@@ -62,10 +76,6 @@
   content: '\2605';
 }
 
-.subscribedIcon {
-  background: var(--golden);
-}
-
 .unsubscribedIcon {
-  background-color: var(--grey-4);
+  background-color: var(--temp-grey-12);
 }

--- a/src/modules/dashboard/components/Community/Community.css
+++ b/src/modules/dashboard/components/Community/Community.css
@@ -10,3 +10,11 @@
 .main table .tableBody tr {
   overflow-x: auto;
 }
+
+.communityRole {
+  margin-left: auto;
+  padding: 0 30px;
+  font-size: var(--size-tiny);
+  font-weight: var(--weight-semi);
+  white-space: nowrap;
+}

--- a/src/modules/dashboard/components/Community/Community.css.d.ts
+++ b/src/modules/dashboard/components/Community/Community.css.d.ts
@@ -1,3 +1,7 @@
 export const main: string;
 export const tableBody: string;
 export const communityRole: string;
+export const subscribeCallToAction: string;
+export const subscribeButton: string;
+export const subscribedIcon: string;
+export const unsubscribedIcon: string;

--- a/src/modules/dashboard/components/Community/Community.css.d.ts
+++ b/src/modules/dashboard/components/Community/Community.css.d.ts
@@ -1,2 +1,3 @@
 export const main: string;
 export const tableBody: string;
+export const communityRole: string;

--- a/src/modules/dashboard/components/Community/Community.css.d.ts
+++ b/src/modules/dashboard/components/Community/Community.css.d.ts
@@ -1,0 +1,2 @@
+export const main: string;
+export const tableBody: string;

--- a/src/modules/dashboard/components/Community/Community.tsx
+++ b/src/modules/dashboard/components/Community/Community.tsx
@@ -7,7 +7,7 @@ import {
   useLoggedInUser,
   useUserColonyAddressesQuery,
   useSubscribeToColonyMutation,
-  ColonySubscribedUsersDocument,
+  cacheUpdates,
 } from '~data/index';
 import { domainsAndRolesFetcher } from '../../fetchers';
 import { getCommunityRoles } from '../../../transformers';
@@ -70,12 +70,7 @@ const Community = ({ colonyAddress }: Props) => {
     if (colonyAddress) {
       subscribeToColonyMutation({
         variables: { input: { colonyAddress } },
-        refetchQueries: [
-          {
-            query: ColonySubscribedUsersDocument,
-            variables: { colonyAddress },
-          },
-        ],
+        update: cacheUpdates.subscribeToColony(colonyAddress),
       });
       setJustSubscribed(true);
       setTimeout(() => setJustSubscribed(false), 3000);

--- a/src/modules/dashboard/components/Community/Community.tsx
+++ b/src/modules/dashboard/components/Community/Community.tsx
@@ -29,7 +29,10 @@ const MSG = defineMessages({
   },
   callToSubscribe: {
     id: 'dashboard.Community.callToSubscribe',
-    defaultMessage: `{action} to become a member of this colony.`,
+    defaultMessage: `{noMembers, select,
+      true {No members yet. {action} to become the first member of this colony.}
+      other {{action} to become a member of this colony.}
+    }`,
   },
   subscribe: {
     id: 'dashboard.Community.subscribe',
@@ -156,6 +159,7 @@ const Community = ({ colonyAddress }: Props) => {
           <FormattedMessage
             {...MSG.callToSubscribe}
             values={{
+              noMembers: !communityUsers.length,
               action: (
                 <Button
                   className={styles.subscribeButton}

--- a/src/modules/dashboard/components/Community/Community.tsx
+++ b/src/modules/dashboard/components/Community/Community.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback } from 'react';
+import React, { FC, useCallback, useState } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
 import { Address } from '~types/index';
@@ -46,6 +46,7 @@ interface Props {
 }
 
 const Community = ({ colonyAddress }: Props) => {
+  const [justSubscribed, setJustSubscribed] = useState<boolean>(false);
   const { walletAddress } = useLoggedInUser();
   const {
     data: currentUserSubscribedColonies,
@@ -73,8 +74,10 @@ const Community = ({ colonyAddress }: Props) => {
           },
         ],
       });
+      setJustSubscribed(true);
+      setTimeout(() => setJustSubscribed(false), 3000);
     }
-  }, [subscribeToColonyMutation, colonyAddress]);
+  }, [subscribeToColonyMutation, colonyAddress, setJustSubscribed]);
 
   const { data: domains, isFetching: isFetchingDomains } = useDataFetcher(
     domainsAndRolesFetcher,
@@ -166,6 +169,16 @@ const Community = ({ colonyAddress }: Props) => {
           />
         </div>
       )}
+      {justSubscribed && (
+        <div className={styles.subscribeCallToAction}>
+          <FormattedMessage
+            {...MSG.subscribedReward}
+            values={{
+              star: <span className={styles.subscribedIcon} />,
+            }}
+          />
+        </div>
+      )}
       <Table scrollable>
         <TableBody className={styles.tableBody}>
           {communityUsers.map(({ id: userAddress, communityRole }) => (
@@ -173,7 +186,6 @@ const Community = ({ colonyAddress }: Props) => {
               address={userAddress}
               key={userAddress}
               showDisplayName
-              showMaskedAddress
               showUsername
               showInfo={false}
             >

--- a/src/modules/dashboard/components/Community/Community.tsx
+++ b/src/modules/dashboard/components/Community/Community.tsx
@@ -1,0 +1,25 @@
+import React, { FC } from 'react';
+
+// import { Address } from '~types/index';
+
+// import { useDataFetcher } from '~utils/hooks';
+// import {
+//   colonyTransactionsFetcher,
+//   colonyUnclaimedTransactionsFetcher,
+// } from '../../fetchers';
+
+// import TransactionList from '~core/TransactionList';
+
+// import styles from './Transactions.css';
+
+// interface Props {
+//   colonyAddress: Address;
+// }
+
+const Community = () => {
+  return <div />;
+};
+
+Community.displayName = 'admin.Community';
+
+export default Community as FC<any>;

--- a/src/modules/dashboard/components/Community/Community.tsx
+++ b/src/modules/dashboard/components/Community/Community.tsx
@@ -48,6 +48,8 @@ interface Props {
   colonyAddress: Address;
 }
 
+const displayName = 'dashboard.Community';
+
 const Community = ({ colonyAddress }: Props) => {
   const [justSubscribed, setJustSubscribed] = useState<boolean>(false);
   const subscribedMessageTimer = useRef<any>(null);
@@ -214,6 +216,6 @@ const Community = ({ colonyAddress }: Props) => {
   );
 };
 
-Community.displayName = 'admin.Community';
+Community.displayName = displayName;
 
 export default Community as FC<Props>;

--- a/src/modules/dashboard/components/Community/Community.tsx
+++ b/src/modules/dashboard/components/Community/Community.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useState } from 'react';
+import React, { FC, useCallback, useState, useRef, useEffect } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
 import { Address } from '~types/index';
@@ -50,6 +50,7 @@ interface Props {
 
 const Community = ({ colonyAddress }: Props) => {
   const [justSubscribed, setJustSubscribed] = useState<boolean>(false);
+  const subscribedMessageTimer = useRef<any>(null);
   const { walletAddress } = useLoggedInUser();
   const {
     data: currentUserSubscribedColonies,
@@ -73,9 +74,21 @@ const Community = ({ colonyAddress }: Props) => {
         update: cacheUpdates.subscribeToColony(colonyAddress),
       });
       setJustSubscribed(true);
-      setTimeout(() => setJustSubscribed(false), 3000);
+      subscribedMessageTimer.current = setTimeout(
+        () => setJustSubscribed(false),
+        3000,
+      );
     }
   }, [subscribeToColonyMutation, colonyAddress, setJustSubscribed]);
+
+  /*
+   * We need to wrap the call in a second function, since only the returned
+   * function gets called on unmount.
+   * The first one is only called on render.
+   */
+  useEffect(() => () => clearTimeout(subscribedMessageTimer.current), [
+    subscribedMessageTimer,
+  ]);
 
   const { data: domains, isFetching: isFetchingDomains } = useDataFetcher(
     domainsAndRolesFetcher,

--- a/src/modules/dashboard/components/Community/Community.tsx
+++ b/src/modules/dashboard/components/Community/Community.tsx
@@ -48,10 +48,10 @@ interface Props {
   colonyAddress: Address;
 }
 
-enum ROLES {
-  FOUNDER = 'founder',
-  ADMIN = 'admin',
-  MEMBER = 'member',
+enum Roles {
+  Founder = 'founder',
+  Admin = 'admin',
+  Member = 'member',
 }
 
 const displayName = 'dashboard.Community';
@@ -131,14 +131,14 @@ const Community = ({ colonyAddress }: Props) => {
       const {
         profile: { walletAddress: userAddress },
       } = user;
-      let communityRole = ROLES.MEMBER;
+      let communityRole = Roles.Member;
       if (communityRoles.founder === userAddress) {
-        communityRole = ROLES.FOUNDER;
+        communityRole = Roles.Founder;
       }
       if (
         communityRoles.admins.find(adminAddress => adminAddress === userAddress)
       ) {
-        communityRole = ROLES.ADMIN;
+        communityRole = Roles.Admin;
       }
       return {
         ...user,
@@ -149,10 +149,10 @@ const Community = ({ colonyAddress }: Props) => {
       sortObjectsBy({
         name: 'communityRole',
         compareFn: role => {
-          if (role === ROLES.FOUNDER) {
+          if (role === Roles.Founder) {
             return -1;
           }
-          if (role === ROLES.MEMBER) {
+          if (role === Roles.Member) {
             return 1;
           }
           return 0;

--- a/src/modules/dashboard/components/Community/Community.tsx
+++ b/src/modules/dashboard/components/Community/Community.tsx
@@ -1,25 +1,71 @@
 import React, { FC } from 'react';
+import { defineMessages } from 'react-intl';
 
-// import { Address } from '~types/index';
+import { Address } from '~types/index';
+import { useColonySubscribedUsersQuery } from '~data/index';
 
-// import { useDataFetcher } from '~utils/hooks';
-// import {
-//   colonyTransactionsFetcher,
-//   colonyUnclaimedTransactionsFetcher,
-// } from '../../fetchers';
+import { Table, TableBody } from '~core/Table';
+import { SpinnerLoader } from '~core/Preloaders';
+import UserListItem from '~admin/UserListItem';
 
-// import TransactionList from '~core/TransactionList';
+import styles from './Community.css';
 
-// import styles from './Transactions.css';
+const MSG = defineMessages({
+  loading: {
+    id: 'dashboard.Community.loading',
+    defaultMessage: "Loading Colony's users...",
+  },
+});
 
-// interface Props {
-//   colonyAddress: Address;
-// }
+interface Props {
+  colonyAddress: Address;
+}
 
-const Community = () => {
-  return <div />;
+const Community = ({ colonyAddress }: Props) => {
+  const {
+    data: colonySubscribedUsers,
+    loading,
+  } = useColonySubscribedUsersQuery({
+    variables: {
+      colonyAddress,
+    },
+  });
+
+  if (!colonySubscribedUsers || loading) {
+    return (
+      <div className={styles.main}>
+        <SpinnerLoader
+          loadingText={MSG.loading}
+          appearance={{ size: 'massive', theme: 'primary' }}
+        />
+      </div>
+    );
+  }
+
+  const {
+    colony: { subscribedUsers },
+  } = colonySubscribedUsers;
+
+  return (
+    <div className={styles.main}>
+      <Table scrollable>
+        <TableBody className={styles.tableBody}>
+          {subscribedUsers.map(({ id: userAddress }) => (
+            <UserListItem
+              address={userAddress}
+              key={userAddress}
+              showDisplayName
+              showMaskedAddress
+              showUsername
+              showInfo={false}
+            />
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
 };
 
 Community.displayName = 'admin.Community';
 
-export default Community as FC<any>;
+export default Community as FC<Props>;

--- a/src/modules/dashboard/components/Community/Community.tsx
+++ b/src/modules/dashboard/components/Community/Community.tsx
@@ -48,6 +48,12 @@ interface Props {
   colonyAddress: Address;
 }
 
+enum ROLES {
+  FOUNDER = 'founder',
+  ADMIN = 'admin',
+  MEMBER = 'member',
+}
+
 const displayName = 'dashboard.Community';
 
 const Community = ({ colonyAddress }: Props) => {
@@ -125,14 +131,14 @@ const Community = ({ colonyAddress }: Props) => {
       const {
         profile: { walletAddress: userAddress },
       } = user;
-      let communityRole = 'member';
+      let communityRole = ROLES.MEMBER;
       if (communityRoles.founder === userAddress) {
-        communityRole = 'founder';
+        communityRole = ROLES.FOUNDER;
       }
       if (
         communityRoles.admins.find(adminAddress => adminAddress === userAddress)
       ) {
-        communityRole = 'admin';
+        communityRole = ROLES.ADMIN;
       }
       return {
         ...user,
@@ -143,10 +149,10 @@ const Community = ({ colonyAddress }: Props) => {
       sortObjectsBy({
         name: 'communityRole',
         compareFn: role => {
-          if (role === 'founder') {
+          if (role === ROLES.FOUNDER) {
             return -1;
           }
-          if (role === 'member') {
+          if (role === ROLES.MEMBER) {
             return 1;
           }
           return 0;

--- a/src/modules/dashboard/components/Community/index.ts
+++ b/src/modules/dashboard/components/Community/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Community';

--- a/src/modules/transformers.ts
+++ b/src/modules/transformers.ts
@@ -186,7 +186,7 @@ export const getCommunityRoles = (
       parseInt(domainId, 10),
       founder,
     );
-    currentDomainAdmins.map(adminAddress => admins.add(adminAddress));
+    return currentDomainAdmins.map(adminAddress => admins.add(adminAddress));
   });
   return {
     founder,

--- a/src/modules/transformers.ts
+++ b/src/modules/transformers.ts
@@ -159,11 +159,35 @@ const getLegacyAdmins = (
  * util can be removed once the DLP project is completed.
  */
 export const getLegacyRoles = (
-  domains,
+  domains: Record<string, DomainType>,
 ): { founder: Address; admins: Address[] } | void => {
   const rootDomainRoles = getDomainRoles(domains, ROOT_DOMAIN);
   const founder = getLegacyFounder(rootDomainRoles);
   const admins = getLegacyAdmins(domains, ROOT_DOMAIN, founder);
+  return {
+    founder,
+    admins: Array.from(admins) as string[],
+  };
+};
+
+/*
+ * @NOTE This differs from the above transformer as it considers roles in any domain (root + subdomains)
+ * to be an admin role
+ */
+export const getCommunityRoles = (
+  domains: Record<string, DomainType>,
+): { founder: Address; admins: Address[] } => {
+  const rootDomainRoles = getDomainRoles(domains, ROOT_DOMAIN);
+  const founder = getLegacyFounder(rootDomainRoles);
+  const admins = new Set();
+  Object.keys(domains).map(domainId => {
+    const currentDomainAdmins = getLegacyAdmins(
+      domains,
+      parseInt(domainId, 10),
+      founder,
+    );
+    currentDomainAdmins.map(adminAddress => admins.add(adminAddress));
+  });
   return {
     founder,
     admins: Array.from(admins) as string[],


### PR DESCRIPTION
## Description

This PR adds in a new Community tab to the colony home, which displays the list of users that are "members" of that colony (subscribed to), along with they're respective role.

Note: for the "Admin" role we consider a user with any form of permissions, be they in the root domain, or in any subdomain

**New stuff**

- [x] `Community` dashboard component

**Changes** 

- [x] `ColonyHome` add `Community` tab
- [x] `ColonySubscribe` refetch colony subscribers query
- [x]  `transformers` refactor for reusability
- [x]  `transformers` add `getCommunityRoles`

**Demo**

Community tab, subscribe / unsubscribe:
![demo-community-tab](https://user-images.githubusercontent.com/1193222/73984634-ca107700-4941-11ea-8de6-b2bf347db7c2.gif)

Community tab, empty state:
![demo-community-tab-empty](https://user-images.githubusercontent.com/1193222/73984646-d0065800-4941-11ea-80fb-f5aabcc048f4.gif)

Resolves #2022 
