### PR TITLE
TokenIcon component updates

### DIFF
--- a/src/modules/dashboard/components/HookedTokenIcon/HookedTokenIcon.tsx
+++ b/src/modules/dashboard/components/HookedTokenIcon/HookedTokenIcon.tsx
@@ -48,7 +48,7 @@ const loadTokenImages = async (address: Address): Promise<Response> => {
 const getBase64image = (blob): Promise<any> => {
   return new Promise((resolve) => {
     const fileReader = new FileReader();
-    fileReader.onload = function () {
+    fileReader.onload = () => {
       return resolve(fileReader.result);
     };
     fileReader.readAsDataURL(blob);

--- a/src/modules/dashboard/components/HookedTokenIcon/HookedTokenIcon.tsx
+++ b/src/modules/dashboard/components/HookedTokenIcon/HookedTokenIcon.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
+import { Network } from '@colony/colony-js';
 
 import { AddressZero } from 'ethers/constants';
-import { TOKEN_LOGOS_REPO_URL } from '~constants';
+import { TOKEN_LOGOS_REPO_URL, DEFAULT_NETWORK } from '~constants';
 
 import Avatar from '~core/Avatar';
 import { useDataFetcher } from '~utils/hooks';
@@ -50,7 +51,7 @@ const HookedTokenIcon = ({
   name,
   token: { iconHash, address },
   iconName,
-  dontFetch = process.env.NODE_ENV === 'development',
+  dontFetch = DEFAULT_NETWORK !== Network.Mainnet,
   ...props
 }: Props) => {
   const [tokenImage, setTokenImage] = useState<string | undefined>();
@@ -68,7 +69,7 @@ const HookedTokenIcon = ({
         return;
       }
 
-      if (address && !iconName) {
+      if (!dontFetch && address && !iconName) {
         const response = await loadTokenImages(address);
         if (response.ok) {
           const blob = await response.blob();

--- a/src/modules/dashboard/components/HookedTokenIcon/HookedTokenIcon.tsx
+++ b/src/modules/dashboard/components/HookedTokenIcon/HookedTokenIcon.tsx
@@ -39,6 +39,8 @@ interface Props {
   dontFetch?: boolean;
 }
 
+const ICON_STORAGE = 'tokenImages';
+
 const loadTokenImages = async (address: Address): Promise<Response> => {
   let tokenImageUrl = `${TOKEN_LOGOS_REPO_URL}${address}/logo.png`;
   if (address === AddressZero) {
@@ -63,10 +65,14 @@ const HookedTokenIcon = ({
 
   useEffect(() => {
     const loadTokenLogo = async () => {
-      const image = localStorage.getItem(address);
-      if (image) {
-        setTokenImage(image);
-        return;
+      const imagesStorage = localStorage.getItem(ICON_STORAGE);
+      const parsedImagesStorage = imagesStorage && JSON.parse(imagesStorage);
+      if (parsedImagesStorage) {
+        const image = parsedImagesStorage[address];
+        if (image) {
+          setTokenImage(image);
+          return;
+        }
       }
 
       if (!dontFetch && address && !iconName) {
@@ -75,7 +81,18 @@ const HookedTokenIcon = ({
           const blob = await response.blob();
           const base64image = await getBase64image(blob);
           if (base64image) {
-            localStorage.setItem(address, base64image);
+            if (parsedImagesStorage) {
+              parsedImagesStorage[address] = base64image;
+              localStorage.setItem(
+                ICON_STORAGE,
+                JSON.stringify(parsedImagesStorage),
+              );
+            } else {
+              localStorage.setItem(
+                ICON_STORAGE,
+                JSON.stringify({ [address]: base64image }),
+              );
+            }
             setTokenImage(base64image);
           }
         }

--- a/src/modules/dashboard/components/HookedTokenIcon/HookedTokenIcon.tsx
+++ b/src/modules/dashboard/components/HookedTokenIcon/HookedTokenIcon.tsx
@@ -48,7 +48,7 @@ const HookedTokenIcon = ({
   name,
   token: { iconHash, address },
   iconName,
-  dontFetch,
+  dontFetch = process.env.NODE_ENV === 'development',
   ...props
 }: Props) => {
   const [tokenImage, setTokenImage] = useState<string | undefined>();
@@ -57,9 +57,10 @@ const HookedTokenIcon = ({
     [iconHash as string], // Technically a bug, shouldn't need type override
     [iconHash],
   );
-
   useEffect(() => {
     const loadTokenLogo = async () => {
+      const icon = localStorage.getItem(address);
+      console.log(icon);
       if (!dontFetch && address && !iconName) {
         const response = await loadTokenImages(address);
         if (!response.ok) {

--- a/src/modules/dashboard/components/HookedTokenIcon/HookedTokenIcon.tsx
+++ b/src/modules/dashboard/components/HookedTokenIcon/HookedTokenIcon.tsx
@@ -8,6 +8,7 @@ import { useDataFetcher } from '~utils/hooks';
 import { AnyToken } from '~data/index';
 import { Address } from '~types/index';
 import Icon from '~core/Icon';
+import { getBase64image } from '~utils/dataReader';
 
 import { ipfsDataFetcher } from '../../../core/fetchers';
 
@@ -45,16 +46,6 @@ const loadTokenImages = async (address: Address): Promise<Response> => {
   return fetch(tokenImageUrl);
 };
 
-const getBase64image = (blob): Promise<any> => {
-  return new Promise((resolve) => {
-    const fileReader = new FileReader();
-    fileReader.onload = () => {
-      return resolve(fileReader.result);
-    };
-    fileReader.readAsDataURL(blob);
-  });
-};
-
 const HookedTokenIcon = ({
   name,
   token: { iconHash, address },
@@ -77,7 +68,7 @@ const HookedTokenIcon = ({
         return;
       }
 
-      if (!dontFetch && address && !iconName) {
+      if (address && !iconName) {
         const response = await loadTokenImages(address);
         if (response.ok) {
           const blob = await response.blob();

--- a/src/utils/dataReader.ts
+++ b/src/utils/dataReader.ts
@@ -1,0 +1,9 @@
+export const getBase64image = (blob): Promise<any> => {
+  return new Promise((resolve) => {
+    const fileReader = new FileReader();
+    fileReader.onload = () => {
+      return resolve(fileReader.result);
+    };
+    fileReader.readAsDataURL(blob);
+  });
+};


### PR DESCRIPTION
## Description

- This PR adds in saving icons to local storage to not fetch them every time

**New stuff** ✨

* Fetching images is not firing if on we're on dev environment
* After first image fetch, image is converted to base64image and save in localStorage

**Changes** 🏗

* Updated useEffect of HookedTokenIcon to check if image exist in local storage and if so, then take it. If not - we're normally fetching image

Resolves DEV-131
