### PR TITLE
Actions Page Recovery Mode Tag - Dev-50

### DIFF
--- a/src/modules/dashboard/components/ActionsPage/ActionsPage.css
+++ b/src/modules/dashboard/components/ActionsPage/ActionsPage.css
@@ -5,6 +5,11 @@
   background-color: white;
 }
 
+.recoveryTag {
+  background-color: var(--pink);
+  color: rgb(249, 250, 250);
+}
+
 .container {
   display: flex;
   align-items: flex-start;

--- a/src/modules/dashboard/components/ActionsPage/ActionsPage.css
+++ b/src/modules/dashboard/components/ActionsPage/ActionsPage.css
@@ -6,13 +6,14 @@
 }
 
 .recoveryTag {
-  padding: 4.5px 8px;
+  padding: 4px 8px;
   height: 20px;
   width: 69px;
   position: absolute;
   top: 129px;
   left: 24.3%;
-  border-radius: 5px;
+  vertical-align: middle;
+  border-radius: var(--radius-large);
   background-color: var(--pink);
   font-size: var(--size-tiny);
   font-weight: var(--weight-bold);

--- a/src/modules/dashboard/components/ActionsPage/ActionsPage.css
+++ b/src/modules/dashboard/components/ActionsPage/ActionsPage.css
@@ -6,8 +6,20 @@
 }
 
 .recoveryTag {
+  padding: 4.5px 8px;
+  height: 20px;
+  width: 69px;
+  position: absolute;
+  top: 129px;
+  left: 24.3%;
+  border-radius: 5px;
   background-color: var(--pink);
-  color: rgb(249, 250, 250);
+  font-size: var(--size-tiny);
+  font-weight: var(--weight-bold);
+  text-align: center;
+  line-height: var(--size-tiny);
+  color: var(--text-invert);
+  letter-spacing: var(--spacing-medium);
 }
 
 .container {

--- a/src/modules/dashboard/components/ActionsPage/ActionsPage.css
+++ b/src/modules/dashboard/components/ActionsPage/ActionsPage.css
@@ -9,7 +9,6 @@
   margin-bottom: 10px;
   padding: 4px 8px;
   height: 20px;
-  width: 69px;
   vertical-align: middle;
   border-radius: var(--radius-large);
   background-color: var(--pink);

--- a/src/modules/dashboard/components/ActionsPage/ActionsPage.css
+++ b/src/modules/dashboard/components/ActionsPage/ActionsPage.css
@@ -10,11 +10,6 @@
   padding: 4px 8px;
   height: 20px;
   width: 69px;
-
-  /* position: absolute; */
-
-  /* top: 129px;
-  left: 24.3%; */
   vertical-align: middle;
   border-radius: var(--radius-large);
   background-color: var(--pink);

--- a/src/modules/dashboard/components/ActionsPage/ActionsPage.css
+++ b/src/modules/dashboard/components/ActionsPage/ActionsPage.css
@@ -6,12 +6,15 @@
 }
 
 .recoveryTag {
+  margin-bottom: 10px;
   padding: 4px 8px;
   height: 20px;
   width: 69px;
-  position: absolute;
-  top: 129px;
-  left: 24.3%;
+
+  /* position: absolute; */
+
+  /* top: 129px;
+  left: 24.3%; */
   vertical-align: middle;
   border-radius: var(--radius-large);
   background-color: var(--pink);
@@ -21,6 +24,13 @@
   line-height: var(--size-tiny);
   color: var(--text-invert);
   letter-spacing: var(--spacing-medium);
+}
+
+.dividerTop {
+  margin: 0 13.19% 0 24.3%;
+  width: 900px;
+  border: none;
+  border-top: 1px solid color-mod(var(--temp-grey-blue-7) alpha(15%));
 }
 
 .container {
@@ -39,7 +49,6 @@
    */
   margin: 0 13.19% 0 24.3%;
   width: 900px;
-  border-top: 1px solid color-mod(var(--temp-grey-blue-7) alpha(15%));
 }
 
 .heading {

--- a/src/modules/dashboard/components/ActionsPage/ActionsPage.css
+++ b/src/modules/dashboard/components/ActionsPage/ActionsPage.css
@@ -21,18 +21,7 @@
   letter-spacing: var(--spacing-medium);
 }
 
