### PR TITLE
Validate from when removing Task Payout

### DIFF
--- a/src/modules/dashboard/components/TaskEditDialog/TaskEditDialog.tsx
+++ b/src/modules/dashboard/components/TaskEditDialog/TaskEditDialog.tsx
@@ -115,8 +115,15 @@ const canAddTokens = (values, maxTokens) =>
 const canRemoveTokens = (values, minTokens) =>
   !minTokens || (values.payouts && values.payouts.length > minTokens);
 
-const removePayout = (arrayHelpers: ArrayHelpers, index: number) =>
-  arrayHelpers.remove(index);
+/*
+ * @TODO Figure out a way to validate the form (without doing by hand, forcefully) when we handle multiple payouts
+ *
+ * For some reason, when you call arrayHelpers.remove(...) the field goes automatically into an error state
+ * disregarding the validation schema rules
+ * For now, we can circumvent this by pop-ing the last index in the array, since we only have one payout / task,
+ * but this will need to be properly fixed once we need to handle multiple payouts
+ */
+const removePayout = (arrayHelpers: ArrayHelpers) => arrayHelpers.pop();
 
 const resetPayout = (
   arrayHelpers: ArrayHelpers,
@@ -346,7 +353,7 @@ const TaskEditDialog = ({
         onSubmit={onSubmit}
         validationSchema={validateForm}
       >
-        {({ status, values, dirty, isSubmitting, isValid }) => {
+        {({ status, values, isSubmitting, isValid }) => {
           const canRemove = canRemoveTokens(values, minTokens);
           return (
             <>
@@ -416,7 +423,7 @@ const TaskEditDialog = ({
                               name={`payouts.${index}`}
                               payout={payout}
                               reputation={0}
-                              remove={() => removePayout(arrayHelpers, index)}
+                              remove={() => removePayout(arrayHelpers)}
                               reset={() =>
                                 resetPayout(arrayHelpers, index, payouts)
                               }
@@ -439,7 +446,7 @@ const TaskEditDialog = ({
                   appearance={{ theme: 'primary', size: 'large' }}
                   text={{ id: 'button.confirm' }}
                   type="submit"
-                  disabled={!dirty || !isValid}
+                  disabled={!isValid}
                   loading={isSubmitting}
                 />
               </div>


### PR DESCRIPTION
## Description

This is a PR that "fixes" the validation of the task payout when removing the payout altogether.

When I say "fix" I mean temporary deffer the problem, until we'll need to deal with multiple task payouts, at which point this will come into effect again.

The underlying issue here is, that "somehow" (I am unable to determine why), `arrayHelpers.remove(index)`, even if removing the last index in the payouts array _(`0`)_ will invalidate the form, even if the the payouts shape _(`{ payouts: [] }`)_ correctly passes the `yup` validation schema.

On the other hand, just `pop()`-ing the last value, doesn't seem to have that problem, resulting the form values being properly validated.

**Changes**

- [x] `TaskEditDialog` pop() the last array element when removing the payout

**Demo**

![demo-remove-task-payout](https://user-images.githubusercontent.com/1193222/76241040-efdcb480-623c-11ea-9d66-1b2004beff91.gif)

Resolves #2037 
