### PR TITLE
TokenEditDialog redesign

### DIFF
--- a/src/modules/admin/components/Tokens/ColonyTokenEditDialog.tsx
+++ b/src/modules/admin/components/Tokens/ColonyTokenEditDialog.tsx
@@ -15,15 +15,9 @@ interface Props {
   colonyAddress: Address;
   cancel: () => void;
   close: () => void;
-  nativeTokenAddress: Address;
 }
 
-const ColonyTokenEditDialog = ({
-  colonyAddress,
-  nativeTokenAddress,
-  cancel,
-  close,
-}: Props) => {
+const ColonyTokenEditDialog = ({ colonyAddress, cancel, close }: Props) => {
   const [setColonyTokensMutation] = useSetColonyTokensMutation({
     refetchQueries: [
       {
@@ -54,27 +48,12 @@ const ColonyTokenEditDialog = ({
     [colonyAddress, colonyTokens, setColonyTokensMutation],
   );
 
-  const removeToken = useCallback(
-    (tokenAddressToRemove: Address) => {
-      const newAddresses = colonyTokens
-        .filter((token) => !tokenIsETH(token))
-        .filter(({ address }) => address !== tokenAddressToRemove)
-        .map(({ address }) => address);
-      return setColonyTokensMutation({
-        variables: { input: { colonyAddress, tokenAddresses: newAddresses } },
-      });
-    },
-    [colonyAddress, colonyTokens, setColonyTokensMutation],
-  );
-
   return (
     <TokenEditDialog
       cancel={cancel}
       close={close}
       tokens={colonyTokens}
-      nativeTokenAddress={nativeTokenAddress}
       addTokenFn={addToken}
-      removeTokenFn={removeToken}
     />
   );
 };

--- a/src/modules/admin/components/Tokens/Tokens.tsx
+++ b/src/modules/admin/components/Tokens/Tokens.tsx
@@ -135,9 +135,8 @@ const Tokens = ({
     () =>
       openTokenEditDialog({
         colonyAddress,
-        nativeTokenAddress,
       }),
-    [openTokenEditDialog, colonyAddress, nativeTokenAddress],
+    [openTokenEditDialog, colonyAddress],
   );
   const handleMintTokens = useCallback(() => {
     if (nativeToken) {

--- a/src/modules/core/components/Dialog/DialogSection.css
+++ b/src/modules/core/components/Dialog/DialogSection.css
@@ -4,6 +4,14 @@
   padding: 20px 30px;
 }
 
+.themeHeading {
+  padding: 36px 20px 20px;
+}
+
+.themeSidePadding {
+  padding: 0 20px;
+}
+
 .alignRight {
   text-align: right;
 }

--- a/src/modules/core/components/Dialog/DialogSection.css.d.ts
+++ b/src/modules/core/components/Dialog/DialogSection.css.d.ts
@@ -1,5 +1,7 @@
 export const borderColor: string;
 export const main: string;
+export const themeHeading: string;
+export const themeSidePadding: string;
 export const alignRight: string;
 export const alignCenter: string;
 export const borderNone: string;

--- a/src/modules/core/components/Dialog/DialogSection.tsx
+++ b/src/modules/core/components/Dialog/DialogSection.tsx
@@ -5,6 +5,7 @@ import { getMainClasses } from '~utils/css';
 import styles from './DialogSection.css';
 
 interface Appearance {
+  theme?: 'heading' | 'sidePadding';
   align?: 'center' | 'right';
   border?: 'top' | 'bottom' | 'none';
 }

--- a/src/modules/core/components/Fields/Input/InputComponent.css
+++ b/src/modules/core/components/Fields/Input/InputComponent.css
@@ -123,7 +123,7 @@
 .colorSchemaGrey {
   border: 1px solid rgb(200, 214, 245);
   background-color: rgb(249, 250, 250);
-  color: rgb(60, 68, 77);
+  color: var(--dark);
   box-shadow: inset 0px 2px 4px rgba(0, 0, 0, 0.07);
 }
 

--- a/src/modules/core/components/Fields/InputLabel/InputLabel.css
+++ b/src/modules/core/components/Fields/InputLabel/InputLabel.css
@@ -3,8 +3,8 @@
   margin-bottom: 6px;
   width: 100%;
   position: relative;
-  font-size: var(--size-small);
-  font-weight: 600;
+  font-size: var(--size-smallish);
+  font-weight: 700;
   text-align: left;
   line-height: calc(var(--size-small) + 2px);
 }
@@ -31,6 +31,11 @@
 
 .colorSchemaDark .labelText {
   color: var(--grey-5);
+}
+
+.colorSchemaGrey .labelText {
+  color: var(--dark);
+  font-weight: var(--weight-bold);
 }
 
 .error, .help {

--- a/src/modules/core/components/Fields/InputLabel/InputLabel.css
+++ b/src/modules/core/components/Fields/InputLabel/InputLabel.css
@@ -4,7 +4,7 @@
   width: 100%;
   position: relative;
   font-size: var(--size-smallish);
-  font-weight: 700;
+  font-weight: var(--weight-bold);
   text-align: left;
   line-height: calc(var(--size-small) + 2px);
 }

--- a/src/modules/core/components/Fields/InputLabel/InputLabel.css
+++ b/src/modules/core/components/Fields/InputLabel/InputLabel.css
@@ -34,8 +34,8 @@
 }
 
 .colorSchemaGrey .labelText {
-  color: var(--dark);
   font-weight: var(--weight-bold);
+  color: var(--dark);
 }
 
 .error, .help {

--- a/src/modules/core/components/Fields/InputLabel/InputLabel.css.d.ts
+++ b/src/modules/core/components/Fields/InputLabel/InputLabel.css.d.ts
@@ -5,6 +5,7 @@ export const themeMinimal: string;
 export const directionHorizontal: string;
 export const colorSchemaDark: string;
 export const labelText: string;
+export const colorSchemaGrey: string;
 export const error: string;
 export const help: string;
 export const helpAlignRight: string;

--- a/src/modules/core/components/Heading/Heading.css
+++ b/src/modules/core/components/Heading/Heading.css
@@ -101,6 +101,7 @@
 
 .weightMedium {
   font-weight: var(--weight-bold);
+  letter-spacing: var(--spacing-medium);
 }
 
 .weightBold {

--- a/src/modules/core/components/TokenEditDialog/TokenEditDialog.css
+++ b/src/modules/core/components/TokenEditDialog/TokenEditDialog.css
@@ -13,5 +13,5 @@
 }
 
 .textarea {
-  margin-top: marginSize;
+  margin-top: calc(marginSize * 2);
 }

--- a/src/modules/core/components/TokenEditDialog/TokenEditDialog.css
+++ b/src/modules/core/components/TokenEditDialog/TokenEditDialog.css
@@ -1,4 +1,17 @@
+@value marginSize: 16px;
+
 .tokenChoiceContainer {
   max-height: 250px;
   overflow: auto;
+  border-bottom: 1px solid color-mod(var(--temp-grey-blue-7) alpha(15%));
+}
+
+.description {
+  margin-bottom: marginSize;
+  font-size: var(--size-normal);
+  color: var(--dark);
+}
+
+.textarea {
+  margin-top: marginSize;
 }

--- a/src/modules/core/components/TokenEditDialog/TokenEditDialog.css.d.ts
+++ b/src/modules/core/components/TokenEditDialog/TokenEditDialog.css.d.ts
@@ -1,1 +1,4 @@
+export const marginSize: string;
 export const tokenChoiceContainer: string;
+export const description: string;
+export const textarea: string;

--- a/src/modules/core/components/TokenEditDialog/TokenEditDialog.tsx
+++ b/src/modules/core/components/TokenEditDialog/TokenEditDialog.tsx
@@ -18,7 +18,7 @@ import styles from './TokenEditDialog.css';
 const MSG = defineMessages({
   title: {
     id: 'core.TokenEditDialog.title',
-    defaultMessage: 'Edit Tokens',
+    defaultMessage: 'Manage tokens',
   },
   errorAddingToken: {
     id: 'core.TokenEditDialog.errorAddingToken',
@@ -92,9 +92,25 @@ const TokenEditDialog = ({
     <Dialog cancel={cancel}>
       <DialogSection>
         <Heading
-          appearance={{ margin: 'none', size: 'medium' }}
+          appearance={{ margin: 'none', size: 'medium', theme: 'dark' }}
           text={MSG.title}
         />
+      </DialogSection>
+      <DialogSection>
+        {tokens.length > 0 ? (
+          <div className={styles.tokenChoiceContainer}>
+            {tokens.map((token) => (
+              <TokenItem
+                key={token.address}
+                nativeTokenAddress={nativeTokenAddress}
+                removeTokenFn={removeTokenFn}
+                token={token}
+              />
+            ))}
+          </div>
+        ) : (
+          <Heading appearance={{ size: 'normal' }} text={MSG.noTokensText} />
+        )}
       </DialogSection>
       <DialogSection appearance={{ border: 'top' }}>
         <Form
@@ -116,22 +132,6 @@ const TokenEditDialog = ({
             </>
           )}
         </Form>
-      </DialogSection>
-      <DialogSection appearance={{ border: 'top' }}>
-        {tokens.length > 0 ? (
-          <div className={styles.tokenChoiceContainer}>
-            {tokens.map((token) => (
-              <TokenItem
-                key={token.address}
-                nativeTokenAddress={nativeTokenAddress}
-                removeTokenFn={removeTokenFn}
-                token={token}
-              />
-            ))}
-          </div>
-        ) : (
-          <Heading appearance={{ size: 'normal' }} text={MSG.noTokensText} />
-        )}
       </DialogSection>
       <DialogSection appearance={{ align: 'right' }}>
         <Button

--- a/src/modules/core/components/TokenEditDialog/TokenEditDialog.tsx
+++ b/src/modules/core/components/TokenEditDialog/TokenEditDialog.tsx
@@ -36,14 +36,6 @@ const MSG = defineMessages({
     id: 'core.TokenEditDialog.textareaLabel',
     defaultMessage: 'Explain why you’re making these changes (optional)',
   },
-  buttonCancel: {
-    id: 'core.TokenEditDialog.buttonCancel',
-    defaultMessage: 'Cancel',
-  },
-  buttonConfirm: {
-    id: 'core.TokenEditDialog.buttonConfirm',
-    defaultMessage: 'Confirm',
-  },
   noTokensText: {
     id: 'core.TokenEditDialog.noTokensText',
     defaultMessage: `It looks no tokens have been added yet. Get started using the form above.`,
@@ -58,8 +50,6 @@ interface Props {
   addTokenFn: (address: Address) => Promise<any>;
   cancel: () => void;
   close: () => void;
-  nativeTokenAddress?: Address;
-  removeTokenFn: (address: Address) => Promise<any>;
   tokens: AnyToken[];
 }
 
@@ -83,10 +73,8 @@ const validationSchema = yup.object({
 const TokenEditDialog = ({
   addTokenFn,
   tokens = [],
-  nativeTokenAddress,
   cancel,
   close,
-  removeTokenFn,
 }: Props) => {
   const { formatMessage } = useIntl();
   const [tokenData, setTokenData] = useState<OneToken | undefined>();
@@ -125,8 +113,6 @@ const TokenEditDialog = ({
             {tokens.map((token) => (
               <TokenItem
                 key={token.address}
-                nativeTokenAddress={nativeTokenAddress}
-                removeTokenFn={removeTokenFn}
                 token={token}
               />
             ))}
@@ -176,12 +162,12 @@ const TokenEditDialog = ({
             <DialogSection appearance={{ align: 'right' }}>
               <Button
                 appearance={{ theme: 'secondary', size: 'large' }}
-                text={MSG.buttonCancel}
+                text={{ id: 'button.cancel' }}
                 onClick={close}
               />
               <Button
                 appearance={{ theme: 'primary', size: 'large' }}
-                text={MSG.buttonConfirm}
+                text={{ id: 'button.confirm' }}
                 loading={isSubmitting}
                 disabled={!isValid || isSubmitting || !dirty}
                 type="submit"

--- a/src/modules/core/components/TokenEditDialog/TokenEditDialog.tsx
+++ b/src/modules/core/components/TokenEditDialog/TokenEditDialog.tsx
@@ -1,15 +1,16 @@
 import React, { useCallback } from 'react';
 import { FormikProps, FormikHelpers } from 'formik';
-import { defineMessages, useIntl } from 'react-intl';
+import { defineMessages, useIntl, FormattedMessage } from 'react-intl';
 import * as yup from 'yup';
 
 import Button from '~core/Button';
 import Dialog, { DialogSection } from '~core/Dialog';
-import { Form, Input } from '~core/Fields';
+import { Form, Input, Textarea } from '~core/Fields';
 import Heading from '~core/Heading';
 import { AnyToken } from '~data/index';
 import { Address } from '~types/index';
 import { createAddress } from '~utils/web3';
+import Paragraph from '~core/Paragraph';
 
 import TokenItem from './TokenItem/index';
 
@@ -26,20 +27,28 @@ const MSG = defineMessages({
   },
   fieldLabel: {
     id: 'core.TokenEditDialog.fieldLabel',
-    defaultMessage: 'Enter a valid token address',
+    defaultMessage: 'Contract address',
   },
-  buttonAddToken: {
-    id: 'core.TokenEditDialog.buttonAddToken',
-    defaultMessage: 'Add Token',
+  textareaLabel: {
+    id: 'core.TokenEditDialog.textareaLabel',
+    defaultMessage: 'Explain why you’re making these changes (optional)',
   },
-  buttonDone: {
-    id: 'core.TokenEditDialog.buttonDone',
-    defaultMessage: 'Done',
+  buttonCancel: {
+    id: 'core.TokenEditDialog.buttonCancel',
+    defaultMessage: 'Cancel',
+  },
+  buttonConfirm: {
+    id: 'core.TokenEditDialog.buttonConfirm',
+    defaultMessage: 'Confirm',
   },
   noTokensText: {
     id: 'core.TokenEditDialog.noTokensText',
     defaultMessage: `It looks no tokens have been added yet. Get started using the form above.`,
   },
+  notListedToken: {
+    id: 'core.TokenEditDialog.notListedToken',
+    defaultMessage: `If token is not listed above, please add any ERC20 compatibile token contract address below.`
+  }
 });
 
 interface Props {
@@ -53,6 +62,7 @@ interface Props {
 
 interface FormValues {
   tokenAddress: Address;
+  description?: string;
 }
 
 const validationSchema = yup.object({
@@ -61,6 +71,7 @@ const validationSchema = yup.object({
     .address()
     // @todo validate against entering a duplicate address
     .required(),
+  description: yup.string().nullable(),
 });
 
 const TokenEditDialog = ({
@@ -90,13 +101,13 @@ const TokenEditDialog = ({
   );
   return (
     <Dialog cancel={cancel}>
-      <DialogSection>
+      <DialogSection appearance={{ theme: 'heading' }}>
         <Heading
           appearance={{ margin: 'none', size: 'medium', theme: 'dark' }}
           text={MSG.title}
         />
       </DialogSection>
-      <DialogSection>
+      <DialogSection appearance={{ theme: 'sidePadding' }}>
         {tokens.length > 0 ? (
           <div className={styles.tokenChoiceContainer}>
             {tokens.map((token) => (
@@ -112,34 +123,50 @@ const TokenEditDialog = ({
           <Heading appearance={{ size: 'normal' }} text={MSG.noTokensText} />
         )}
       </DialogSection>
-      <DialogSection appearance={{ border: 'top' }}>
-        <Form
-          initialValues={{
-            tokenAddress: '',
-          }}
-          onSubmit={handleSubmit}
-          validationSchema={validationSchema}
-        >
-          {({ isSubmitting, isValid, dirty }: FormikProps<FormValues>) => (
-            <>
-              <Input label={MSG.fieldLabel} name="tokenAddress" />
+      <Form
+        initialValues={{
+          tokenAddress: '',
+          description: '',
+        }}
+        onSubmit={handleSubmit}
+        validationSchema={validationSchema}
+      >
+        {({ isSubmitting, isValid, dirty }: FormikProps<FormValues>) => (
+          <>
+            <DialogSection>
+              <Paragraph className={styles.description}>
+                <FormattedMessage {...MSG.notListedToken} />
+              </Paragraph>
+              <Input label={MSG.fieldLabel} name="tokenAddress" appearance={{ colorSchema: "grey" }} />
+              <div className={styles.textarea}>
+                <Textarea
+                  appearance={{
+                    colorSchema: 'grey',
+                    resizable: 'vertical',
+                  }}
+                  label={MSG.textareaLabel}
+                  name="description"
+                  maxLength={4000}
+                />
+              </div>
+            </DialogSection>
+            <DialogSection appearance={{ align: 'right' }}>
               <Button
-                disabled={!isValid || isSubmitting || !dirty}
+                appearance={{ theme: 'secondary', size: 'large' }}
+                text={MSG.buttonCancel}
+                onClick={close}
+              />
+              <Button
+                appearance={{ theme: 'primary', size: 'large' }}
+                text={MSG.buttonConfirm}
                 loading={isSubmitting}
-                text={MSG.buttonAddToken}
+                disabled={!isValid || isSubmitting || !dirty}
                 type="submit"
               />
-            </>
-          )}
-        </Form>
-      </DialogSection>
-      <DialogSection appearance={{ align: 'right' }}>
-        <Button
-          appearance={{ theme: 'primary', size: 'large' }}
-          text={MSG.buttonDone}
-          onClick={close}
-        />
-      </DialogSection>
+            </DialogSection>
+          </>
+        )}
+      </Form>
     </Dialog>
   );
 };

--- a/src/modules/core/components/TokenEditDialog/TokenEditDialog.tsx
+++ b/src/modules/core/components/TokenEditDialog/TokenEditDialog.tsx
@@ -70,12 +70,7 @@ const validationSchema = yup.object({
   tokenSymbol: yup.string().max(6),
 });
 
-const TokenEditDialog = ({
-  addTokenFn,
-  tokens = [],
-  cancel,
-  close,
-}: Props) => {
+const TokenEditDialog = ({ addTokenFn, tokens = [], cancel, close }: Props) => {
   const { formatMessage } = useIntl();
   const [tokenData, setTokenData] = useState<OneToken | undefined>();
 
@@ -111,10 +106,7 @@ const TokenEditDialog = ({
         {tokens.length > 0 ? (
           <div className={styles.tokenChoiceContainer}>
             {tokens.map((token) => (
-              <TokenItem
-                key={token.address}
-                token={token}
-              />
+              <TokenItem key={token.address} token={token} />
             ))}
           </div>
         ) : (

--- a/src/modules/core/components/TokenEditDialog/TokenItem/TokenItem.css
+++ b/src/modules/core/components/TokenEditDialog/TokenItem/TokenItem.css
@@ -12,7 +12,7 @@
 }
 
 .tokenChoiceSymbol {
+  margin: 0 10px;
   font-size: var(--size-small);
   color: var(--temp-grey-blue-7);
-  margin: 0 10px;
 }

--- a/src/modules/core/components/TokenEditDialog/TokenItem/TokenItem.css
+++ b/src/modules/core/components/TokenEditDialog/TokenItem/TokenItem.css
@@ -8,9 +8,11 @@
 .tokenChoice {
   display: flex;
   align-items: center;
-  margin: 20px 0;
+  margin: 8px 0;
 }
 
 .tokenChoiceSymbol {
+  font-size: var(--size-small);
+  color: var(--temp-grey-blue-7);
   margin: 0 10px;
 }

--- a/src/modules/core/components/TokenEditDialog/TokenItem/TokenItem.tsx
+++ b/src/modules/core/components/TokenEditDialog/TokenItem/TokenItem.tsx
@@ -30,7 +30,7 @@ const TokenItem = ({ nativeTokenAddress, removeTokenFn, token }: Props) => {
   return (
     <div className={styles.main}>
       <div className={styles.tokenChoice}>
-        <TokenIcon token={token} name={token.name || undefined} size="xs"/>
+        <TokenIcon token={token} name={token.name || undefined} size="xs" />
         <span className={styles.tokenChoiceSymbol}>
           <Heading
             text={token.symbol || token.name || MSG.unknownToken}

--- a/src/modules/core/components/TokenEditDialog/TokenItem/TokenItem.tsx
+++ b/src/modules/core/components/TokenEditDialog/TokenItem/TokenItem.tsx
@@ -4,12 +4,8 @@ import { defineMessages } from 'react-intl';
 import Heading from '~core/Heading';
 import TokenIcon from '~dashboard/HookedTokenIcon';
 import { AnyToken } from '~data/index';
-import { Address } from '~types/index';
-
-import { tokenIsETH } from '../../../checks';
 
 import styles from './TokenItem.css';
-import Button from '~core/Button';
 
 const MSG = defineMessages({
   unknownToken: {
@@ -19,14 +15,10 @@ const MSG = defineMessages({
 });
 
 interface Props {
-  nativeTokenAddress?: Address;
-  removeTokenFn: (address: Address) => void;
   token: AnyToken;
 }
 
-const TokenItem = ({ nativeTokenAddress, removeTokenFn, token }: Props) => {
-  const canRemoveToken =
-    nativeTokenAddress !== token.address && !tokenIsETH(token);
+const TokenItem = ({ token }: Props) => {
   return (
     <div className={styles.main}>
       <div className={styles.tokenChoice}>
@@ -39,15 +31,6 @@ const TokenItem = ({ nativeTokenAddress, removeTokenFn, token }: Props) => {
           {(!!token.symbol && token.name) || token.address}
         </span>
       </div>
-      {canRemoveToken && (
-        <div>
-          <Button
-            appearance={{ theme: 'dangerLink' }}
-            text={{ id: 'button.remove' }}
-            onClick={() => removeTokenFn(token.address)}
-          />
-        </div>
-      )}
     </div>
   );
 };

--- a/src/modules/core/components/TokenEditDialog/TokenItem/TokenItem.tsx
+++ b/src/modules/core/components/TokenEditDialog/TokenItem/TokenItem.tsx
@@ -30,11 +30,11 @@ const TokenItem = ({ nativeTokenAddress, removeTokenFn, token }: Props) => {
   return (
     <div className={styles.main}>
       <div className={styles.tokenChoice}>
-        <TokenIcon token={token} name={token.name || undefined} />
+        <TokenIcon token={token} name={token.name || undefined} size="xs"/>
         <span className={styles.tokenChoiceSymbol}>
           <Heading
             text={token.symbol || token.name || MSG.unknownToken}
-            appearance={{ size: 'small', margin: 'none' }}
+            appearance={{ size: 'normal', margin: 'none', theme: 'dark' }}
           />
           {(!!token.symbol && token.name) || token.address}
         </span>

--- a/src/modules/dashboard/components/CreateColonyWizard/TokenSelector.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/TokenSelector.tsx
@@ -3,7 +3,6 @@ import { defineMessages, MessageDescriptor, useIntl } from 'react-intl';
 import { useApolloClient } from '@apollo/client';
 
 import { Input } from '~core/Fields';
-import Button from '~core/Button';
 import { log } from '~utils/debug';
 import { Appearance } from '~core/Fields/Input/Input';
 import { usePrevious } from '~utils/hooks';
@@ -146,7 +145,8 @@ const TokenSelector = ({
     handleGetTokenError,
   ]);
 
-  const labelText = label && typeof label === 'object' ? formatMessage(label) : label;
+  const labelText =
+    label && typeof label === 'object' ? formatMessage(label) : label;
 
   return (
     /**

--- a/src/modules/dashboard/components/CreateColonyWizard/TokenSelector.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/TokenSelector.tsx
@@ -1,10 +1,11 @@
 import React, { useCallback, useEffect, useState, ReactNode } from 'react';
-import { defineMessages } from 'react-intl';
+import { defineMessages, MessageDescriptor, useIntl } from 'react-intl';
 import { useApolloClient } from '@apollo/client';
 
 import { Input } from '~core/Fields';
 import Button from '~core/Button';
 import { log } from '~utils/debug';
+import { Appearance } from '~core/Fields/Input/Input';
 import { usePrevious } from '~utils/hooks';
 import { isAddress } from '~utils/web3';
 import {
@@ -14,8 +15,6 @@ import {
   TokenQueryVariables,
 } from '~data/index';
 import { DEFAULT_NETWORK_INFO } from '~constants';
-
-import styles from './StepSelectToken.css';
 
 const MSG = defineMessages({
   inputLabel: {
@@ -32,7 +31,7 @@ const MSG = defineMessages({
   },
   preview: {
     id: 'dashboard.CreateColonyWizard.TokenSelector.preview',
-    defaultMessage: 'Token Preview: {name} ({symbol})',
+    defaultMessage: '{name} ({symbol})',
   },
   statusLoading: {
     id: 'dashboard.CreateColonyWizard.TokenSelector.statusLoading',
@@ -48,6 +47,8 @@ interface Props {
   tokenAddress: string;
   onTokenSelect: (arg0: OneToken | null | void) => any;
   tokenData?: OneToken;
+  label?: string | MessageDescriptor;
+  appearance?: Appearance;
 
   /** Extra node to render on the top right in the label */
   extra?: ReactNode;
@@ -77,8 +78,11 @@ const TokenSelector = ({
   onTokenSelect,
   tokenData,
   extra,
+  label,
+  appearance,
 }: Props) => {
   const apolloClient = useApolloClient();
+  const { formatMessage } = useIntl();
   const getToken = useCallback(async () => {
     const { data } = await apolloClient.query<TokenQuery, TokenQueryVariables>({
       query: TokenDocument,
@@ -142,20 +146,19 @@ const TokenSelector = ({
     handleGetTokenError,
   ]);
 
+  const labelText = label && typeof label === 'object' ? formatMessage(label) : label;
+
   return (
     /**
      * @todo Define custom input component for token addresses
      */
-    <div className={styles.main}>
+    <div>
       <Input
         name="tokenAddress"
-        label={MSG.inputLabel}
-        extra={
-          extra || (
-            <Button text={MSG.learnMore} appearance={{ theme: 'blue' }} />
-          )
-        }
+        label={labelText || MSG.inputLabel}
+        extra={extra}
         {...getStatusText(isLoading, tokenData)}
+        appearance={appearance}
       />
     </div>
   );

--- a/src/modules/dashboard/components/Wallet/UserTokenEditDialog.tsx
+++ b/src/modules/dashboard/components/Wallet/UserTokenEditDialog.tsx
@@ -48,26 +48,12 @@ const UserTokenEditDialog = ({ cancel, close, walletAddress }: Props) => {
     [setUserTokensMutation, userTokens],
   );
 
-  const removeToken = useCallback(
-    (tokenAddressToRemove: Address) => {
-      const newAddresses = userTokens
-        .filter((token) => !tokenIsETH(token))
-        .filter(({ address }) => address !== tokenAddressToRemove)
-        .map(({ address }) => address);
-      return setUserTokensMutation({
-        variables: { input: { tokenAddresses: newAddresses } },
-      });
-    },
-    [setUserTokensMutation, userTokens],
-  );
-
   return (
     <TokenEditDialog
       cancel={cancel}
       close={close}
       tokens={userTokens}
       addTokenFn={addToken}
-      removeTokenFn={removeToken}
     />
   );
 };


### PR DESCRIPTION
## Description

- This PR apply new design into TokenEditDialog and logic for displaying token name after writing token address in input

**New stuff** ✨

* Added TokenSelector component for Manage tokens dialog form
* Added description textarea to Manage tokens dialog

**Changes** 🏗

* Added theme with "heading" and "sidePadding" options, as dialogs from new design seems to have bigger top padding, and some sections without bottom/top paddings
* Updated InputLabel to bigger size 13px (it seems to be size for all labels in new designs). Updated Label color for theme - grey
* TokenSelector update to take and pass input appearance object. Also making label customisable 

<img width="623" alt="Screenshot 2020-11-25 at 17 38 00" src="https://user-images.githubusercontent.com/13069555/100257370-2337ae80-2f46-11eb-976c-32d0bcd16a0e.png">


## TODO

- Find out what with displaying tokens (top of dialog from designs)


(Resolves | Contributes to) DEV-19
