### PR TITLE
Revert "Bump gas prices from ethgasstation by one level"

### DIFF
--- a/src/modules/core/sagas/utils/getGasPrices.ts
+++ b/src/modules/core/sagas/utils/getGasPrices.ts
@@ -61,13 +61,13 @@ const fetchGasPrices = async (
       timestamp: Date.now(),
       network: new BigNumber(networkGasPrice),
 
-      suggested: new BigNumber(data.fast).mul(pointOneGwei),
-      cheaper: new BigNumber(data.average).mul(pointOneGwei),
-      faster: new BigNumber(data.fastest).mul(pointOneGwei),
+      suggested: new BigNumber(data.average).mul(pointOneGwei),
+      cheaper: new BigNumber(data.safeLow).mul(pointOneGwei),
+      faster: new BigNumber(data.fast).mul(pointOneGwei),
 
-      suggestedWait: data.fastWait * 60,
-      cheaperWait: data.avgWait * 60,
-      fasterWait: data.fastestWait * 60,
+      suggestedWait: data.avgWait * 60,
+      cheaperWait: data.safeLowWait * 60,
+      fasterWait: data.fastWait * 60,
     };
   } catch (caughtError) {
     log.warn(`Could not get ETH gas prices: ${caughtError.message}`);


### PR DESCRIPTION
This reverts commit 5ef65497efdcc75aefc70673506ef7d7e7ad80eb, bringing gas prices from ethgasstation back down a level.

Jack's been seeing a lot of chatter about how everything is very expensive, so this is an easy 'fix'.