### PR TITLE
Colony home navigation

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.css
@@ -12,11 +12,15 @@
 
 .mainContentGrid {
   display: grid;
-  grid-template-columns: 23% auto 26%;
+  grid-template-columns: 23% auto 26.5%;
 }
 
 .leftAside {
-  padding: 17px 5% 20px;
+  padding: 17px 7% 20px 25%;
+}
+
+.leftAsideNav {
+  margin-top: 53px;
 }
 
 .mainContent {

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.css
@@ -1,5 +1,3 @@
-@value wideButton: 160px;
-
 .main {
   composes: stretchVertical stretchHorizontal from '~styles/layout.css';
   display: grid;
@@ -7,7 +5,7 @@
 }
 
 .colonyList {
-  border-right: 1px solid #E3E0E3;
+  border-right: 1px solid rgb(227, 224, 227);
 }
 
 .mainContentGrid {

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.css.d.ts
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.css.d.ts
@@ -1,4 +1,3 @@
-export const wideButton: string;
 export const main: string;
 export const colonyList: string;
 export const mainContentGrid: string;

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.css.d.ts
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.css.d.ts
@@ -3,5 +3,6 @@ export const main: string;
 export const colonyList: string;
 export const mainContentGrid: string;
 export const leftAside: string;
+export const leftAsideNav: string;
 export const mainContent: string;
 export const rightAside: string;

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
@@ -10,9 +10,9 @@ import { useColonyFromNameQuery } from '~data/index';
 import ColonyNavigation from '~dashboard/ColonyNavigation';
 import LoadingTemplate from '~pages/LoadingTemplate';
 import {
-  COLONY_ACTIONS_ROUTE,
   COLONY_EVENTS_ROUTE,
   COLONY_EXTENSIONS_ROUTE,
+  COLONY_HOME_ROUTE,
   NOT_FOUND_ROUTE,
 } from '~routes/index';
 import { useTransformer } from '~utils/hooks';
@@ -135,12 +135,12 @@ const ColonyHome = ({ match, location }: Props) => {
         </aside>
         <div className={styles.mainContent}>
           <Switch>
-            <Route path={COLONY_ACTIONS_ROUTE} component={() => <>Actions</>} />
             <Route path={COLONY_EVENTS_ROUTE} component={() => <>Events</>} />
             <Route
               path={COLONY_EXTENSIONS_ROUTE}
               component={() => <>Extensions</>}
             />
+            <Route path={COLONY_HOME_ROUTE} component={() => <>Actions</>} />
           </Switch>
         </div>
         <aside className={styles.rightAside}>

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
@@ -1,14 +1,20 @@
 import React from 'react';
 import { defineMessages } from 'react-intl';
-import { Redirect, RouteChildrenProps } from 'react-router-dom';
+import { Redirect, Route, RouteChildrenProps, Switch } from 'react-router-dom';
 import { parse as parseQS } from 'query-string';
 import { ROOT_DOMAIN_ID } from '@colony/colony-js';
 
 import { COLONY_TOTAL_BALANCE_DOMAIN_ID } from '~constants';
 import { useLoggedInUser } from '~data/helpers';
 import { useColonyFromNameQuery } from '~data/index';
+import ColonyNavigation from '~dashboard/ColonyNavigation';
 import LoadingTemplate from '~pages/LoadingTemplate';
-import { NOT_FOUND_ROUTE } from '~routes/index';
+import {
+  COLONY_ACTIONS_ROUTE,
+  COLONY_EVENTS_ROUTE,
+  COLONY_EXTENSIONS_ROUTE,
+  NOT_FOUND_ROUTE,
+} from '~routes/index';
 import { useTransformer } from '~utils/hooks';
 
 import { getUserRolesForDomain } from '../../../transformers';
@@ -121,8 +127,22 @@ const ColonyHome = ({ match, location }: Props) => {
     <div className={styles.main}>
       <div className={styles.colonyList}>A</div>
       <div className={styles.mainContentGrid}>
-        <aside className={styles.leftAside}>b</aside>
-        <div className={styles.mainContent}>c</div>
+        <aside className={styles.leftAside}>
+          {/* Put new colony home title display (#2268) here */}
+          <div className={styles.leftAsideNav}>
+            <ColonyNavigation />
+          </div>
+        </aside>
+        <div className={styles.mainContent}>
+          <Switch>
+            <Route path={COLONY_ACTIONS_ROUTE} component={() => <>Actions</>} />
+            <Route path={COLONY_EVENTS_ROUTE} component={() => <>Events</>} />
+            <Route
+              path={COLONY_EXTENSIONS_ROUTE}
+              component={() => <>Extensions</>}
+            />
+          </Switch>
+        </div>
         <aside className={styles.rightAside}>
           <ColonyFunding colony={colony} currentDomainId={filteredDomainId} />
         </aside>

--- a/src/modules/dashboard/components/ColonyNavigation/ColonyNavigation.tsx
+++ b/src/modules/dashboard/components/ColonyNavigation/ColonyNavigation.tsx
@@ -36,7 +36,7 @@ const ColonyNavigation = () => {
   const items = useMemo<ComponentProps<typeof NavItem>[]>(
     () => [
       {
-        linkTo: `/colony/${colonyName}/actions`,
+        linkTo: `/colony/${colonyName}`,
         showDot: hasNewActions,
         text: MSG.linkTextActions,
       },

--- a/src/modules/dashboard/components/ColonyNavigation/ColonyNavigation.tsx
+++ b/src/modules/dashboard/components/ColonyNavigation/ColonyNavigation.tsx
@@ -1,0 +1,70 @@
+import React, { ComponentProps, useMemo } from 'react';
+import { defineMessages } from 'react-intl';
+import { useParams } from 'react-router';
+
+import NavItem from './NavItem';
+
+const MSG = defineMessages({
+  linkTextActions: {
+    id: 'dashboard.ColonyNavigation.linkTextActions',
+    defaultMessage: 'Actions',
+  },
+  linkTextEvents: {
+    id: 'dashboard.ColonyNavigation.linkTextEvents',
+    defaultMessage: 'Events',
+  },
+  linkTextExtensions: {
+    id: 'dashboard.ColonyNavigation.linkTextExtensions',
+    defaultMessage: 'Extensions',
+  },
+  linkExtraExtensions: {
+    id: 'dashboard.ColonyNavigation.linkExtraExtensions',
+    defaultMessage: 'Coming Soon',
+  },
+});
+
+const displayName = 'dashboard.ColonyNavigation';
+
+const ColonyNavigation = () => {
+  const { colonyName } = useParams<{ colonyName: string }>();
+
+  // @TODO actually determine these
+  const hasNewActions = false;
+  const hasNewEvents = true;
+  const hasNewExtensions = false;
+
+  const items = useMemo<ComponentProps<typeof NavItem>[]>(
+    () => [
+      {
+        linkTo: `/colony/${colonyName}/actions`,
+        showDot: hasNewActions,
+        text: MSG.linkTextActions,
+      },
+      {
+        linkTo: `/colony/${colonyName}/events`,
+        showDot: hasNewEvents,
+        text: MSG.linkTextEvents,
+      },
+      {
+        disabled: true,
+        extra: MSG.linkExtraExtensions,
+        linkTo: `/colony/${colonyName}/extensions`,
+        showDot: hasNewExtensions,
+        text: MSG.linkTextExtensions,
+      },
+    ],
+    [colonyName, hasNewActions, hasNewEvents, hasNewExtensions],
+  );
+
+  return (
+    <nav role="navigation">
+      {items.map((itemProps) => (
+        <NavItem key={itemProps.linkTo} {...itemProps} />
+      ))}
+    </nav>
+  );
+};
+
+ColonyNavigation.displayName = displayName;
+
+export default ColonyNavigation;

--- a/src/modules/dashboard/components/ColonyNavigation/NavItem.css
+++ b/src/modules/dashboard/components/ColonyNavigation/NavItem.css
@@ -1,0 +1,44 @@
+
+.main {
+  display: block;
+  font-weight: var(--weight-bold);
+
+  & + .main {
+    margin-top: 18px;
+  }
+
+  &[aria-disabled="true"] {
+    pointer-events: none;
+
+    & .text {
+      opacity: 0.4;
+    }
+  }
+}
+
+.text {
+  font-size: var(--size-normal);
+  color: var(--text-dark);
+}
+
+.main:hover .text,
+.main:focus .text,
+.active .text {
+  color: var(--primary);
+}
+
+.extra {
+  margin-left: 20px;
+  font-size: var(--size-unreadable);
+}
+
+.showDot .text::after {
+  display: inline-block;
+  margin-bottom: 2px;
+  margin-left: 7px;
+  height: 5px;
+  width: 5px;
+  border-radius: 50%;
+  background-color: var(--colony-blue);
+  content: '';
+}

--- a/src/modules/dashboard/components/ColonyNavigation/NavItem.css.d.ts
+++ b/src/modules/dashboard/components/ColonyNavigation/NavItem.css.d.ts
@@ -1,0 +1,5 @@
+export const main: string;
+export const text: string;
+export const active: string;
+export const extra: string;
+export const showDot: string;

--- a/src/modules/dashboard/components/ColonyNavigation/NavItem.tsx
+++ b/src/modules/dashboard/components/ColonyNavigation/NavItem.tsx
@@ -1,0 +1,59 @@
+import React, { KeyboardEvent, useCallback } from 'react';
+import { MessageDescriptor, useIntl } from 'react-intl';
+
+import NavLink from '~core/NavLink';
+import { ENTER } from '~types/index';
+
+import styles from './NavItem.css';
+
+interface Props {
+  disabled?: boolean;
+  extra?: MessageDescriptor;
+  linkTo: string;
+  showDot?: boolean;
+  text: MessageDescriptor;
+}
+
+const displayName = 'dashboard.ColonyNavigation.NavItem';
+
+const NavItem = ({
+  disabled = false,
+  extra: extraProp,
+  linkTo,
+  showDot = false,
+  text: textProp,
+}: Props) => {
+  const { formatMessage } = useIntl();
+
+  const handleLinkKeyDown = useCallback(
+    (evt: KeyboardEvent<HTMLAnchorElement>) => {
+      if (disabled && evt.key === ENTER) {
+        evt.preventDefault();
+      }
+    },
+    [disabled],
+  );
+
+  const text = formatMessage(textProp);
+  const extra = extraProp ? formatMessage(extraProp) : undefined;
+  const classNames = [styles.main];
+  if (showDot) {
+    classNames.push(styles.showDot);
+  }
+  return (
+    <NavLink
+      activeClassName={styles.active}
+      aria-disabled={disabled}
+      className={classNames.join(' ')}
+      onKeyDown={handleLinkKeyDown}
+      to={linkTo}
+    >
+      <span className={styles.text}>{text}</span>
+      {extra && <span className={styles.extra}>{extra}</span>}
+    </NavLink>
+  );
+};
+
+NavItem.displayName = displayName;
+
+export default NavItem;

--- a/src/modules/dashboard/components/ColonyNavigation/NavItem.tsx
+++ b/src/modules/dashboard/components/ColonyNavigation/NavItem.tsx
@@ -45,6 +45,7 @@ const NavItem = ({
       activeClassName={styles.active}
       aria-disabled={disabled}
       className={classNames.join(' ')}
+      exact
       onKeyDown={handleLinkKeyDown}
       to={linkTo}
     >

--- a/src/modules/dashboard/components/ColonyNavigation/index.ts
+++ b/src/modules/dashboard/components/ColonyNavigation/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ColonyNavigation';

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -27,22 +27,23 @@ import { ActionTypes } from '~redux/index';
 import appLoadingContext from '~context/appLoadingState';
 
 import {
-  CONNECT_ROUTE,
+  ADMIN_DASHBOARD_ROUTE,
+  COLONY_ACTIONS_ROUTE,
+  COLONY_EVENTS_ROUTE,
+  COLONY_EXTENSIONS_ROUTE,
   COLONY_HOME_ROUTE,
+  CONNECT_ROUTE,
   CREATE_COLONY_ROUTE,
   CREATE_USER_ROUTE,
-  LEVEL_EDIT_ROUTE,
-  NOT_FOUND_ROUTE,
-  PROGRAM_ROUTE,
-  TASK_ROUTE,
   CREATE_WALLET_ROUTE,
   DASHBOARD_ROUTE,
-  ADMIN_DASHBOARD_ROUTE,
   INBOX_ROUTE,
+  LEVEL_EDIT_ROUTE,
+  NOT_FOUND_ROUTE,
+  TASK_ROUTE,
   USER_EDIT_ROUTE,
   USER_ROUTE,
   WALLET_ROUTE,
-  LEVEL_ROUTE,
 } from './routeConstants';
 
 import AlwaysAccesibleRoute from './AlwaysAccesibleRoute';
@@ -160,7 +161,12 @@ const Routes = () => {
         />
         <AlwaysAccesibleRoute
           exact
-          path={[COLONY_HOME_ROUTE, LEVEL_ROUTE, PROGRAM_ROUTE]}
+          path={[
+            COLONY_HOME_ROUTE,
+            COLONY_ACTIONS_ROUTE,
+            COLONY_EVENTS_ROUTE,
+            COLONY_EXTENSIONS_ROUTE,
+          ]}
           component={ColonyHome}
           layout={SimpleNav}
           routeProps={{

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -28,7 +28,6 @@ import appLoadingContext from '~context/appLoadingState';
 
 import {
   ADMIN_DASHBOARD_ROUTE,
-  COLONY_ACTIONS_ROUTE,
   COLONY_EVENTS_ROUTE,
   COLONY_EXTENSIONS_ROUTE,
   COLONY_HOME_ROUTE,
@@ -163,7 +162,6 @@ const Routes = () => {
           exact
           path={[
             COLONY_HOME_ROUTE,
-            COLONY_ACTIONS_ROUTE,
             COLONY_EVENTS_ROUTE,
             COLONY_EXTENSIONS_ROUTE,
           ]}

--- a/src/routes/routeConstants.ts
+++ b/src/routes/routeConstants.ts
@@ -1,6 +1,5 @@
 export const CONNECT_ROUTE = '/connect';
 export const COLONY_HOME_ROUTE = '/colony/:colonyName';
-export const COLONY_ACTIONS_ROUTE = `${COLONY_HOME_ROUTE}/actions`;
 export const COLONY_EVENTS_ROUTE = `${COLONY_HOME_ROUTE}/events`;
 export const COLONY_EXTENSIONS_ROUTE = `${COLONY_HOME_ROUTE}/extensions`;
 export const PROGRAM_ROUTE = `${COLONY_HOME_ROUTE}/program/:programId`;

--- a/src/routes/routeConstants.ts
+++ b/src/routes/routeConstants.ts
@@ -1,5 +1,8 @@
 export const CONNECT_ROUTE = '/connect';
 export const COLONY_HOME_ROUTE = '/colony/:colonyName';
+export const COLONY_ACTIONS_ROUTE = `${COLONY_HOME_ROUTE}/actions`;
+export const COLONY_EVENTS_ROUTE = `${COLONY_HOME_ROUTE}/events`;
+export const COLONY_EXTENSIONS_ROUTE = `${COLONY_HOME_ROUTE}/extensions`;
 export const PROGRAM_ROUTE = `${COLONY_HOME_ROUTE}/program/:programId`;
 export const LEVEL_ROUTE = `${PROGRAM_ROUTE}/level/:levelId`;
 export const LEVEL_EDIT_ROUTE = `${PROGRAM_ROUTE}/level/:levelId/edit`;


### PR DESCRIPTION
> ⚠️ This PR is based on #2271 

## Description

This PR adds navigation, along with routes, for the Colony Simplified page.

**New stuff** ✨

* New colony routes
* `ColonyNavigation` component

**Changes** 🏗

* Improve padding accuracies
* Cleanup some unused css in `ColonyHome`


**Screenshot** 📷 

<img width="1505" alt="Screen Shot 2020-10-07 at 12 16 04 PM" src="https://user-images.githubusercontent.com/3052635/95364797-e1b84a80-0896-11eb-89a6-97ebc49ba422.png">

Closes #2269 

