### PR TITLE
Wire "Colony Actions" filter by domain

### DIFF
--- a/src/modules/dashboard/components/ColonyActions/ColonyActions.tsx
+++ b/src/modules/dashboard/components/ColonyActions/ColonyActions.tsx
@@ -19,7 +19,10 @@ import {
 } from '../shared/actionsSort';
 import { getActionsListData } from '../../transformers';
 import { useTransformer } from '~utils/hooks';
-import { FormattedAction } from '~types/index';
+import {
+  ColonyActions as ColonyActionTypes,
+  FormattedAction,
+} from '~types/index';
 
 import styles from './ColonyActions.css';
 
@@ -38,7 +41,7 @@ const MSG = defineMessages({
   },
   noActionsFound: {
     id: 'dashboard.ColonyActions.noActionsFound',
-    defaultMessage: `The colony did not create any actions yet.
+    defaultMessage: `There are no actions yet.
       {isDevMode, select,
         true {
           {break}
@@ -104,11 +107,20 @@ const ColonyActions = ({
     commentCount?.transactionMessagesCount,
   ]);
 
+  /* Needs to be tested when all action types are wirde up & reflected in the list */
   const filteredActions = useMemo(
     () =>
       !ethDomainId
         ? actions
-        : actions.filter((action) => Number(action.fromDomain) === ethDomainId),
+        : actions.filter(
+            (action) =>
+              Number(action.fromDomain) === ethDomainId ||
+              /* when no specific domain in the action it is displayed in Root */
+              (ethDomainId === 1 && action.fromDomain === undefined) ||
+              /* when transfering funds the list shows both sender & recipient */
+              (action.actionType === ColonyActionTypes.MoveFunds &&
+                Number(action.toDomain) === ethDomainId),
+          ),
     [ethDomainId, actions],
   );
 

--- a/src/modules/dashboard/components/ColonyActions/ColonyActions.tsx
+++ b/src/modules/dashboard/components/ColonyActions/ColonyActions.tsx
@@ -67,6 +67,7 @@ const displayName = 'dashboard.ColonyActions';
 const ColonyActions = ({
   colony: { colonyAddress, colonyName },
   colony,
+  ethDomainId,
 }: Props) => {
   const [actionsSortOption, setActionsSortOption] = useState<string>(
     ActionsSortOptions.NEWEST,
@@ -102,6 +103,14 @@ const ColonyActions = ({
     paymentActions,
     commentCount?.transactionMessagesCount,
   ]);
+
+  const filteredActions = useMemo(
+    () =>
+      !ethDomainId
+        ? actions
+        : actions.filter((action) => Number(action.fromDomain) === ethDomainId),
+    [ethDomainId, actions],
+  );
 
   /*
    * @NOTE This is why we can't have nice things
@@ -151,8 +160,8 @@ const ColonyActions = ({
   );
 
   const sortedActionsData: FormattedAction[] = useMemo(
-    () => actions.sort(actionsSort),
-    [actionsSort, actions],
+    () => filteredActions.sort(actionsSort),
+    [actionsSort, filteredActions],
   );
 
   const handleActionRedirect = useCallback(

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
@@ -200,7 +200,12 @@ const ColonyHome = ({ match, location }: Props) => {
             />
             <Route
               path={COLONY_HOME_ROUTE}
-              component={() => <ColonyActions colony={data.colony} />}
+              component={() => (
+                <ColonyActions
+                  colony={data.colony}
+                  ethDomainId={domainIdFilter}
+                />
+              )}
             />
           </Switch>
         </div>

--- a/src/modules/dashboard/components/shared/actionsSort.ts
+++ b/src/modules/dashboard/components/shared/actionsSort.ts
@@ -32,8 +32,9 @@ export const ActionsSortSelectOptions = [
     label: FILTER_MSG.oldest,
     value: ActionsSortOptions.OLDEST,
   },
-  {
-    label: FILTER_MSG.haveActivity,
-    value: ActionsSortOptions.HAVE_ACTIVITY,
-  },
+  /* temporarily disabling sorting by activity as this is not available yet */
+  // {
+  //   label: FILTER_MSG.haveActivity,
+  //   value: ActionsSortOptions.HAVE_ACTIVITY,
+  // },
 ];


### PR DESCRIPTION
## Description

This PR adds filtering by domain to Colony Actions list

**New stuff** ✨

- add filtering for actions based on domain id

**Changes** 🏗

- updated copy when there are no actions (made it more general)

**Deletions** ⚰️

- commented out sorting by `activity` as this is not available yet

## TODO

- ideally to test all of the filtering cases but all of the actions need to be wired up and shown in the list to do this.

Resolves DEV-152


![filter-gif](https://user-images.githubusercontent.com/34057551/104761799-4f5bf880-575b-11eb-9826-94fc6c95239c.gif)

