### PR TITLE
Don't upload Colony ENS name to IPFS metadata

### DIFF
--- a/src/modules/core/components/Fields/Checkbox/Checkbox.css
+++ b/src/modules/core/components/Fields/Checkbox/Checkbox.css
@@ -17,7 +17,7 @@
   height: 18px;
   width: 18px;
   position: relative;
-  border: 1px solid var(--temp-grey-blue-4);
+  border: 1px solid var(--primary);
   border-radius: 2px;
   background-color: var(--colony-white);
   box-shadow: 0 0 0 2px color-mod(var(--temp-grey-blue-4) alpha(25%));

--- a/src/modules/dashboard/components/ColonyActions/ColonyActions.tsx
+++ b/src/modules/dashboard/components/ColonyActions/ColonyActions.tsx
@@ -14,6 +14,7 @@ import {
   useTransactionMessagesCountQuery,
   useSubscriptionSubgraphOneTxSubscription,
   useSubscriptionSubgraphEventsThatAreActionsSubscription,
+  useOneTxPaymentExtensionAddressQuery,
 } from '~data/index';
 import {
   ActionsSortOptions,
@@ -109,9 +110,14 @@ const ColonyActions = ({
     variables: { colonyAddress },
   });
 
+  const {
+    data: oneTxPaymentExtensionData,
+  } = useOneTxPaymentExtensionAddressQuery();
+
   const actions = useTransformer(getActionsListData, [
     { ...oneTxActions, ...eventsActions },
     commentCount?.transactionMessagesCount,
+    oneTxPaymentExtensionData?.oneTxPaymentExtensionAddress,
   ]);
 
   /* Needs to be tested when all action types are wirde up & reflected in the list */

--- a/src/modules/dashboard/sagas/actions.ts
+++ b/src/modules/dashboard/sagas/actions.ts
@@ -1096,7 +1096,6 @@ function* editColonyAction({
     colonyMetadataIpfsHash = yield call(
       ipfsUpload,
       JSON.stringify({
-        colonyName,
         colonyDisplayName,
         colonyAvatarHash: hasAvatarChanged
           ? colonyAvatarIpfsHash

--- a/src/modules/dashboard/sagas/colonyFinishDeployment.ts
+++ b/src/modules/dashboard/sagas/colonyFinishDeployment.ts
@@ -119,6 +119,7 @@ function* colonyRestartDeployment({
         startingIndex -= 2;
         channelNames.push('deployTokenAuthority');
         channelNames.push('setTokenAuthority');
+        channelNames.push('setOwner');
       }
     }
 
@@ -182,6 +183,7 @@ function* colonyRestartDeployment({
       deployOneTx,
       setOneTxRoleAdministration,
       setOneTxRoleFunding,
+      setOwner,
     } = channels;
 
     const createGroupedTransaction = (
@@ -204,12 +206,15 @@ function* colonyRestartDeployment({
         identifier: colonyAddress,
         ready: false,
       });
-      // }
-
-      // if (setTokenAuthority) {
       yield createGroupedTransaction(setTokenAuthority, {
         context: ClientType.TokenClient,
         methodName: 'setAuthority',
+        identifier: colonyAddress,
+        ready: false,
+      });
+      yield createGroupedTransaction(setOwner, {
+        context: ClientType.TokenClient,
+        methodName: 'setOwner',
         identifier: colonyAddress,
         ready: false,
       });
@@ -283,6 +288,13 @@ function* colonyRestartDeployment({
         setTokenAuthority.channel,
         ActionTypes.TRANSACTION_SUCCEEDED,
       );
+
+      /*
+       * Set the Token's owner
+       */
+      yield put(transactionAddParams(setOwner.id, [colonyAddress]));
+      yield put(transactionReady(setOwner.id));
+      yield takeFrom(setOwner.channel, ActionTypes.TRANSACTION_SUCCEEDED);
     }
 
     if (deployOneTx) {

--- a/src/modules/dashboard/transformers.ts
+++ b/src/modules/dashboard/transformers.ts
@@ -57,7 +57,7 @@ export const getActionsListData = (
           if (linkedDomainAddedEvent) return acc;
         }
         /* filtering out events that are already shown in `oneTxPayments` */
-        const isTransactionRepeated = unformattedActions?.oneTxPayments.some(
+        const isTransactionRepeated = unformattedActions?.oneTxPayments?.some(
           (paymentAction) =>
             paymentAction.transaction?.hash === event.transaction?.hash,
         );


### PR DESCRIPTION
This PR removes `colonyName` (the colony's ens name) from being uploaded to the ipfs metadata object. This is done because of two things:
- while we're not using it right now, someone, down the line will and that will be a problem since it's unreliable _(it can be modified outside of the dapp)_
- shaving a few bytes off the upload data

Obiously one is more important than the other :)

**Changes** 

- [x] Remove `colonyName` from the metadata ipfs upload in the `editColonyAction` saga

Resolves DEV-196
