### PR TITLE
Join/Leave Colony Copy Updates

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyMeta/ColonySubscribe.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMeta/ColonySubscribe.tsx
@@ -20,12 +20,12 @@ const MSG = defineMessages({
     id: 'dashboard.ColonyHome.ColonySubscribe.changingSubscription',
     defaultMessage: 'Please wait',
   },
-  subscribe: {
-    id: 'dashboard.ColonyHome.ColonySubscribe.subscribe',
+  join: {
+    id: 'dashboard.ColonyHome.ColonySubscribe.join',
     defaultMessage: 'Join the Colony',
   },
-  unsubscribe: {
-    id: 'dashboard.ColonyHome.ColonySubscribe.unsubscribe',
+  leave: {
+    id: 'dashboard.ColonyHome.ColonySubscribe.leave',
     defaultMessage: 'Leave the Colony',
   },
 });
@@ -75,9 +75,7 @@ const ColonySubscribe = ({ colonyAddress }: Props) => {
     <Tooltip
       content={
         <span>
-          <FormattedMessage
-            {...(isSubscribed ? MSG.unsubscribe : MSG.subscribe)}
-          />
+          <FormattedMessage {...(isSubscribed ? MSG.leave : MSG.join)} />
         </span>
       }
     >

--- a/src/modules/dashboard/components/ColonyHome/ColonyMeta/ColonySubscribe.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMeta/ColonySubscribe.tsx
@@ -22,11 +22,11 @@ const MSG = defineMessages({
   },
   subscribe: {
     id: 'dashboard.ColonyHome.ColonySubscribe.subscribe',
-    defaultMessage: 'Add to My Colonies',
+    defaultMessage: 'Join the Colony',
   },
   unsubscribe: {
     id: 'dashboard.ColonyHome.ColonySubscribe.unsubscribe',
-    defaultMessage: 'Remove from My Colonies',
+    defaultMessage: 'Leave the Colony',
   },
 });
 

--- a/src/modules/dashboard/components/Community/Community.tsx
+++ b/src/modules/dashboard/components/Community/Community.tsx
@@ -27,19 +27,19 @@ const MSG = defineMessages({
     id: 'dashboard.Community.loading',
     defaultMessage: "Loading Colony's users...",
   },
-  callToSubscribe: {
-    id: 'dashboard.Community.callToSubscribe',
+  callToJoin: {
+    id: 'dashboard.Community.callToJoin',
     defaultMessage: `{noMembers, select,
       true {No members yet. {action} to become the first member of this colony.}
       other {{action} to become a member of this colony.}
     }`,
   },
-  subscribe: {
-    id: 'dashboard.Community.subscribe',
+  join: {
+    id: 'dashboard.Community.join',
     defaultMessage: `Join now`,
   },
-  subscribedReward: {
-    id: 'dashboard.Community.subscribedReward',
+  joined: {
+    id: 'dashboard.Community.joined',
     defaultMessage: `{star} Joined!`,
   },
 });
@@ -173,7 +173,7 @@ const Community = ({ colonyAddress }: Props) => {
       {currentUserSubscribedColonies && !isSubscribed && (
         <div className={styles.subscribeCallToAction}>
           <FormattedMessage
-            {...MSG.callToSubscribe}
+            {...MSG.callToJoin}
             values={{
               noMembers: !communityUsers.length,
               action: (
@@ -182,7 +182,7 @@ const Community = ({ colonyAddress }: Props) => {
                   onClick={subscribeToColony}
                 >
                   <span className={styles.unsubscribedIcon} />
-                  <FormattedMessage {...MSG.subscribe} />
+                  <FormattedMessage {...MSG.join} />
                 </Button>
               ),
             }}
@@ -192,7 +192,7 @@ const Community = ({ colonyAddress }: Props) => {
       {justSubscribed && (
         <div className={styles.subscribeCallToAction}>
           <FormattedMessage
-            {...MSG.subscribedReward}
+            {...MSG.joined}
             values={{
               star: <span className={styles.subscribedIcon} />,
             }}

--- a/src/modules/dashboard/components/Community/Community.tsx
+++ b/src/modules/dashboard/components/Community/Community.tsx
@@ -36,11 +36,11 @@ const MSG = defineMessages({
   },
   subscribe: {
     id: 'dashboard.Community.subscribe',
-    defaultMessage: `Subscribe now`,
+    defaultMessage: `Join now`,
   },
   subscribedReward: {
     id: 'dashboard.Community.subscribedReward',
-    defaultMessage: `{star} Subscribed!`,
+    defaultMessage: `{star} Joined!`,
   },
 });
 

--- a/src/modules/dashboard/components/TaskList/TaskList.tsx
+++ b/src/modules/dashboard/components/TaskList/TaskList.tsx
@@ -34,13 +34,9 @@ const MSG = defineMessages({
     defaultMessage: `It looks like you don't have any tasks.
       Visit your colonies to find a task to work on.`,
   },
-  subscribe: {
-    id: 'dashboard.TaskList.subscribe',
-    defaultMessage: 'Subscribe to Colony',
-  },
-  myColonies: {
-    id: 'dashboard.TaskList.myColonies',
-    defaultMessage: 'My Colonies',
+  colonyToJoin: {
+    id: 'dashboard.TaskList.colonyToJoin',
+    defaultMessage: 'Colony',
   },
   noTaskDescription: {
     id: 'dashboard.TaskList.noTaskDescription',
@@ -57,12 +53,12 @@ const MSG = defineMessages({
       other {the Colony}
     }!`,
   },
-  subscribeToColony: {
-    id: 'dashboard.TaskList.subscribeToColony',
+  joinColony: {
+    id: 'dashboard.TaskList.joinColony',
     defaultMessage: `It looks like there are no open tasks right now.
-      {isSubscribed, select,
+      {hasJoined, select,
         true {}
-        false {Add this colony to {myColonies},
+        false {Join the {colonyToJoin},
           grab a coffee, and check again later.}}`,
   },
 });
@@ -165,7 +161,7 @@ const TaskList = ({
     variables: { address: walletAddress },
   });
 
-  const isSubscribed =
+  const hasJoined =
     typeof colonyAddress == 'string' &&
     userData &&
     userData.user &&
@@ -231,19 +227,22 @@ const TaskList = ({
               <div className={taskListItemStyles.emptyStateElements}>
                 <FormattedMessage
                   tagName="p"
-                  {...MSG.subscribeToColony}
+                  {...MSG.joinColony}
                   values={{
                     /*
                      * If the current user hasn't claimed a profile yet, then don't show the
                      * subscribe to colony call to action
                      */
-                    isSubscribed: username ? isSubscribed : true,
-                    myColonies: (
+                    hasJoined: username ? hasJoined : true,
+                    colonyToJoin: (
                       <Button
                         className={taskListItemStyles.subscribe}
                         onClick={subscribeToColony}
                       >
-                        <FormattedMessage tagName="span" {...MSG.myColonies} />
+                        <FormattedMessage
+                          tagName="span"
+                          {...MSG.colonyToJoin}
+                        />
                       </Button>
                     ),
                   }}

--- a/src/modules/users/components/UserProfile/UserColonies.tsx
+++ b/src/modules/users/components/UserProfile/UserColonies.tsx
@@ -20,11 +20,11 @@ interface Props {
 const MSG = defineMessages({
   currentUserNoColonies: {
     id: 'users.UserProfile.UserColonies.currentUserNoColonies',
-    defaultMessage: `It looks like you're not subscribed to any Colonies yet. You’ll need an invite link to join one. Ask your community for a link or {createColonyLink}.`,
+    defaultMessage: `It looks like you have not joined any Colonies yet. You’ll need an invite link to join one. Ask your community for a link or {createColonyLink}.`,
   },
   otherUserNoColonies: {
     id: 'users.UserProfile.UserColonies.otherUserNoColonies',
-    defaultMessage: `It looks like {friendlyUsername} isn't subscribed to any Colonies yet. You’ll might want to send them an invite link from a Colony you're part of.`,
+    defaultMessage: `It looks like {friendlyUsername} hasn't joined any Colonies yet. You’ll might want to send them an invite link from a Colony you're part of.`,
   },
   createColonyLink: {
     id: 'users.UserProfile.UserColonies.createColonyLink',


### PR DESCRIPTION
## Description

This PR changes all instances where we refer to "subscribing" to a colony to be "join"-ing a colony.

For this, we've updated all message descriptions text and in some cases the message descriptor id itself.

Note, that there's a further thing that can be done here, rename a component, from `ColonySubscribe` to `ColonyJoin`, but that is outside the scope of this PR

**Changes**

- [x] `ColonySubscribe` copy and message descriptors id names
- [x] `Community` copy and message descriptors id names
- [x] `TaskList` copy, message descriptors id names, and minor logic
- [x] `UserColonies` copy

**Screenshots**

![Screenshot from 2020-02-12 17-46-01](https://user-images.githubusercontent.com/1193222/74351353-b0e34c80-4dbf-11ea-90a2-752b52d92e59.png)
![Screenshot from 2020-02-12 17-46-04](https://user-images.githubusercontent.com/1193222/74351360-b17be300-4dbf-11ea-9848-abd4aed009b4.png)


Resolves #2034 