### PR TITLE
InfoPopover Display Token Data

### DIFF
--- a/src/modules/core/components/InfoPopover/InfoPopover.css
+++ b/src/modules/core/components/InfoPopover/InfoPopover.css
@@ -11,6 +11,23 @@
   color: var(--colony-black);
 }
 
+/*
+ * @NOTE Directly adding element styles
+ * This is because we needed to create a super-custom, super-small size for the icon
+ * Using our image sizing logic, this would have been: `xxxxs`
+ */
+.displayName div {
+  display: inline-block;
+  margin-right: 8px;
+  height: 12px;
+  width: 12px;
+}
+
+.displayName figure {
+  margin-right: 2px;
+  vertical-align: bottom;
+}
+
 .userName {
   composes: inlineEllipsis from '~styles/text.css';
   margin: 0 0 6px 0;
@@ -37,6 +54,10 @@
 }
 
 .etherscanDivider {
+  /*
+   * @NOTE Negative Margins
+   * This is be able to extend the border divider past the container's margin constraints
+   */
   margin: 10px -10px 0 -10px;
   padding: 12px 0 0 10px;
   border-top: 1px solid var(--temp-grey-5);

--- a/src/modules/core/components/InfoPopover/InfoPopover.css
+++ b/src/modules/core/components/InfoPopover/InfoPopover.css
@@ -24,3 +24,10 @@
 .address button {
   height: auto;
 }
+
+.symbol {
+  composes: inlineEllipsis from '~styles/text.css';
+  margin: 0 0 6px 0;
+  font-weight: var(--weight-medium);
+  color: var(--pink);
+}

--- a/src/modules/core/components/InfoPopover/InfoPopover.css
+++ b/src/modules/core/components/InfoPopover/InfoPopover.css
@@ -31,3 +31,13 @@
   font-weight: var(--weight-medium);
   color: var(--pink);
 }
+
+.nativeTokenMessage {
+  margin-top: 6px;
+}
+
+.etherscanDivider {
+  margin: 10px -10px 0 -10px;
+  padding: 12px 0 0 10px;
+  border-top: 1px solid var(--temp-grey-5);
+}

--- a/src/modules/core/components/InfoPopover/InfoPopover.css.d.ts
+++ b/src/modules/core/components/InfoPopover/InfoPopover.css.d.ts
@@ -3,3 +3,5 @@ export const displayName: string;
 export const userName: string;
 export const address: string;
 export const symbol: string;
+export const nativeTokenMessage: string;
+export const etherscanDivider: string;

--- a/src/modules/core/components/InfoPopover/InfoPopover.css.d.ts
+++ b/src/modules/core/components/InfoPopover/InfoPopover.css.d.ts
@@ -2,3 +2,4 @@ export const main: string;
 export const displayName: string;
 export const userName: string;
 export const address: string;
+export const symbol: string;

--- a/src/modules/core/components/InfoPopover/InfoPopover.tsx
+++ b/src/modules/core/components/InfoPopover/InfoPopover.tsx
@@ -15,7 +15,7 @@ interface Props {
   /** Children elemnts or components to wrap the tooltip around */
   children?: ReactNode;
   /** The address */
-  user: AnyUser;
+  user?: AnyUser;
   /** How the popover gets triggered */
   trigger?: 'hover' | 'click' | 'disabled';
 }
@@ -26,7 +26,7 @@ interface TooltipProps {
   walletAddress: Address;
 }
 
