### PR TITLE
UI improvements to displaying dialog and names

### DIFF
--- a/src/modules/core/components/Dialog/Dialog.css
+++ b/src/modules/core/components/Dialog/Dialog.css
@@ -1,5 +1,5 @@
 .modal {
-  max-height: max-content;
+  max-height: calc(100vh - 28px);
   position: relative;
   z-index: var(--z-index-dialog);
   overflow-y: auto;

--- a/src/modules/core/components/Fields/SelectOption/SelectOption.css
+++ b/src/modules/core/components/Fields/SelectOption/SelectOption.css
@@ -46,5 +46,6 @@
 
 .value {
   composes: inlineEllipsis from '~styles/text.css';
+  display: inline-block;
   max-width: 200px;
 }

--- a/src/modules/core/components/Fields/SelectOption/SelectOption.css
+++ b/src/modules/core/components/Fields/SelectOption/SelectOption.css
@@ -43,3 +43,8 @@
   min-height: 32px;
   line-height: 32px;
 }
+
+.value {
+  composes: inlineEllipsis from '~styles/text.css';
+  max-width: 200px;
+}

--- a/src/modules/core/components/Fields/SelectOption/SelectOption.css
+++ b/src/modules/core/components/Fields/SelectOption/SelectOption.css
@@ -46,6 +46,6 @@
 
 .value {
   composes: inlineEllipsis from '~styles/text.css';
-  display: inline-block;
+  display: block;
   max-width: 200px;
 }

--- a/src/modules/core/components/Fields/SelectOption/SelectOption.css.d.ts
+++ b/src/modules/core/components/Fields/SelectOption/SelectOption.css.d.ts
@@ -3,3 +3,4 @@ export const checkedMsg: string;
 export const selectedHelpText: string;
 export const stateBordered: string;
 export const stateIsBasicLabel: string;
+export const value: string;

