### PR TITLE
Refactor TokenIcon component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12039,11 +12039,6 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
-    "eth-contract-metadata": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/eth-contract-metadata/-/eth-contract-metadata-1.13.0.tgz",
-      "integrity": "sha512-9CjXHX8IdXysUEvOHdbCsjdAwM1E98jaeK2HeOqm/9S/vOZ8YryaBBt/YSiBq3MkpCwf+d1pEQ53p96rsdy52w=="
-    },
     "eth-ens-namehash-ms": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/eth-ens-namehash-ms/-/eth-ens-namehash-ms-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -145,7 +145,6 @@
     "copy-to-clipboard": "^3.0.8",
     "draft-js": "^0.11.4",
     "eslint-plugin-eslint-comments": "^3.1.2",
-    "eth-contract-metadata": "^1.13.0",
     "eth-ens-namehash-ms": "^2.2.0",
     "ethereumjs-tx": "^2.1.2",
     "ethers": "^4.0.47",

--- a/src/modules/constants.ts
+++ b/src/modules/constants.ts
@@ -121,3 +121,7 @@ export const ALLDOMAINS_DOMAIN_SELECTION = {
   name: 'All Domains',
   ethParentDomainId: null,
 };
+
+export const TOKEN_LOGOS_REPO_URL =
+  'https://raw.githubusercontent.com/trustwallet' +
+  '/assets/master/blockchains/ethereum/';

--- a/src/modules/dashboard/components/HookedTokenIcon/HookedTokenIcon.tsx
+++ b/src/modules/dashboard/components/HookedTokenIcon/HookedTokenIcon.tsx
@@ -69,7 +69,7 @@ const HookedTokenIcon = ({
       }
     };
     loadTokenLogo();
