### PR TITLE
Experimental Subgraph Integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,5 @@ NODE_ENV=development
 
 # HTTP endpoint for graphql server
 SERVER_ENDPOINT=http://127.0.0.1:3000
+
+GRAPH_ENDPOINT=http://127.0.0.1:8000/subgraphs/name/joinColony/subgraph

--- a/.env.example
+++ b/.env.example
@@ -24,4 +24,4 @@ NODE_ENV=development
 # HTTP endpoint for graphql server
 SERVER_ENDPOINT=http://127.0.0.1:3000
 
-GRAPH_ENDPOINT=http://127.0.0.1:8000/subgraphs/name/joinColony/subgraph
+SUBGRAPH_ENDPOINT=http://127.0.0.1:8000/subgraphs/name/joinColony/subgraph

--- a/src/context/apolloClient.ts
+++ b/src/context/apolloClient.ts
@@ -15,7 +15,7 @@ const httpLink = createHttpLink({
 });
 
 const subgraphHttpLink = createHttpLink({
-  uri: 'http://127.0.0.1:8000/subgraphs/name/joinColony/subgraph',
+  uri: `${process.env.SUBGRAPH_ENDPOINT}/graphql`,
 });
 
 const authLink = setContext((_, { headers }) => {

--- a/src/context/apolloClient.ts
+++ b/src/context/apolloClient.ts
@@ -15,7 +15,7 @@ const httpLink = createHttpLink({
 });
 
 const subgraphHttpLink = createHttpLink({
-  uri: `${process.env.SUBGRAPH_ENDPOINT}/graphql`,
+  uri: 'http://127.0.0.1:8000/subgraphs/name/joinColony/subgraph',
 });
 
 const authLink = setContext((_, { headers }) => {

--- a/src/context/apolloClient.ts
+++ b/src/context/apolloClient.ts
@@ -1,6 +1,7 @@
 import ApolloClient from 'apollo-client';
 import { createHttpLink } from 'apollo-link-http';
 import { setContext } from 'apollo-link-context';
+import { ApolloLink } from 'apollo-link';
 
 import { cache, typeDefs } from '~data/index';
 import { TEMP_getNewContext } from '~context/index';
@@ -11,6 +12,10 @@ export { ApolloProvider } from '@apollo/react-hooks';
 
 const httpLink = createHttpLink({
   uri: `${process.env.SERVER_ENDPOINT}/graphql`,
+});
+
+const subgraphHttpLink = createHttpLink({
+  uri: `${process.env.SUBGRAPH_ENDPOINT}/graphql`,
 });
 
 const authLink = setContext((_, { headers }) => {
@@ -28,7 +33,11 @@ const authLink = setContext((_, { headers }) => {
 });
 
 export default new ApolloClient({
-  link: authLink.concat(httpLink),
+  link: ApolloLink.split(
+    (operation) => operation.getContext().endpoint === 'subgraph',
+    subgraphHttpLink,
+    authLink.concat(httpLink),
+  ),
   cache,
   typeDefs,
   // All resolvers are added via addResolvers

--- a/src/modules/admin/components/Domains/DomainList.tsx
+++ b/src/modules/admin/components/Domains/DomainList.tsx
@@ -47,7 +47,14 @@ const DomainList = ({
   colonyAddress,
 }: Props) => {
   const { data: subgraphDomainsData } = useQuery(GET_SUBGRAPH_DOMAINS, {
-    context: { endpoint: 'subgraph' }
+    /**
+     * Tell the apollo client to use the subgraph endpoint link
+    */
+    context: { endpoint: 'subgraph' },
+    /**
+     * Fake having this in real time
+    */
+    pollInterval: 500,
   });
   const subgraphDomains = useMemo(
     () => {
@@ -73,10 +80,7 @@ const DomainList = ({
               subgraphDomains.map(({ id, name }) => (
                 <DomainListItem
                   key={id}
-                  domain={{
-                    id,
-                    name,
-                  }}
+                  domain={{ id, name }}
                   viewOnly
                   colonyAddress={colonyAddress}
                 />

--- a/src/modules/admin/components/Domains/DomainList.tsx
+++ b/src/modules/admin/components/Domains/DomainList.tsx
@@ -8,7 +8,7 @@ import { Address, DomainsMapType } from '~types/index';
 
 import { Table, TableBody } from '~core/Table';
 import Heading from '~core/Heading';
-import { filterSgDomains } from '../../transformers';
+import { filterSgDomains, normalizeSgDomains } from '../../transformers';
 
 import DomainListItem from './DomainListItem';
 
@@ -77,7 +77,7 @@ const DomainList = ({
         <Table scrollable>
           <TableBody>
             {subgraphDomains ? (
-              subgraphDomains.map(({ id, name }) => (
+              normalizeSgDomains(subgraphDomains).map(({ id, name }) => (
                 <DomainListItem
                   key={id}
                   domain={{ id, name }}

--- a/src/modules/admin/transformers.ts
+++ b/src/modules/admin/transformers.ts
@@ -3,8 +3,14 @@ import { createAddress } from '~utils/web3';
 export const extractSgAddressFromDomainId = (idString: string): string =>
   createAddress(idString.replace(/_\d/, ''));
 
+export const extractSgDomainId = (idString: string): number =>
+  parseInt(idString.replace(/.+_/, ''), 10);
+
 export const filterSgDomains = (domains: Array<any>, colonyAddress: string) =>
   domains.filter(({ id: idString }) => {
     const extractedColonyAddress = extractSgAddressFromDomainId(idString);
     return extractedColonyAddress === colonyAddress;
   });
+
+export const normalizeSgDomains = (filteredDomains: Array<any>) =>
+  filteredDomains.map(({ id, name }) => ({ id: extractSgDomainId(id), name }));

--- a/src/modules/admin/transformers.ts
+++ b/src/modules/admin/transformers.ts
@@ -1,0 +1,10 @@
+import { createAddress } from '~utils/web3';
+
+export const extractSgAddressFromDomainId = (idString: string): string =>
+  createAddress(idString.replace(/_\d/, ''));
+
+export const filterSgDomains = (domains: Array<any>, colonyAddress: string) =>
+  domains.filter(({ id: idString }) => {
+    const extractedColonyAddress = extractSgAddressFromDomainId(idString);
+    return extractedColonyAddress === colonyAddress;
+  });


### PR DESCRIPTION
**Do not** merge this PR!

This PR is an exploration of integrating a subgraph node alongside our infrastructure and pulling data from the chain, via graphql queries directly.

### Setup

This PR works alongside its server branch companion: [colonyServer/feat/the-graph](https://github.com/JoinColony/colonyServer/tree/feat/the-graph)

There are a lot of moving parts involved in setting this up in our current environment:
- manual server and mongo DB instances
- manual ganache instance
- manual deployment of the contracts
- starting the dapp without ganache, without the server and the database, and without truffle deploying contracts
- a manual instance of the graph node

![Screenshot from 2020-07-27 15-25-57](https://user-images.githubusercontent.com/1193222/88549603-2ae35700-d029-11ea-819b-61345240bb9d.png)

Now that I've scared you enough, @area has set up a nice step by step guide to get this started: https://github.com/JoinColony/colonyServer/blob/feat/the-graph/Readme.md#setup

### Limitations

1. The [event handlers](https://github.com/JoinColony/subgraph/blob/master/src/mappings/colony.ts) listening for contract events get compiled into Web Assembly before being deployed to the graph node. The source from which they get compiled is Typescript. This means that you need **uncompiled** TS code in order to properly compile. This limits the number of external libraries we can use server-side, as most just ship the TS definitions rather then the actual code.
2. During migration, we will have to use two graphql endpoints. While I got this working _(see: "Where the magic happens")_ it is not officially supported.
3. During migration, we will most likely run into graphql query naming collisions.
4. Since we couldn't use external libraries on the server-side, I couldn't checksum addresses when creating the event handlers and had to move that client-side. This prevents me from using query filtering, and I had to fetch all the domains at once. If we can't find a solution for this, it going to be very problematic on `mainnet`

![Screenshot from 2020-07-27 15-27-45](https://user-images.githubusercontent.com/1193222/88549609-30d93800-d029-11ea-92e7-6e8920d24c60.png)

### Where the magic happens

The only thing special about this is using two endpoints for the apollo client:

https://github.com/JoinColony/colonyDapp/blob/feat/the-graph/src/context/apolloClient.ts#L36-L40

While I couldn't find specific documentation references to this, I found a bunch of GH issues where contributors pointed out that this is not officially supported. So if we decide to go this route, it's something to keep in mind.

### Current implementation

The current implementation is pretty naive and very basic, as the query itself is hard-coded inside the component bypassing resolvers and code generation. But I guess it's good enough for demo purposes.

https://github.com/JoinColony/colonyDapp/blob/feat/the-graph/src/modules/admin/components/Domains/DomainList.tsx#L49-L67

### Demo

![demo-subgraph-domains](https://user-images.githubusercontent.com/1193222/88549633-359dec00-d029-11ea-9b80-f678a4576953.gif)
