### PR TITLE
ItemsList correctly set the current item element

### DIFF
--- a/src/modules/core/components/ItemsList/ItemsList.tsx
+++ b/src/modules/core/components/ItemsList/ItemsList.tsx
@@ -234,7 +234,7 @@ const ItemsList = ({
   }, [currentItem, listTouched, needsCleanup, selectedItem]);
 
   const currentItemElement = useMemo(
-    () => list.find(({ id }) => id === currentItem || itemId),
+    () => list.find(({ id }) => id === (currentItem || itemId)),
     [currentItem, itemId, list],
   );
 


### PR DESCRIPTION
This PR is a simple fix for the core `ItemsList` component that makes the selected value "stick", and not change after the page re-renders.

While the code fix seems trivial, it was quite hard to pinpoint. It turns out that after setting the value initially, at some point in time, the page re-renders. At that point, `itemId` is `undefined` and the `.find()` operation returns true for the `id === currentItem` comparison, which just returns the first item.

Now, for the first item, it was always ".Net Core", since the items list gets sorted alphabetically by name, and since that has a dot in it it gets sorted first.

**Changes**

- [x] `ItemsList` correctly fetch the current item element

**Demos**

_Before_
![broken-tasklist-reset-value](https://user-images.githubusercontent.com/1193222/82908918-4f5f7c00-9f71-11ea-8834-c4902318b306.gif)

_After_
![demo-tasklist-value-does-not-reset](https://user-images.githubusercontent.com/1193222/82908944-55555d00-9f71-11ea-91dd-a9669df62cb7.gif)

Resolves #2171 