### PR TITLE
Prevent ColonyHome children constant re-rendering

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyFinishDeployment/ColonyFinishDeployment.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyFinishDeployment/ColonyFinishDeployment.css
@@ -1,0 +1,17 @@
+.finishDeploymentBannerContainer {
+  width: 100%;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  font-weight: var(--weight-bold);
+  text-align: center;
+}
+
+.finishDeploymentBannerContainer button {
+  margin-top: -38px;
+  float: right;
+}
+
+.finishDeploymentBanner {
+  padding: 15px 0;
+}

--- a/src/modules/dashboard/components/ColonyHome/ColonyFinishDeployment/ColonyFinishDeployment.css.d.ts
+++ b/src/modules/dashboard/components/ColonyHome/ColonyFinishDeployment/ColonyFinishDeployment.css.d.ts
@@ -1,0 +1,2 @@
+export const finishDeploymentBannerContainer: string;
+export const finishDeploymentBanner: string;

--- a/src/modules/dashboard/components/ColonyHome/ColonyFinishDeployment/ColonyFinishDeployment.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyFinishDeployment/ColonyFinishDeployment.tsx
@@ -1,0 +1,95 @@
+import React, { useCallback } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import Alert from '~core/Alert';
+import { ActionButton } from '~core/Button';
+
+import { Colony, useNetworkContracts } from '~data/index';
+import { useLoggedInUser } from '~data/helpers';
+import { useTransformer } from '~utils/hooks';
+import { ActionTypes } from '~redux/index';
+import { mapPayload } from '~utils/actions';
+import { canBeUpgraded } from '../../../checks';
+import { hasRoot, canEnterRecoveryMode } from '../../../../users/checks';
+import { getAllUserRoles } from '../../../../transformers';
+
+import styles from './ColonyFinishDeployment.css';
+
+const MSG = defineMessages({
+  deploymentNotFinished: {
+    id: `dashboard.ColonyHome.ColonyFinishDeployment.deploymentNotFinished`,
+    defaultMessage: `Colony creation incomplete. Click to continue 👉`,
+  },
+  buttonFinishDeployment: {
+    id: `dashboard.ColonyHome.ColonyFinishDeployment.buttonFinishDeployment`,
+    defaultMessage: `Finish Deployment`,
+  },
+});
+
+type Props = {
+  colony: Colony;
+};
+
+const displayName = 'dashboard.ColonyHome.ColonyFinishDeployment';
+
+const ColonyFinishDeployment = ({
+  colony,
+  colony: { isDeploymentFinished, colonyAddress },
+}: Props) => {
+  const { version: networkVersion } = useNetworkContracts();
+  const { walletAddress, username, ethereal } = useLoggedInUser();
+
+  const transform = useCallback(
+    mapPayload(() => ({
+      colonyAddress,
+    })),
+    [colonyAddress],
+  );
+
+  const allUserRoles = useTransformer(getAllUserRoles, [colony, walletAddress]);
+
+  const hasRegisteredProfile = !!username && !ethereal;
+  const canUpgradeColony = hasRegisteredProfile && hasRoot(allUserRoles);
+  const canFinishDeployment =
+    canUpgradeColony && canEnterRecoveryMode(allUserRoles);
+
+  /*
+   * @NOTE As a future upgrade, we can have a mapping where we keep track of
+   * past and current network versions so that we can control, more granularly,
+   * which versions *must* be upgraded, and which can function as-is, even with
+   * an older version
+   */
+  const mustUpgradeColony = canBeUpgraded(
+    colony,
+    parseInt(networkVersion || '0', 10),
+  );
+
+  return !mustUpgradeColony && !isDeploymentFinished && canFinishDeployment ? (
+    <div className={styles.finishDeploymentBannerContainer}>
+      <Alert
+        appearance={{
+          theme: 'danger',
+          margin: 'none',
+          borderRadius: 'none',
+        }}
+      >
+        <div className={styles.finishDeploymentBanner}>
+          <FormattedMessage {...MSG.deploymentNotFinished} />
+        </div>
+        <ActionButton
+          appearance={{ theme: 'primary', size: 'medium' }}
+          text={MSG.buttonFinishDeployment}
+          submit={ActionTypes.COLONY_DEPLOYMENT_RESTART}
+          error={ActionTypes.COLONY_DEPLOYMENT_RESTART_ERROR}
+          success={ActionTypes.COLONY_DEPLOYMENT_RESTART_SUCCESS}
+          transform={transform}
+          disabled={!canFinishDeployment}
+        />
+      </Alert>
+    </div>
+  ) : null;
+};
+
+ColonyFinishDeployment.displayName = displayName;
+
+export default ColonyFinishDeployment;

--- a/src/modules/dashboard/components/ColonyHome/ColonyFinishDeployment/index.ts
+++ b/src/modules/dashboard/components/ColonyHome/ColonyFinishDeployment/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ColonyFinishDeployment';

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.css
@@ -60,24 +60,6 @@
   display: block;
 }
 
