### PR TITLE
Add Annotations core component

### DIFF
--- a/src/modules/core/components/Fields/Annotations/Annotations.css
+++ b/src/modules/core/components/Fields/Annotations/Annotations.css
@@ -1,0 +1,4 @@
+.container label {
+  font-size: var(--size-smallish);
+  color: var(--dark);
+}

--- a/src/modules/core/components/Fields/Annotations/Annotations.css.d.ts
+++ b/src/modules/core/components/Fields/Annotations/Annotations.css.d.ts
@@ -1,0 +1,1 @@
+export const container: string;

--- a/src/modules/core/components/Fields/Annotations/Annotations.tsx
+++ b/src/modules/core/components/Fields/Annotations/Annotations.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import Textarea, { TextareaComponentProps } from '../Textarea';
+
+import styles from './Annotations.css';
+
+const Annotations = (props: TextareaComponentProps) => (
+  <div className={styles.container}>
+    <Textarea {...props} />
+  </div>
+);
+
+Annotations.displayName = 'Annotations';
+
+export default Annotations;

--- a/src/modules/core/components/Fields/Annotations/Annotations.tsx
+++ b/src/modules/core/components/Fields/Annotations/Annotations.tsx
@@ -4,11 +4,23 @@ import Textarea, { TextareaComponentProps } from '../Textarea';
 
 import styles from './Annotations.css';
 
-const Annotations = (props: TextareaComponentProps) => (
-  <div className={styles.container}>
-    <Textarea {...props} />
-  </div>
-);
+const Annotations = ({
+  appearance = { colorSchema: 'grey', resizable: 'vertical' },
+  maxLength = 4000,
+  ...props
+}: TextareaComponentProps) => {
+  const textAreaProps: TextareaComponentProps = {
+    appearance,
+    maxLength,
+    ...props,
+  };
+
+  return (
+    <div className={styles.container}>
+      <Textarea {...textAreaProps} />
+    </div>
+  );
+};
 
 Annotations.displayName = 'Annotations';
 

--- a/src/modules/core/components/Fields/Annotations/index.ts
+++ b/src/modules/core/components/Fields/Annotations/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Annotations';

--- a/src/modules/core/components/Fields/Textarea/index.ts
+++ b/src/modules/core/components/Fields/Textarea/index.ts
@@ -1,2 +1,3 @@
 export { default } from './Textarea';
+export { Props as TextareaComponentProps } from './Textarea';
 export { default as TextareaAutoresize } from './TextareaAutoresize';

--- a/src/modules/core/components/Fields/index.ts
+++ b/src/modules/core/components/Fields/index.ts
@@ -10,6 +10,7 @@ export { default as Select, SelectOption } from './Select';
 export { default as Textarea, TextareaAutoresize } from './Textarea';
 export { default as Radio } from './Radio';
 export { default as RadioGroup } from './RadioGroup';
+export { default as Annotations } from './Annotations';
 
 export { default as asFieldArray } from './asFieldArray';
 

--- a/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialogForm.css
+++ b/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialogForm.css
@@ -28,8 +28,7 @@
 }
 
 .tokenAmount label,
