### PR TITLE
Properly refresh info after upgrading a colony

### DIFF
--- a/src/modules/dashboard/sagas/colony.ts
+++ b/src/modules/dashboard/sagas/colony.ts
@@ -149,6 +149,7 @@ function* colonyUpgradeContract({
       variables: {
         address: colonyAddress,
       },
+      fetchPolicy: 'network-only',
     });
   } catch (error) {
     return yield putError(


### PR DESCRIPTION
Fix refreshing the colony info after upgrading it.
