### PR TITLE
Handle Removing the Task's Due Date

### DIFF
--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -1069,7 +1069,7 @@ export type SetTaskDomainInput = {
 export type SetTaskDueDateEvent = TaskEvent & {
   type: EventType,
   taskId: Scalars['String'],
-  dueDate: Scalars['DateTime'],
+  dueDate?: Maybe<Scalars['DateTime']>,
   colonyAddress?: Maybe<Scalars['String']>,
 };
 

--- a/src/modules/dashboard/components/TaskDate/TaskDate.tsx
+++ b/src/modules/dashboard/components/TaskDate/TaskDate.tsx
@@ -44,7 +44,7 @@ const TaskDate = ({ draftId, dueDate: existingDueDate, disabled }: Props) => {
 
   const onSubmit = useCallback(
     ({ taskDueDate: taskDueDateValue }: FormValues) => {
-      const taskDueDate = taskDueDateValue.toISOString();
+      const taskDueDate = taskDueDateValue && taskDueDateValue.toISOString();
       // only update if the date has changed
       if (taskDueDate !== existingDueDate) {
         setDueDate({


### PR DESCRIPTION
## Description

This is a simple PR that add minor logic fixes in order to fix removing a tasks's due date.

So most of the logic here was already added in, and it "worked", the only thing being that it would always expect the task's due date value to be set. 

The way the server works is if a value is provided, then set it (or re-set it) in the database, otherwise, if no value is provided, unset it in the database.

This PR just fixes the value assignment in order to account for a value not being set.

**Reviewer's note**: This PR needs to be tested along side JoinColony/colonyServer#61

**Changes** 

- [x] `TaskDate` handle a empty date value _(when un-setting it)_
- [x] Import the new server type requirements (or lack there of), by re-generating the graphql hooks and types

**Demo**

![demo-task-date-set-unset](https://user-images.githubusercontent.com/1193222/76975075-b42ba400-693a-11ea-913a-13d8f75e5ec0.gif)

Resolves #2099 