### PR TITLE
Rework auth local storage token

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -16,16 +16,56 @@ const postRequest = async (path: string, data: object) => {
   return response.json();
 };
 
-export const setToken = (walletAddress: string, token: string) =>
-  localStorage.setItem(`${TOKEN_STORAGE}-${walletAddress}`, token);
-export const getToken = (walletAddress: string) =>
-  localStorage.getItem(`${TOKEN_STORAGE}-${walletAddress}`);
-export const clearToken = (walletAddress: string) =>
+export const setToken = (walletAddress: string, token: string) => {
+  const storedTokens = localStorage.getItem(TOKEN_STORAGE);
+
+  if (storedTokens) {
+    const parsedStoredTokens = JSON.parse(storedTokens);
+
+    parsedStoredTokens[`${TOKEN_STORAGE}-${walletAddress}`] = token;
+
+    localStorage.setItem(TOKEN_STORAGE, JSON.stringify(parsedStoredTokens));
+  }
+};
+
+export const getToken = (walletAddress: string) => {
+  const storedTokens = localStorage.getItem(TOKEN_STORAGE);
+
+  if (storedTokens) {
+    const parsedStoredTokens = JSON.parse(storedTokens);
+
+    return parsedStoredTokens[`${TOKEN_STORAGE}-${walletAddress}`];
+  }
+
+  return null;
+};
+
+export const clearToken = (walletAddress: string) => {
   localStorage.removeItem(`${TOKEN_STORAGE}-${walletAddress}`);
+  const storedTokens = localStorage.getItem(TOKEN_STORAGE);
+
+  if (storedTokens) {
+    const parsedStoredTokens = JSON.parse(storedTokens);
+
+    delete parsedStoredTokens[`${TOKEN_STORAGE}-${walletAddress}`];
+
+    localStorage.setItem(TOKEN_STORAGE, JSON.stringify(parsedStoredTokens));
+  }
+};
+
+export const setTokenStorage = () =>
+  localStorage.setItem(TOKEN_STORAGE, JSON.stringify({}));
 
 export const authenticate = async (wallet) => {
   try {
+    const hasTokenStorageSet = !!localStorage.getItem(TOKEN_STORAGE);
+
+    if (!hasTokenStorageSet) {
+      setTokenStorage();
+    }
+
     const token = getToken(wallet.address);
+
     if (token) {
       const tokenData = jwtDecode(token);
       if (

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -16,8 +16,15 @@ const postRequest = async (path: string, data: object) => {
   return response.json();
 };
 
+export const setTokenStorage = () =>
+  localStorage.setItem(TOKEN_STORAGE, JSON.stringify({}));
+
 export const setToken = (walletAddress: string, token: string) => {
   const storedTokens = localStorage.getItem(TOKEN_STORAGE);
+
+  if (!storedTokens) {
+    setTokenStorage();
+  }
 
   if (storedTokens) {
     const parsedStoredTokens = JSON.parse(storedTokens);
@@ -41,7 +48,6 @@ export const getToken = (walletAddress: string) => {
 };
 
 export const clearToken = (walletAddress: string) => {
-  localStorage.removeItem(`${TOKEN_STORAGE}-${walletAddress}`);
   const storedTokens = localStorage.getItem(TOKEN_STORAGE);
 
   if (storedTokens) {
@@ -53,17 +59,8 @@ export const clearToken = (walletAddress: string) => {
   }
 };
 
-export const setTokenStorage = () =>
-  localStorage.setItem(TOKEN_STORAGE, JSON.stringify({}));
-
 export const authenticate = async (wallet) => {
   try {
-    const hasTokenStorageSet = !!localStorage.getItem(TOKEN_STORAGE);
-
-    if (!hasTokenStorageSet) {
-      setTokenStorage();
-    }
-
     const token = getToken(wallet.address);
 
     if (token) {


### PR DESCRIPTION
Reworked auth local storage tokens so they occupy 1 storage slot in the local storage instead of using 1 slot for each token

**Changes** 🏗

* Reworked setToken, getToken, clearToken so that they store, get, and clear tokens from a single localStorage slot
*  Added function to check if the localStorage slot is already in use

Resolves DEV-132
