### PR TITLE
Update default state when nativeToken is fetched

### DIFF
--- a/src/modules/dashboard/components/ColonyTotalFunds/ColonyTotalFunds.tsx
+++ b/src/modules/dashboard/components/ColonyTotalFunds/ColonyTotalFunds.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
 import { COLONY_TOTAL_BALANCE_DOMAIN_ID } from '~constants';
@@ -62,6 +62,10 @@ const ColonyTotalFunds = ({
     },
   });
 
+  useEffect(() => {
+    setCurrentTokenAddress(nativeTokenAddress);
+  }, [nativeTokenAddress]);
+
   const currentToken = useMemo(() => {
     if (data && data.tokens) {
       return data.tokens.find(
@@ -70,7 +74,6 @@ const ColonyTotalFunds = ({
     }
     return undefined;
   }, [data, currentTokenAddress]);
-
   if (!data || !currentToken || isLoadingTokenBalances) {
     return (
       <div className={styles.main}>


### PR DESCRIPTION
## Description

- This PR is fixing bug with displaying token information on home page

**Changes** 🏗

* Added useEffect to ColonyTotalFunds component to update default state whenever nativeToken is changing. The reason behind this is that while switching between colonies, nativeToken from previous company was set as default state

Resolves DEV-153