### PR TITLE
Address scrolls with rest of page

### DIFF
--- a/src/modules/pages/components/WizardTemplateColony/WizardTemplateColony.css
+++ b/src/modules/pages/components/WizardTemplateColony/WizardTemplateColony.css
@@ -33,6 +33,7 @@
   justify-content: flex-end;
   justify-content: space-between;
   width: 185px;
+  position: relative;
   font-weight: var(--weight-medium);
 }
 


### PR DESCRIPTION
## Description

This PR fixes an issue with an absolutely positioned element, by wrapping it in a relatively positioned element.

**Changes** 🏗

* Add `position: relative` to `.address`

**Demo** 🎥 

![ScrollingAddress](https://user-images.githubusercontent.com/3052635/76993634-22f90500-691b-11ea-8de9-d770cad885e5.gif)

Closes #1918 