--- a/src/modules/core/components/Fields/SelectOption/SelectOption.tsx
+++ b/src/modules/core/components/Fields/SelectOption/SelectOption.tsx
@@ -80,7 +80,7 @@ const SelectOption = ({
       onMouseEnter={handleItemSelect}
       data-checked={checked}
     >
-      <span title={label}>
+      <span title={label} className={styles.value}>
         {option.children || (
           <>
             {label}

--- a/src/modules/core/components/FriendlyName/FriendlyName.css
+++ b/src/modules/core/components/FriendlyName/FriendlyName.css
@@ -1,3 +1,7 @@
 .main {
-  display: inline;
+  display: inline-block;
+  vertical-align: text-bottom;
+  max-width: 150px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/src/modules/core/components/FriendlyName/FriendlyName.css
+++ b/src/modules/core/components/FriendlyName/FriendlyName.css
@@ -4,4 +4,5 @@
   max-width: 150px;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/src/modules/core/components/FriendlyName/FriendlyName.css
+++ b/src/modules/core/components/FriendlyName/FriendlyName.css
@@ -1,6 +1,6 @@
 .main {
   composes: inlineEllipsis from '~styles/text.css';
   display: inline-block;
-  vertical-align: text-bottom;
   max-width: 150px;
+  vertical-align: text-bottom;
 }

--- a/src/modules/core/components/FriendlyName/FriendlyName.css
+++ b/src/modules/core/components/FriendlyName/FriendlyName.css
@@ -1,8 +1,6 @@
 .main {
+  composes: inlineEllipsis from '~styles/text.css';
   display: inline-block;
   vertical-align: text-bottom;
   max-width: 150px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }

--- a/src/modules/core/components/TokenEditDialog/TokenEditDialog.tsx
+++ b/src/modules/core/components/TokenEditDialog/TokenEditDialog.tsx
@@ -49,7 +49,7 @@ const MSG = defineMessages({
   },
   notListedToken: {
     id: 'core.TokenEditDialog.notListedToken',
-    defaultMessage: `If token is not listed above, please add any ERC20 compatibile token contract address below.`,
+    defaultMessage: `If token is not listed above, please add any ERC20 compatible token contract address below.`,
   },
   noPermission: {
     id: 'core.TokenEditDialog.noPermission',

--- a/src/modules/dashboard/components/ActionsPage/ActionsPage.css
+++ b/src/modules/dashboard/components/ActionsPage/ActionsPage.css
@@ -54,6 +54,8 @@
   line-height: 24px;
   color: var(--dark);
   letter-spacing: var(--spacing-medium);
+  composes: inlineEllipsis from '~styles/text.css';
+  max-width: 250px;
 }
 
 .heading span {

--- a/src/modules/dashboard/components/ActionsPage/ActionsPage.css
+++ b/src/modules/dashboard/components/ActionsPage/ActionsPage.css
@@ -48,14 +48,14 @@
 }
 
 .heading {
+  composes: inlineEllipsis from '~styles/text.css';
   margin-bottom: 20px;
+  max-width: 250px;
   font-size: var(--size-medium-l);
   font-weight: var(--weight-bold);
   line-height: 24px;
   color: var(--dark);
   letter-spacing: var(--spacing-medium);
-  composes: inlineEllipsis from '~styles/text.css';
-  max-width: 250px;
 }
 
 .heading span {

--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.css
@@ -18,7 +18,9 @@
 }
 
 .value {
+  composes: inlineEllipsis from '~styles/text.css';
   color: color-mod(var(--dark) alpha(85%));
+  max-width: 200px;
 }
 
 .value i {

--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.css
@@ -19,8 +19,8 @@
 
 .value {
   composes: inlineEllipsis from '~styles/text.css';
-  color: color-mod(var(--dark) alpha(85%));
   max-width: 200px;
+  color: color-mod(var(--dark) alpha(85%));
 }
 
 .value i {

--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidgetTeam/DetailsWidgetTeam.css
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidgetTeam/DetailsWidgetTeam.css
@@ -1,0 +1,7 @@
+.text {
+  composes: inlineEllipsis from '~styles/text.css';
+  max-width: 150px;
+  display: inline-block;
+  vertical-align: bottom;
+  margin-left: 5px;
+}

--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidgetTeam/DetailsWidgetTeam.css
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidgetTeam/DetailsWidgetTeam.css
@@ -1,7 +1,7 @@
 .text {
   composes: inlineEllipsis from '~styles/text.css';
-  max-width: 150px;
   display: inline-block;
-  vertical-align: bottom;
   margin-left: 5px;
+  max-width: 150px;
+  vertical-align: bottom;
 }

--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidgetTeam/DetailsWidgetTeam.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidgetTeam/DetailsWidgetTeam.css.d.ts
@@ -1,0 +1,1 @@
+export const text: string;

--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidgetTeam/DetailsWidgetTeam.tsx
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidgetTeam/DetailsWidgetTeam.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { OneDomain } from '~data/index';
 import ColorTag, { Color } from '~core/ColorTag';
 
+import styles from './DetailsWidgetTeam.css';
+
 const displayName = 'dashboard.ActionsPage.DetailsWidget.DetailsWidgetTeam';
 
 interface Props {
@@ -11,7 +13,7 @@ interface Props {
 const DetailsWidgetTeam = ({ domain }: Props) => (
   <div>
     <ColorTag color={domain?.color || Color.LightPink} />
-    {` ${domain?.name}`}
+    <span className={styles.text}>{` ${domain?.name}`}</span>
   </div>
 );
 

--- a/src/modules/dashboard/components/DomainDropdown/DomainSelectItem.css
+++ b/src/modules/dashboard/components/DomainDropdown/DomainSelectItem.css
@@ -19,7 +19,7 @@
 }
 
 .color {
-  flex-basis: 19px;
+  margin-right: 6px;
 }
 
 .rootText {
@@ -52,10 +52,11 @@
 }
 
 .headingWrapper {
-  max-width: 150px;
+  width: 200px;
 }
 
 .headingWrapper h4 {
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/src/modules/dashboard/components/DomainDropdown/DomainSelectItem.css
+++ b/src/modules/dashboard/components/DomainDropdown/DomainSelectItem.css
@@ -50,3 +50,12 @@
 .editButton:focus-within {
   opacity: 1;
 }
+
+.headingWrapper {
+  max-width: 150px;
+}
+
+.headingWrapper h4 {
+  text-overflow: ellipsis;
+  overflow: hidden;
+}

--- a/src/modules/dashboard/components/DomainDropdown/DomainSelectItem.css
+++ b/src/modules/dashboard/components/DomainDropdown/DomainSelectItem.css
@@ -56,6 +56,6 @@
 }
 
 .headingWrapper h4 {
-  text-overflow: ellipsis;
   overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/src/modules/dashboard/components/DomainDropdown/DomainSelectItem.css.d.ts
+++ b/src/modules/dashboard/components/DomainDropdown/DomainSelectItem.css.d.ts
@@ -7,3 +7,4 @@ export const rootText: string;
 export const description: string;
 export const editButtonCol: string;
 export const editButton: string;
+export const headingWrapper: string;

--- a/src/modules/dashboard/components/DomainDropdown/DomainSelectItem.tsx
+++ b/src/modules/dashboard/components/DomainDropdown/DomainSelectItem.tsx
@@ -78,10 +78,12 @@ const DomainSelectItem = ({
              */}
             <ColorTag color={color || Color.LightPink} />
           </div>
-          <Heading
-            appearance={{ margin: 'none', size: 'normal', theme: 'dark' }}
-            text={name}
-          />
+          <div className={styles.headingWrapper}>
+            <Heading
+              appearance={{ margin: 'none', size: 'normal', theme: 'dark' }}
+              text={name}
+            />
+          </div>
           {ethDomainId === ROOT_DOMAIN_ID && (
             <div className={styles.rootText}>(Root)</div>
           )}

--- a/src/modules/dashboard/components/Members/Members.css
+++ b/src/modules/dashboard/components/Members/Members.css
@@ -85,3 +85,10 @@
   margin-bottom: 35px;
   border-bottom: 1px solid var(--temp-grey-13);
 }
+
+.titleContainer h3 {
+  max-width: 250px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}


### PR DESCRIPTION
## Description

This PR updates dialog to fit all screens height as well as adds in text-elipsis to all names

**New stuff** ✨

* New stuff goes here

**Changes** 🏗

* Added ellipsis and max width to FriendlyName component 
* Added ellipsis to domain name in DomainSelectItem component
* Updated typo in TokenEditDialog (compatible)
* Added ellipsis to action page title
* Added ellipsis to DetailsWidget values
* Updated Dialog component to fit all screens
* Added ellipsis to Member Page dropdown
* Added ellipsis to Members Page heading

Resolves DEV-163
Resolves DEV-180

Updated dialog

https://user-images.githubusercontent.com/13069555/106478810-e5a55380-64a9-11eb-95a1-38e5125d8b56.mov

Friendly name 
<img width="793" alt="Screenshot 2021-02-01 at 16 39 30" src="https://user-images.githubusercontent.com/13069555/106480899-2bfbb200-64ac-11eb-8c81-fb3598b57893.png">
DomainSelectItem
<img width="409" alt="Screenshot 2021-02-01 at 16 47 18" src="https://user-images.githubusercontent.com/13069555/106482002-4aae7880-64ad-11eb-857b-d3e1c1bcfa62.png">

Action page title
<img width="609" alt="Screenshot 2021-02-02 at 09 51 42" src="https://user-images.githubusercontent.com/13069555/106575413-58f7a580-653c-11eb-8934-68f6feb30db5.png">

DetailsWidget values
<img width="441" alt="Screenshot 2021-02-02 at 09 59 34" src="https://user-images.githubusercontent.com/13069555/106576473-6feac780-653d-11eb-97e2-5c4de0bc4cd1.png">

Members Page dropdown
<img width="325" alt="Screenshot 2021-02-02 at 10 04 06" src="https://user-images.githubusercontent.com/13069555/106576969-0fa85580-653e-11eb-9ed5-363388f477ca.png">

Members Page heading
<img width="776" alt="Screenshot 2021-02-02 at 13 50 27" src="https://user-images.githubusercontent.com/13069555/106602715-aafcf300-655d-11eb-9682-297b3904e5cc.png">
