### PR TITLE
Handle SetTaskPayout notification message

### DIFF
--- a/src/modules/users/components/Inbox/InboxItem/InboxItem.tsx
+++ b/src/modules/users/components/Inbox/InboxItem/InboxItem.tsx
@@ -295,7 +295,7 @@ const InboxItem = ({
 
               {amount && token && (
                 <span>
-                  <span className={styles.pipe}>|</span>
+                  {colonyName && <span className={styles.pipe}>|</span>}
                   <Numeral
                     suffix={` ${token ? token.symbol : ''}`}
                     integerSeparator=""

--- a/src/modules/users/components/Inbox/events.ts
+++ b/src/modules/users/components/Inbox/events.ts
@@ -15,6 +15,7 @@ const notificationsToEventsMapping = {
   [EventType.TaskMessage]: 'notificationUserMentioned',
   [EventType.SendWorkInvite]: 'actionWorkerInviteReceived',
   [EventType.UnassignWorker]: 'notificationWorkerUnassigned',
+  [EventType.SetTaskPayout]: 'notificationTaskPayoutSet',
 };
 
 export const transformNotificationEventNames = (eventName: string): string =>

--- a/src/modules/users/components/Inbox/messages.ts
+++ b/src/modules/users/components/Inbox/messages.ts
@@ -101,6 +101,10 @@ const messages = defineMessages({
     id: 'dashboard.Inbox.InboxItem.notificationTaskFinalized',
     defaultMessage: '{user} finalized {task} and payouts have been made.',
   },
+  notificationTaskPayoutSet: {
+    id: 'dashboard.Inbox.InboxItem.notificationTaskPayoutSet',
+    defaultMessage: '{user} added payout to {task}: {amount}',
+  },
   /*
    * These are currently unused:
    *


### PR DESCRIPTION
## Description

This is a simple PR that adds in the required message descriptor  in order for the app to be able to handle _set task payout_ notification events

**Changes** 

- [x] Added `Inbox` messages set task payout message descriptor
- [x] `InboxItem` conditionally show the pipe char next to the amount context display

**Screenshots**

Before
![Screenshot from 2020-02-27 18-41-26](https://user-images.githubusercontent.com/1193222/75467597-94850980-5994-11ea-99fc-e1f1e6a326d6.png)

After
![Screenshot from 2020-02-27 19-02-01](https://user-images.githubusercontent.com/1193222/75467574-8c2cce80-5994-11ea-8356-d0e7985f21fe.png)

Resolves #2050 