### PR TITLE
Properly handle decimals when checking funding availability

### DIFF
--- a/src/modules/dashboard/components/TaskFinalizeDialog/useDomainFundsCheck.ts
+++ b/src/modules/dashboard/components/TaskFinalizeDialog/useDomainFundsCheck.ts
@@ -2,6 +2,8 @@ import { useCallback } from 'react';
 import { useApolloClient } from '@apollo/react-hooks';
 import moveDecimal from 'move-decimal-point';
 
+import { getTokenDecimalsWithFallback } from '~utils/tokens';
+
 import { useDialog } from '~core/Dialog';
 import TaskFinalizeDialog from './TaskFinalizeDialog';
 
@@ -44,7 +46,10 @@ const useDomainFundsCheck = (
         ({ amount: availableDomainAmount }) =>
           !bnLessThan(
             availableDomainAmount,
-            moveDecimal(amount, domainBalances.decimals || 18),
+            moveDecimal(
+              amount,
+              getTokenDecimalsWithFallback(domainBalances.decimals),
+            ),
           ),
       );
     });


### PR DESCRIPTION
## Description

This is a simple fix, that makes the funding availability check behave properly when verifying the available amount you can use to pay out a task.

The issue was that when we moved to use the `getTokenDecimalsWithFallback` util, we missed changing it here.

Kudos to @chmanie for suggesting the fix here :tada: 

**Changes**

- [x] `useDomainFundsCheck` now properly handles token decimals

Resolves #2162 