### PR TITLE
Move form validate function to a better place

### DIFF
--- a/src/modules/core/components/AvatarUploader/AvatarUploadItem.tsx
+++ b/src/modules/core/components/AvatarUploader/AvatarUploadItem.tsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import { defineMessages } from 'react-intl';
 
 import { FieldEnhancedProps } from '~core/Fields/types';
 import { log } from '~utils/debug';
@@ -11,17 +10,6 @@ import { FileReaderFile, UploadFile } from '../FileUpload';
 import fileReader from '../../../../lib/fileReader';
 import { asField } from '../Fields';
 import Icon from '../Icon';
-
-const MSG = defineMessages({
-  uploadError: {
-    id: 'AvatarUploadItem.uploadError',
-    defaultMessage: 'There was an error uploading your file',
-  },
-  filetypeError: {
-    id: 'AvatarUploadItem.filetypeError',
-    defaultMessage: 'This filetype is not allowed or file is too big',
-  },
-});
 
 interface Props {
   /** Array of allowed file types */
@@ -112,9 +100,6 @@ class AvatarUploadItem extends Component<
   }
 }
 
-const validate = (value: UploadFile) =>
-  value.error ? MSG[value.error] : undefined;
-
-export default asField<Props, UploadFile>({ alwaysConnected: true, validate })(
+export default asField<Props, UploadFile>({ alwaysConnected: true })(
   AvatarUploadItem,
 );

--- a/src/modules/core/components/Fields/Form/Form.tsx
+++ b/src/modules/core/components/Fields/Form/Form.tsx
@@ -3,11 +3,7 @@ import React from 'react';
 
 const displayName = 'Form';
 
-interface Props extends FormikConfig<any> {
-  className?: string;
-}
-
-const Form = ({ children, ...props }: Props) => (
+const Form = ({ children, ...props }: FormikConfig<any>) => (
   <Formik {...props}>
     {injectedProps => (
       <FormikForm>

--- a/src/modules/core/components/Fields/asField.ts
+++ b/src/modules/core/components/Fields/asField.ts
@@ -38,7 +38,7 @@ const formatIntl = (
   return formatMessage(text, textValues);
 };
 
-const connectFormik = <P, V>({ alwaysConnected, validate }) => (
+const connectFormik = <P, V>({ alwaysConnected }) => (
   FieldComponent: ComponentType<any>,
 ) => ({
   connect = true,
@@ -49,7 +49,6 @@ const connectFormik = <P, V>({ alwaysConnected, validate }) => (
   connect || alwaysConnected
     ? createElement<FieldAttributes<any>>(Field, {
         component: FieldComponent,
-        validate,
 
         /*
          * Expose the connect prop to use in more complex form wrapped components
@@ -76,10 +75,10 @@ const asField = <
   // `T` allows passing props along to element of type `T`
   // @todo default `T` to never type? Since most components won't pass props along to element of type `T`
   T extends HTMLAttributes<HTMLElement> | never = HTMLAttributes<HTMLElement>
->({ alwaysConnected, validate, initialValue }: AsFieldConfig<V> = {}) =>
+>({ alwaysConnected, initialValue }: AsFieldConfig<V> = {}) =>
   compose<InnerProps<P, V, T>, OuterProps<P, V, T>>(
     injectIntl,
-    connectFormik<P, V>({ alwaysConnected, validate }),
+    connectFormik<P, V>({ alwaysConnected }),
     mapProps<FieldEnhancedProps<V, T>, PropsMapperOuterProps<P, V>>(
       ({
         connect = true,

--- a/src/modules/core/components/Fields/types.ts
+++ b/src/modules/core/components/Fields/types.ts
@@ -1,6 +1,6 @@
 import { HTMLAttributes } from 'react';
 import { MessageDescriptor } from 'react-intl';
-import { FieldProps, FieldInputProps } from 'formik';
+import { FieldProps, FieldInputProps, FieldValidator } from 'formik';
 
 import { SimpleMessageValues } from '../../../../types/index';
 
@@ -11,7 +11,6 @@ export type FormatMessage = (
 
 export interface AsFieldConfig<V> {
   alwaysConnected?: boolean;
-  validate?: (value: V) => boolean;
   initialValue?: V;
 }
 
@@ -62,4 +61,5 @@ export interface ExtraFieldProps<V> {
   $value?: V;
   form?: Partial<FieldProps<any>['form']>;
   field?: Partial<FieldProps<V>['field']>;
+  validate?: FieldValidator;
 }

--- a/src/modules/core/components/FileUpload/FileUpload.tsx
+++ b/src/modules/core/components/FileUpload/FileUpload.tsx
@@ -28,6 +28,14 @@ const MSG = defineMessages({
     id: 'FileUpload.labelError',
     defaultMessage: 'There was an error processing your file. Try again.',
   },
+  uploadError: {
+    id: 'FileUpload.uploadError',
+    defaultMessage: 'There was an error uploading your file',
+  },
+  filetypeError: {
+    id: 'FileUpload.filetypeError',
+    defaultMessage: 'This filetype is not allowed or file is too big',
+  },
   dropzoneTextBrowseAction: {
     id: 'FileUpload.dropzoneTextBrowseAction',
     defaultMessage: 'browse',
@@ -106,6 +114,9 @@ const Placeholder = () => (
     />
   </div>
 );
+
+const validateFile = (value: UploadFile) =>
+  value.error ? MSG[value.error] : undefined;
 
 class FileUpload extends Component<Props> {
   static displayName = 'FileUpload';
@@ -230,6 +241,7 @@ class FileUpload extends Component<Props> {
                       remove={remove}
                       reset={resetForm}
                       upload={upload}
+                      validate={validateFile}
                     />
                   ))}
                 </div>

--- a/src/modules/core/components/FileUpload/UploadItem.tsx
+++ b/src/modules/core/components/FileUpload/UploadItem.tsx
@@ -17,14 +17,6 @@ const MSG = defineMessages({
     id: 'UploadItem.removeActionText',
     defaultMessage: 'Remove',
   },
-  uploadError: {
-    id: 'UploadItem.uploadError',
-    defaultMessage: 'There was an error uploading your file',
-  },
-  filetypeError: {
-    id: 'UploadItem.filetypeError',
-    defaultMessage: 'This filetype is not allowed or file is too big',
-  },
 });
 
 interface Props {
@@ -138,9 +130,6 @@ class UploadItem extends Component<Props & FieldEnhancedProps<UploadFile>> {
   }
 }
 
-const validate = (value: UploadFile) =>
-  value.error ? MSG[value.error] : undefined;
-
-export default asField<Props, UploadFile>({ alwaysConnected: true, validate })(
+export default asField<Props, UploadFile>({ alwaysConnected: true })(
   UploadItem,
 );

--- a/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.css
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.css
@@ -18,11 +18,6 @@
   font-weight: var(--weight-medium);
 }
 
-.nameForm {
-  margin-top: 40px;
-  width: 460px;
-}
-
 .tokenDetails {
   margin-top: 50px;
 }

--- a/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.css.d.ts
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.css.d.ts
@@ -2,7 +2,6 @@ export const main: string;
 export const header: string;
 export const labelContainer: string;
 export const title: string;
-export const nameForm: string;
 export const tokenDetails: string;
 export const input: string;
 export const buttons: string;

--- a/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.tsx
@@ -132,7 +132,6 @@ const StepSelectToken = ({
         </Heading>
       </div>
       <Form
-        className={styles.nameForm}
         onSubmit={nextStep}
         validationSchema={validationSchema}
         initialValues={initialValues}


### PR DESCRIPTION
## Description

This PR allows us to pass in the `validation` function dynamically into `Fields` as opposed to in the HoC params.

**Changes** 🏗

* Use `validate` as props, not in HoC
* Also remove `className` from `Form` props as it didn't work anyways
