### PR TITLE
Fix `TokenInfoPopover` infinite loop render

### DIFF
--- a/src/modules/core/components/InfoPopover/TokenInfoPopover.tsx
+++ b/src/modules/core/components/InfoPopover/TokenInfoPopover.tsx
@@ -3,6 +3,7 @@ import { isEmpty } from 'lodash';
 
 import { AnyToken } from '~data/index';
 
+import TokenInfo from './TokenInfo';
 import NotAvailableMessage from './NotAvailableMessage';
 
 import styles from './InfoPopover.css';
@@ -17,8 +18,8 @@ const displayName = 'InfoPopover.TokenInfoPopover';
 const TokenInfoPopover = ({ token, isTokenNative }: Props) => {
   return (
     <>
-      {!isEmpty(token) ? (
-        <TokenInfoPopover token={token} isTokenNative={isTokenNative} />
+      {!isEmpty(token) && token ? (
+        <TokenInfo token={token} isTokenNative={isTokenNative} />
       ) : (
         <div className={styles.section}>
           <NotAvailableMessage notAvailableDataName="Token" />


### PR DESCRIPTION
## Description

This PR is an emergency fix for an issue that was introduced via #2321 that causes an infinite loop render by trying to render the component itself.

The fix for this just requires to render the proper component.

**Changes** 

- [x] `TokenInfoPopover` render `TokenInfo` and not itself