-const renderTooltipContent = ({
+const userTooltipContent = ({
   displayName,
   username,
   walletAddress,
@@ -48,16 +48,23 @@ const renderTooltipContent = ({
   </div>
 );
 
+const conditionallyRenderContent = (user: AnyUser) => {
+  if (user) {
+    const { displayName, username, walletAddress } = user.profile;
+    return userTooltipContent({
+      displayName,
+      username,
+      walletAddress,
+    });
+  }
+  return null;
+};
+
 const InfoPopover = ({ user, children, trigger = 'click' }: Props) => {
-  const { displayName, username, walletAddress } = user.profile;
   return (
     <Tooltip
-      content={renderTooltipContent({
-        displayName,
-        username,
-        walletAddress,
-      })}
-      trigger={trigger}
+      content={conditionallyRenderContent(user)}
+      trigger={user ? trigger : 'disabled'}
       darkTheme={false}
     >
       {children}

--- a/src/modules/core/components/InfoPopover/InfoPopover.tsx
+++ b/src/modules/core/components/InfoPopover/InfoPopover.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
 
 import { Address } from '~types/index';
 import { AnyUser, AnyToken } from '~data/index';
@@ -6,10 +7,20 @@ import { AnyUser, AnyToken } from '~data/index';
 import { Tooltip } from '~core/Popover';
 import UserMention from '~core/UserMention';
 import CopyableAddress from '~core/CopyableAddress';
+import TokenLink from '~core/TokenLink';
 
 import styles from './InfoPopover.css';
 
-const componentDisplayName = 'InfoPopover';
+const MSG = defineMessages({
+  nativeTokenMessage: {
+    id: 'InfoPopover.nativeTokenMessage',
+    defaultMessage: "*This is the colony's native token",
+  },
+  viewOnEtherscan: {
+    id: 'InfoPopover.viewOnEtherscan',
+    defaultMessage: 'View on Etherscan',
+  },
+});
 
 interface Props {
   /** Children elemnts or components to wrap the tooltip around */
@@ -36,7 +47,7 @@ interface Props {
 interface ConditionalTooltipProps {
   user?: AnyUser;
   token?: AnyToken;
-  isTokenNative?: boolean;
+  isTokenNative: boolean;
 }
 
 interface UserTooltipProps {
@@ -51,6 +62,8 @@ interface TokenTooltipProps {
   address: Address;
   isTokenNative: boolean;
 }
+
+const componentDisplayName = 'InfoPopover';
 
 const userTooltipContent = ({
   displayName,
@@ -94,6 +107,14 @@ const tokenTooltipContent = ({
     <div title={address} className={styles.address}>
       <CopyableAddress full>{address}</CopyableAddress>
     </div>
+    {isTokenNative && (
+      <p className={styles.nativeTokenMessage}>
+        <FormattedMessage {...MSG.nativeTokenMessage} />
+      </p>
+    )}
+    <div className={styles.etherscanDivider}>
+      <TokenLink tokenAddress={address} text={MSG.viewOnEtherscan} />
+    </div>
   </div>
 );
 
@@ -112,8 +133,8 @@ const conditionallyRenderContent = ({
   }
   if (token) {
     const { name, symbol, address } = token;
-    console.log(token);
-    console.log(isTokenNative);
+    // console.log(token);
+    // console.log(isTokenNative);
     return tokenTooltipContent({
       name,
       symbol,

--- a/src/modules/core/components/InfoPopover/InfoPopover.tsx
+++ b/src/modules/core/components/InfoPopover/InfoPopover.tsx
@@ -8,6 +8,7 @@ import { Tooltip } from '~core/Popover';
 import UserMention from '~core/UserMention';
 import CopyableAddress from '~core/CopyableAddress';
 import TokenLink from '~core/TokenLink';
+import TokenIcon from '~dashboard/HookedTokenIcon';
 
 import styles from './InfoPopover.css';
 
@@ -87,36 +88,35 @@ const userTooltipContent = ({
   </div>
 );
 
-const tokenTooltipContent = ({
-  name,
-  symbol,
-  address,
-  isTokenNative,
-}: TokenTooltipProps) => (
-  <div className={styles.main}>
-    {name && (
-      <p title={name} className={styles.displayName}>
-        {name}
-      </p>
-    )}
-    {symbol && (
-      <p title={symbol} className={styles.symbol}>
-        {symbol}
-      </p>
-    )}
-    <div title={address} className={styles.address}>
-      <CopyableAddress full>{address}</CopyableAddress>
+const tokenTooltipContent = (token: AnyToken, isTokenNative: boolean) => {
+  const { name, symbol, address } = token;
+  return (
+    <div className={styles.main}>
+      {name && (
+        <div title={name} className={styles.displayName}>
+          <TokenIcon token={token} name={token.name || undefined} size="xxs" />
+          {name}
+        </div>
+      )}
+      {symbol && (
+        <p title={symbol} className={styles.symbol}>
+          {symbol}
+        </p>
+      )}
+      <div title={address} className={styles.address}>
+        <CopyableAddress full>{address}</CopyableAddress>
+      </div>
+      {isTokenNative && (
+        <p className={styles.nativeTokenMessage}>
+          <FormattedMessage {...MSG.nativeTokenMessage} />
+        </p>
+      )}
+      <div className={styles.etherscanDivider}>
+        <TokenLink tokenAddress={address} text={MSG.viewOnEtherscan} />
+      </div>
     </div>
-    {isTokenNative && (
-      <p className={styles.nativeTokenMessage}>
-        <FormattedMessage {...MSG.nativeTokenMessage} />
-      </p>
-    )}
-    <div className={styles.etherscanDivider}>
-      <TokenLink tokenAddress={address} text={MSG.viewOnEtherscan} />
-    </div>
-  </div>
-);
+  );
+};
 
 const conditionallyRenderContent = ({
   user,
@@ -132,15 +132,7 @@ const conditionallyRenderContent = ({
     });
   }
   if (token) {
-    const { name, symbol, address } = token;
-    // console.log(token);
-    // console.log(isTokenNative);
-    return tokenTooltipContent({
-      name,
-      symbol,
-      address,
-      isTokenNative,
-    });
+    return tokenTooltipContent(token, isTokenNative);
   }
   return null;
 };

--- a/src/modules/core/components/InfoPopover/InfoPopover.tsx
+++ b/src/modules/core/components/InfoPopover/InfoPopover.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react';
 
 import { Address } from '~types/index';
-import { AnyUser } from '~data/index';
+import { AnyUser, AnyToken } from '~data/index';
 
 import { Tooltip } from '~core/Popover';
 import UserMention from '~core/UserMention';
@@ -14,23 +14,49 @@ const componentDisplayName = 'InfoPopover';
 interface Props {
   /** Children elemnts or components to wrap the tooltip around */
   children?: ReactNode;
-  /** The address */
+  /** The complete user object, optional */
   user?: AnyUser;
+  /** The complete token object, optional */
+  token?: AnyToken;
+  /** Used in conjuction with `token` to be able to display a user message informing that we're dealing with a native token */
+  /*
+   * @NOTE This is used because we don't really (and can't really) have a proper method to check if a token is native or not
+   *
+   * One way to do it, would be to create a query that looks through all the colonies and see if the current token is listed
+   * as a native token for that colony
+   *
+   * I opted for the alternative, since all the instances we wish to display this we already have the colony data, and we can
+   * just check for this
+   */
+  isTokenNative?: boolean;
   /** How the popover gets triggered */
   trigger?: 'hover' | 'click' | 'disabled';
 }
 
-interface TooltipProps {
+interface ConditionalTooltipProps {
+  user?: AnyUser;
+  token?: AnyToken;
+  isTokenNative?: boolean;
+}
+
+interface UserTooltipProps {
   displayName?: string | null;
   username?: string | null;
   walletAddress: Address;
+}
+
+interface TokenTooltipProps {
+  name?: string | null;
+  symbol?: string | null;
+  address: Address;
+  isTokenNative: boolean;
 }
 
 const userTooltipContent = ({
   displayName,
   username,
   walletAddress,
-}: TooltipProps) => (
+}: UserTooltipProps) => (
   <div className={styles.main}>
     {displayName && (
       <p title={displayName} className={styles.displayName}>
@@ -48,7 +74,34 @@ const userTooltipContent = ({
   </div>
 );
 
-const conditionallyRenderContent = (user: AnyUser) => {
+const tokenTooltipContent = ({
+  name,
+  symbol,
+  address,
+  isTokenNative,
+}: TokenTooltipProps) => (
+  <div className={styles.main}>
+    {name && (
+      <p title={name} className={styles.displayName}>
+        {name}
+      </p>
+    )}
+    {symbol && (
+      <p title={symbol} className={styles.symbol}>
+        {symbol}
+      </p>
+    )}
+    <div title={address} className={styles.address}>
+      <CopyableAddress full>{address}</CopyableAddress>
+    </div>
+  </div>
+);
+
+const conditionallyRenderContent = ({
+  user,
+  token,
+  isTokenNative,
+}: ConditionalTooltipProps) => {
   if (user) {
     const { displayName, username, walletAddress } = user.profile;
     return userTooltipContent({
@@ -57,14 +110,31 @@ const conditionallyRenderContent = (user: AnyUser) => {
       walletAddress,
     });
   }
+  if (token) {
+    const { name, symbol, address } = token;
+    console.log(token);
+    console.log(isTokenNative);
+    return tokenTooltipContent({
+      name,
+      symbol,
+      address,
+      isTokenNative,
+    });
+  }
   return null;
 };
 
-const InfoPopover = ({ user, children, trigger = 'click' }: Props) => {
+const InfoPopover = ({
+  user,
+  token,
+  isTokenNative = false,
+  children,
+  trigger = 'click',
+}: Props) => {
   return (
     <Tooltip
-      content={conditionallyRenderContent(user)}
-      trigger={user ? trigger : 'disabled'}
+      content={conditionallyRenderContent({ user, token, isTokenNative })}
+      trigger={user || token ? trigger : 'disabled'}
       darkTheme={false}
     >
       {children}

--- a/src/modules/core/components/PayoutsList/PayoutsList.css
+++ b/src/modules/core/components/PayoutsList/PayoutsList.css
@@ -25,3 +25,13 @@
 .native {
   color: var(--violet);
 }
+
+.tokenInfo {
+  font-weight: normal;
+  text-align: left;
+  cursor: pointer;
+}
+
+.tokenPayout {
+  font-weight: var(--weight-semi);
+}

--- a/src/modules/core/components/PayoutsList/PayoutsList.css.d.ts
+++ b/src/modules/core/components/PayoutsList/PayoutsList.css.d.ts
@@ -3,3 +3,5 @@ export const payoutNumber: string;
 export const popoverContent: string;
 export const payoutPopover: string;
 export const native: string;
+export const tokenInfo: string;
+export const tokenPayout: string;

--- a/src/modules/core/components/PayoutsList/PayoutsList.tsx
+++ b/src/modules/core/components/PayoutsList/PayoutsList.tsx
@@ -3,6 +3,7 @@ import { defineMessages, FormattedMessage, FormattedNumber } from 'react-intl';
 import cx from 'classnames';
 import BigNumber from 'bn.js';
 import moveDecimal from 'move-decimal-point';
+import InfoPopover from '~core/InfoPopover';
 
 import { DEFAULT_TOKEN_DECIMALS } from '~constants';
 import { Payouts } from '~data/index';
@@ -59,15 +60,25 @@ const PayoutsList = ({ maxLines = 1, nativeTokenAddress, payouts }: Props) => {
     <div className={styles.main}>
       <div>
         {firstPayouts.map(({ amount, token }) => (
-          <Numeral
-            className={cx(styles.payoutNumber, {
-              [styles.native]: token.address === nativeTokenAddress,
-            })}
-            key={token.address}
-            suffix={` ${token.symbol} `}
-            unit={DEFAULT_TOKEN_DECIMALS}
-            value={new BigNumber(moveDecimal(amount, token.decimals || 18))}
-          />
+          <div key={token.address} className={styles.tokenInfo}>
+            <InfoPopover
+              token={token}
+              isTokenNative={token.address === nativeTokenAddress}
+            >
+              <div className={styles.tokenPayout}>
+                <Numeral
+                  className={cx(styles.payoutNumber, {
+                    [styles.native]: token.address === nativeTokenAddress,
+                  })}
+                  suffix={` ${token.symbol} `}
+                  unit={DEFAULT_TOKEN_DECIMALS}
+                  value={
+                    new BigNumber(moveDecimal(amount, token.decimals || 18))
+                  }
+                />
+              </div>
+            </InfoPopover>
+          </div>
         ))}
       </div>
       {extraPayouts && extraPayouts.length ? (

--- a/src/modules/core/components/TokenLink/TokenLink.md
+++ b/src/modules/core/components/TokenLink/TokenLink.md
@@ -1,0 +1,16 @@
+Link to Etherscan to provide extra information about a particular token.
+
+### Normal Token link
+
+```jsx
+<TokenLink tokenAddress="0xcBA6e1D695fe0A4078A884902D3aAa32c60Ad18E" />
+```
+
+### Token link with custom text
+
+```jsx
+<TokenLink
+  tokenAddress="0xcBA6e1D695fe0A4078A884902D3aAa32c60Ad18E"
+  text="View this token on Etherscan"
+/>
+```

--- a/src/modules/core/components/TokenLink/TokenLink.tsx
+++ b/src/modules/core/components/TokenLink/TokenLink.tsx
@@ -1,0 +1,51 @@
+import { MessageDescriptor, MessageValues } from 'react-intl';
+import React from 'react';
+
+import { DEFAULT_NETWORK } from '~constants';
+import ExternalLink from '~core/ExternalLink';
+import { getEtherscanLink } from '~utils/external';
+
+interface Props {
+  /*
+   * Allows for link style customization (Eg: we need to disquise the link as a button)
+   * Don't abuse it!
+   */
+  className?: string;
+
+  /** Address of the token to link to */
+  tokenAddress: string;
+
+  /** Optionally override current network */
+  network?: string;
+
+  /** A string or a `messageDescriptor` that make up the link's text. Defaults to `tokenAddress`. */
+  text?: MessageDescriptor | string;
+
+  /** Values for text (react-intl interpolation) */
+  textValues?: MessageValues;
+}
+
+const displayName = 'TokenLink';
+
+const TokenLink = ({
+  className,
+  tokenAddress,
+  network = DEFAULT_NETWORK,
+  text,
+  textValues,
+}: Props) => (
+  <ExternalLink
+    className={className}
+    href={getEtherscanLink({
+      network,
+      linkType: 'token',
+      addressOrHash: tokenAddress,
+    })}
+    text={text || tokenAddress}
+    textValues={textValues}
+  />
+);
+
+TokenLink.displayName = displayName;
+
+export default TokenLink;

--- a/src/modules/core/components/TokenLink/index.ts
+++ b/src/modules/core/components/TokenLink/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TokenLink';

--- a/src/modules/core/components/TransactionLink/TransactionLink.tsx
+++ b/src/modules/core/components/TransactionLink/TransactionLink.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import { DEFAULT_NETWORK } from '~constants';
 import ExternalLink from '~core/ExternalLink';
+import { getEtherscanLink } from '~utils/external';
 
 interface Props {
   /*
@@ -32,21 +33,18 @@ const TransactionLink = ({
   network = DEFAULT_NETWORK,
   text,
   textValues,
-}: Props) => {
-  const linkText = text || hash;
-  const tld = network === 'tobalaba' ? 'com' : 'io';
-  const networkSubdomain =
-    network === 'homestead' || network === 'mainnet' ? '' : `${network}.`;
-  const href = `https://${networkSubdomain}etherscan.${tld}/tx/${hash}`;
-  return (
-    <ExternalLink
-      className={className}
-      href={href}
-      text={linkText}
-      textValues={textValues}
-    />
-  );
-};
+}: Props) => (
+  <ExternalLink
+    className={className}
+    href={getEtherscanLink({
+      network,
+      linkType: 'tx',
+      addressOrHash: hash,
+    })}
+    text={text || hash}
+    textValues={textValues}
+  />
+);
 
 TransactionLink.displayName = displayName;
 

--- a/src/modules/core/components/WalletLink/WalletLink.tsx
+++ b/src/modules/core/components/WalletLink/WalletLink.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import { DEFAULT_NETWORK } from '~constants';
 import ExternalLink from '~core/ExternalLink';
+import { getEtherscanLink } from '~utils/external';
 
 interface Props {
   /*
@@ -32,22 +33,18 @@ const WalletLink = ({
   network = DEFAULT_NETWORK,
   text,
   textValues,
-}: Props) => {
-  const linkText = text || walletAddress;
-  const tld = network === 'tobalaba' ? 'com' : 'io';
-  const networkSubdomain =
-    network === 'homestead' || network === 'mainnet' ? '' : `${network}.`;
-  // eslint-disable-next-line max-len
-  const href = `https://${networkSubdomain}etherscan.${tld}/address/${walletAddress}`;
-  return (
-    <ExternalLink
-      className={className}
-      href={href}
-      text={linkText}
-      textValues={textValues}
-    />
-  );
-};
+}: Props) => (
+  <ExternalLink
+    className={className}
+    href={getEtherscanLink({
+      network,
+      linkType: 'address',
+      addressOrHash: walletAddress,
+    })}
+    text={text || walletAddress}
+    textValues={textValues}
+  />
+);
 
 WalletLink.displayName = displayName;
 

--- a/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.css
@@ -1,3 +1,8 @@
 .fundingButton {
   margin-left: 30px;
 }
+
+.tokenBalance {
+  display: inline-block;
+  cursor: pointer;
+}

--- a/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.css.d.ts
+++ b/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.css.d.ts
@@ -1,1 +1,2 @@
 export const fundingButton: string;
+export const tokenBalance: string;

--- a/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.tsx
@@ -6,6 +6,7 @@ import Button from '~core/Button';
 import { DialogType } from '~core/Dialog';
 import withDialog from '~core/Dialog/withDialog';
 import Heading from '~core/Heading';
+import InfoPopover from '~core/InfoPopover';
 import { DomainsMapType } from '~types/index';
 import {
   useLoggedInUser,
@@ -54,7 +55,7 @@ const ColonyFunding = ({
     [walletAddress, domains],
   );
 
-  const { colonyAddress, tokens: colonyTokens } = colony;
+  const { colonyAddress, tokens: colonyTokens, nativeTokenAddress } = colony;
 
   const handleMoveTokens = useCallback(
     () =>
@@ -96,11 +97,16 @@ const ColonyFunding = ({
       {data && !isLoadingTokenBalances ? (
         <ul>
           {data.tokens.map(token => (
-            <TokenItem
-              currentDomainId={currentDomainId}
-              key={token.address}
-              token={token}
-            />
+            <li key={token.address}>
+              <InfoPopover
+                token={token}
+                isTokenNative={token.address === nativeTokenAddress}
+              >
+                <div className={styles.tokenBalance}>
+                  <TokenItem currentDomainId={currentDomainId} token={token} />
+                </div>
+              </InfoPopover>
+            </li>
           ))}
         </ul>
       ) : (

--- a/src/modules/dashboard/components/ColonyHome/ColonyFunding/TokenItem.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyFunding/TokenItem.tsx
@@ -19,9 +19,7 @@ const TokenItem = ({
   );
   const balance = domainBalance && domainBalance.amount;
   return typeof balance === 'undefined' ? null : (
-    <li>
-      <Numeral unit={decimals || 18} value={balance} suffix={` ${symbol}`} />
-    </li>
+    <Numeral unit={decimals || 18} value={balance} suffix={` ${symbol}`} />
   );
 };
 

--- a/src/modules/dashboard/components/TaskFeed/TaskFeed.tsx
+++ b/src/modules/dashboard/components/TaskFeed/TaskFeed.tsx
@@ -103,6 +103,7 @@ const TaskFeed = ({ colonyAddress, draftId }: Props) => {
                     return (
                       <Fragment key={sourceId}>
                         <TaskFeedCompleteInfo
+                          colonyAddress={colonyAddress}
                           payouts={payouts}
                           finalizedAt={finalizedAt}
                           finalizedPayment={finalizedPayment}

--- a/src/modules/dashboard/components/TaskFeed/TaskFeedCompleteInfo.css
+++ b/src/modules/dashboard/components/TaskFeed/TaskFeedCompleteInfo.css
@@ -37,3 +37,7 @@
   color: var(--colony-blue);
   letter-spacing: var(--spacing-medium);
 }
+
+.tokenInfo {
+  cursor: pointer;
+}

--- a/src/modules/dashboard/components/TaskFeed/TaskFeedCompleteInfo.css.d.ts
+++ b/src/modules/dashboard/components/TaskFeed/TaskFeedCompleteInfo.css.d.ts
@@ -5,3 +5,4 @@ export const receiptContainer: string;
 export const receiptSideBorder: string;
 export const receiptTextBlock: string;
 export const receiptLink: string;
+export const tokenInfo: string;

--- a/src/modules/dashboard/components/TaskFeed/TaskFeedCompleteInfo.tsx
+++ b/src/modules/dashboard/components/TaskFeed/TaskFeedCompleteInfo.tsx
@@ -74,9 +74,9 @@ const TaskFeedCompleteInfo = ({
   const { data: colonyData, loading: isLoadingColony } = useColonyQuery({
     variables: { address: colonyAddress },
   });
-  const { decimals = 18, symbol = '', address } =
+  const { decimals = 18, symbol = '', address = '' } =
     (tokenData && tokenData.token) || {};
-  const { nativeTokenAddress } = (colonyData && colonyData.colony) || {};
+  const { nativeTokenAddress = '' } = (colonyData && colonyData.colony) || {};
   const metaColonyFee = new BigNumber(
     moveDecimal(fullPayoutAmount, decimals),
   ).sub(new BigNumber(amount));

--- a/src/modules/dashboard/components/TaskFeed/TaskFeedCompleteInfo.tsx
+++ b/src/modules/dashboard/components/TaskFeed/TaskFeedCompleteInfo.tsx
@@ -104,67 +104,65 @@ const TaskFeedCompleteInfo = ({
         <div className={styles.receiptContainer}>
           <div className={styles.receiptSideBorder} />
           <div className={styles.receiptTextBlock}>
-            <p>
-              <FormattedMessage
-                {...MSG.receiptRecipientText}
-                values={{
-                  address: workerAddress,
-                }}
-              />
-              <br />
-              <FormattedMessage
-                {...MSG.tokenAddressText}
-                values={{ tokenAddress }}
-              />
-              <br />
-              <FormattedMessage
-                {...MSG.receiptAmountText}
-                values={{
-                  amount: (
-                    <InfoPopover
-                      token={tokenData && tokenData.token}
-                      isTokenNative={address === nativeTokenAddress}
-                    >
-                      <span className={styles.tokenInfo}>
-                        <Numeral
-                          integerSeparator=""
-                          unit={decimals || 18}
-                          value={amount}
-                        />
-                      </span>
-                    </InfoPopover>
-                  ),
-                  symbol,
-                }}
-              />
-              <br />
-              <FormattedMessage
-                {...MSG.receiptColonyFeeText}
-                values={{
-                  amount: (
-                    <InfoPopover
-                      token={tokenData && tokenData.token}
-                      isTokenNative={address === nativeTokenAddress}
-                    >
-                      <span className={styles.tokenInfo}>
-                        <Numeral unit={decimals || 18} value={metaColonyFee} />
-                      </span>
-                    </InfoPopover>
-                  ),
-                  symbol,
-                }}
-              />
-              {transactionHash && (
-                <>
-                  <br />
-                  <TransactionLink
-                    className={styles.receiptLink}
-                    hash={transactionHash}
-                    text={MSG.receiptViewTxLinkText}
-                  />
-                </>
-              )}
-            </p>
+            <FormattedMessage
+              {...MSG.receiptRecipientText}
+              values={{
+                address: workerAddress,
+              }}
+            />
+            <br />
+            <FormattedMessage
+              {...MSG.tokenAddressText}
+              values={{ tokenAddress }}
+            />
+            <br />
+            <FormattedMessage
+              {...MSG.receiptAmountText}
+              values={{
+                amount: (
+                  <InfoPopover
+                    token={tokenData && tokenData.token}
+                    isTokenNative={address === nativeTokenAddress}
+                  >
+                    <span className={styles.tokenInfo}>
+                      <Numeral
+                        integerSeparator=""
+                        unit={decimals || 18}
+                        value={amount}
+                      />
+                    </span>
+                  </InfoPopover>
+                ),
+                symbol,
+              }}
+            />
+            <br />
+            <FormattedMessage
+              {...MSG.receiptColonyFeeText}
+              values={{
+                amount: (
+                  <InfoPopover
+                    token={tokenData && tokenData.token}
+                    isTokenNative={address === nativeTokenAddress}
+                  >
+                    <span className={styles.tokenInfo}>
+                      <Numeral unit={decimals || 18} value={metaColonyFee} />
+                    </span>
+                  </InfoPopover>
+                ),
+                symbol,
+              }}
+            />
+            {transactionHash && (
+              <>
+                <br />
+                <TransactionLink
+                  className={styles.receiptLink}
+                  hash={transactionHash}
+                  text={MSG.receiptViewTxLinkText}
+                />
+              </>
+            )}
           </div>
         </div>
       )}

--- a/src/modules/dashboard/components/TaskFeed/TaskFeedEvent.css
+++ b/src/modules/dashboard/components/TaskFeed/TaskFeedEvent.css
@@ -26,4 +26,5 @@
   font-size: var(--size-small);
   font-weight: var(--weight-semi);
   color: var(--text);
+  cursor: pointer;
 }

--- a/src/modules/dashboard/components/TaskFeed/TaskFeedEvent.tsx
+++ b/src/modules/dashboard/components/TaskFeed/TaskFeedEvent.tsx
@@ -230,9 +230,9 @@ const TaskFeedEventPayoutSet = ({
   const { data: colonyData } = useColonyQuery({
     variables: { address: colonyAddress },
   });
-  const { decimals = 18, symbol = '', address } =
+  const { decimals = 18, symbol = '', address = '' } =
     (tokenData && tokenData.token) || {};
-  const { nativeTokenAddress } = (colonyData && colonyData.colony) || {};
+  const { nativeTokenAddress = '' } = (colonyData && colonyData.colony) || {};
   return (
     <FormattedMessage
       {...MSG.payoutSet}

--- a/src/modules/dashboard/components/TaskFeed/TaskFeedEvent.tsx
+++ b/src/modules/dashboard/components/TaskFeed/TaskFeedEvent.tsx
@@ -18,6 +18,7 @@ import styles from '~dashboard/TaskFeed/TaskFeedEvent.css';
 import {
   useUser,
   useTokenQuery,
+  useColonyQuery,
   AnyUser,
   EventType,
   TaskEventFragment,
@@ -217,27 +218,40 @@ const TaskFeedEventDueDateSet = ({
 );
 
 const TaskFeedEventPayoutSet = ({
+  colonyAddress,
   context: { amount, tokenAddress },
   initiator: {
     profile: { walletAddress },
   },
 }: EventProps<SetTaskPayoutEvent>) => {
-  const { data } = useTokenQuery({ variables: { address: tokenAddress } });
-  const { decimals = 18, symbol = '' } = (data && data.token) || {};
+  const { data: tokenData } = useTokenQuery({
+    variables: { address: tokenAddress },
+  });
+  const { data: colonyData } = useColonyQuery({
+    variables: { address: colonyAddress },
+  });
+  const { decimals = 18, symbol = '', address } =
+    (tokenData && tokenData.token) || {};
+  const { nativeTokenAddress } = (colonyData && colonyData.colony) || {};
   return (
     <FormattedMessage
       {...MSG.payoutSet}
       values={{
         user: <InteractiveUsername userAddress={walletAddress} />,
         payout: (
-          <span className={styles.highlightNumeral}>
-            <Numeral
-              integerSeparator=""
-              unit={decimals || 18}
-              value={new BigNumber(moveDecimal(amount, decimals || 18))}
-              suffix={` ${symbol}`}
-            />
-          </span>
+          <InfoPopover
+            token={tokenData && tokenData.token}
+            isTokenNative={address === nativeTokenAddress}
+          >
+            <span className={styles.highlightNumeral}>
+              <Numeral
+                integerSeparator=""
+                unit={decimals || 18}
+                value={new BigNumber(moveDecimal(amount, decimals || 18))}
+                suffix={` ${symbol}`}
+              />
+            </span>
+          </InfoPopover>
         ),
       }}
     />

--- a/src/utils/external/index.ts
+++ b/src/utils/external/index.ts
@@ -1,6 +1,8 @@
 import BN from 'bn.js';
 import { fromWei } from 'ethjs-unit';
 
+import { DEFAULT_NETWORK } from '~constants';
+
 interface EthUsdResponse {
   status: string;
   message: string;
@@ -12,6 +14,12 @@ interface EthUsdResponse {
     ethusd_timestamp: string;
     /* eslint-enable camelcase */
   };
+}
+
+interface EtherscanLinkProps {
+  network?: string;
+  linkType?: 'address' | 'tx' | 'token';
+  addressOrHash: string;
 }
 
 /*
@@ -63,4 +71,18 @@ export const getEthToUsd = (ethValue: BN): Promise<number | void> => {
       return fromWei(ethValue, 'ether') * parseFloat(ethUsd);
     })
     .catch(console.warn);
+};
+
+export const getEtherscanLink = ({
+  network = DEFAULT_NETWORK,
+  linkType = 'address',
+  addressOrHash,
+}: EtherscanLinkProps): string => {
+  if (!addressOrHash) {
+    return '';
+  }
+  const tld = network === 'tobalaba' ? 'com' : 'io';
+  const networkSubdomain =
+    network === 'homestead' || network === 'mainnet' ? '' : `${network}.`;
+  return `https://${networkSubdomain}etherscan.${tld}/${linkType}/${addressOrHash}`;
 };


### PR DESCRIPTION
## Description

This PR refactors the `InfoPopover` component in order to make it able to display token related information.

Using that feature, we display token data in various places:
- colony funding sidebar
- task feed
- task payouts list

_*Note*: When showing the ETH icon, there is a funky DOM nesting validation error. This is known and should be tackled in a different PR:_

![Screenshot from 2020-02-13 00-21-39](https://user-images.githubusercontent.com/1193222/74384106-39caaa00-4df9-11ea-8394-8e97c1020f0c.png)

**New stuff** 

- [x] Added `getEtherscanLink` external util function
- [x] Added `TokenLink` component

**Changes**

- [x] `InfoPopover` can now display token information as well as user info _(and with minimal effort it can also display colony info)_
- [x] `ColonyFunding` displays token infos using `InfoPopover`
- [x] `PayoutsList` displays token infos using `InfoPopover`
- [x] `TaskFeedEvent` displays token infos using `InfoPopover` _(the payout set event)_
- [x] `TaskFeedCompletedInfo` displays token infos using `InfoPopover`

**Screenshots**

![Screenshot from 2020-02-13 00-18-59](https://user-images.githubusercontent.com/1193222/74383716-6b8f4100-4df8-11ea-9e94-77f6648f3a88.png)
![Screenshot from 2020-02-13 00-19-06](https://user-images.githubusercontent.com/1193222/74383718-6c27d780-4df8-11ea-856b-799454989858.png)

**Demo**

![demo-token-infopopver](https://user-images.githubusercontent.com/1193222/74383746-73e77c00-4df8-11ea-841b-b1d3d6a04f79.gif)

Resolves #2025 
