### PR TITLE
Create User Wizard Prevent Skipping after Transaction Creation

### DIFF
--- a/src/modules/dashboard/components/CreateUserWizard/StepConfirmTransaction.tsx
+++ b/src/modules/dashboard/components/CreateUserWizard/StepConfirmTransaction.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { defineMessages, FormattedMessage } from 'react-intl';
+import { defineMessages } from 'react-intl';
 import { Redirect } from 'react-router-dom';
 
 import { DASHBOARD_ROUTE } from '~routes/index';
@@ -12,7 +12,6 @@ import {
   findNewestGroup,
 } from '~users/GasStation/transactionGroup';
 import Heading from '~core/Heading';
-import Link from '~core/Link';
 import GasStationContent from '~users/GasStation/GasStationContent';
 import styles from './StepConfirmTransaction.css';
 
@@ -21,10 +20,6 @@ const MSG = defineMessages({
     id: 'dashboard.CreateUserWizard.StepConfirmTransaction.heading',
     defaultMessage: `Complete this transaction to continue
       setting up your account`,
-  },
-  later: {
-    id: 'dashboard.CreateUserWizard.StepUserName.later',
-    defaultMessage: `I'll do it later`,
   },
 });
 
@@ -56,13 +51,6 @@ const StepConfirmTransaction = () => {
             transactionAndMessageGroups={[colonyTransaction]}
           />
         )}
-      </div>
-      <div className={styles.buttons}>
-        <p className={styles.reminder}>
-          <Link to={DASHBOARD_ROUTE}>
-            <FormattedMessage {...MSG.later} />
-          </Link>
-        </p>
       </div>
     </section>
   );


### PR DESCRIPTION
## Description

This is a simple removal that disables the "I'll do this later" link on the transaction confirmation page, for the User Creation Wizard.

Turns out a lot of users, when creating they're profile, would sign the transaction, then skip out using that link, in the process messing up they're profile creation.

**Changes**

- [x] `StepConfirmTransaction` don't allow the user to change route to the Dashboard

**Screenshot**

![Screenshot from 2020-02-21 14-50-10](https://user-images.githubusercontent.com/1193222/75036933-ac075280-54bb-11ea-935d-14ed8d1b1578.png)

Resolves #2066 