### PR TITLE
Use token decimals for `Numeral` units

### DIFF
--- a/src/modules/core/components/PayoutsList/PayoutsList.tsx
+++ b/src/modules/core/components/PayoutsList/PayoutsList.tsx
@@ -71,9 +71,14 @@ const PayoutsList = ({ maxLines = 1, nativeTokenAddress, payouts }: Props) => {
                     [styles.native]: token.address === nativeTokenAddress,
                   })}
                   suffix={` ${token.symbol} `}
-                  unit={DEFAULT_TOKEN_DECIMALS}
+                  unit={token.decimals || DEFAULT_TOKEN_DECIMALS}
                   value={
-                    new BigNumber(moveDecimal(amount, token.decimals || 18))
+                    new BigNumber(
+                      moveDecimal(
+                        amount,
+                        token.decimals || DEFAULT_TOKEN_DECIMALS,
+                      ),
+                    )
                   }
                 />
               </div>
@@ -92,9 +97,14 @@ const PayoutsList = ({ maxLines = 1, nativeTokenAddress, payouts }: Props) => {
                   })}
                   key={token.address}
                   value={
-                    new BigNumber(moveDecimal(amount, token.decimals || 18))
+                    new BigNumber(
+                      moveDecimal(
+                        amount,
+                        token.decimals || DEFAULT_TOKEN_DECIMALS,
+                      ),
+                    )
                   }
-                  unit={DEFAULT_TOKEN_DECIMALS}
+                  unit={token.decimals || DEFAULT_TOKEN_DECIMALS}
                   suffix={` ${token.symbol} `}
                 />
               ))}


### PR DESCRIPTION
## Description

As the title says, don't always assume 18 decimals 🙂 

**Changes** 🏗

* Move decimal based on actual token details

Takes care of the issue raised in [this Slack thread](https://joincolony.slack.com/archives/C02R9SP3J/p1582914779036900).