### PR TITLE
Make tooltip copy message customisable

### DIFF
--- a/src/modules/core/components/InvisibleCopyableAddress/InvisibleCopyableAddress.tsx
+++ b/src/modules/core/components/InvisibleCopyableAddress/InvisibleCopyableAddress.tsx
@@ -1,5 +1,10 @@
 import React, { ReactNode, useState, useEffect } from 'react';
-import { defineMessages, FormattedMessage } from 'react-intl';
+import {
+  defineMessages,
+  FormattedMessage,
+  MessageDescriptor,
+  useIntl,
+} from 'react-intl';
 
 import copyToClipboard from 'copy-to-clipboard';
 import { Address } from '~types/index';
@@ -12,6 +17,8 @@ interface Props {
   children: ReactNode;
   /** Address to display and copy */
   address: Address;
+  /** Text which will display in tooltip when hovering on address */
+  copyMessage?: MessageDescriptor;
 }
 
 const MSG = defineMessages({
@@ -19,15 +26,25 @@ const MSG = defineMessages({
     id: 'InvisibleCopyableAddress.copyAddressTooltip',
     defaultMessage: `{copied, select,
       true {Copied}
-      false {Click to copy colony address}
+      false {{tooltipMessage}}
     }`,
+  },
+  copyMessage: {
+    id: 'InvisibleCopyableAddress.copyMessage',
+    defaultMessage: 'Click to copy address',
   },
 });
 
 const displayName = 'InvisibleCopyableAddress';
 
-const InvisibleCopyableAddress = ({ children, address }: Props) => {
+const InvisibleCopyableAddress = ({
+  children,
+  address,
+  copyMessage,
+}: Props) => {
   const [copied, setCopied] = useState(false);
+  const { formatMessage } = useIntl();
+
   const handleClipboardCopy = () => {
     setCopied(true);
     copyToClipboard(address);
@@ -42,14 +59,19 @@ const InvisibleCopyableAddress = ({ children, address }: Props) => {
       clearTimeout(timeout);
     };
   }, [copied]);
-
+  const tooltipMessage =
+    (copyMessage && formatMessage(copyMessage)) ||
+    formatMessage(MSG.copyMessage);
   return (
     <Tooltip
       placement="right"
       trigger="hover"
       content={
         <div className={styles.copyAddressTooltip}>
-          <FormattedMessage {...MSG.copyAddressTooltip} values={{ copied }} />
+          <FormattedMessage
+            {...MSG.copyAddressTooltip}
+            values={{ copied, tooltipMessage }}
+          />
         </div>
       }
     >

--- a/src/modules/dashboard/components/ColonyHome/ColonyTitle/ColonyTitle.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyTitle/ColonyTitle.tsx
@@ -14,6 +14,10 @@ const MSG = defineMessages({
     id: 'dashboard.ColonyHome.ColonyTitle.fallbackColonyName',
     defaultMessage: 'Unknown Colony',
   },
+  copyMessage: {
+    id: 'dashboard.ColonyHome.ColonyTitle.copyMessage',
+    defaultMessage: 'Click to copy colony address',
+  },
 });
 
 type Props = {
@@ -40,7 +44,10 @@ const ColonyTitle = ({
       </div>
       <div>
         {colonyAddress && (
-          <InvisibleCopyableAddress address={colonyAddress}>
+          <InvisibleCopyableAddress
+            address={colonyAddress}
+            copyMessage={MSG.copyMessage}
+          >
             <div className={styles.colonyAddress}>
               <MaskedAddress address={colonyAddress} />
             </div>


### PR DESCRIPTION
## Description

- This PR adds in possibility to customise tooltip message. Message which is showing when we hover over address

**Changes** 🏗

* Added optional copyMessage prop to InvisibleCopyableAddress component. If message is not provided we are using default one
<img width="425" alt="Screenshot 2020-12-09 at 10 26 11" src="https://user-images.githubusercontent.com/13069555/101610775-fafd8480-3a08-11eb-87ee-576aea24d364.png">

Resolves DEV-125