-.upgradeBannerContainer {
-  width: 100%;
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  font-weight: var(--weight-bold);
-  text-align: center;
-}
-
-.upgradeBannerContainer button {
-  margin-top: -38px;
-  float: right;
-}
-
-.upgradeBanner {
-  padding: 15px 0;
-}
-
 .loadingWrapper {
   height: 100%;
   position: relative;

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.css.d.ts
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.css.d.ts
@@ -7,6 +7,4 @@ export const domainsDropdownContainer: string;
 export const contentActionsPanel: string;
 export const rightAside: string;
 export const events: string;
-export const upgradeBannerContainer: string;
-export const upgradeBanner: string;
 export const loadingWrapper: string;

--- a/src/modules/dashboard/components/ColonyHome/ColonyUpgrade/ColonyUpgrade.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyUpgrade/ColonyUpgrade.css
@@ -1,0 +1,17 @@
+.upgradeBannerContainer {
+  width: 100%;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  font-weight: var(--weight-bold);
+  text-align: center;
+}
+
+.upgradeBannerContainer button {
+  margin-top: -38px;
+  float: right;
+}
+
+.upgradeBanner {
+  padding: 15px 0;
+}

--- a/src/modules/dashboard/components/ColonyHome/ColonyUpgrade/ColonyUpgrade.css.d.ts
+++ b/src/modules/dashboard/components/ColonyHome/ColonyUpgrade/ColonyUpgrade.css.d.ts
@@ -1,0 +1,2 @@
+export const upgradeBannerContainer: string;
+export const upgradeBanner: string;

--- a/src/modules/dashboard/components/ColonyHome/ColonyUpgrade/ColonyUpgrade.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyUpgrade/ColonyUpgrade.tsx
@@ -1,0 +1,85 @@
+import React, { useCallback } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import { useDialog } from '~core/Dialog';
+import NetworkContractUpgradeDialog from '~dashboard/NetworkContractUpgradeDialog';
+import Alert from '~core/Alert';
+import Button from '~core/Button';
+
+import { Colony, useNetworkContracts } from '~data/index';
+import { useLoggedInUser } from '~data/helpers';
+import { useTransformer } from '~utils/hooks';
+import { canBeUpgraded } from '../../../checks';
+import { hasRoot } from '../../../../users/checks';
+import { getAllUserRoles } from '../../../../transformers';
+
+import styles from './ColonyUpgrade.css';
+
+const MSG = defineMessages({
+  upgradeRequired: {
+    id: `dashboard.ColonyHome.ColonyUpgrade.upgradeRequired`,
+    defaultMessage: `This colony uses a version of the network that is no
+      longer supported. You must upgrade to continue using this application.`,
+  },
+});
+
+type Props = {
+  colony: Colony;
+};
+
+const displayName = 'dashboard.ColonyHome.ColonyUpgrade';
+
+const ColonyUpgrade = ({ colony }: Props) => {
+  const openUpgradeVersionDialog = useDialog(NetworkContractUpgradeDialog);
+  const { version: networkVersion } = useNetworkContracts();
+  const { walletAddress, username, ethereal } = useLoggedInUser();
+
+  const handleUpgradeColony = useCallback(
+    () =>
+      openUpgradeVersionDialog({
+        colony,
+      }),
+    [colony, openUpgradeVersionDialog],
+  );
+
+  const allUserRoles = useTransformer(getAllUserRoles, [colony, walletAddress]);
+
+  const hasRegisteredProfile = !!username && !ethereal;
+  const canUpgradeColony = hasRegisteredProfile && hasRoot(allUserRoles);
+  /*
+   * @NOTE As a future upgrade, we can have a mapping where we keep track of
+   * past and current network versions so that we can control, more granularly,
+   * which versions *must* be upgraded, and which can function as-is, even with
+   * an older version
+   */
+  const mustUpgradeColony = canBeUpgraded(
+    colony,
+    parseInt(networkVersion || '0', 10),
+  );
+
+  return mustUpgradeColony ? (
+    <div className={styles.upgradeBannerContainer}>
+      <Alert
+        appearance={{
+          theme: 'danger',
+          margin: 'none',
+          borderRadius: 'none',
+        }}
+      >
+        <div className={styles.upgradeBanner}>
+          <FormattedMessage {...MSG.upgradeRequired} />
+        </div>
+        <Button
+          appearance={{ theme: 'primary', size: 'medium' }}
+          text={{ id: 'button.upgrade' }}
+          onClick={handleUpgradeColony}
+          disabled={!canUpgradeColony}
+        />
+      </Alert>
+    </div>
+  ) : null;
+};
+
+ColonyUpgrade.displayName = displayName;
+
+export default ColonyUpgrade;

--- a/src/modules/dashboard/components/ColonyHome/ColonyUpgrade/index.ts
+++ b/src/modules/dashboard/components/ColonyHome/ColonyUpgrade/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ColonyUpgrade';


### PR DESCRIPTION
## Description

This PR fixes the problem of the actions and events lists constantly re-rendering when having the UAC modals opened and clicking around them.

This happened, apparently, because the `useDialog` hook instantiated in `ColonyHome` and which would change every time a modal would change (it's `id` would change actually), which will make the whole component re-render, including its children.

So since we don't actually need the upgrade colony modal to be declared in the `ColonyHome` component, we created a subcomponent to hold the logic that instantiates the `useDialog` hook.

**Changes**

- [x] Added `ColonyUpgrade` subcomponent
- [x] Added `ColonyFinishDeployment` subcomponent

Resolves DEV-195