-  }, [address, iconName]);
+  }, [address, iconName, dontFetch]);
 
   return (
     <>

--- a/src/modules/dashboard/components/HookedTokenIcon/HookedTokenIcon.tsx
+++ b/src/modules/dashboard/components/HookedTokenIcon/HookedTokenIcon.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
+
 import { AddressZero } from 'ethers/constants';
+import { TOKEN_LOGOS_REPO_URL } from '~constants';
 
 import Avatar from '~core/Avatar';
 import { useDataFetcher } from '~utils/hooks';
@@ -29,11 +31,10 @@ interface Props {
 
   /** If provided than icon is display instead of Avatar */
   iconName?: string;
-}
 
-const TOKEN_LOGOS_REPO_URL =
-  'https://raw.githubusercontent.com/trustwallet' +
-  '/assets/master/blockchains/ethereum/';
+  /** If true logo fetching wont be fire */
+  dontFetch?: boolean;
+}
 
 const loadTokenImages = async (address: Address): Promise<Response> => {
   let tokenImageUrl = `${TOKEN_LOGOS_REPO_URL}${address}/logo.png`;
@@ -47,6 +48,7 @@ const HookedTokenIcon = ({
   name,
   token: { iconHash, address },
   iconName,
+  dontFetch,
   ...props
 }: Props) => {
   const [tokenImage, setTokenImage] = useState<string | undefined>();
@@ -58,7 +60,7 @@ const HookedTokenIcon = ({
 
   useEffect(() => {
     const loadTokenLogo = async () => {
-      if (address && !iconName) {
+      if (!dontFetch && address && !iconName) {
         const response = await loadTokenImages(address);
         if (!response.ok) {
           return;
@@ -72,11 +74,7 @@ const HookedTokenIcon = ({
   return (
     <>
       {iconName ? (
-        <Icon
-          appearance={{ size: 'medium' }}
-          name={iconName}
-          title={iconName}
-        />
+        <Icon name={iconName} title={name || address} {...props} />
       ) : (
         <Avatar
           avatarURL={tokenImage || ipfsIcon || undefined}

--- a/src/modules/dashboard/components/HookedTokenIcon/HookedTokenIcon.tsx
+++ b/src/modules/dashboard/components/HookedTokenIcon/HookedTokenIcon.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, ComponentType } from 'react';
-import mapping from 'eth-contract-metadata';
 import { AddressZero } from 'ethers/constants';
 
 import Avatar from '~core/Avatar';
@@ -26,10 +25,6 @@ interface Props {
   name?: string;
 }
 
-const checkSVG = (fileName: string) =>
-  fileName &&
-  fileName.substring(fileName.length - 3, fileName.length) === 'svg';
-
 const loadTokenImages = async (logo): Promise<ImageType> =>
   import(
     /* webpackMode: "eager" */ `../../../../../node_modules/eth-contract-metadata/images/${logo}`
@@ -41,48 +36,11 @@ const HookedTokenIcon = ({
   ...props
 }: Props) => {
   const [tokenImage, setTokenImage] = useState<string | undefined>();
-  const [tokenSVG, setTokenSVG] = useState<ImageType['default'] | undefined>();
   const { data: ipfsIcon } = useDataFetcher(
     ipfsDataFetcher,
     [iconHash as string], // Technically a bug, shouldn't need type override
     [iconHash],
   );
-
-  /* Here we will pick the right solution to show
-   *  the token icons depending from if they are png or svg or a blockie
-   *  case 1: if it's a .png we can just pass through the tokenImage
-   *  case 2: it's an svg and we just import it manually
-   *  case 3: there's no data about the token icon and we show a blockie
-   *  case 4: if there's an ipfsHash show the concerning image
-   */
-
-  useEffect(() => {
-    const checkAndLoadImages = async () => {
-      if (ipfsIcon || tokenImage || tokenSVG) {
-        return;
-      }
-
-      const metaData = mapping[address];
-
-      if (metaData) {
-        const response = await loadTokenImages(metaData.logo);
-        if (response) {
-          if (checkSVG(metaData.logo)) {
-            setTokenSVG(response.default);
-          } else {
-            setTokenImage(response.default as string);
-          }
-        }
-      }
-      if (address === AddressZero) {
-        const response = await import(
-          /* webpackMode: "eager" */ `../../../../img/tokens/ether.svg`
-        );
-        setTokenSVG(response.default);
-      }
-    };
-    checkAndLoadImages();
-  }, [ipfsIcon, tokenImage, setTokenImage, address, tokenSVG]);
 
   return (
     <Avatar
@@ -91,9 +49,7 @@ const HookedTokenIcon = ({
       seed={address}
       title={name || address}
       {...props}
-    >
-      {tokenSVG}
-    </Avatar>
+    />
   );
 };
 

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -86,7 +86,6 @@ const config = {
         loader: 'file-loader',
         include: [
           path.resolve('src'),
-          path.resolve('node_modules', 'eth-contract-metadata', 'images'),
         ],
         options: {
           esModule: false,
@@ -124,18 +123,9 @@ const config = {
           },
         ],
       },
-      /*
-       * Only parse svg images from the `eth-contract-metadata` package.
-       */
       {
         test: /\.svg$/,
         include: [
-          path.resolve(
-            __dirname,
-            'node_modules',
-            'eth-contract-metadata',
-            'images',
-          ),
           path.resolve(__dirname, 'src', 'img', 'tokens'),
         ],
         use: [


### PR DESCRIPTION
## Description

- This PR refactor current HookedTokenIcon component

**New stuff** ✨

* Fetching logos from trustwallet api
* Added iconName prop to HookedTokenIcon component

**Changes** 🏗

* If iconName provided then displaying Icon component instead of Avatar
*. Clearing not needed code

**Deletions** ⚰️

* eth-metadata-lib

Fetched ETH logo and blockie fallback for "A" token:
<img width="708" alt="Screenshot 2020-12-10 at 18 18 03" src="https://user-images.githubusercontent.com/13069555/101806553-63855800-3b14-11eb-9df6-f4ee4a5b0986.png">

Icon name provided:
<img width="489" alt="Screenshot 2020-12-10 at 18 24 33" src="https://user-images.githubusercontent.com/13069555/101807169-19e93d00-3b15-11eb-83fe-45157921d8a1.png">

**TODO**
Find out if we can safely remove "name" prop from HookedTokenIcon component

Resolves DEV-122
