### PR TITLE
Fix typo issues across the app

### DIFF
--- a/src/i18n/en-events.ts
+++ b/src/i18n/en-events.ts
@@ -5,7 +5,7 @@ import { ColonyAndExtensionsEvents } from '~types/index';
 const eventsMessageDescriptors = {
   'event.title': `{eventName, select,
       ${ColonyAndExtensionsEvents.OneTxPaymentMade} {{initiator} paid {amount} {tokenSymbol} from {fromDomain} to {recipient}}
-      ${ColonyAndExtensionsEvents.ColonyFundsMovedBetweenFundingPots} {{initiator} transferred {amount} {tokenSymbol} from the {fromDomain} to the {toDomain}}
+      ${ColonyAndExtensionsEvents.ColonyFundsMovedBetweenFundingPots} {{initiator} transferred {amount} {tokenSymbol} from the {fromDomain} to {toDomain}}
       ${ColonyAndExtensionsEvents.TokensMinted} {{initiator} minted {amount} {tokenSymbol} to {recipient}}
       ${ColonyAndExtensionsEvents.DomainAdded} {{initiator} added Team: {fromDomain}}
       ${ColonyAndExtensionsEvents.ColonyUpgraded} {This colony has upgraded to {newVersion}}

--- a/src/i18n/en-events.ts
+++ b/src/i18n/en-events.ts
@@ -14,7 +14,7 @@ const eventsMessageDescriptors = {
   /*
    * This needs to be declared separely since we can't nest select declarations
    */
-  [`event.${ColonyAndExtensionsEvents.ColonyMetadata}.nameLogo`]: `{initiator} changed this colony's name to {colonyName} and it's logo`,
+  [`event.${ColonyAndExtensionsEvents.ColonyMetadata}.nameLogo`]: `{initiator} changed this colony's name to {colonyName} and its logo`,
   [`event.${ColonyAndExtensionsEvents.ColonyMetadata}.name`]: `{initiator} changed this colony's name to {colonyName}`,
   [`event.${ColonyAndExtensionsEvents.ColonyMetadata}.logo`]: `{initiator} changed this colony's logo`,
   [`event.${ColonyAndExtensionsEvents.ColonyMetadata}.tokens`]: `{initiator} changed this colony's tokens`,

--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.tsx
@@ -49,7 +49,7 @@ const MSG = defineMessages({
   },
   domainDescription: {
     id: 'dashboard.ActionsPage.DetailsWidget.domainDescription',
-    defaultMessage: 'Team Purpouse',
+    defaultMessage: 'Team Purpose',
   },
   colonyName: {
     id: 'dashboard.ActionsPage.DetailsWidget.colonyName',

--- a/src/modules/dashboard/components/ColonyHome/ColonySubscription/ColonySubscriptionInfoPopover.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonySubscription/ColonySubscriptionInfoPopover.tsx
@@ -19,7 +19,7 @@ const MSG = defineMessages({
   },
   nativeTokenTitle: {
     id: 'dashboard.ColonyHome.ColonySubscriptionInfoPopover.nativeTokenTitle',
-    defaultMessage: 'NativeTokenAddress',
+    defaultMessage: 'Native Token Address',
   },
 });
 

--- a/src/modules/dashboard/components/CreateEditDomainDialog/CreateEditDomainDialog.tsx
+++ b/src/modules/dashboard/components/CreateEditDomainDialog/CreateEditDomainDialog.tsx
@@ -15,7 +15,7 @@ import DialogForm from './CreateEditDomainDialogForm';
 import { Color } from '~core/ColorTag';
 
 export interface FormValues {
-  domainName: string;
+  teamName: string;
   domainColor?: Color;
   domainPurpose?: string;
   annotationMessage?: string;
@@ -43,7 +43,7 @@ const CreateEditDomainDialog = ({
   const history = useHistory();
 
   const validationSchema = yup.object().shape({
-    domainName: yup.string().required(),
+    teamName: yup.string().required(),
     domainColor: yup.string(),
     domainPurpose: yup.string(),
     annotationMessage: yup.string().max(4000),
@@ -54,6 +54,7 @@ const CreateEditDomainDialog = ({
       mapPayload((payload) => ({
         colonyAddress,
         colonyName,
+        domainName: payload.teamName,
         ...payload,
       })),
       withMeta({ history }),
@@ -64,7 +65,7 @@ const CreateEditDomainDialog = ({
   return (
     <ActionForm
       initialValues={{
-        domainName: undefined,
+        teamName: undefined,
         domainColor: Color.LightPink,
         domainPurpose: undefined,
         annotationMessage: undefined,

--- a/src/modules/dashboard/components/CreateEditDomainDialog/CreateEditDomainDialogForm.tsx
+++ b/src/modules/dashboard/components/CreateEditDomainDialog/CreateEditDomainDialogForm.tsx
@@ -99,7 +99,7 @@ const CreateEditDomainDialogForm = ({
           <div className={styles.domainName}>
             <Input
               label={MSG.name}
-              name="domainName"
+              name="teamName"
               appearance={{ colorSchema: 'grey', theme: 'fat' }}
               disabled={!canCreateEditDomain}
               maxLength={20}


### PR DESCRIPTION
## Description

This PR fixes small typo issues, which was noticed on QA

**Changes** 🏗

* Remove "the" before second team name
* Rename domainName to teamName
* Add spaces to Native token address
* Purpouse to Purpose typo
* Remove not needed apostrophe
<img width="531" alt="1" src="https://user-images.githubusercontent.com/13069555/107056871-156a9900-67d3-11eb-888d-4ccc953ba841.png">
<img width="542" alt="2" src="https://user-images.githubusercontent.com/13069555/107056877-17345c80-67d3-11eb-951b-d00757a96be0.png">
<img width="455" alt="3" src="https://user-images.githubusercontent.com/13069555/107056879-17ccf300-67d3-11eb-8b3c-8b601056fad3.png">
<img width="429" alt="4" src="https://user-images.githubusercontent.com/13069555/107056881-17ccf300-67d3-11eb-9376-d95ec431195d.png">
<img width="455" alt="5" src="https://user-images.githubusercontent.com/13069555/107056883-18658980-67d3-11eb-851d-648192db38fa.png">

Resolves DEV-191
