### PR TITLE
Update Node version in Github Actions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,7 +10,7 @@ jobs:
   build-and-deploy:
     strategy:
       matrix:
-        node-version: [12.16.3]
+        node-version: [12.19.0]
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.16.3]
+        node-version: [12.19.0]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, feature/* ]
 
 jobs:
   build:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "colony-dapp",
   "private": true,
   "engines": {
-    "node": ">=12.16.3 <13"
+    "node": ">=12.19.0 <13"
   },
   "version": "3.0.2",
   "description": "",


### PR DESCRIPTION
## Description

This is a simple PR that updates the node version in various places we use it, as not all were updated when the node version changed in #2237

**Changes** 

- [x] Updated node version in the Node Build github action
- [x] Updated node version in the GH Pages Build github action
- [x] Updated node version in `packages.json`
- [x] Allow the Node Build github action to be run on `feature` branches as well
