### PR TITLE
Add "Load more" logic to Colony Actions

### DIFF
--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -856,6 +856,8 @@ export type QueryEventsArgs = {
 
 
 export type QueryOneTxPaymentsArgs = {
+  skip?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars['Int']>;
   where: ActionsFilter;
 };
 
@@ -1970,6 +1972,8 @@ export type TransactionMessagesCountQueryVariables = Exact<{
 export type TransactionMessagesCountQuery = { transactionMessagesCount: { colonyTransactionMessages: Array<Pick<TransactionCount, 'transactionHash' | 'count'>> } };
 
 export type SubgraphActionsQueryVariables = Exact<{
+  skip: Scalars['Int'];
+  first: Scalars['Int'];
   colonyAddress: Scalars['String'];
 }>;
 
@@ -5035,8 +5039,8 @@ export type TransactionMessagesCountQueryHookResult = ReturnType<typeof useTrans
 export type TransactionMessagesCountLazyQueryHookResult = ReturnType<typeof useTransactionMessagesCountLazyQuery>;
 export type TransactionMessagesCountQueryResult = Apollo.QueryResult<TransactionMessagesCountQuery, TransactionMessagesCountQueryVariables>;
 export const SubgraphActionsDocument = gql`
-    query SubgraphActions($colonyAddress: String!) {
-  oneTxPayments(where: {payment_contains: $colonyAddress}) {
+    query SubgraphActions($skip: Int!, $first: Int!, $colonyAddress: String!) {
+  oneTxPayments(skip: $skip, first: $first, where: {payment_contains: $colonyAddress}) {
     id
     agent
     transaction {
@@ -5098,6 +5102,8 @@ export const SubgraphActionsDocument = gql`
  * @example
  * const { data, loading, error } = useSubgraphActionsQuery({
  *   variables: {
+ *      skip: // value for 'skip'
+ *      first: // value for 'first'
  *      colonyAddress: // value for 'colonyAddress'
  *   },
  * });

--- a/src/data/graphql/queries.graphql
+++ b/src/data/graphql/queries.graphql
@@ -553,7 +553,7 @@ query TransactionMessagesCount($colonyAddress: String!) {
 # otherwise they will be sent to our own graphql server
 # Prepending them with `Subgraph` allows the client to decide what endpoint to use
 
-query SubgraphActions($skip: String!, $first: String!, $colonyAddress: String!) {
+query SubgraphActions($skip: Int!, $first: Int!, $colonyAddress: String!) {
   # @TODO Pagination
   # See the schema for the correct filters we need to pass in for pagination
   oneTxPayments(skip: $skip, first: $first, where: { payment_contains: $colonyAddress }) {

--- a/src/data/graphql/queries.graphql
+++ b/src/data/graphql/queries.graphql
@@ -553,10 +553,10 @@ query TransactionMessagesCount($colonyAddress: String!) {
 # otherwise they will be sent to our own graphql server
 # Prepending them with `Subgraph` allows the client to decide what endpoint to use
 
-query SubgraphActions($colonyAddress: String!) {
+query SubgraphActions($skip: String!, $first: String!, $colonyAddress: String!) {
   # @TODO Pagination
   # See the schema for the correct filters we need to pass in for pagination
-  oneTxPayments(where: { payment_contains: $colonyAddress }) {
+  oneTxPayments(skip: $skip, first: $first, where: { payment_contains: $colonyAddress }) {
     id
     agent
     transaction {

--- a/src/data/graphql/typeDefs.ts
+++ b/src/data/graphql/typeDefs.ts
@@ -249,7 +249,11 @@ export default gql`
   }
 
   extend type Query {
-    oneTxPayments(where: ActionsFilter!): [OneTxPayment!]!
+    oneTxPayments(
+      skip: Int!
+      first: Int!
+      where: ActionsFilter!
+    ): [OneTxPayment!]!
     events(where: EventsFilter!): [SubgraphEvent!]!
   }
 `;

--- a/src/modules/core/components/Button/index.ts
+++ b/src/modules/core/components/Button/index.ts
@@ -1,4 +1,4 @@
-export { default } from './Button';
+export { default, Props } from './Button';
 export { default as ActionButton } from './ActionButton';
 export { default as ConfirmButton } from './ConfirmButton';
 export { default as DottedAddButton } from './DottedAddButton';

--- a/src/modules/core/components/LoadMoreButton/LoadMoreButton.css
+++ b/src/modules/core/components/LoadMoreButton/LoadMoreButton.css
@@ -1,0 +1,9 @@
+.loadMoreButton {
+  margin-top: 22px;
+  text-align: center;
+}
+
+.loadMoreButton button {
+  font-size: var(--size-small);
+  font-weight: var(--weight-bold);
+}

--- a/src/modules/core/components/LoadMoreButton/LoadMoreButton.css.d.ts
+++ b/src/modules/core/components/LoadMoreButton/LoadMoreButton.css.d.ts
@@ -1,0 +1,1 @@
+export const loadMoreButton: string;

--- a/src/modules/core/components/LoadMoreButton/LoadMoreButton.tsx
+++ b/src/modules/core/components/LoadMoreButton/LoadMoreButton.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { defineMessages } from 'react-intl';
+
+import Button, { Props as DefaultButtonProps } from '~core/Button';
+
+import styles from './LoadMoreButton.css';
+
+const MSG = defineMessages({
+  label: {
+    id: 'LoadMoreButton.label',
+    defaultMessage: 'Load More',
+  },
+});
+
+interface Props extends DefaultButtonProps {
+  isLoadingData: boolean;
+}
+
+const LoadMoreButton = ({ isLoadingData, ...props }: Props) => (
+  <div className={styles.loadMoreButton}>
+    <Button
+      appearance={{ size: 'medium', theme: 'primary' }}
+      text={MSG.label}
+      loading={isLoadingData}
+      {...props}
+    />
+  </div>
+);
+
+export default LoadMoreButton;

--- a/src/modules/core/components/LoadMoreButton/index.ts
+++ b/src/modules/core/components/LoadMoreButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from './LoadMoreButton';


### PR DESCRIPTION
Update subgraph query to wire up "load more" logic into action lists, included with a "Load more" button core component

**New stuff** ✨

* Added LoadMoreButton core component 
* Connected Colony Home action list with "Load more" logic

**Changes** 🏗

* Added first and skip params to colony action query

## How to test

- [ ] Go to `src/modules/dashboard/components/ColonyActions/ColonyActions.tsx`
- [ ] In line 74, change `const ITEMS_PER_PAGE = 10;` to `const ITEMS_PER_PAGE = 1;`
- [ ] Create some new actions like `Mint tokens`, `Create payment` ...
- [ ] Watch a `Load More` button appear when more than 1 executed action exists. Then click it to load actions from 1 to 1 :D

Resolves DEV-150
