### PR TITLE
Fix Cache Update on Colony Creation

### DIFF
--- a/src/data/cacheUpdates.ts
+++ b/src/data/cacheUpdates.ts
@@ -105,10 +105,10 @@ const cacheUpdates = {
         });
         const createLevelData = data && data.createLevel;
         if (cacheData && createLevelData) {
-          const levels = cacheData.program.levels || [];
-          levels.push(createLevelData);
-          const levelIds = cacheData.program.levelIds || [];
-          levelIds.push(createLevelData.id);
+          const existingLevels = cacheData.program.levels || [];
+          const levels = [...existingLevels, createLevelData];
+          const existingLevelIds = cacheData.program.levelIds || [];
+          const levelIds = [...existingLevelIds, createLevelData.id];
           cache.writeQuery<ProgramQuery, ProgramQueryVariables>({
             data: {
               program: {
@@ -222,8 +222,8 @@ const cacheUpdates = {
         });
         const createProgramData = data && data.createProgram;
         if (cacheData && createProgramData) {
-          const programs = cacheData.colony.programs || [];
-          programs.push(createProgramData);
+          const existingPrograms = cacheData.colony.programs || [];
+          const programs = [...existingPrograms, createProgramData];
           cache.writeQuery<ColonyProgramsQuery, ColonyProgramsQueryVariables>({
             data: {
               colony: {
@@ -257,8 +257,8 @@ const cacheUpdates = {
         });
         const createTaskData = data && data.createTask;
         if (cacheData && createTaskData) {
-          const tasks = cacheData.colony.tasks || [];
-          tasks.push(createTaskData);
+          const existingTasks = cacheData.colony.tasks || [];
+          const tasks = [...existingTasks, createTaskData];
           cache.writeQuery<ColonyTasksQuery, ColonyTasksQueryVariables>({
             query: ColonyTasksDocument,
             data: {
@@ -331,8 +331,8 @@ const cacheUpdates = {
         });
         const createTaskData = data && data.createTaskFromSuggestion;
         if (cacheData && createTaskData) {
-          const tasks = cacheData.colony.tasks || [];
-          tasks.push(createTaskData);
+          const existingTasks = cacheData.colony.tasks || [];
+          const tasks = [...existingTasks, createTaskData];
           cache.writeQuery<ColonyTasksQuery, ColonyTasksQueryVariables>({
             query: ColonyTasksDocument,
             data: {

--- a/src/modules/core/components/Fields/Form/Form.tsx
+++ b/src/modules/core/components/Fields/Form/Form.tsx
@@ -3,14 +3,18 @@ import React from 'react';
 
 import SaveGuard from './SaveGuard';
 
-interface Props extends FormikConfig<any> {
+interface Props<V> extends FormikConfig<V> {
   saveGuard?: boolean;
 }
 
 const displayName = 'Form';
 
-const Form = ({ children, saveGuard = false, ...props }: Props) => (
-  <Formik {...props}>
+const Form = <V extends Record<string, any>>({
+  children,
+  saveGuard = false,
+  ...props
+}: Props<V>) => (
+  <Formik<V> {...props}>
     {(injectedProps) => (
       <FormikForm>
         {saveGuard && <SaveGuard />}

--- a/src/modules/core/components/Wizard/types.ts
+++ b/src/modules/core/components/Wizard/types.ts
@@ -12,9 +12,7 @@ export interface WizardProps<FormValues> {
   stepCompleted: boolean;
   wizardValues: FormValues;
   wizardForm: {
-    initialValues: {
-      [formValue: string]: any;
-    };
+    initialValues: FormValues;
     validateOnMount: boolean;
   };
 }

--- a/src/modules/core/components/Wizard/withWizard.ts
+++ b/src/modules/core/components/Wizard/withWizard.ts
@@ -19,10 +19,11 @@ export type StepsFn<T> = (step: number, values: any, props?: T) => StepType;
 
 type Steps = StepType[] | StepsFn<any>;
 
-type WizardArgs = {
+interface WizardArgs {
+  initialValues?: Record<string, any>[];
   stepCount?: number;
   steps: Steps;
-};
+}
 
 const all = (values: ValueList) =>
   values.reduceRight((map, curr) => map.merge(curr), ImmutableMap()).toJS();
@@ -30,10 +31,11 @@ const all = (values: ValueList) =>
 const getStep = (steps: Steps, step: number, values: any, props?: any) =>
   typeof steps === 'function' ? steps(step, values, props) : steps[step];
 
-const withWizard = ({ steps, stepCount: maxSteps }: WizardArgs) => <P>(
-  OuterComponent: ComponentType,
-  stepsProps?: P,
-) => {
+const withWizard = ({
+  initialValues = [],
+  steps,
+  stepCount: maxSteps,
+}: WizardArgs) => <P>(OuterComponent: ComponentType, stepsProps?: P) => {
   class Wizard extends Component<Props, State> {
     state = { step: 0, values: List() };
 
@@ -76,6 +78,7 @@ const withWizard = ({ steps, stepCount: maxSteps }: WizardArgs) => <P>(
       const stepCount = maxSteps || (steps as any).length;
 
       const stepValues = values.get(step);
+      const initialStepValues = initialValues[step];
 
       return createElement(
         OuterComponent,
@@ -100,7 +103,7 @@ const withWizard = ({ steps, stepCount: maxSteps }: WizardArgs) => <P>(
           // Wizard form helpers to take some shortcuts if needed
           wizardForm: {
             // Get values just for this step
-            initialValues: stepValues || {},
+            initialValues: stepValues || initialStepValues || {},
             // It should be valid if we submitted values for this step before
             validateOnMount: !!stepValues,
           },

--- a/src/modules/dashboard/components/CreateColonyWizard/CreateColonyCardRow.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/CreateColonyCardRow.tsx
@@ -12,15 +12,15 @@ export interface Row {
   valueKey: string | [string, string];
 }
 
-interface FormValues {
+export interface FormValues {
   colonyName: string;
   displayName: string;
-  tokenAddress?: string;
-  tokenChoice: 'create' | 'select';
-  tokenIcon: string;
+  tokenAddress: string;
+  tokenChoice?: 'create' | 'select';
+  tokenIcon?: string;
   tokenName: string;
   tokenSymbol: string;
-  username: string;
+  username?: string;
 }
 
 interface CardProps {

--- a/src/modules/dashboard/components/CreateColonyWizard/CreateColonyWizard.ts
+++ b/src/modules/dashboard/components/CreateColonyWizard/CreateColonyWizard.ts
@@ -72,9 +72,25 @@ const stepFunction: StepsFn<any> = (
   return stepArray[step] as ComponentType<any>;
 };
 
+const initialValues = [
+  {
+    colonyName: '',
+    displayName: '',
+  },
+  {
+    tokenChoice: '',
+  },
+  {
+    tokenAddress: '',
+    tokenName: '',
+    tokenSymbol: '',
+  },
+];
+
 const CreateColonyContainer = compose(
   withLoggedInUser,
   withWizard({
+    initialValues,
     steps: stepFunction,
   }),
 )(WizardTemplate);

--- a/src/modules/dashboard/components/CreateColonyWizard/StepConfirmAllInput.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepConfirmAllInput.tsx
@@ -9,19 +9,8 @@ import Heading from '~core/Heading';
 import Button from '~core/Button';
 import { ActionForm, FormStatus } from '~core/Fields';
 import { ActionTypes } from '~redux/index';
-import CardRow, { Row } from './CreateColonyCardRow';
+import CardRow, { Row, FormValues } from './CreateColonyCardRow';
 import styles from './StepConfirmAllInput.css';
-
-interface FormValues {
-  colonyName: string;
-  displayName: string;
-  tokenAddress?: string;
-  tokenChoice: 'create' | 'select';
-  tokenIcon: string;
-  tokenName: string;
-  tokenSymbol: string;
-  username: string;
-}
 
 type Props = WizardProps<FormValues>;
 

--- a/src/modules/dashboard/components/Task/TaskInviteDialog.tsx
+++ b/src/modules/dashboard/components/Task/TaskInviteDialog.tsx
@@ -34,7 +34,7 @@ const MSG = defineMessages({
 });
 
 interface FormValues {
-  payouts: FormPayout;
+  payouts: FormPayout[];
   workerAddress: Address;
 }
 
@@ -96,10 +96,10 @@ const TaskInviteDialog = ({
 
   return (
     <FullscreenDialog cancel={cancel}>
-      <Form
+      <Form<FormValues>
         initialValues={{
           payouts: initialPayouts,
-          worker: currentUser,
+          workerAddress: walletAddress,
         }}
         onSubmit={onSubmit}
       >
@@ -138,7 +138,7 @@ const TaskInviteDialog = ({
                       ? values.payouts.map((payout, index) => {
                           return (
                             <Payout
-                              key={payout.token.address}
+                              key={payout.token}
                               payout={payout}
                               name={`payouts.${index}`}
                               tokens={tokens}

--- a/src/modules/dashboard/components/TaskDate/TaskDate.tsx
+++ b/src/modules/dashboard/components/TaskDate/TaskDate.tsx
@@ -28,7 +28,7 @@ const MSG = defineMessages({
 });
 
 interface FormValues {
-  taskDueDate: Date;
+  taskDueDate?: Date;
 }
 
 interface Props {
@@ -68,7 +68,7 @@ const TaskDate = ({ draftId, dueDate: existingDueDate, disabled }: Props) => {
           text={MSG.title}
         />
         {!disabled && (
-          <Form
+          <Form<FormValues>
             initialValues={{
               taskDueDate: existingDueDate
                 ? new Date(existingDueDate)

--- a/src/modules/dashboard/components/TaskEditDialog/TaskEditDialog.tsx
+++ b/src/modules/dashboard/components/TaskEditDialog/TaskEditDialog.tsx
@@ -19,7 +19,6 @@ import {
   AnyUser,
   AnyTask,
   useTaskToEditQuery,
-  Payouts,
   useAssignWorkerMutation,
   useUnassignWorkerMutation,
   useSetTaskPayoutMutation,
@@ -128,7 +127,7 @@ const removePayout = (arrayHelpers: ArrayHelpers) => arrayHelpers.pop();
 const resetPayout = (
   arrayHelpers: ArrayHelpers,
   index: number,
-  payouts: Payouts,
+  payouts: FormPayout[],
 ) =>
   payouts.length > 0 && payouts[index].amount !== '.'
     ? arrayHelpers.replace(index, payouts[index])
@@ -178,7 +177,7 @@ const TaskEditDialog = ({
   }, [maxTokens, minTokens]);
 
   const addTokenFunding = useCallback(
-    (values: { payouts?: AnyTask['payouts'] }, helpers: () => void) => {
+    (values: FormValues, helpers: ArrayHelpers) => {
       if (canAddTokens(values, maxTokens))
         (helpers as any).push({
           id: nanoid(),
@@ -348,7 +347,7 @@ const TaskEditDialog = ({
        */
       isDismissable={false}
     >
-      <Form
+      <Form<FormValues>
         initialValues={initialValues}
         onSubmit={onSubmit}
         validationSchema={validateForm}
@@ -408,7 +407,7 @@ const TaskEditDialog = ({
                               appearance={{ theme: 'blue', size: 'small' }}
                               text={MSG.add}
                               onClick={() =>
-                                addTokenFunding(values, arrayHelpers as any)
+                                addTokenFunding(values, arrayHelpers)
                               }
                             />
                           )}
@@ -418,8 +417,7 @@ const TaskEditDialog = ({
                             <Payout
                               canRemove={canRemove}
                               colonyAddress={colonyAddress}
-                              // will have at least one of `id` or `token`
-                              key={payout.id || payout.token}
+                              key={payout.token}
                               name={`payouts.${index}`}
                               payout={payout}
                               reputation={0}

--- a/src/modules/dashboard/components/TaskRatingDialogs/ManagerRatingDialog.tsx
+++ b/src/modules/dashboard/components/TaskRatingDialogs/ManagerRatingDialog.tsx
@@ -67,7 +67,7 @@ const MSG = defineMessages({
 });
 
 interface FormValues {
-  rating: 1 | 2 | 3;
+  rating?: 1 | 2 | 3;
   workDescription: string;
 }
 
@@ -99,9 +99,9 @@ const validationSchemaExtended = validationSchema.shape({
 
 const ManagerRatingDialog = ({ close, cancel, submitWork }: Props) => (
   <Dialog cancel={cancel}>
-    <Form
+    <Form<FormValues>
       initialValues={{
-        rating: '',
+        rating: undefined,
         workDescription: '',
       }}
       onSubmit={close}

--- a/src/modules/dashboard/components/TaskRatingDialogs/WorkerRatingDialog.tsx
+++ b/src/modules/dashboard/components/TaskRatingDialogs/WorkerRatingDialog.tsx
@@ -52,7 +52,7 @@ const MSG = defineMessages({
 });
 
 interface FormValues {
-  rating: 1 | 2 | 3;
+  rating?: 1 | 2 | 3;
 }
 
 interface Props {
@@ -75,7 +75,7 @@ const WorkerRatingDialog = ({ close, cancel, workSubmitted }: Props) => (
   <Dialog cancel={cancel}>
     <Form
       initialValues={{
-        rating: '',
+        rating: undefined,
       }}
       onSubmit={close}
       validationSchema={validationSchema}

--- a/src/modules/dashboard/sagas/colonyCreate.ts
+++ b/src/modules/dashboard/sagas/colonyCreate.ts
@@ -459,8 +459,12 @@ function* colonyCreate({
               },
             });
             if (cacheData) {
-              const colonyAddresses = cacheData.user.colonyAddresses || [];
-              colonyAddresses.push(colonyAddress);
+              const existingColonyAddresses =
+                cacheData.user.colonyAddresses || [];
+              const colonyAddresses = [
+                ...existingColonyAddresses,
+                colonyAddress,
+              ];
               cache.writeQuery<
                 UserColonyAddressesQuery,
                 UserColonyAddressesQueryVariables

--- a/src/modules/dashboard/sagas/domains.ts
+++ b/src/modules/dashboard/sagas/domains.ts
@@ -83,8 +83,8 @@ function* domainCreate({
             variables: { colonyAddress },
           });
           if (cacheData && data && data.createDomain) {
-            const domains = cacheData.colony.domains || [];
-            domains.push(data.createDomain);
+            const existingDomains = cacheData.colony.domains || [];
+            const domains = [...existingDomains, data.createDomain];
             cache.writeQuery<ColonyDomainsQuery, ColonyDomainsQueryVariables>({
               query: ColonyDomainsDocument,
               data: {

--- a/src/modules/users/components/UserProfileEdit/UserProfileEdit.tsx
+++ b/src/modules/users/components/UserProfileEdit/UserProfileEdit.tsx
@@ -98,12 +98,12 @@ const UserProfileEdit = () => {
         appearance={{ theme: 'dark', size: 'medium' }}
         text={MSG.heading}
       />
-      <Form
+      <Form<FormValues>
         initialValues={{
-          displayName: user.profile.displayName,
-          bio: user.profile.bio,
-          website: user.profile.website,
-          location: user.profile.location,
+          displayName: user.profile.displayName || undefined,
+          bio: user.profile.bio || undefined,
+          website: user.profile.website || undefined,
+          location: user.profile.location || undefined,
         }}
         onSubmit={onSubmit}
         validationSchema={validationSchema}


### PR DESCRIPTION
## Description

This PR fixes the cache update on colony creation (along with all other post-insertion cache updates). It also fixes an issue that I observed along the way.... which was an uncontrolled -> controlled input error (a result of having no initial values for form steps in the wizard), along with tightening up types (optionally) our `Form` component by accepting a generic type argument.

**Changes** 🏗

* Form type improvements
  * Accept generic type argument for form values in `Form` component
  * Update initial values in certain forms to better match typings
* Allow optional `initialValues` for the wizard, which fixes the uncontrolled -> controlled input error
* Use shallow copies for cache updates instead of `push` (missed during apollo v3 update)

Closes #2250 