### PR TITLE
Wire `Mint Tokens` annotation

### DIFF
--- a/src/modules/dashboard/components/TokenMintDialog/TokenMintDialog.tsx
+++ b/src/modules/dashboard/components/TokenMintDialog/TokenMintDialog.tsx
@@ -44,7 +44,7 @@ type Props = DialogProps &
 const displayName = 'dashboard.TokenMintDialog';
 
 const validationSchema = yup.object().shape({
-  annotation: yup.string(),
+  annotation: yup.string().max(4000),
   mintAmount: yup
     .number()
     .required(() => MSG.errorAmountRequired)
@@ -66,21 +66,24 @@ const TokenMintDialog = ({
 
   const transform = useCallback(
     pipe(
-      mapPayload(({ mintAmount: inputAmount }) => {
-        // Find the selected token's decimals
-        const amount = bigNumberify(
-          moveDecimal(
-            inputAmount,
-            getTokenDecimalsWithFallback(nativeToken?.decimals),
-          ),
-        );
-        return {
-          colonyAddress,
-          colonyName,
-          nativeTokenAddress: nativeToken?.address,
-          amount,
-        };
-      }),
+      mapPayload(
+        ({ mintAmount: inputAmount, annotation: annotationMessage }) => {
+          // Find the selected token's decimals
+          const amount = bigNumberify(
+            moveDecimal(
+              inputAmount,
+              getTokenDecimalsWithFallback(nativeToken?.decimals),
+            ),
+          );
+          return {
+            colonyAddress,
+            colonyName,
+            nativeTokenAddress: nativeToken?.address,
+            amount,
+            annotationMessage,
+          };
+        },
+      ),
       withMeta({ history }),
     ),
     [],

--- a/src/modules/dashboard/sagas/actions.ts
+++ b/src/modules/dashboard/sagas/actions.ts
@@ -317,7 +317,13 @@ function* createMoveFundsAction({
 }
 
 function* createMintTokensAction({
-  payload: { colonyAddress, colonyName, nativeTokenAddress, amount },
+  payload: {
+    colonyAddress,
+    colonyName,
+    nativeTokenAddress,
+    amount,
+    annotationMessage,
+  },
   meta: { id: metaId, history },
   meta,
 }: Action<ActionTypes.COLONY_ACTION_MINT_TOKENS>) {
@@ -327,6 +333,16 @@ function* createMintTokensAction({
 
     if (!amount) {
       throw new Error('Amount to mint not set for mintTokens transaction');
+    }
+
+    let ipfsHash = null;
+    if (annotationMessage) {
+      ipfsHash = yield call(
+        ipfsUpload,
+        JSON.stringify({
+          annotationMessage,
+        }),
+      );
     }
 
     txChannel = yield call(getTxChannel, metaId);
@@ -340,6 +356,10 @@ function* createMintTokensAction({
     const claimColonyFunds = {
       id: `${metaId}-claimColonyFunds`,
       channel: yield call(getTxChannel, `${metaId}-claimColonyFunds`),
+    };
+    const annotateMintTokens = {
+      id: `${metaId}-annotateMintTokens`,
+      channel: yield call(getTxChannel, `${metaId}-annotateMintTokens`),
     };
 
     // create transactions
@@ -368,10 +388,32 @@ function* createMintTokensAction({
       ready: false,
     });
 
+    if (annotationMessage) {
+      yield fork(createTransaction, annotateMintTokens.id, {
+        context: ClientType.ColonyClient,
+        methodName: 'annotateTransaction',
+        identifier: colonyAddress,
+        params: [],
+        group: {
+          key: batchKey,
+          id: metaId,
+          index: 1,
+        },
+        ready: false,
+      });
+    }
+
     yield takeFrom(mintTokens.channel, ActionTypes.TRANSACTION_CREATED);
     yield takeFrom(claimColonyFunds.channel, ActionTypes.TRANSACTION_CREATED);
+    if (annotationMessage) {
+      yield takeFrom(
+        annotateMintTokens.channel,
+        ActionTypes.TRANSACTION_CREATED,
+      );
+    }
 
     yield put(transactionReady(mintTokens.id));
+
     const {
       payload: { hash: txHash },
     } = yield takeFrom(
@@ -381,6 +423,19 @@ function* createMintTokensAction({
     yield takeFrom(mintTokens.channel, ActionTypes.TRANSACTION_SUCCEEDED);
     yield put(transactionReady(claimColonyFunds.id));
     yield takeFrom(claimColonyFunds.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+
+    if (annotationMessage) {
+      yield put(
+        transactionAddParams(annotateMintTokens.id, [txHash, ipfsHash]),
+      );
+
+      yield put(transactionReady(annotateMintTokens.id));
+
+      yield takeFrom(
+        annotateMintTokens.channel,
+        ActionTypes.TRANSACTION_SUCCEEDED,
+      );
+    }
 
     if (colonyName) {
       yield routeRedirect(`/colony/${colonyName}/tx/${txHash}`, history);

--- a/src/modules/dashboard/sagas/actions.ts
+++ b/src/modules/dashboard/sagas/actions.ts
@@ -12,7 +12,11 @@ import {
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
 import { COLONY_TOTAL_BALANCE_DOMAIN_ID } from '~constants';
-import { createTransaction, getTxChannel } from '../../core/sagas';
+import {
+  createTransaction,
+  createTransactionChannels,
+  getTxChannel,
+} from '../../core/sagas';
 import { ipfsUpload } from '../../core/sagas/ipfs';
 import {
   transactionReady,
@@ -349,18 +353,16 @@ function* createMintTokensAction({
 
     // setup batch ids and channels
     const batchKey = 'mintTokens';
-    const mintTokens = {
-      id: `${metaId}-mintTokens`,
-      channel: yield call(getTxChannel, `${metaId}-mintTokens`),
-    };
-    const claimColonyFunds = {
-      id: `${metaId}-claimColonyFunds`,
-      channel: yield call(getTxChannel, `${metaId}-claimColonyFunds`),
-    };
-    const annotateMintTokens = {
-      id: `${metaId}-annotateMintTokens`,
-      channel: yield call(getTxChannel, `${metaId}-annotateMintTokens`),
-    };
+
+    const {
+      mintTokens,
+      claimColonyFunds,
+      annotateMintTokens,
+    } = yield createTransactionChannels(metaId, [
+      'mintTokens',
+      'claimColonyFunds',
+      'annotateMintTokens',
+    ]);
 
     // create transactions
     yield fork(createTransaction, mintTokens.id, {

--- a/src/redux/types/actions/colonyActions.ts
+++ b/src/redux/types/actions/colonyActions.ts
@@ -64,6 +64,7 @@ export type ColonyActionsActionTypes =
         colonyName?: string;
         nativeTokenAddress: Address;
         amount: BigNumber;
+        annotationMessage?: string;
       },
       MetaWithHistory<object>
     >


### PR DESCRIPTION
## Description

This wires up annotation in `Mint Tokens` dialog

**New stuff** ✨

- add annotation wiring in `TokenMintForm` dialog
- add annotation & types in payload in `createMintTokensAction`

**Changes** 🏗

none

**Deletions** ⚰️

none

## TODO

none

Resolves DEV-159

![mint-add-annotation](https://user-images.githubusercontent.com/34057551/104964702-d962c600-59d4-11eb-86ea-b874f33e5477.gif)

<img width="521" alt="Screenshot 2021-01-18 at 18 13 45" src="https://user-images.githubusercontent.com/34057551/104964711-dec01080-59d4-11eb-8e66-ffce06f9d918.png">

