### PR TITLE
Handle CancelTask notification message

### DIFF
--- a/src/modules/users/components/Inbox/events.ts
+++ b/src/modules/users/components/Inbox/events.ts
@@ -17,6 +17,7 @@ const notificationsToEventsMapping = {
   [EventType.UnassignWorker]: 'notificationWorkerUnassigned',
   [EventType.SetTaskPayout]: 'notificationTaskPayoutSet',
   [EventType.RemoveTaskPayout]: 'notificationTaskPayoutRemove',
+  [EventType.CancelTask]: 'notificationTaskCancel',
 };
 
 export const transformNotificationEventNames = (eventName: string): string =>

--- a/src/modules/users/components/Inbox/messages.ts
+++ b/src/modules/users/components/Inbox/messages.ts
@@ -109,6 +109,10 @@ const messages = defineMessages({
     id: 'dashboard.Inbox.InboxItem.notificationTaskPayoutRemove',
     defaultMessage: '{user} removed the payout from {task}',
   },
+  notificationTaskCancel: {
+    id: 'dashboard.Inbox.InboxItem.notificationTaskCancel',
+    defaultMessage: '{user} has cancelled the task: {task}.',
+  },
   /*
    * These are currently unused:
    *


### PR DESCRIPTION
## Description

This is a simple PR that adds in the required message descriptor in order for the app to be able to handle the cancel task notification events.

**Changes**

- [x] `Inbox` handle `CancelTask` event type
- [x] `Inbox` `messages` message desscriptor for the `CancelTask` event type

**Screenshots**

Before:
![Screenshot from 2020-03-16 12-50-33](https://user-images.githubusercontent.com/1193222/76750826-8eaa6900-6787-11ea-892b-9fd1cf99e77e.png)

After:
![Screenshot from 2020-03-16 13-00-24](https://user-images.githubusercontent.com/1193222/76750837-91a55980-6787-11ea-8a1a-dd5bd733171d.png)
