### PR TITLE
Calculate and display user reputation percentage data

### DIFF
--- a/src/modules/core/components/MembersList/MembersList.tsx
+++ b/src/modules/core/components/MembersList/MembersList.tsx
@@ -6,6 +6,11 @@ import { Address } from '~types/index';
 
 import MembersListItem from './MembersListItem';
 
+
+interface Reputation {
+  userReputation: string;
+}
+
 interface Props<U> {
   colonyAddress: Address;
   extraItemContent?: (user: U) => ReactNode;
@@ -13,6 +18,7 @@ interface Props<U> {
   showUserInfo?: boolean;
   domainId: number | undefined;
   users: U[];
+  totalReputation: Reputation;
 }
 
 const displayName = 'MembersList';
@@ -24,6 +30,7 @@ const MembersList = <U extends AnyUser = AnyUser>({
   showUserInfo = true,
   domainId,
   users,
+  totalReputation,
 }: Props<U>) => (
   <ListGroup>
     {users.map((user) => (
@@ -35,6 +42,7 @@ const MembersList = <U extends AnyUser = AnyUser>({
         showUserInfo={showUserInfo}
         domainId={domainId}
         user={user}
+        totalReputation={totalReputation}
       />
     ))}
   </ListGroup>

--- a/src/modules/core/components/MembersList/MembersList.tsx
+++ b/src/modules/core/components/MembersList/MembersList.tsx
@@ -6,7 +6,6 @@ import { Address } from '~types/index';
 
 import MembersListItem from './MembersListItem';
 
-
 interface Reputation {
   userReputation: string;
 }
@@ -18,7 +17,7 @@ interface Props<U> {
   showUserInfo?: boolean;
   domainId: number | undefined;
   users: U[];
-  totalReputation: Reputation;
+  totalReputation: Reputation | undefined;
 }
 
 const displayName = 'MembersList';

--- a/src/modules/core/components/MembersList/MembersListItem.css
+++ b/src/modules/core/components/MembersList/MembersListItem.css
@@ -48,6 +48,7 @@
   align-items: center;
   justify-content: center;
   margin-left: 30px;
+  width: 65px;
 }
 
 .reputationSection svg {

--- a/src/modules/core/components/MembersList/MembersListItem.css
+++ b/src/modules/core/components/MembersList/MembersListItem.css
@@ -43,12 +43,17 @@
   color: reputationColor;
 }
 
-.reputationSection {
+.reputationSection,
+.noReputation {
   display: flex;
   align-items: center;
   justify-content: center;
   margin-left: 30px;
   width: 65px;
+}
+
+.noReputation {
+  color: reputationColor;
 }
 
 .reputationSection svg {

--- a/src/modules/core/components/MembersList/MembersListItem.css.d.ts
+++ b/src/modules/core/components/MembersList/MembersListItem.css.d.ts
@@ -7,4 +7,5 @@ export const username: string;
 export const address: string;
 export const reputation: string;
 export const reputationSection: string;
+export const noReputation: string;
 export const icon: string;

--- a/src/modules/core/components/MembersList/MembersListItem.tsx
+++ b/src/modules/core/components/MembersList/MembersListItem.tsx
@@ -1,7 +1,6 @@
 import React, { KeyboardEvent, ReactNode, useCallback, useMemo } from 'react';
 
 import { defineMessages } from 'react-intl';
-import { AddressZero } from 'ethers/constants';
 import { bigNumberify } from 'ethers/utils';
 import UserMention from '~core/UserMention';
 import { ListGroupItem } from '~core/ListGroup';
@@ -22,6 +21,10 @@ const MSG = defineMessages({
   },
 });
 
+interface Reputation {
+  userReputation: string;
+}
+
 interface Props<U> {
   extraItemContent?: (user: U) => ReactNode;
   colonyAddress: Address;
@@ -29,10 +32,7 @@ interface Props<U> {
   showUserInfo: boolean;
   domainId: number | undefined;
   user: U;
-}
-
-interface Reputation {
-  userReputation: string;
+  totalReputation: Reputation;
 }
 
 enum ZeroValue {
@@ -81,6 +81,7 @@ const MembersListItem = <U extends AnyUser = AnyUser>(props: Props<U>) => {
     onRowClick,
     showUserInfo,
     user,
+    totalReputation
   } = props;
   const {
     profile: { walletAddress },
@@ -92,13 +93,9 @@ const MembersListItem = <U extends AnyUser = AnyUser>(props: Props<U>) => {
     variables: { address: walletAddress, colonyAddress, domainId },
   });
 
-  const { data: totalReputationData } = useUserReputationQuery({
-    variables: { address: AddressZero, colonyAddress, domainId },
-  });
-
   const userPercentageReputation = calculatePercentageReputation(
     userReputationData,
-    totalReputationData,
+    totalReputation,
   );
 
   const handleRowClick = useCallback(() => {

--- a/src/modules/core/components/MembersList/MembersListItem.tsx
+++ b/src/modules/core/components/MembersList/MembersListItem.tsx
@@ -32,7 +32,7 @@ interface Props<U> {
   showUserInfo: boolean;
   domainId: number | undefined;
   user: U;
-  totalReputation: Reputation;
+  totalReputation: Reputation | undefined;
 }
 
 enum ZeroValue {
@@ -45,15 +45,15 @@ type PercentageReputationType = ZeroValue | number | null;
 const UserAvatar = HookedUserAvatar({ fetchUser: false });
 
 const calculatePercentageReputation = (
+  decimalPlaces: number,
   userReputation?: Reputation,
   totalReputation?: Reputation,
 ): PercentageReputationType => {
   if (!userReputation || !totalReputation) return null;
   const userReputationNumber = bigNumberify(userReputation.userReputation);
   const totalReputationNumber = bigNumberify(totalReputation.userReputation);
-  const DECIMAL_PLACES = 2;
 
-  const reputationSafeguard = bigNumberify(100).pow(DECIMAL_PLACES);
+  const reputationSafeguard = bigNumberify(100).pow(decimalPlaces);
 
   if (userReputationNumber.isZero()) {
     return ZeroValue.Zero;
@@ -68,8 +68,10 @@ const calculatePercentageReputation = (
     .div(totalReputationNumber)
     .toNumber();
 
-  return reputation / 10 ** DECIMAL_PLACES;
+  return reputation / 10 ** decimalPlaces;
 };
+
+const DECIMAL_PLACES = 2;
 
 const componentDisplayName = 'MembersList.MembersListItem';
 
@@ -81,7 +83,7 @@ const MembersListItem = <U extends AnyUser = AnyUser>(props: Props<U>) => {
     onRowClick,
     showUserInfo,
     user,
-    totalReputation
+    totalReputation,
   } = props;
   const {
     profile: { walletAddress },
@@ -94,6 +96,7 @@ const MembersListItem = <U extends AnyUser = AnyUser>(props: Props<U>) => {
   });
 
   const userPercentageReputation = calculatePercentageReputation(
+    DECIMAL_PLACES,
     userReputationData,
     totalReputation,
   );

--- a/src/modules/core/components/MembersList/MembersListItem.tsx
+++ b/src/modules/core/components/MembersList/MembersListItem.tsx
@@ -19,6 +19,10 @@ const MSG = defineMessages({
     id: 'MembersList.MembersListItem.starReputationTitle',
     defaultMessage: `User reputation value: {reputation}`,
   },
+  starNoReputationTitle: {
+    id: 'MembersList.MembersListItem.starNoReputationTitle',
+    defaultMessage: `User has no reputation`,
+  },
 });
 
 interface Reputation {
@@ -137,13 +141,15 @@ const MembersListItem = <U extends AnyUser = AnyUser>(props: Props<U>) => {
         // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
         tabIndex={onRowClick ? 0 : undefined}
       >
-        {userPercentageReputation && (
-          <div className={styles.reputationSection}>
-            {userPercentageReputation === ZeroValue.NearZero ? (
-              <div className={styles.reputation}>
-                {userPercentageReputation}%
-              </div>
-            ) : (
+        <div className={styles.reputationSection}>
+          {!userPercentageReputation && (
+            <div className={styles.reputation}>— %</div>
+          )}
+          {userPercentageReputation === ZeroValue.NearZero && (
+            <div className={styles.reputation}>{userPercentageReputation}%</div>
+          )}
+          {userPercentageReputation &&
+            userPercentageReputation !== ZeroValue.NearZero && (
               <Numeral
                 className={styles.reputation}
                 appearance={{ theme: 'primary' }}
@@ -151,17 +157,20 @@ const MembersListItem = <U extends AnyUser = AnyUser>(props: Props<U>) => {
                 suffix="%"
               />
             )}
-            <Icon
-              name="star"
-              appearance={{ size: 'extraTiny' }}
-              className={styles.icon}
-              title={MSG.starReputationTitle}
-              titleValues={{
-                reputation: userPercentageReputation,
-              }}
-            />
-          </div>
-        )}
+          <Icon
+            name="star"
+            appearance={{ size: 'extraTiny' }}
+            className={styles.icon}
+            title={
+              userPercentageReputation
+                ? MSG.starReputationTitle
+                : MSG.starNoReputationTitle
+            }
+            titleValues={{
+              reputation: userPercentageReputation,
+            }}
+          />
+        </div>
         <div className={styles.section}>
           <UserAvatar
             size="s"

--- a/src/modules/core/components/MembersList/MembersListItem.tsx
+++ b/src/modules/core/components/MembersList/MembersListItem.tsx
@@ -1,18 +1,17 @@
 import React, { KeyboardEvent, ReactNode, useCallback, useMemo } from 'react';
 
 import { defineMessages } from 'react-intl';
+import { AddressZero } from 'ethers/constants';
+import { bigNumberify } from 'ethers/utils';
 import UserMention from '~core/UserMention';
 import { ListGroupItem } from '~core/ListGroup';
 import { AnyUser, useUserReputationQuery, useUser } from '~data/index';
-import { AddressZero } from 'ethers/constants';
 import { Address, ENTER } from '~types/index';
 import HookedUserAvatar from '~users/HookedUserAvatar';
 import { getMainClasses } from '~utils/css';
 import MaskedAddress from '~core/MaskedAddress';
 import Numeral from '~core/Numeral';
-import { useTokenInfo } from '~utils/hooks/useTokenInfo';
 import Icon from '~core/Icon';
-import { bigNumberify } from 'ethers/utils';
 
 import styles from './MembersListItem.css';
 
@@ -33,7 +32,7 @@ interface Props<U> {
 }
 
 interface Reputation {
-  userReputation: string,
+  userReputation: string;
 }
 
 enum ZeroValue {
@@ -45,7 +44,10 @@ type PercentageReputationType = ZeroValue | number | null;
 
 const UserAvatar = HookedUserAvatar({ fetchUser: false });
 
-const calculatePercentageReputation = (userReputation?: Reputation, totalReputation?: Reputation): PercentageReputationType => {
+const calculatePercentageReputation = (
+  userReputation?: Reputation,
+  totalReputation?: Reputation,
+): PercentageReputationType => {
   if (!userReputation || !totalReputation) return null;
   const userReputationNumber = bigNumberify(userReputation.userReputation);
   const totalReputationNumber = bigNumberify(totalReputation.userReputation);
@@ -57,11 +59,7 @@ const calculatePercentageReputation = (userReputation?: Reputation, totalReputat
     return ZeroValue.Zero;
   }
 
-  if (
-    userReputationNumber
-      .mul(reputationSafeguard)
-      .lt(totalReputationNumber)
-  ) {
+  if (userReputationNumber.mul(reputationSafeguard).lt(totalReputationNumber)) {
     return ZeroValue.NearZero;
   }
 
@@ -70,8 +68,8 @@ const calculatePercentageReputation = (userReputation?: Reputation, totalReputat
     .div(totalReputationNumber)
     .toNumber();
 
-    return reputation / 10 ** DECIMAL_PLACES;
-}
+  return reputation / 10 ** DECIMAL_PLACES;
+};
 
 const componentDisplayName = 'MembersList.MembersListItem';
 
@@ -98,9 +96,10 @@ const MembersListItem = <U extends AnyUser = AnyUser>(props: Props<U>) => {
     variables: { address: AddressZero, colonyAddress, domainId },
   });
 
-  const userPercentageReputation = calculatePercentageReputation(userReputationData, totalReputationData);
-  // Refactor MemberInfoPopover to use this hook if works fine after reputation tests
-  const { tokenInfoData } = useTokenInfo();
+  const userPercentageReputation = calculatePercentageReputation(
+    userReputationData,
+    totalReputationData,
+  );
 
   const handleRowClick = useCallback(() => {
     if (onRowClick) {
@@ -141,8 +140,10 @@ const MembersListItem = <U extends AnyUser = AnyUser>(props: Props<U>) => {
         {userPercentageReputation && (
           <div className={styles.reputationSection}>
             {userPercentageReputation === ZeroValue.NearZero ? (
-              <div className={styles.reputation}>{userPercentageReputation}%</div>
-            ): (
+              <div className={styles.reputation}>
+                {userPercentageReputation}%
+              </div>
+            ) : (
               <Numeral
                 className={styles.reputation}
                 appearance={{ theme: 'primary' }}

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -5,7 +5,6 @@ import { defineMessages } from 'react-intl';
 import Members from '~dashboard/Members';
 import { useColonyFromNameQuery } from '~data/index';
 import styles from './ColonyMembers.css';
-import { TokenInfoProvider } from '~utils/hooks/useTokenInfo';
 import Button from '~core/Button';
 
 const displayName = 'dashboard.ColonyMembers';
@@ -31,9 +30,7 @@ const ColonyMembers = () => {
       <div className={styles.mainContentGrid}>
         <div className={styles.mainContent}>
           {colonyData && colonyData.colony && (
-            <TokenInfoProvider colonyAddress={colonyData.colony.colonyAddress}>
-              <Members colony={colonyData.colony} />
-            </TokenInfoProvider>
+            <Members colony={colonyData.colony} />
           )}
         </div>
         <aside className={styles.rightAside}>

--- a/src/modules/dashboard/components/Members/Members.tsx
+++ b/src/modules/dashboard/components/Members/Members.tsx
@@ -4,9 +4,9 @@ import { ColonyRole, ROOT_DOMAIN_ID } from '@colony/colony-js';
 import sortBy from 'lodash/sortBy';
 import { useParams } from 'react-router-dom';
 
+import { AddressZero } from 'ethers/constants';
 import MembersList from '~core/MembersList';
 import { SpinnerLoader } from '~core/Preloaders';
-import { AddressZero } from 'ethers/constants';
 import UserPermissions from '~admin/Permissions/UserPermissions';
 import Heading from '~core/Heading';
 import { Select, Form } from '~core/Fields';
@@ -17,7 +17,7 @@ import {
   AnyUser,
   Colony,
   useColonyMembersWithReputationQuery,
-  useUserReputationQuery
+  useUserReputationQuery,
 } from '~data/index';
 import {
   COLONY_TOTAL_BALANCE_DOMAIN_ID,

--- a/src/modules/dashboard/components/Members/Members.tsx
+++ b/src/modules/dashboard/components/Members/Members.tsx
@@ -6,10 +6,10 @@ import { useParams } from 'react-router-dom';
 
 import MembersList from '~core/MembersList';
 import { SpinnerLoader } from '~core/Preloaders';
+import { AddressZero } from 'ethers/constants';
 import UserPermissions from '~admin/Permissions/UserPermissions';
 import Heading from '~core/Heading';
 import { Select, Form } from '~core/Fields';
-import { AddressZero } from 'ethers/constants';
 
 import { getAllUserRolesForDomain } from '../../../transformers';
 import { useTransformer } from '~utils/hooks';
@@ -131,7 +131,11 @@ const Members = ({ colony: { colonyAddress }, colony }: Props) => {
   }, [data]);
 
   const { data: totalReputationData } = useUserReputationQuery({
-    variables: { address: AddressZero, colonyAddress: colony.colonyAddress, domainId: selectedDomainId },
+    variables: {
+      address: AddressZero,
+      colonyAddress: colony.colonyAddress,
+      domainId: selectedDomainId,
+    },
   });
 
   const domainRoles = useTransformer(getAllUserRolesForDomain, [

--- a/src/modules/dashboard/components/Members/Members.tsx
+++ b/src/modules/dashboard/components/Members/Members.tsx
@@ -9,6 +9,7 @@ import { SpinnerLoader } from '~core/Preloaders';
 import UserPermissions from '~admin/Permissions/UserPermissions';
 import Heading from '~core/Heading';
 import { Select, Form } from '~core/Fields';
+import { AddressZero } from 'ethers/constants';
 
 import { getAllUserRolesForDomain } from '../../../transformers';
 import { useTransformer } from '~utils/hooks';
@@ -16,6 +17,7 @@ import {
   AnyUser,
   Colony,
   useColonyMembersWithReputationQuery,
+  useUserReputationQuery
 } from '~data/index';
 import {
   COLONY_TOTAL_BALANCE_DOMAIN_ID,
@@ -127,6 +129,10 @@ const Members = ({ colony: { colonyAddress }, colony }: Props) => {
       profile: { walletAddress },
     }));
   }, [data]);
+
+  const { data: totalReputationData } = useUserReputationQuery({
+    variables: { address: AddressZero, colonyAddress: colony.colonyAddress, domainId: selectedDomainId },
+  });
 
   const domainRoles = useTransformer(getAllUserRolesForDomain, [
     colony,
@@ -242,6 +248,7 @@ const Members = ({ colony: { colonyAddress }, colony }: Props) => {
           )}
           domainId={currentDomainId}
           users={members}
+          totalReputation={totalReputationData}
         />
       ) : (
         <FormattedMessage {...MSG.failedToFetch} />


### PR DESCRIPTION
## Description

- This PR fetches userReputationData and totalReputation data and calculate user reputation percentage based on those two values

**New stuff** ✨

* calculatePercentageReputation method which return PercentageReputationType value

**Changes** 🏗

* Updates way of displaying user reputation data in MembersListItem
* Unpluged useTokenInfo hook as this data is not needed anymore here

3 states of user item:
<img width="739" alt="Screenshot 2020-11-27 at 13 37 35" src="https://user-images.githubusercontent.com/13069555/100451294-71b88a80-30b7-11eb-9e20-61e06782878e.png">
<img width="754" alt="Screenshot 2020-11-27 at 13 34 36" src="https://user-images.githubusercontent.com/13069555/100451299-741ae480-30b7-11eb-8323-dd2a04836500.png">
<img width="775" alt="Screenshot 2020-11-27 at 13 33 08" src="https://user-images.githubusercontent.com/13069555/100451303-74b37b00-30b7-11eb-90b9-673da09ad903.png">


Resolves DEV-80
