### PR TITLE
Colony Members Avatars

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.css
@@ -1,3 +1,9 @@
+.main h4 {
+  font-size: var(--size-smallish);
+  color: var(--dark);
+  letter-spacing: var(--spacing-medium);
+}
+
 .fundingButton {
   margin-left: 30px;
 }

--- a/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.css.d.ts
+++ b/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.css.d.ts
@@ -1,2 +1,3 @@
+export const main: string;
 export const fundingButton: string;
 export const tokenBalance: string;

--- a/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.tsx
@@ -74,7 +74,7 @@ const ColonyFunding = ({ colony, currentDomainId }: Props) => {
   });
 
   return (
-    <div>
+    <div className={styles.main}>
       <Heading appearance={{ size: 'normal', weight: 'bold' }}>
         <FormattedMessage {...MSG.title} />
         {canMoveTokens && (

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
@@ -10,6 +10,8 @@ import { useColonyFromNameQuery } from '~data/index';
 import ColonyNavigation from '~dashboard/ColonyNavigation';
 import SubscribedColoniesList from '~dashboard/SubscribedColoniesList/SubscribedColoniesList';
 import LoadingTemplate from '~pages/LoadingTemplate';
+import ColonyMembers from '~dashboard/ColonyMembers';
+
 import {
   COLONY_EVENTS_ROUTE,
   COLONY_EXTENSIONS_ROUTE,
@@ -170,6 +172,7 @@ const ColonyHome = ({ match, location }: Props) => {
         </div>
         <aside className={styles.rightAside}>
           <ColonyFunding colony={colony} currentDomainId={filteredDomainId} />
+          <ColonyMembers colony={colony} />
         </aside>
       </div>
     </div>

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css
@@ -1,0 +1,3 @@
+.main {
+  display: block;
+}

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css
@@ -14,13 +14,19 @@
   color: var(--colony-blue);
 }
 
-.userAvatars {}
+.userAvatars {
+  max-width: 130px;
+}
 
 .userAvatar {
   display: inline-block;
   margin: 0 15px 15px 0;
   border: 2px solid transparent;
   border-radius: 50px;
+}
+
+.userAvatar:nth-child(3n+0) {
+  margin-right: 0px;
 }
 
 .userAvatar figure {

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css
@@ -1,3 +1,33 @@
 .main {
   display: block;
+  margin-top: 40px;
+}
+
+.main h4 {
+  font-size: var(--size-smallish);
+  color: var(--dark);
+  letter-spacing: var(--spacing-medium);
+}
+
+.main h4:hover, .main h4:active {
+  text-decoration: underline;
+  color: var(--colony-blue);
+}
+
+.userAvatars {}
+
+.userAvatar {
+  display: inline-block;
+  margin: 0 15px 15px 0;
+  border: 2px solid transparent;
+  border-radius: 50px;
+}
+
+.userAvatar figure {
+  height: 28px;
+  width: 28px;
+}
+
+.userAvatar:hover {
+  border-color: var(--primary);
 }

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css
@@ -1,18 +1,22 @@
 .main {
   display: block;
   margin-top: 40px;
-  max-width: 130px;
 }
 
 .main h4 {
+  display: inline-block;
   font-size: var(--size-smallish);
   color: var(--dark);
   letter-spacing: var(--spacing-medium);
 }
 
-.main h4:hover, .main h4:active {
+.main a h4:hover, .main a h4:active {
   text-decoration: underline;
   color: var(--colony-blue);
+}
+
+.userAvatars {
+  max-width: 130px;
 }
 
 .userAvatar {
@@ -50,4 +54,12 @@
   color: var(--temp-grey-13);
   cursor: default;
   letter-spacing: var(--spacing-medium);
+}
+
+.loadingText {
+  display: inline-block;
+  margin: -8px 0 0 5px;
+  vertical-align: middle;
+  font-size: var(--size-small);
+  letter-spacing: initial;
 }

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css
@@ -1,6 +1,7 @@
 .main {
   display: block;
   margin-top: 40px;
+  max-width: 130px;
 }
 
 .main h4 {
@@ -14,10 +15,6 @@
   color: var(--colony-blue);
 }
 
-.userAvatars {
-  max-width: 130px;
-}
-
 .userAvatar {
   display: inline-block;
   margin: 0 15px 15px 0;
@@ -29,11 +26,28 @@
   margin-right: 0px;
 }
 
-.userAvatar figure {
-  height: 28px;
-  width: 28px;
+.userAvatar:nth-child(13), .userAvatar:nth-child(14), .userAvatar:nth-child(15) {
+  margin-bottom: 0px;
 }
 
 .userAvatar:hover {
   border-color: var(--primary);
+}
+
+.remaningAvatars {
+  display: inline-block;
+  margin: 0;
+  padding-top: 5px;
+  height: 30px;
+  width: 30px;
+  vertical-align: top;
+  border: 2px solid transparent;
+  border-radius: 50px;
+  background-color: var(--colony-white);
+  font-size: var(--size-tiny);
+  font-weight: var(--weight-bold);
+  text-align: center;
+  color: var(--temp-grey-13);
+  cursor: default;
+  letter-spacing: var(--spacing-medium);
 }

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css.d.ts
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css.d.ts
@@ -1,0 +1,3 @@
+export const main: string;
+export const userAvatars: string;
+export const userAvatar: string;

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css.d.ts
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css.d.ts
@@ -1,3 +1,5 @@
 export const main: string;
+export const userAvatars: string;
 export const userAvatar: string;
 export const remaningAvatars: string;
+export const loadingText: string;

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css.d.ts
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css.d.ts
@@ -1,3 +1,3 @@
 export const main: string;
-export const userAvatars: string;
 export const userAvatar: string;
+export const remaningAvatars: string;

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -129,13 +129,6 @@ const ColonyMembers = ({ colony: { colonyAddress } }: Props) => {
                 popperProps={{
                   placement: 'bottom',
                   showArrow: false,
-                  /*
-                   * @NOTE This is the price we have to pay for the ability
-                   * to customize the Popor library, which is nested under the
-                   * Popover component, which is nested under UserInfo,
-                   * which is nested under UserAvatar
-                   */
-                  children: () => null,
                   modifiers: [
                     {
                       name: 'offset',

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -1,21 +1,66 @@
 import React from 'react';
 import { defineMessages } from 'react-intl';
 
+import NavLink from '~core/NavLink';
+import Heading from '~core/Heading';
+import HookedUserAvatar from '~users/HookedUserAvatar';
+import { DASHBOARD_ROUTE } from '~routes/index';
+import { Colony, useLoggedInUser } from '~data/index';
+
 import styles from './ColonyMembers.css';
 
 const MSG = defineMessages({
-  text: {
-    id: 'dashboard.ColonyMembers.text',
-    defaultMessage: 'Text',
+  title: {
+    id: 'dashboard.ColonyMembers.title',
+    defaultMessage: 'Members ({count})',
   },
 });
 
-interface Props {}
+interface Props {
+  colony: Colony;
+}
+
+const UserAvatar = HookedUserAvatar({ fetchUser: false });
 
 const displayName = 'dashboard.ColonyMembers';
 
-const ColonyMembers = () => {
-  return <div className={styles.main} />;
+const ColonyMembers = ({ colony: { colonyAddress } }: Props) => {
+  const { walletAddress } = useLoggedInUser();
+  return (
+    <div className={styles.main}>
+      <NavLink
+        /*
+         * @TODO Put in the Community route, once that is created in DEV-13
+         */
+        to={DASHBOARD_ROUTE}
+      >
+        <Heading
+          appearance={{ size: 'normal', weight: 'bold' }}
+          text={MSG.title}
+          /*
+           * @TODO Put in actual count value
+           */
+          textValues={{ count: 33 }}
+        />
+      </NavLink>
+      <ul className={styles.userAvatars}>
+        <li className={styles.userAvatar}>
+          <UserAvatar
+            colonyAddress={colonyAddress}
+            address={walletAddress}
+            // user={user}
+            showInfo
+            notSet={false}
+            popperProps={{
+              placement: 'left',
+              showArrow: false,
+              children: () => null,
+            }}
+          />
+        </li>
+      </ul>
+    </div>
+  );
 };
 
 ColonyMembers.displayName = displayName;

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -109,9 +109,30 @@ const ColonyMembers = ({ colony: { colonyAddress } }: Props) => {
                 showInfo
                 notSet={false}
                 popperProps={{
-                  placement: 'left',
+                  placement: 'bottom',
                   showArrow: false,
+                  /*
+                   * @NOTE This is the price we have to pay for the ability
+                   * to customize the Popor library, which is nested under the
+                   * Popover component, which is nested under UserInfo,
+                   * which is nested under UserAvatar
+                   */
                   children: () => null,
+                  modifiers: [
+                    {
+                      name: 'offset',
+                      options: {
+                        /*
+                         * @NOTE Values are set manual, exactly as the ones provided in the figma spec.
+                         *
+                         * There's no logic to how they are calculated, so next time you need
+                         * to change them you'll either have to go by exact specs, or change
+                         * them until it "feels right" :)
+                         */
+                        offset: [-208, -12],
+                      },
+                    },
+                  ],
                 }}
               />
             </li>

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { defineMessages } from 'react-intl';
+
+import styles from './ColonyMembers.css';
+
+const MSG = defineMessages({
+  text: {
+    id: 'dashboard.ColonyMembers.text',
+    defaultMessage: 'Text',
+  },
+});
+
+interface Props {}
+
+const displayName = 'dashboard.ColonyMembers';
+
+const ColonyMembers = () => {
+  return <div className={styles.main} />;
+};
+
+ColonyMembers.displayName = displayName;
+
+export default ColonyMembers;

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -55,6 +55,22 @@ const ColonyMembers = ({ colony: { colonyAddress } }: Props) => {
     return MAX_AVATARS - 1;
   }, [colonySubscribedUsers]);
 
+  const remainingAvatarsCount = useMemo(() => {
+    if (
+      !colonySubscribedUsers ||
+      !colonySubscribedUsers.colony.subscribedUsers.length
+    ) {
+      return 0;
+    }
+    const {
+      colony: { subscribedUsers },
+    } = colonySubscribedUsers;
+    if (subscribedUsers.length <= MAX_AVATARS) {
+      return 0;
+    }
+    return subscribedUsers.length - MAX_AVATARS;
+  }, [colonySubscribedUsers]);
+
   if (!colonySubscribedUsers || loadingColonySubscribedUsers) {
     /*
      * @TODO Add loading spinner
@@ -80,12 +96,13 @@ const ColonyMembers = ({ colony: { colonyAddress } }: Props) => {
           textValues={{ count: subscribedUsers.length }}
         />
       </NavLink>
-      <ul className={styles.userAvatars}>
+      <ul>
         {(subscribedUsers as AnyUser[])
           .slice(0, avatarsDisplaySplitRules)
           .map((user) => (
             <li className={styles.userAvatar} key={user.id}>
               <UserAvatar
+                size="xs"
                 colonyAddress={colonyAddress}
                 address={user.profile.walletAddress}
                 user={user}
@@ -99,6 +116,13 @@ const ColonyMembers = ({ colony: { colonyAddress } }: Props) => {
               />
             </li>
           ))}
+        {!!remainingAvatarsCount && (
+          <li className={styles.remaningAvatars}>
+            {remainingAvatarsCount < 99
+              ? remainingAvatarsCount
+              : `>${remainingAvatarsCount}`}
+          </li>
+        )}
       </ul>
     </div>
   );

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -1,9 +1,11 @@
 import React, { useMemo } from 'react';
-import { defineMessages } from 'react-intl';
+import { defineMessages, FormattedMessage } from 'react-intl';
 
 import NavLink from '~core/NavLink';
 import Heading from '~core/Heading';
 import HookedUserAvatar from '~users/HookedUserAvatar';
+import { SpinnerLoader } from '~core/Preloaders';
+
 import { DASHBOARD_ROUTE } from '~routes/index';
 import { Colony, useColonySubscribedUsersQuery, AnyUser } from '~data/index';
 
@@ -12,7 +14,14 @@ import styles from './ColonyMembers.css';
 const MSG = defineMessages({
   title: {
     id: 'dashboard.ColonyMembers.title',
-    defaultMessage: 'Members ({count})',
+    defaultMessage: `Members{hasCounter, select,
+      true { ({count})}
+      false {}
+    }`,
+  },
+  loadingData: {
+    id: 'dashboard.ColonyMembers.loadingData',
+    defaultMessage: 'Loading members information...',
   },
 });
 
@@ -72,10 +81,19 @@ const ColonyMembers = ({ colony: { colonyAddress } }: Props) => {
   }, [colonySubscribedUsers]);
 
   if (!colonySubscribedUsers || loadingColonySubscribedUsers) {
-    /*
-     * @TODO Add loading spinner
-     */
-    return <div className={styles.main} />;
+    return (
+      <div className={styles.main}>
+        <Heading
+          appearance={{ size: 'normal', weight: 'bold' }}
+          text={MSG.title}
+          textValues={{ hasCounter: false }}
+        />
+        <SpinnerLoader appearance={{ size: 'small' }} />
+        <span className={styles.loadingText}>
+          <FormattedMessage {...MSG.loadingData} />
+        </span>
+      </div>
+    );
   }
 
   const {
@@ -93,10 +111,10 @@ const ColonyMembers = ({ colony: { colonyAddress } }: Props) => {
         <Heading
           appearance={{ size: 'normal', weight: 'bold' }}
           text={MSG.title}
-          textValues={{ count: subscribedUsers.length }}
+          textValues={{ count: subscribedUsers.length, hasCounter: true }}
         />
       </NavLink>
-      <ul>
+      <ul className={styles.userAvatars}>
         {(subscribedUsers as AnyUser[])
           .slice(0, avatarsDisplaySplitRules)
           .map((user) => (

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { defineMessages } from 'react-intl';
 
 import NavLink from '~core/NavLink';
@@ -21,6 +21,7 @@ interface Props {
 }
 
 const UserAvatar = HookedUserAvatar({ fetchUser: false });
+const MAX_AVATARS = 15;
 
 const displayName = 'dashboard.ColonyMembers';
 
@@ -37,6 +38,22 @@ const ColonyMembers = ({ colony: { colonyAddress } }: Props) => {
       colonyAddress,
     },
   });
+
+  const avatarsDisplaySplitRules = useMemo(() => {
+    if (
+      !colonySubscribedUsers ||
+      !colonySubscribedUsers.colony.subscribedUsers.length
+    ) {
+      return 0;
+    }
+    const {
+      colony: { subscribedUsers },
+    } = colonySubscribedUsers;
+    if (subscribedUsers.length <= MAX_AVATARS) {
+      return subscribedUsers.length;
+    }
+    return MAX_AVATARS - 1;
+  }, [colonySubscribedUsers]);
 
   if (!colonySubscribedUsers || loadingColonySubscribedUsers) {
     /*
@@ -64,22 +81,24 @@ const ColonyMembers = ({ colony: { colonyAddress } }: Props) => {
         />
       </NavLink>
       <ul className={styles.userAvatars}>
-        {(subscribedUsers as AnyUser[]).map((user) => (
-          <li className={styles.userAvatar} key={user.id}>
-            <UserAvatar
-              colonyAddress={colonyAddress}
-              address={user.profile.walletAddress}
-              user={user}
-              showInfo
-              notSet={false}
-              popperProps={{
-                placement: 'left',
-                showArrow: false,
-                children: () => null,
-              }}
-            />
-          </li>
-        ))}
+        {(subscribedUsers as AnyUser[])
+          .slice(0, avatarsDisplaySplitRules)
+          .map((user) => (
+            <li className={styles.userAvatar} key={user.id}>
+              <UserAvatar
+                colonyAddress={colonyAddress}
+                address={user.profile.walletAddress}
+                user={user}
+                showInfo
+                notSet={false}
+                popperProps={{
+                  placement: 'left',
+                  showArrow: false,
+                  children: () => null,
+                }}
+              />
+            </li>
+          ))}
       </ul>
     </div>
   );

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -157,9 +157,7 @@ const ColonyMembers = ({ colony: { colonyAddress } }: Props) => {
           ))}
         {!!remainingAvatarsCount && (
           <li className={styles.remaningAvatars}>
-            {remainingAvatarsCount < 99
-              ? remainingAvatarsCount
-              : `>${remainingAvatarsCount}`}
+            {remainingAvatarsCount < 99 ? remainingAvatarsCount : `>99`}
           </li>
         )}
       </ul>

--- a/src/modules/dashboard/components/ColonyMembers/index.ts
+++ b/src/modules/dashboard/components/ColonyMembers/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ColonyMembers';

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -100,6 +100,7 @@
   --size-unreadable: 10px;
   --size-tiny: 11px;
   --size-small: 12px;
+  --size-smallish: 13px; /* This shows up more and more in Colony Simplified */
   --size-normal: 14px;
   --size-medium: 16px;
   --size-medium-l: 18px;


### PR DESCRIPTION
## Description

This PR adds in the colony members avatars display on the right aside, which will show the users in that colony with the most reputation.

Currently the reputation filter feature is not implemented _(as it requires changes to the reputation oracle)_, as well as not featuring the community page route link, which will only be implemented in DEV-13

**Changes**

- [x] Refactored code `UserAvatar` and `InfoPopover` to support configuring the underlying `Popover` component via simple props
- [x] Added `ColonyMembers` component

**Demo**

![cs-colony-members](https://user-images.githubusercontent.com/1193222/97765674-ae767d80-1b1b-11eb-8fb4-6ceac2a1fce2.gif)

Resolves #2270
Resolves DEV-6