### PR TITLE
Wire up `Move Funds` action query

### DIFF
--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -153,7 +153,7 @@ export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K]
   }
 };
       export default result;
-    
+
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -4249,7 +4249,7 @@ export const SubgraphActionsDocument = gql`
       }
     }
   }
-  events(where: {associatedColony_contains: $colonyAddress, name_in: ["TokensMinted(address,address,uint256)", "DomainAdded(address,uint256)", "ColonyMetadata(address,string)"]}) {
+  events(where: {associatedColony_contains: $colonyAddress, name_in: ["TokensMinted(address,address,uint256)", "DomainAdded(address,uint256)", "ColonyMetadata(address,string)", "ColonyFundsMovedBetweenFundingPots(address,uint256,uint256,uint256,address)]}) {
     id
     transaction {
       hash: id

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -153,7 +153,7 @@ export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K]
   }
 };
       export default result;
-
+    
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -4249,7 +4249,7 @@ export const SubgraphActionsDocument = gql`
       }
     }
   }
-  events(where: {associatedColony_contains: $colonyAddress, name_in: ["TokensMinted(address,address,uint256)", "DomainAdded(address,uint256)", "ColonyMetadata(address,string)", "ColonyFundsMovedBetweenFundingPots(address,uint256,uint256,uint256,address)]}) {
+  events(where: {associatedColony_contains: $colonyAddress, name_in: ["TokensMinted(address,address,uint256)", "DomainAdded(address,uint256)", "ColonyMetadata(address,string)", "ColonyFundsMovedBetweenFundingPots(address,uint256,uint256,uint256,address)"]}) {
     id
     transaction {
       hash: id

--- a/src/data/graphql/queries.graphql
+++ b/src/data/graphql/queries.graphql
@@ -388,7 +388,7 @@ query SubgraphActions($skip: Int!, $first: Int!, $colonyAddress: String!) {
       "TokensMinted(address,address,uint256)",
       "DomainAdded(address,uint256)",
       "ColonyMetadata(address,string)",
-      "FundsMovedBetweenFundingPots(address,uint256,uint256,uint256,address)"
+      "ColonyFundsMovedBetweenFundingPots(address,uint256,uint256,uint256,address)"
     ] }) {
     id
     transaction {

--- a/src/data/graphql/queries.graphql
+++ b/src/data/graphql/queries.graphql
@@ -387,7 +387,8 @@ query SubgraphActions($skip: Int!, $first: Int!, $colonyAddress: String!) {
     name_in: [
       "TokensMinted(address,address,uint256)",
       "DomainAdded(address,uint256)",
-      "ColonyMetadata(address,string)"
+      "ColonyMetadata(address,string)",
+      "FundsMovedBetweenFundingPots(address,uint256,uint256,uint256,address)"
     ] }) {
     id
     transaction {

--- a/src/modules/dashboard/components/ColonyActions/ColonyActions.tsx
+++ b/src/modules/dashboard/components/ColonyActions/ColonyActions.tsx
@@ -133,12 +133,17 @@ const ColonyActions = ({
   ]);
 
   useEffect(() => {
-    getDomainsforMoveFundsActions(colonyAddress, actions, colonyManager).then(
-      (result) => {
-        setFormattedActions(result);
-      },
-    );
-  }, [actions, colonyAddress, colonyManager]);
+    if (
+      formattedActions.length === 0 ||
+      actions?.length !== formattedActions.length
+    ) {
+      getDomainsforMoveFundsActions(
+        colonyAddress,
+        actions,
+        colonyManager,
+      ).then((result) => setFormattedActions(result));
+    }
+  }, [actions, colonyAddress, colonyManager, formattedActions]);
 
   /* Needs to be tested when all action types are wirde up & reflected in the list */
   const filteredActions = useMemo(

--- a/src/modules/dashboard/components/ColonyActions/ColonyActions.tsx
+++ b/src/modules/dashboard/components/ColonyActions/ColonyActions.tsx
@@ -104,20 +104,21 @@ const ColonyActions = ({
 
   /* filtering at this level as it is more performant
   & we reduce the number of events passing through transformers */
-  const uniqueEvents = useMemo(
-    () =>
-      /* additional check for types to work */
-      data === undefined
-        ? []
-        : data.events.filter(
-            (action) =>
-              !data?.oneTxPayments.some(
-                (paymentAction) =>
-                  paymentAction.transaction?.hash === action.transaction.hash,
-              ),
-          ),
-    [data],
-  );
+  const uniqueEvents = useMemo(() => {
+    /* additional check for types to work */
+    if (data === undefined) {
+      return [];
+    }
+
+    return data.events.filter((event) => {
+      /* filtering out events that are already shown in `oneTxPayments` */
+      const isTransactionRepeated = data?.oneTxPayments.some(
+        (paymentAction) =>
+          paymentAction.transaction?.hash === event.transaction?.hash,
+      );
+      return !isTransactionRepeated;
+    });
+  }, [data]);
 
   const {
     data: commentCount,

--- a/src/modules/dashboard/components/ColonyActions/ColonyActions.tsx
+++ b/src/modules/dashboard/components/ColonyActions/ColonyActions.tsx
@@ -103,12 +103,24 @@ const ColonyActions = ({
     commentCount?.transactionMessagesCount,
   ]);
 
+  const uniqueActions = actions.filter(
+    (action) =>
+      !(
+        action.actionType === ColonyActionTypes.MoveFunds &&
+        actions.some(
+          (innerAction: FormattedAction) =>
+            innerAction.actionType === ColonyActionTypes.Payment &&
+            action.transactionHash === innerAction.transactionHash,
+        )
+      ),
+  );
+
   /* Needs to be tested when all action types are wirde up & reflected in the list */
   const filteredActions = useMemo(
     () =>
       !ethDomainId
-        ? actions
-        : actions.filter(
+        ? uniqueActions
+        : uniqueActions.filter(
             (action) =>
               Number(action.fromDomain) === ethDomainId ||
               /* when no specific domain in the action it is displayed in Root */
@@ -117,7 +129,7 @@ const ColonyActions = ({
               (action.actionType === ColonyActionTypes.MoveFunds &&
                 Number(action.toDomain) === ethDomainId),
           ),
-    [ethDomainId, actions],
+    [ethDomainId, uniqueActions],
   );
 
   const handleDataPagination = useCallback(() => {

--- a/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.tsx
@@ -178,7 +178,7 @@ const StepCreateToken = ({
                 appearance={{ theme: 'fat' }}
                 maxLength={5}
                 data-test="defineTokenSymbol"
-                formattingOptions={{ uppercase: true }}
+                formattingOptions={{ uppercase: true, blocks: [5] }}
                 label={MSG.labelTokenSymbol}
                 help={MSG.helpTokenSymbol}
               />

--- a/src/modules/dashboard/sagas/actions.ts
+++ b/src/modules/dashboard/sagas/actions.ts
@@ -334,6 +334,12 @@ function* createMoveFundsAction({
       methodName: 'moveFundsBetweenPotsWithProofs',
       identifier: colonyAddress,
       params: [fromPot, toPot, amount, tokenAddress],
+      group: {
+        key: batchKey,
+        id: metaId,
+        index: 0,
+      },
+      ready: false,
     });
 
     if (annotationMessage) {
@@ -351,12 +357,15 @@ function* createMoveFundsAction({
       });
     }
 
+    yield takeFrom(moveFunds.channel, ActionTypes.TRANSACTION_CREATED);
     if (annotationMessage) {
       yield takeFrom(
         annotateMoveFunds.channel,
         ActionTypes.TRANSACTION_CREATED,
       );
     }
+
+    yield put(transactionReady(moveFunds.id));
 
     const {
       payload: { hash: txHash },

--- a/src/utils/colonyActions.ts
+++ b/src/utils/colonyActions.ts
@@ -69,6 +69,14 @@ export const getValuesForActionType = (
         initiator: argsObj.agent,
       };
     }
+    case ColonyActions.MoveFunds: {
+      return {
+        amount: argsObj.amount,
+        fromDomain: argsObj.fromPot,
+        toDomain: argsObj.toPot,
+        initiator: argsObj.agent,
+      };
+    }
     default: {
       return {};
     }

--- a/src/utils/events/index.ts
+++ b/src/utils/events/index.ts
@@ -12,6 +12,7 @@ import {
   ColonyActions,
   ColonyAndExtensionsEvents,
   Address,
+  FormattedAction,
 } from '~types/index';
 import { ParsedEvent } from '~data/index';
 import { ProcessedEvent } from '~data/resolvers/colonyActions';
@@ -456,4 +457,36 @@ export const getAnnotation = async (
     (annotationLog) => colonyClient.interface.parseLog(annotationLog),
   );
   return allColonyParseAnnotations.pop();
+};
+
+export const getDomainsforMoveFundsActions = async (
+  colonyAddress: string,
+  actions: FormattedAction[],
+  colonyManager: any,
+) => {
+  const colonyClient = await colonyManager.getClient(
+    ClientType.ColonyClient,
+    colonyAddress,
+  );
+
+  return Promise.all(
+    actions.map(async (action) => {
+      if (action.actionType !== ColonyActions.MoveFunds) {
+        return action;
+      }
+
+      const fromDomain = await colonyClient.getDomainFromFundingPot(
+        action.fromDomain,
+      );
+      const toDomain = await colonyClient.getDomainFromFundingPot(
+        action.toDomain,
+      );
+
+      return {
+        ...action,
+        fromDomain: bigNumberify(fromDomain).toString(),
+        toDomain: bigNumberify(toDomain).toString(),
+      };
+    }),
+  );
 };


### PR DESCRIPTION
## Description

Create and wire up "Move Funds" actions Subgraph queries. Corresponds to the subgraph#14 PR `Add `funds moved` to subgraph`.

Checked that filtering by domain for move funds action works (2nd screenshot as an example)

**New stuff** ✨

- add `MoveFunds` case to `getValuesForActionType`
- add `ColonyFundsMovedBetweenFundingPots` event to graphql actions query
- add `getDomainsforMoveFundsActions` helper function in `utils/events` to get correct domains from funding pots
- format and filter events in `ColonyActions` component
- add hard limit on the token symbol input when creating Colony (Dev-164)

**Changes** 🏗

- add missing parts in move funds action

**Deletions** ⚰️

none

## TODO

- potentially move `TEMP_getContext(ContextModule.ColonyManager)` initialisation from `ColonyAction` component to `getDomainsforMoveFundsActions` helper function

Resolves DEV-135
Resolves DEV-164

<img width="752" alt="Screenshot 2021-01-27 at 14 35 27" src="https://user-images.githubusercontent.com/34057551/106007751-88c32b00-60ae-11eb-9f81-972949435353.png">
<img width="537" alt="Screenshot 2021-01-27 at 14 35 51" src="https://user-images.githubusercontent.com/34057551/106007760-89f45800-60ae-11eb-8ece-e6bb21a4466c.png">

