### PR TITLE
Fix wizard initial values

### DIFF
--- a/src/modules/core/components/Wizard/withWizard.ts
+++ b/src/modules/core/components/Wizard/withWizard.ts
@@ -19,8 +19,12 @@ export type StepsFn<T> = (step: number, values: any, props?: T) => StepType;
 
 type Steps = StepType[] | StepsFn<any>;
 
+type InitialValues =
+  | Record<string, any>[]
+  | ((props?: any) => Record<string, any>[]);
+
 interface WizardArgs {
-  initialValues?: Record<string, any>[];
+  initialValues?: InitialValues;
   stepCount?: number;
   steps: Steps;
 }
@@ -32,7 +36,7 @@ const getStep = (steps: Steps, step: number, values: any, props?: any) =>
   typeof steps === 'function' ? steps(step, values, props) : steps[step];
 
 const withWizard = ({
-  initialValues = [],
+  initialValues: initialValuesProp = [],
   steps,
   stepCount: maxSteps,
 }: WizardArgs) => <P>(OuterComponent: ComponentType, stepsProps?: P) => {
@@ -78,6 +82,10 @@ const withWizard = ({
       const stepCount = maxSteps || (steps as any).length;
 
       const stepValues = values.get(step);
+      const initialValues =
+        typeof initialValuesProp === 'function'
+          ? initialValuesProp(this.props)
+          : initialValuesProp;
       const initialStepValues = initialValues[step];
 
       return createElement(

--- a/src/modules/dashboard/components/CreateColonyWizard/CreateColonyWizard.ts
+++ b/src/modules/dashboard/components/CreateColonyWizard/CreateColonyWizard.ts
@@ -72,20 +72,34 @@ const stepFunction: StepsFn<any> = (
   return stepArray[step] as ComponentType<any>;
 };
 
-const initialValues = [
-  {
-    colonyName: '',
-    displayName: '',
-  },
-  {
-    tokenChoice: '',
-  },
-  {
-    tokenAddress: '',
-    tokenName: '',
-    tokenSymbol: '',
-  },
-];
+const initialValues = (props?: any) => {
+  const guaranteedStepValues = [
+    {
+      colonyName: '',
+      displayName: '',
+    },
+    {
+      tokenChoice: '',
+    },
+    {
+      tokenAddress: '',
+      tokenName: '',
+      tokenSymbol: '',
+    },
+  ];
+  if (props) {
+    const { username } = props.loggedInUser;
+    if (!username) {
+      return [
+        {
+          username: '',
+        },
+        ...guaranteedStepValues,
+      ];
+    }
+  }
+  return guaranteedStepValues;
+};
 
 const CreateColonyContainer = compose(
   withLoggedInUser,


### PR DESCRIPTION
## Description

This PR allow `initialValues` in the `withWizard` HOC to accept an array **or** a function in the case of non-linear wizards.

**Changes** 🏗

* Update `withWizard` to accept a function for non-linear wizards

