### PR TITLE
Patch TaskDomains to display selected domain

### DIFF
--- a/src/modules/dashboard/components/TaskDomains/TaskDomains.tsx
+++ b/src/modules/dashboard/components/TaskDomains/TaskDomains.tsx
@@ -144,8 +144,20 @@ Props) => {
           disabled: false,
           /* disabled: !domainHasEnoughFunds(parseInt(id, 10)), */
           id: parseInt(id, 10),
-        })),
-    [domains],
+        }))
+        /**
+         * @NOTE Temporary patch
+         *
+         * This will return just the selected domain from the consumables array
+         * This is needed since the items list will sort the array and such will
+         * always return ROOT as the first domain, which will be "selected" on the task
+         *
+         * This is a visual change only, to display the "correct" domain, but one
+         * that will need to be removed once we bring back the feature to be able
+         * to select domains after a task's creation.
+         */
+        .filter(({ id }) => id === ethDomainId),
+    [domains, ethDomainId],
   );
 
   return (


### PR DESCRIPTION
## Description

This PR is a simple fix/patch for the `TaskDomains` component so that it displays the correct domain in which the task was created.

This happened because, from it, we pass along a `consumableDomains` array which contains all the domains in the colony. This is the correct functionality and was expected when we were able to re-select the task's domain after creation.

Since that is no longer the case, the whole domain array gets passed, it gets sorted, then the first entry gets selected _(always domain id 1 === root)_.

The changes in this PR just filters out the current task domain from that array, and passes the filtered array along.

**Changes** 

- [x] Patched `TaskDomain` to only return the selected domain from the consumables array

**Screenshot**

![Screenshot from 2020-05-25 21-25-42](https://user-images.githubusercontent.com/1193222/82836900-3f439000-9ed0-11ea-8103-956a373174d6.png)

Resolves #2170 