### PR TITLE
Add beta caution banner

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,6 @@ import { ApolloProvider } from '@apollo/client';
 
 import layout from '~styles/layout.css';
 import { DialogProvider } from '~core/Dialog';
-import BetaCautionAlert from '~core/BetaCautionAlert';
 
 import messages from './i18n/en.json';
 import actionMessages from './i18n/en-actions';
@@ -40,7 +39,6 @@ const App = ({ store }: Props) => (
             <DialogProvider>
               <div className={layout.stretch}>
                 <Routes />
-                <BetaCautionAlert />
               </div>
             </DialogProvider>
           </BrowserRouter>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { ApolloProvider } from '@apollo/client';
 
 import layout from '~styles/layout.css';
 import { DialogProvider } from '~core/Dialog';
+import BetaCautionAlert from '~core/BetaCautionAlert';
 
 import messages from './i18n/en.json';
 import actionMessages from './i18n/en-actions';
@@ -39,6 +40,7 @@ const App = ({ store }: Props) => (
             <DialogProvider>
               <div className={layout.stretch}>
                 <Routes />
+                <BetaCautionAlert />
               </div>
             </DialogProvider>
           </BrowserRouter>

--- a/src/modules/core/components/BetaCautionAlert/BetaCautionAlert.css
+++ b/src/modules/core/components/BetaCautionAlert/BetaCautionAlert.css
@@ -30,3 +30,12 @@
   font-weight: var(--weight-bold);
   color: color-mod(var(--temp-grey-blue-7) alpha(85%));
 }
+
+.link {
+  margin: 18px 0;
+  width: 100%;
+  font-size: var(--size-tiny);
+  font-weight: var(--weight-bold);
+  text-align: center;
+  color: var(--sky-blue);
+}

--- a/src/modules/core/components/BetaCautionAlert/BetaCautionAlert.css
+++ b/src/modules/core/components/BetaCautionAlert/BetaCautionAlert.css
@@ -1,0 +1,32 @@
+.container {
+  display: flex;
+  padding: 2px;
+  height: 54px;
+  width: 143px;
+  position: absolute;
+  bottom: 12px;
+  left: 60px;
+  border-radius: var(--radius-normal);
+  background-color: var(--grey-blue-2);
+  box-shadow: 0px 4px 27px color-mod(var(--temp-grey-8) alpha(25%));
+}
+
+.pinkStripe {
+  margin-right: 13px;
+  height: 50px;
+  width: 4px;
+  border-radius: var(--radius-normal);
+  background-color: var(--pink);
+}
+
+.betaText {
+  padding-top: 6px;
+  font-weight: var(--weight-bold);
+  color: color-mod(var(--dark) alpha(85%));
+}
+
+.cautionText {
+  font-size: var(--size-tiny);
+  font-weight: var(--weight-bold);
+  color: color-mod(var(--temp-grey-blue-7) alpha(85%));
+}

--- a/src/modules/core/components/BetaCautionAlert/BetaCautionAlert.css.d.ts
+++ b/src/modules/core/components/BetaCautionAlert/BetaCautionAlert.css.d.ts
@@ -2,3 +2,4 @@ export const container: string;
 export const pinkStripe: string;
 export const betaText: string;
 export const cautionText: string;
+export const link: string;

--- a/src/modules/core/components/BetaCautionAlert/BetaCautionAlert.css.d.ts
+++ b/src/modules/core/components/BetaCautionAlert/BetaCautionAlert.css.d.ts
@@ -1,0 +1,4 @@
+export const container: string;
+export const pinkStripe: string;
+export const betaText: string;
+export const cautionText: string;

--- a/src/modules/core/components/BetaCautionAlert/BetaCautionAlert.tsx
+++ b/src/modules/core/components/BetaCautionAlert/BetaCautionAlert.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+
+import styles from './BetaCautionAlert.css';
+
+const MSG = {
+  beta: {
+    id: 'BetaCautionAlert.beta',
+    defaultMessage: 'BETA 🤓',
+  },
+  cautionText: {
+    id: 'BetaCautionAlert.cautionText',
+    defaultMessage: 'Use with caution!',
+  },
+};
+
+const BetaCautionAlert = () => {
+  return (
+    <div className={styles.container}>
+      <div className={styles.pinkStripe} />
+      <div>
+        <div className={styles.betaText}>
+          <FormattedMessage {...MSG.beta} />
+        </div>
+        <div className={styles.cautionText}>
+          <FormattedMessage {...MSG.cautionText} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BetaCautionAlert;

--- a/src/modules/core/components/BetaCautionAlert/BetaCautionAlert.tsx
+++ b/src/modules/core/components/BetaCautionAlert/BetaCautionAlert.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import styles from './BetaCautionAlert.css';
@@ -12,20 +12,46 @@ const MSG = {
     id: 'BetaCautionAlert.cautionText',
     defaultMessage: 'Use with caution!',
   },
+  learnMore: {
+    id: 'BetaCautionAlert.learnMore',
+    defaultMessage: 'Learn more',
+  },
 };
 
 const BetaCautionAlert = () => {
+  const [isHovered, setIsHovered] = useState(false);
+
+  const toggleHover = (hasHover) => setIsHovered(hasHover);
+
   return (
-    <div className={styles.container}>
-      <div className={styles.pinkStripe} />
-      <div>
-        <div className={styles.betaText}>
-          <FormattedMessage {...MSG.beta} />
-        </div>
-        <div className={styles.cautionText}>
-          <FormattedMessage {...MSG.cautionText} />
-        </div>
-      </div>
+    <div
+      className={styles.container}
+      onMouseEnter={() => toggleHover(true)}
+      onMouseLeave={() => toggleHover(false)}
+    >
+      {isHovered ? (
+        <a
+          // need to provide a proper link (probably to notion page)
+          href="https://colony.io"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={styles.link}
+        >
+          <FormattedMessage {...MSG.learnMore} />
+        </a>
+      ) : (
+        <>
+          <div className={styles.pinkStripe} />
+          <div>
+            <div className={styles.betaText}>
+              <FormattedMessage {...MSG.beta} />
+            </div>
+            <div className={styles.cautionText}>
+              <FormattedMessage {...MSG.cautionText} />
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/src/modules/core/components/BetaCautionAlert/BetaCautionAlert.tsx
+++ b/src/modules/core/components/BetaCautionAlert/BetaCautionAlert.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 
+import ExternalLink from '~core/ExternalLink';
+
 import styles from './BetaCautionAlert.css';
 
 const MSG = {
@@ -30,15 +32,11 @@ const BetaCautionAlert = () => {
       onMouseLeave={() => toggleHover(false)}
     >
       {isHovered ? (
-        <a
-          // need to provide a proper link (probably to notion page)
-          href="https://colony.io"
-          target="_blank"
-          rel="noopener noreferrer"
+        <ExternalLink
+          text={MSG.learnMore}
           className={styles.link}
-        >
-          <FormattedMessage {...MSG.learnMore} />
-        </a>
+          href="https://colony.io"
+        />
       ) : (
         <>
           <div className={styles.pinkStripe} />

--- a/src/modules/core/components/BetaCautionAlert/BetaCautionAlert.tsx
+++ b/src/modules/core/components/BetaCautionAlert/BetaCautionAlert.tsx
@@ -20,6 +20,8 @@ const MSG = {
   },
 };
 
+const LEARN_MORE_LINK = 'https://colony.io';
+
 const BetaCautionAlert = () => {
   const [isHovered, setIsHovered] = useState(false);
 
@@ -35,7 +37,7 @@ const BetaCautionAlert = () => {
         <ExternalLink
           text={MSG.learnMore}
           className={styles.link}
-          href="https://colony.io"
+          href={LEARN_MORE_LINK}
         />
       ) : (
         <>

--- a/src/modules/core/components/BetaCautionAlert/index.ts
+++ b/src/modules/core/components/BetaCautionAlert/index.ts
@@ -1,0 +1,1 @@
+export { default } from './BetaCautionAlert';

--- a/src/modules/pages/components/RouteLayouts/NavBar/NavBar.tsx
+++ b/src/modules/pages/components/RouteLayouts/NavBar/NavBar.tsx
@@ -1,11 +1,7 @@
-import { defineMessages } from 'react-intl';
 import React, { ReactNode } from 'react';
 import { useLocation } from 'react-router-dom';
 
-import Alert from '~core/Alert';
-import { useLoggedInUser } from '~data/index';
 import { getMainClasses } from '~utils/css';
-import { DEFAULT_NETWORK_INFO } from '~constants';
 
 import HistoryNavigation from '../HistoryNavigation';
 import UserNavigation from '../UserNavigation';
@@ -14,15 +10,6 @@ import { RouteComponentProps } from '~pages/RouteLayouts';
 import styles from './NavBar.css';
 
 const displayName = 'pages.NavBar';
-
-const MSG = defineMessages({
-  mainnetAlert: {
-    id: `pages.NavBar.mainnetAlert`,
-    defaultMessage:
-      /* eslint-disable-next-line max-len */
-      'Heads up! Colony is a beta product on {networkName}. Please be careful.',
-  },
-});
 
 interface Props {
   children: ReactNode;
@@ -39,7 +26,6 @@ const NavBar = ({
   } = {},
   children,
 }: Props) => {
-  const { username } = useLoggedInUser();
   const location = useLocation<{ hasBackLink?: boolean }>();
 
   const backLinkExists =
@@ -64,24 +50,7 @@ const NavBar = ({
             <UserNavigation />
           </div>
         </nav>
-        <main className={styles.content}>
-          {children}
-          {!username && (
-            <div className={styles.alertBanner}>
-              <Alert
-                appearance={{
-                  theme: 'danger',
-                  borderRadius: 'round',
-                }}
-                text={MSG.mainnetAlert}
-                textValues={{
-                  networkName: DEFAULT_NETWORK_INFO.name,
-                }}
-                isDismissible
-              />
-            </div>
-          )}
-        </main>
+        <main className={styles.content}>{children}</main>
       </div>
     </div>
   );

--- a/src/routes/AlwaysAccesibleRoute.tsx
+++ b/src/routes/AlwaysAccesibleRoute.tsx
@@ -1,6 +1,7 @@
 import React, { ComponentType } from 'react';
 import { Route, RouteProps } from 'react-router-dom';
 
+import BetaCautionAlert from '~core/BetaCautionAlert';
 import { RouteComponentProps } from '~pages/RouteLayouts';
 
 type routePropsFn = (params: any) => RouteComponentProps;
@@ -28,6 +29,7 @@ const AlwaysAccesibleRoute = ({
       return (
         <Layout routeProps={passedDownRouteProps} {...props}>
           <Component routeProps={passedDownRouteProps} {...props} />
+          <BetaCautionAlert />
         </Layout>
       );
     }}

--- a/src/routes/WalletRequiredRoute.tsx
+++ b/src/routes/WalletRequiredRoute.tsx
@@ -6,8 +6,9 @@ import {
   RouteComponentProps as ReactRouterComponentProps,
 } from 'react-router-dom';
 import { Location } from 'history';
-
 import { StaticContext } from 'react-router';
+
+import BetaCautionAlert from '~core/BetaCautionAlert';
 import { RouteComponentProps } from '~pages/RouteLayouts';
 
 import {
@@ -42,6 +43,7 @@ const WalletRequiredRoute = ({
   const RouteComponent = ({ ...props }) => (
     <Layout routeProps={routeProps} {...props}>
       <Component routeProps={routeProps} {...props} />
+      <BetaCautionAlert />
     </Layout>
   );
   const locationPath = location && `${location.pathname}${location.search}`;
@@ -123,6 +125,7 @@ const WalletRequiredRoute = ({
             return (
               <Layout routeProps={routeProps} {...props}>
                 <Component routeProps={routeProps} {...props} />
+                <BetaCautionAlert />
               </Layout>
             );
           }


### PR DESCRIPTION
## Description

Add a little alert that cautions that it's BETA version. It should be displayed on each page and stay in the same place when scrolled.

I've added the component to the `App.tsx` file as it seems the most appropriate place to me.

**New stuff** ✨

- add `BetaCautionAlert` component & css

**Changes** 🏗

-  none

**Deletions** ⚰️

- delete the old alert that was on the transaction details page when not loggedin

## TODO

none

Resolves DEV-192

<img width="1153" alt="Screenshot 2021-02-09 at 10 05 33" src="https://user-images.githubusercontent.com/34057551/107348386-d6806000-6abe-11eb-9ab2-924f419705d2.png">