-.dividerTop {
-  margin: 0 13.19% 0 24.3%;
-  width: 900px;
-  border: none;
-  border-top: 1px solid color-mod(var(--temp-grey-blue-7) alpha(15%));
-}
-
-.container {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-
+.setMarginWidth {
   /*
    * @NOTE On specs
    *
@@ -44,6 +33,19 @@
    */
   margin: 0 13.19% 0 24.3%;
   width: 900px;
+}
+
+.dividerTop {
+  composes: setMarginWidth;
+  height: 1px;
+  background-color: color-mod(var(--temp-grey-blue-7) alpha(15%));
+}
+
+.container {
+  composes: setMarginWidth;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
 }
 
 .heading {

--- a/src/modules/dashboard/components/ActionsPage/ActionsPage.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/ActionsPage.css.d.ts
@@ -1,5 +1,6 @@
 export const main: string;
 export const recoveryTag: string;
+export const dividerTop: string;
 export const container: string;
 export const heading: string;
 export const content: string;

--- a/src/modules/dashboard/components/ActionsPage/ActionsPage.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/ActionsPage.css.d.ts
@@ -1,4 +1,5 @@
 export const main: string;
+export const recoveryTag: string;
 export const container: string;
 export const heading: string;
 export const content: string;

--- a/src/modules/dashboard/components/ActionsPage/ActionsPage.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/ActionsPage.css.d.ts
@@ -1,5 +1,6 @@
 export const main: string;
 export const recoveryTag: string;
+export const setMarginWidth: string;
 export const dividerTop: string;
 export const container: string;
 export const heading: string;

--- a/src/modules/dashboard/components/ActionsPage/ActionsPage.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsPage.tsx
@@ -270,8 +270,9 @@ const ActionsPage = () => {
 
   return (
     <div className={styles.main}>
-      <p className={styles.recoveryTag}>{formatMessage(MSG.recoveryTag)}</p>
-      {actionType === ColonyActions.Recovery && <p>Recovery</p>}
+      {actionType === ColonyActions.Recovery && (
+        <p className={styles.recoveryTag}>{formatMessage(MSG.recoveryTag)}</p>
+      )}
       <div className={styles.container}>
         <div className={styles.content}>
           {/*

--- a/src/modules/dashboard/components/ActionsPage/ActionsPage.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsPage.tsx
@@ -268,15 +268,12 @@ const ActionsPage = () => {
 
   return (
     <div className={styles.main}>
-      <div className={styles.container}>
-        <p className={styles.recoveryTag}>
-          <FormattedMessage {...MSG.recoveryTag} />
-        </p>
-      </div>
       {actionType === ColonyActions.Recovery && (
-        <p className={styles.recoveryTag}>
-          <FormattedMessage {...MSG.recoveryTag} />
-        </p>
+        <div className={styles.container}>
+          <p className={styles.recoveryTag}>
+            <FormattedMessage {...MSG.recoveryTag} />
+          </p>
+        </div>
       )}
       <hr className={styles.dividerTop} />
       <div className={styles.container}>

--- a/src/modules/dashboard/components/ActionsPage/ActionsPage.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { useParams, Redirect } from 'react-router-dom';
-import { defineMessages, FormattedMessage } from 'react-intl';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import { ColonyRole } from '@colony/colony-js';
 
 import Heading from '~core/Heading';
@@ -48,6 +48,10 @@ const MSG = defineMessages({
     id: 'dashboard.ActionsPage.returnToColony',
     defaultMessage: `Return to colony`,
   },
+  recoveryTag: {
+    id: 'dashboard.ActionsPage.recovery',
+    defaultMessage: `Recovery`,
+  },
 });
 
 /**
@@ -72,6 +76,8 @@ const STATUS_MAP = {
 };
 
 const ActionsPage = () => {
+  const { formatMessage } = useIntl();
+
   const { transactionHash, colonyName } = useParams<{
     transactionHash?: string;
     colonyName: string;
@@ -264,7 +270,7 @@ const ActionsPage = () => {
 
   return (
     <div className={styles.main}>
-      <p className={styles.recoveryTag}>Recovery</p>
+      <p className={styles.recoveryTag}>{formatMessage(MSG.recoveryTag)}</p>
       {actionType === ColonyActions.Recovery && <p>Recovery</p>}
       <div className={styles.container}>
         <div className={styles.content}>

--- a/src/modules/dashboard/components/ActionsPage/ActionsPage.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsPage.tsx
@@ -268,11 +268,17 @@ const ActionsPage = () => {
 
   return (
     <div className={styles.main}>
+      <div className={styles.container}>
+        <p className={styles.recoveryTag}>
+          <FormattedMessage {...MSG.recoveryTag} />
+        </p>
+      </div>
       {actionType === ColonyActions.Recovery && (
         <p className={styles.recoveryTag}>
           <FormattedMessage {...MSG.recoveryTag} />
         </p>
       )}
+      <hr className={styles.dividerTop} />
       <div className={styles.container}>
         <div className={styles.content}>
           {/*

--- a/src/modules/dashboard/components/ActionsPage/ActionsPage.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { useParams, Redirect } from 'react-router-dom';
-import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
+import { defineMessages, FormattedMessage } from 'react-intl';
 import { ColonyRole } from '@colony/colony-js';
 
 import Heading from '~core/Heading';
@@ -76,8 +76,6 @@ const STATUS_MAP = {
 };
 
 const ActionsPage = () => {
-  const { formatMessage } = useIntl();
-
   const { transactionHash, colonyName } = useParams<{
     transactionHash?: string;
     colonyName: string;
@@ -271,7 +269,9 @@ const ActionsPage = () => {
   return (
     <div className={styles.main}>
       {actionType === ColonyActions.Recovery && (
-        <p className={styles.recoveryTag}>{formatMessage(MSG.recoveryTag)}</p>
+        <p className={styles.recoveryTag}>
+          <FormattedMessage {...MSG.recoveryTag} />
+        </p>
       )}
       <div className={styles.container}>
         <div className={styles.content}>

--- a/src/modules/dashboard/components/ActionsPage/ActionsPage.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsPage.tsx
@@ -264,6 +264,8 @@ const ActionsPage = () => {
 
   return (
     <div className={styles.main}>
+      <p className={styles.recoveryTag}>Recovery</p>
+      {actionType === ColonyActions.Recovery && <p>Recovery</p>}
       <div className={styles.container}>
         <div className={styles.content}>
           {/*


### PR DESCRIPTION
## Description

This is a simple issue that adds a "Recovery" tag element at the top of the actions page, when the colony is put into recovery mode.

**New stuff** ✨

* Added `Recovery` string via `defineMessages` & `useIntl` hook
* Added styles for `Recovery` tag

Resolves Dev-50
