### PR TITLE
Fix Token Move Dialog

### DIFF
--- a/src/modules/admin/components/Tokens/TokensMoveDialog.tsx
+++ b/src/modules/admin/components/Tokens/TokensMoveDialog.tsx
@@ -14,8 +14,8 @@ import { useColonyTokensQuery } from '~data/index';
 import DialogForm from './TokensMoveDialogForm';
 
 export interface FormValues {
-  fromDomain?: number;
-  toDomain?: number;
+  fromDomain?: string;
+  toDomain?: string;
   amount: string;
   tokenAddress?: Address;
 }
@@ -60,7 +60,13 @@ const TokensMoveDialog = ({
         // Convert amount string with decimals to BigInt (eth to wei)
         const amount = new BigNumber(moveDecimal(payload.amount, decimals));
 
-        return { ...payload, colonyAddress, amount };
+        return {
+          ...payload,
+          colonyAddress,
+          amount,
+          fromDomain: parseInt(payload.fromDomain, 10),
+          toDomain: parseInt(payload.toDomain, 10),
+        };
       }),
       withKey(colonyAddress),
     ),

--- a/src/modules/admin/components/Tokens/TokensMoveDialogForm.tsx
+++ b/src/modules/admin/components/Tokens/TokensMoveDialogForm.tsx
@@ -89,6 +89,14 @@ const TokensMoveDialogForm = ({
   tokens,
   values,
 }: Props & FormikProps<FormValues>) => {
+  const { tokenAddress, amount } = values;
+  const fromDomain = values.fromDomain
+    ? parseInt(values.fromDomain, 10)
+    : ROOT_DOMAIN;
+  const toDomain = values.toDomain
+    ? parseInt(values.toDomain, 10)
+    : ROOT_DOMAIN;
+
   const selectedToken = useMemo(
     () => tokens.find(token => token.address === values.tokenAddress),
     [tokens, values.tokenAddress],
@@ -113,13 +121,13 @@ const TokensMoveDialogForm = ({
 
   const fromDomainRoles = useTransformer(getUserRoles, [
     domains,
-    values.fromDomain || ROOT_DOMAIN,
+    fromDomain,
     walletAddress,
   ]);
 
   const toDomainRoles = useTransformer(getUserRoles, [
     domains,
-    values.toDomain || ROOT_DOMAIN,
+    toDomain,
     walletAddress,
   ]);
 
@@ -136,12 +144,6 @@ const TokensMoveDialogForm = ({
     [domains],
   );
 
-  const {
-    fromDomain = ROOT_DOMAIN,
-    toDomain = ROOT_DOMAIN,
-    tokenAddress,
-    amount,
-  } = values;
   const [
     loadTokenBalances,
     { data: tokenBalancesData },


### PR DESCRIPTION
## Description

Issue originally reported in #qa: https://joincolony.slack.com/archives/C7HNTLE3T/p1582631697028000

This issue was introduced by 1532fe1cdfdce2b18d62f8528b74ef9a2e198eeb which made the `Select` core component expect all `value` fields as `string`s

This changed the way `TokenMoveDialogForm` acted, as the domain ids would now be converted into a string, and that would fail fetching the respective domain's token balance.

The fix for this involved making sure the values that `TokenMoveDialogForm` sends out are indeed `number`s.

An alternative way to fix this would have been to make the `Select` component accept values as both `string` and `number`, but I was reluctant to do so, due to the many ways we use this component, as this would have most likely introduce regressions.

**Changes**

- [x] `TokenMoveDialog` now expects the form values as `string`s, then transforms them into `number`s before passing them along

**Screenshot**

![Screenshot from 2020-02-25 14-52-55](https://user-images.githubusercontent.com/1193222/75250688-935fab00-57e1-11ea-86ae-73803a0c8db1.png)

