### PR TITLE
Avoid memory leak in move tokens dialog

### DIFF
--- a/src/i18n/en-validation.json
+++ b/src/i18n/en-validation.json
@@ -3,7 +3,7 @@
       "equalTo": "${path} must be the same as ${reference}"
     },
     "number": {
-        "lessThanPot": "Not enough funds in the pot"
+        "notEqualTo": "${path} cannot be the same as ${reference}"
     },
     "string": {
         "cid": "This is not a valid CID",

--- a/src/modules/admin/components/Tokens/TokensMoveDialog.tsx
+++ b/src/modules/admin/components/Tokens/TokensMoveDialog.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import { defineMessages } from 'react-intl';
 import { FormikProps } from 'formik';
 import * as yup from 'yup';
 import moveDecimal from 'move-decimal-point';
@@ -12,6 +13,13 @@ import { ActionForm } from '~core/Fields';
 import { useColonyTokensQuery } from '~data/index';
 
 import DialogForm from './TokensMoveDialogForm';
+
+const MSG = defineMessages({
+  samePot: {
+    id: 'admin.Tokens.TokensMoveDialog.samePot',
+    defaultMessage: 'Cannot move to same domain pot',
+  },
+});
 
 export interface FormValues {
   fromDomain?: string;
@@ -27,6 +35,8 @@ interface Props {
   toDomain?: number;
 }
 
+const displayName = 'admin.Tokens.TokensMoveDialog';
+
 const TokensMoveDialog = ({
   colonyAddress,
   toDomain,
@@ -35,9 +45,15 @@ const TokensMoveDialog = ({
 }: Props) => {
   const validationSchema = yup.object().shape({
     fromDomain: yup.number().required(),
-    toDomain: yup.number().required(),
+    toDomain: yup
+      .number()
+      .notEqualTo(yup.ref('fromDomain'), () => MSG.samePot)
+      .required(),
     amount: yup.string().required(),
-    tokenAddress: yup.string().required(),
+    tokenAddress: yup
+      .string()
+      .address()
+      .required(),
   });
 
   const { data: colonyTokensData } = useColonyTokensQuery({
@@ -103,6 +119,6 @@ const TokensMoveDialog = ({
   );
 };
 
-TokensMoveDialog.displayName = 'admin.Tokens.TokensMoveDialog';
+TokensMoveDialog.displayName = displayName;
 
 export default TokensMoveDialog;

--- a/src/modules/validations.ts
+++ b/src/modules/validations.ts
@@ -2,7 +2,6 @@ import * as yup from 'yup';
 import { isIPFS } from 'ipfs';
 import { isAddress } from 'web3-utils';
 import { normalize as ensNormalize } from 'eth-ens-namehash-ms';
-import BigNumber from 'bn.js';
 
 import en from '../i18n/en-validation.json';
 
@@ -30,6 +29,19 @@ function equalTo(ref, msg) {
     },
     test(value) {
       return value === this.resolve(ref);
+    },
+  });
+}
+
+function notEqualTo(ref, msg) {
+  return this.test({
+    name: 'notEqualTo',
+    message: msg || en.number.notEqualTo,
+    params: {
+      reference: ref.path,
+    },
+    test(value) {
+      return value !== this.resolve(ref);
     },
   });
 }
@@ -82,15 +94,8 @@ function includes(searchVal, msg) {
   });
 }
 
-export class BigNumberSchemaType extends yup.object {
-  _typeCheck(value: any) {
-    // @ts-ignore (_typeCheck is not typed in external types)
-    // eslint-disable-next-line no-underscore-dangle
-    return super._typeCheck(value) || BigNumber.isBN(value);
-  }
-}
-
 yup.addMethod(yup.mixed, 'equalTo', equalTo);
+yup.addMethod(yup.number, 'notEqualTo', notEqualTo);
 yup.addMethod(yup.string, 'address', address);
 yup.addMethod(yup.string, 'ensAddress', ensAddress);
 yup.addMethod(yup.array, 'includes', includes);

--- a/src/typeDefs/yup/index.d.ts
+++ b/src/typeDefs/yup/index.d.ts
@@ -1,8 +1,12 @@
-import { StringSchema, TestOptionsMessage } from 'yup';
+import { NumberSchema, Ref, StringSchema, TestOptionsMessage } from 'yup';
 
 declare module 'yup' {
-  interface StringSchema {
-    address(message?: TestOptionsMessage);
-    ensAddress(message?: TestOptionsMessage);
+  interface NumberSchema<T> {
+    notEqualTo(ref: Ref, message?: TestOptionsMessage): NumberSchema<T>;
+  }
+
+  interface StringSchema<T> {
+    address(message?: TestOptionsMessage): StringSchema<T>;
+    ensAddress(message?: TestOptionsMessage): StringSchema<T>;
   }
 }


### PR DESCRIPTION
## Description

This PR fixes a memory leak which caused the move tokens dialog to re-render in an infinite loop. Additionally, this PR fixes the move tokens validation.

**New stuff** ✨

* `notEqualTo` validation rule

**Changes** 🏗

* Use `yup` for same domain validation
* Alter `useEffect` deps to pass shallow compare
* Fix typings of added `yup` schemas so typescript knows they're chain-able


**Deletions** ⚰️

* `BigNumberSchemaType`
