### PR TITLE
Manually disable Colony Contract Upgrades

### DIFF
--- a/src/modules/admin/components/Profile/ProfileAdvanced.tsx
+++ b/src/modules/admin/components/Profile/ProfileAdvanced.tsx
@@ -25,6 +25,15 @@ const TOKEN_LOCKED_URL =
   // eslint-disable-next-line max-len
   'https://help.colony.io/hc/en-us/articles/360025429094-How-to-unlock-your-colony-s-native-token';
 
+/*
+ * @NOTE This const has an obnoxious name to draw attention to the fact
+ * that we manually hard-code, or otherwise interfere with the default operation
+ * of the dapp, in this case, by disabling the user's ability to upgrade the
+ * colony contract to the latest version.
+ */
+// eslint-disable-next-line no-underscore-dangle
+const __MANUALLY_DISABLE_COLONY_UPGRADES__ = true;
+
 const MSG = defineMessages({
   labelVersion: {
     id: 'admin.Profile.ProfileAdvanced.labelVersion',
@@ -130,7 +139,11 @@ const ProfileAdvanced = ({
           success={ActionTypes.COLONY_VERSION_UPGRADE_SUCCESS}
           error={ActionTypes.COLONY_VERSION_UPGRADE_ERROR}
           values={{ colonyAddress }}
-          disabled={!networkVersion || !canBeUpgraded(colony, networkVersion)}
+          disabled={
+            __MANUALLY_DISABLE_COLONY_UPGRADES__ ||
+            !networkVersion ||
+            !canBeUpgraded(colony, networkVersion)
+          }
         />
       </section>
       <section className={styles.section}>


### PR DESCRIPTION
## Description

This PR manually disables the colony contract upgrade functionality in preparation for the "burgundy glider" contract version release.

Once we've properly tested the app with the above version of the contracts, we can then remove this hard-coded block.

**Changes**

- [x] `admin` `ProfileAdvanced` disable colony contract upgrades

**Screenshot**

![Screenshot from 2020-03-17 12-07-32](https://user-images.githubusercontent.com/1193222/76845766-10fa6200-6848-11ea-955c-42e1213bbb99.png)

