### PR TITLE
Temporarily Disable Colony Creation

### DIFF
--- a/src/modules/dashboard/components/CreateColonyWizard/CreateColonyWizard.ts
+++ b/src/modules/dashboard/components/CreateColonyWizard/CreateColonyWizard.ts
@@ -38,10 +38,11 @@ type StepValues = {
  */
 const stepFunction: StepsFn<any> = (
   step: number,
+  _,
   props?: any,
 ): ComponentType<any> => {
   if (props) {
-    const username = props?.loggedInUser?.username;
+    const { username } = props.loggedInUser;
 
     /*
      * In case the username is already registered

--- a/src/modules/dashboard/components/CreateColonyWizard/CreateColonyWizard.ts
+++ b/src/modules/dashboard/components/CreateColonyWizard/CreateColonyWizard.ts
@@ -1,5 +1,4 @@
 import { ComponentType } from 'react';
-import { $Values } from 'utility-types';
 import compose from 'recompose/compose';
 
 import WizardTemplate from '~pages/WizardTemplateColony';
@@ -7,22 +6,9 @@ import { StepsFn, StepType } from '~core/Wizard/withWizard';
 import { withLoggedInUser } from '~data/index';
 
 import { withWizard } from '../../../core/components/Wizard';
-import StepTokenChoice from './StepTokenChoice';
 import StepColonyName from './StepColonyName';
-import StepSelectToken from './StepSelectToken';
-import StepCreateToken from './StepCreateToken';
-import StepConfirmAllInput from './StepConfirmAllInput';
 import StepUserName from '../CreateUserWizard/StepUserName';
-import StepConfirmColonyTransactions from './StepConfirmTransactions';
 import StepConfirmUserTransaction from '../CreateUserWizard/StepConfirmTransaction';
-
-const stepArray: StepType[] = [
-  StepColonyName,
-  StepTokenChoice,
-  StepCreateToken,
-  StepConfirmAllInput,
-  StepConfirmColonyTransactions,
-];
 
 /**
  * @NOTE Colony Creation Wizard Flow is DISABLED
@@ -34,6 +20,9 @@ const stepArray: StepType[] = [
  *
  * This will first register a username, then redirect to the colony flow (which will be
  * skipping the create user step), which currently is disabled
+ *
+ * Also, this file has been severly gutten to accomodate this change, so please
+ * restore it from history when this is no longer needed
  */
 const stepArrayJustUserRegistration: StepType[] = [
   StepUserName,
@@ -44,18 +33,11 @@ type StepValues = {
   tokenChoice: 'create' | 'select';
 };
 
-const pickTokenStep = (tokenChoice: $Values<StepValues>) => {
-  if (tokenChoice === 'create') return StepCreateToken;
-  if (tokenChoice === 'select') return StepSelectToken;
-  return StepCreateToken;
-};
-
 /* This is a step function to allow the wizard flow to branch
  * off into two instead of just stepping through an array in a linear manner
  */
 const stepFunction: StepsFn<any> = (
   step: number,
-  { tokenChoice }: StepValues,
   props?: any,
 ): ComponentType<any> => {
   if (props) {
@@ -68,24 +50,10 @@ const stepFunction: StepsFn<any> = (
 
     /* When username hasn't been created flow through wizard is different */
     if (!username) {
-      if (step === 3) {
-        return pickTokenStep(tokenChoice);
-      }
       return stepArrayJustUserRegistration[step] as ComponentType<any>;
     }
-
-    /* Standard wizard flow  */
-    if (step === 0) {
-      if (username && stepArray[0].stepName === 'StepUserName') {
-        stepArray.shift();
-        return stepArray[step] as ComponentType<any>;
-      }
-    }
-    if (step === 2) {
-      return pickTokenStep(tokenChoice);
-    }
   }
-  return stepArray[step] as ComponentType<any>;
+  return StepColonyName;
 };
 
 const initialValues = (props?: any) => {

--- a/src/modules/dashboard/components/CreateColonyWizard/CreateColonyWizard.ts
+++ b/src/modules/dashboard/components/CreateColonyWizard/CreateColonyWizard.ts
@@ -17,7 +17,6 @@ import StepConfirmColonyTransactions from './StepConfirmTransactions';
 import StepConfirmUserTransaction from '../CreateUserWizard/StepConfirmTransaction';
 
 const stepArray: StepType[] = [
-  StepUserName,
   StepColonyName,
   StepTokenChoice,
   StepCreateToken,

--- a/src/modules/dashboard/components/CreateColonyWizard/CreateColonyWizard.ts
+++ b/src/modules/dashboard/components/CreateColonyWizard/CreateColonyWizard.ts
@@ -12,8 +12,9 @@ import StepColonyName from './StepColonyName';
 import StepSelectToken from './StepSelectToken';
 import StepCreateToken from './StepCreateToken';
 import StepConfirmAllInput from './StepConfirmAllInput';
-import StepUserName from './StepUserName';
-import StepConfirmTransactions from './StepConfirmTransactions';
+import StepUserName from '../CreateUserWizard/StepUserName';
+import StepConfirmColonyTransactions from './StepConfirmTransactions';
+import StepConfirmUserTransaction from '../CreateUserWizard/StepConfirmTransaction';
 
 const stepArray: StepType[] = [
   StepUserName,
@@ -21,7 +22,23 @@ const stepArray: StepType[] = [
   StepTokenChoice,
   StepCreateToken,
   StepConfirmAllInput,
-  StepConfirmTransactions,
+  StepConfirmColonyTransactions,
+];
+
+/**
+ * @NOTE Colony Creation Wizard Flow is DISABLED
+ *
+ * Until the gas costs die down, the create your colony wizard is being disabled, while
+ * leaving the User creation flow still operational.
+ * Due to this we've had to segment the steps array, and return just the user one in
+ * case of a user without claimed account who also wants to create a new colony.
+ *
+ * This will first register a username, then redirect to the colony flow (which will be
+ * skipping the create user step), which currently is disabled
+ */
+const stepArrayJustUserRegistration: StepType[] = [
+  StepUserName,
+  StepConfirmUserTransaction,
 ];
 
 type StepValues = {
@@ -55,7 +72,7 @@ const stepFunction: StepsFn<any> = (
       if (step === 3) {
         return pickTokenStep(tokenChoice);
       }
-      return stepArray[step] as ComponentType<any>;
+      return stepArrayJustUserRegistration[step] as ComponentType<any>;
     }
 
     /* Standard wizard flow  */

--- a/src/modules/dashboard/components/CreateColonyWizard/CreateColonyWizard.ts
+++ b/src/modules/dashboard/components/CreateColonyWizard/CreateColonyWizard.ts
@@ -41,7 +41,7 @@ const stepFunction: StepsFn<any> = (
   props?: any,
 ): ComponentType<any> => {
   if (props) {
-    const { username } = props.loggedInUser;
+    const username = props?.loggedInUser?.username;
 
     /*
      * In case the username is already registered

--- a/src/modules/dashboard/components/CreateColonyWizard/StepColonyName.css
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepColonyName.css
@@ -34,4 +34,5 @@
 
 .tooltipContent {
   min-width: 280px;
+  max-width: 280px;
 }

--- a/src/modules/dashboard/components/CreateColonyWizard/StepColonyName.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepColonyName.tsx
@@ -71,6 +71,10 @@ const MSG = defineMessages({
     id: 'users.CreateColonyWizard.StepColonyName.tooltip',
     defaultMessage: `We use ENS to create a .joincolony.eth subdomain for your colony. You can use this to create a custom URL and invite people to join your colony.`,
   },
+  tooltipColonyCreationDisabled: {
+    id: 'users.CreateColonyWizard.StepColonyName.tooltipColonyCreationDisabled',
+    defaultMessage: `Due to the extraordinarily high Ethereum gas prices, we’ve decided to disable the colony creation flow to prevent new users from incurring unexpectedly high costs in setting up their colony. Colony creation will be accessible again on xDai very soon!`,
+  },
 });
 
 const displayName = 'dashboard.CreateColonyWizard.StepColonyName';
@@ -79,6 +83,14 @@ const validationSchema = yup.object({
   colonyName: yup.string().required().ensAddress(),
   displayName: yup.string().required(),
 });
+
+/**
+ * @NOTE Colony Creation DISABLED due to high gas costs
+ *
+ * Please remove this and re-enable when the time comes, or when we deploy this
+ * to xDai
+ */
+const DISABLE_COLONY_CREATION_DUE_TO_HIGH_GAS_COSTS = true;
 
 const StepColonyName = ({
   wizardForm,
@@ -226,14 +238,30 @@ const StepColonyName = ({
                 }
               />
               <div className={styles.buttons}>
-                <Button
-                  appearance={{ theme: 'primary', size: 'large' }}
-                  type="submit"
-                  data-test="claimColonyNameConfirm"
-                  disabled={!isValid || (!dirty && !stepCompleted)}
-                  loading={isSubmitting}
-                  text={MSG.continue}
-                />
+                <Tooltip
+                  content={
+                    <div className={styles.tooltipContent}>
+                      <FormattedMessage
+                        {...MSG.tooltipColonyCreationDisabled}
+                      />
+                    </div>
+                  }
+                >
+                  <div>
+                    <Button
+                      appearance={{ theme: 'primary', size: 'large' }}
+                      type="submit"
+                      data-test="claimColonyNameConfirm"
+                      disabled={
+                        DISABLE_COLONY_CREATION_DUE_TO_HIGH_GAS_COSTS ||
+                        !isValid ||
+                        (!dirty && !stepCompleted)
+                      }
+                      loading={isSubmitting}
+                      text={MSG.continue}
+                    />
+                  </div>
+                </Tooltip>
               </div>
             </div>
           </section>

--- a/src/modules/dashboard/components/CreateColonyWizard/StepColonyName.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepColonyName.tsx
@@ -73,7 +73,7 @@ const MSG = defineMessages({
   },
   tooltipColonyCreationDisabled: {
     id: 'users.CreateColonyWizard.StepColonyName.tooltipColonyCreationDisabled',
-    defaultMessage: `Due to the extraordinarily high Ethereum gas prices, we’ve decided to disable the colony creation flow to prevent new users from incurring unexpectedly high costs in setting up their colony. Colony creation will be accessible again on xDai very soon!`,
+    defaultMessage: `Due to the extraordinarily high Ethereum gas prices, we’ve decided to disable colony creation to prevent new users from incurring unexpectedly high costs. A new and improved Colony V2 will be available on xDai soon!`,
   },
 });
 


### PR DESCRIPTION
## Description

This PR prevents users from creating new colonies, by disabling the submit button on the first step of the create colony flow. This change came about the high gas costs currently floating about on the Ethereum network.

However, this should be rolled back when the times is right, or for the xDai deployment.

**Reviewer Note**: @ceolson01 I've added you as a reviewer, but in the interest of time, most likely this will have been already merged.

**Changes**

- [x] `CreateColonyWizard` disabled the step array, but still allow username creation
- [x] `StepColonyName` disable submit button, and wrap it in a tooltip

**Screenshots**

![Screenshot from 2020-09-03 12-26-28](https://user-images.githubusercontent.com/1193222/92099699-80a6de00-ede3-11ea-8f38-8d0b28cdb5b7.png)