-.domainSelects label,
-.textAreaSection label {
+.domainSelects label {
   font-size: var(--size-smallish);
   color: var(--dark);
 }

--- a/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialogForm.tsx
+++ b/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialogForm.tsx
@@ -13,7 +13,7 @@ import PermissionsLabel from '~core/PermissionsLabel';
 import Button from '~core/Button';
 import { ItemDataType } from '~core/OmniPicker';
 import DialogSection from '~core/Dialog/DialogSection';
-import { Select, Input, Textarea } from '~core/Fields';
+import { Select, Input, Annotations } from '~core/Fields';
 import Heading from '~core/Heading';
 import SingleUserPicker, { filterUserSelection } from '~core/SingleUserPicker';
 import PermissionRequiredInfo from '~core/PermissionRequiredInfo';
@@ -332,15 +332,11 @@ const CreatePaymentDialogForm = ({
         </div>
       </DialogSection>
       <DialogSection>
-        <div className={styles.textAreaSection}>
-          <Textarea
-            appearance={{ resizable: 'vertical', colorSchema: 'grey' }}
-            label={MSG.annotation}
-            name="annotation"
-            maxLength={4000}
-            disabled={!userHasPermission}
-          />
-        </div>
+        <Annotations
+          label={MSG.annotation}
+          name="annotation"
+          disabled={!userHasPermission}
+        />
       </DialogSection>
       {!userHasPermission && (
         <DialogSection>

--- a/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementForm.tsx
+++ b/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementForm.tsx
@@ -5,7 +5,7 @@ import sortBy from 'lodash/sortBy';
 
 import { Address } from '~types/index';
 import { DomainFieldsFragment } from '~data/generated';
-import { InputLabel, Textarea, Select } from '~core/Fields';
+import { InputLabel, Select, Annotations } from '~core/Fields';
 
 import PermissionManagementCheckbox from './PermissionManagementCheckbox';
 import { availableRoles } from './constants';
@@ -124,12 +124,7 @@ const PermissionManagementForm = ({
           );
         })}
       </div>
-      <Textarea
-        appearance={{ resizable: 'vertical', colorSchema: 'grey' }}
-        label={MSG.annotation}
-        name="annotation"
-        maxLength={4000}
-      />
+      <Annotations label={MSG.annotation} name="annotation" />
     </>
   );
 };

--- a/src/modules/dashboard/components/TokenMintDialog/TokenMintDialog.tsx
+++ b/src/modules/dashboard/components/TokenMintDialog/TokenMintDialog.tsx
@@ -5,7 +5,7 @@ import { defineMessages } from 'react-intl';
 import Button from '~core/Button';
 import Dialog from '~core/Dialog';
 import DialogSection from '~core/Dialog/DialogSection';
-import { Input, Textarea } from '~core/Fields';
+import { Annotations, Input } from '~core/Fields';
 import Heading from '~core/Heading';
 import { ColonyTokens } from '~data/index';
 import { Address } from '~types/index';
@@ -84,15 +84,7 @@ const TokenMintDialog = ({
           </DialogSection>
           <DialogSection appearance={{ theme: 'sidePadding' }}>
             <div className={styles.annotation}>
-              <Textarea
-                appearance={{
-                  colorSchema: 'grey',
-                  resizable: 'vertical',
-                }}
-                label={MSG.justificationLabel}
-                name="annotation"
-                maxLength={4000}
-              />
+              <Annotations label={MSG.justificationLabel} name="annotation" />
             </div>
           </DialogSection>
           <DialogSection appearance={{ align: 'right', theme: 'footer' }}>

--- a/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialogForm.css
+++ b/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialogForm.css
@@ -47,8 +47,7 @@
 }
 
 .tokenAmount label,
-.domainSelects label,
-.textAreaSection label {
+.domainSelects label {
   font-size: var(--size-smallish);
   color: var(--dark);
 }

--- a/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialogForm.css.d.ts
+++ b/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialogForm.css.d.ts
@@ -6,4 +6,3 @@ export const domainPotBalance: string;
 export const domainSelects: string;
 export const transferIcon: string;
 export const title: string;
-export const textAreaSection: string;

--- a/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialogForm.tsx
+++ b/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialogForm.tsx
@@ -10,7 +10,7 @@ import { AddressZero } from 'ethers/constants';
 import { useTransformer } from '~utils/hooks';
 import Button from '~core/Button';
 import DialogSection from '~core/Dialog/DialogSection';
-import { Select, Input, FormStatus, Textarea } from '~core/Fields';
+import { Select, Input, FormStatus, Annotations } from '~core/Fields';
 import Heading from '~core/Heading';
 import {
   useLoggedInUser,
@@ -52,8 +52,8 @@ const MSG = defineMessages({
     id: 'dashboard.TransferFundsDialog.TransferFundsDialogForm.address',
     defaultMessage: 'Token',
   },
-  reason: {
-    id: 'dashboard.TransferFundsDialog.TransferFundsDialogForm.reason',
+  annotation: {
+    id: 'dashboard.TransferFundsDialog.TransferFundsDialogForm.annotation',
     defaultMessage: 'Explain why you’re transferring these funds (optional)',
   },
   domainTokenAmount: {
@@ -335,14 +335,7 @@ const TransferFundsDialogForm = ({
         </div>
       </DialogSection>
       <DialogSection>
-        <div className={styles.textAreaSection}>
-          <Textarea
-            appearance={{ resizable: 'vertical', colorSchema: 'grey' }}
-            label={MSG.reason}
-            name="reason"
-            maxLength={4000}
-          />
-        </div>
+        <Annotations label={MSG.annotation} name="annotation" />
       </DialogSection>
       <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
         <Button


### PR DESCRIPTION
Add the annotations component that is shared across UAC modals as a core component

**New stuff** ✨

* Annotation textarea core component

**Changes** 🏗

* Changed Textarea core component used for UAC Dialog for annotations to new Annotation core component

![FireShot Capture 052 - Colony - localhost](https://user-images.githubusercontent.com/18473896/101682351-42543700-3a42-11eb-83bf-f9b85055afb0.png)

Resolves DEV-81
