### PR TITLE
Fix task finalize from Transaction hash

### DIFF
--- a/src/data/resolvers/task.ts
+++ b/src/data/resolvers/task.ts
@@ -56,7 +56,7 @@ const finalizeTaskWithTxHash = async (
     const userAddress = await colonyClient.signer.getAddress();
     const domainRoles = getRolesForUserAndDomain(
       roles,
-      userAddress,
+      createAddress(userAddress),
       ethDomainId,
     );
     if (domainRoles.includes(ColonyRole.Administration)) {


### PR DESCRIPTION
## Description

This is a small change that fixes the resolver which checks, upon loading a task, if it was already finalized, extracting the required data from the transaction, then firing the appropriate mutation to update/create database entries. 

The issue at play here was that the user address used to get the user's roles in the colony was no checksummed, so it would always fail the check.

**Changes**

- [x] `finalizeTaskWithTxHash` the uses the checksummed version of `userAddress`
