### PR TITLE
Add feedback link & integrate feedback.fish

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,6 @@ SUBGRAPH_WS_ENDPOINT=ws://127.0.0.1:8001/subgraphs/name/joinColony/subgraph
 # Pinata.cloud Secret. Only use it on local if you want to test this specifically,
 # otherwise you'll pollute your account with random data
 # PINATA_API_SECRET=
+
+# feedback.fish project ID
+FEEDBACK_FISH_PROJECT_ID=

--- a/package-lock.json
+++ b/package-lock.json
@@ -1701,6 +1701,11 @@
         "@ethersproject/logger": "^5.0.5"
       }
     },
+    "@feedback-fish/react": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@feedback-fish/react/-/react-1.2.1.tgz",
+      "integrity": "sha512-4YFD2hE93xBIT/Ko0x0l6UB0OyaxJcWKLGrnznsUVoLE5Q9vB8I1LEbMySYyuvbU9ul3yM3FjGkVZhYVPdwEyA=="
+    },
     "@formatjs/intl-displaynames": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-1.2.8.tgz",

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "@apollo/client": "^3.0.2",
     "@colony/colony-js": "^3.0.0-rc.3",
     "@colony/redux-promise-listener": "^1.2.0",
+    "@feedback-fish/react": "^1.2.1",
     "@formatjs/intl-pluralrules": "^1.5.7",
     "@formatjs/intl-relativetimeformat": "^4.5.14",
     "@formatjs/intl-unified-numberformat": "^3.3.5",

--- a/src/modules/core/components/FeedbackWidget/FeedbackWidget.css
+++ b/src/modules/core/components/FeedbackWidget/FeedbackWidget.css
@@ -12,4 +12,8 @@
   font-weight: var(--weight-bold);
   color: color-mod(var(--temp-grey-blue-7) alpha(85%));
   cursor: pointer;
+
+  &:focus {
+    outline: none;
+  }
 }

--- a/src/modules/core/components/FeedbackWidget/FeedbackWidget.css
+++ b/src/modules/core/components/FeedbackWidget/FeedbackWidget.css
@@ -1,0 +1,15 @@
+.container {
+  position: absolute;
+  right: 34px;
+  bottom: 16px;
+}
+
+.button {
+  padding: 0;
+  border: none;
+  background-color: transparent;
+  font-size: var(--size-tiny);
+  font-weight: var(--weight-bold);
+  color: color-mod(var(--temp-grey-blue-7) alpha(85%));
+  cursor: pointer;
+}

--- a/src/modules/core/components/FeedbackWidget/FeedbackWidget.css
+++ b/src/modules/core/components/FeedbackWidget/FeedbackWidget.css
@@ -1,16 +1,23 @@
 .button {
   padding: 0;
+  padding-right: 9px;
+  width: 320px;
   position: absolute;
-  right: 34px;
+  right: 25px;
   bottom: 16px;
   border: none;
   background-color: transparent;
   font-size: var(--size-tiny);
   font-weight: var(--weight-bold);
+  text-align: right;
   color: color-mod(var(--temp-grey-blue-7) alpha(85%));
   cursor: pointer;
 
   &:focus {
     outline: none;
   }
+}
+
+.heart {
+  color: rgb(221, 46, 68);
 }

--- a/src/modules/core/components/FeedbackWidget/FeedbackWidget.css
+++ b/src/modules/core/components/FeedbackWidget/FeedbackWidget.css
@@ -1,11 +1,8 @@
-.container {
+.button {
+  padding: 0;
   position: absolute;
   right: 34px;
   bottom: 16px;
-}
-
-.button {
-  padding: 0;
   border: none;
   background-color: transparent;
   font-size: var(--size-tiny);

--- a/src/modules/core/components/FeedbackWidget/FeedbackWidget.css.d.ts
+++ b/src/modules/core/components/FeedbackWidget/FeedbackWidget.css.d.ts
@@ -1,0 +1,2 @@
+export const container: string;
+export const button: string;

--- a/src/modules/core/components/FeedbackWidget/FeedbackWidget.css.d.ts
+++ b/src/modules/core/components/FeedbackWidget/FeedbackWidget.css.d.ts
@@ -1,1 +1,2 @@
 export const button: string;
+export const heart: string;

--- a/src/modules/core/components/FeedbackWidget/FeedbackWidget.css.d.ts
+++ b/src/modules/core/components/FeedbackWidget/FeedbackWidget.css.d.ts
@@ -1,2 +1,1 @@
-export const container: string;
 export const button: string;

--- a/src/modules/core/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/src/modules/core/components/FeedbackWidget/FeedbackWidget.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+
+import Button from '~core/Button';
+
+import styles from './FeedbackWidget.css';
+
+const MSG = {
+  loveFeedback: {
+    id: 'FeedbackWidget.loveFeedback',
+    defaultMessage: 'We ♥️ feedback!',
+  },
+};
+
+const FeedbackWidget = () => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [isOpen, setIsOpen] = useState(false);
+
+  const openFeedbackFish = () => {
+    setIsOpen(true);
+  };
+
+  return (
+    <div className={styles.container}>
+      <Button
+        appearance={{ theme: 'no-style' }}
+        className={styles.button}
+        text={MSG.loveFeedback}
+        onClick={openFeedbackFish}
+      />
+    </div>
+  );
+};
+
+export default FeedbackWidget;

--- a/src/modules/core/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/src/modules/core/components/FeedbackWidget/FeedbackWidget.tsx
@@ -1,8 +1,14 @@
-import React, { useState } from 'react';
+import React from 'react';
+import { FeedbackFish } from '@feedback-fish/react';
 
 import Button from '~core/Button';
+import { useLoggedInUser } from '~data/index';
 
 import styles from './FeedbackWidget.css';
+
+/* can add real project id from personal account if need to test.
+I've tested the feedback.fish process - works very well */
+const PROJECT_ID = '';
 
 const MSG = {
   loveFeedback: {
@@ -12,21 +18,26 @@ const MSG = {
 };
 
 const FeedbackWidget = () => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [isOpen, setIsOpen] = useState(false);
+  const { username } = useLoggedInUser();
 
-  const openFeedbackFish = () => {
-    setIsOpen(true);
-  };
+  const isDevelopment = process.env.NODE_ENV === 'development';
 
   return (
     <div className={styles.container}>
-      <Button
-        appearance={{ theme: 'no-style' }}
-        className={styles.button}
-        text={MSG.loveFeedback}
-        onClick={openFeedbackFish}
-      />
+      <FeedbackFish
+        projectId={
+          process.env.FEEDBACK_FISH_PROJECT_ID === undefined || isDevelopment
+            ? PROJECT_ID
+            : process.env.FEEDBACK_FISH_PROJECT_ID
+        }
+        userId={username === null ? undefined : username}
+      >
+        <Button
+          appearance={{ theme: 'no-style' }}
+          className={styles.button}
+          text={MSG.loveFeedback}
+        />
+      </FeedbackFish>
     </div>
   );
 };

--- a/src/modules/core/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/src/modules/core/components/FeedbackWidget/FeedbackWidget.tsx
@@ -25,7 +25,9 @@ const FeedbackWidget = () => {
   return (
     <FeedbackFish
       projectId={
-        process.env.FEEDBACK_FISH_PROJECT_ID === undefined || isDevelopment
+        /* the second check is for the types
+        if the projectId is an empty string the feedback won't be sent */
+        isDevelopment || process.env.FEEDBACK_FISH_PROJECT_ID === undefined
           ? PROJECT_ID
           : process.env.FEEDBACK_FISH_PROJECT_ID
       }

--- a/src/modules/core/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/src/modules/core/components/FeedbackWidget/FeedbackWidget.tsx
@@ -23,22 +23,20 @@ const FeedbackWidget = () => {
   const isDevelopment = process.env.NODE_ENV === 'development';
 
   return (
-    <div className={styles.container}>
-      <FeedbackFish
-        projectId={
-          process.env.FEEDBACK_FISH_PROJECT_ID === undefined || isDevelopment
-            ? PROJECT_ID
-            : process.env.FEEDBACK_FISH_PROJECT_ID
-        }
-        userId={username === null ? undefined : username}
-      >
-        <Button
-          appearance={{ theme: 'no-style' }}
-          className={styles.button}
-          text={MSG.loveFeedback}
-        />
-      </FeedbackFish>
-    </div>
+    <FeedbackFish
+      projectId={
+        process.env.FEEDBACK_FISH_PROJECT_ID === undefined || isDevelopment
+          ? PROJECT_ID
+          : process.env.FEEDBACK_FISH_PROJECT_ID
+      }
+      userId={username === null ? undefined : username}
+    >
+      <Button
+        appearance={{ theme: 'no-style' }}
+        className={styles.button}
+        text={MSG.loveFeedback}
+      />
+    </FeedbackFish>
   );
 };
 

--- a/src/modules/core/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/src/modules/core/components/FeedbackWidget/FeedbackWidget.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FormattedMessage } from 'react-intl';
 import { FeedbackFish } from '@feedback-fish/react';
 
 import Button from '~core/Button';
@@ -13,7 +14,7 @@ const PROJECT_ID = '';
 const MSG = {
   loveFeedback: {
     id: 'FeedbackWidget.loveFeedback',
-    defaultMessage: 'We ♥️ feedback!',
+    defaultMessage: 'We {heart} feedback!',
   },
 };
 
@@ -33,11 +34,18 @@ const FeedbackWidget = () => {
       }
       userId={username === null ? undefined : username}
     >
-      <Button
-        appearance={{ theme: 'no-style' }}
-        className={styles.button}
-        text={MSG.loveFeedback}
-      />
+      <Button appearance={{ theme: 'no-style' }} className={styles.button}>
+        <FormattedMessage
+          {...MSG.loveFeedback}
+          values={{
+            heart: (
+              <span role="img" className={styles.heart} aria-label="">
+                ♥️
+              </span>
+            ),
+          }}
+        />
+      </Button>
     </FeedbackFish>
   );
 };

--- a/src/modules/core/components/FeedbackWidget/index.ts
+++ b/src/modules/core/components/FeedbackWidget/index.ts
@@ -1,0 +1,1 @@
+export { default } from './FeedbackWidget';

--- a/src/routes/AlwaysAccesibleRoute.tsx
+++ b/src/routes/AlwaysAccesibleRoute.tsx
@@ -2,6 +2,7 @@ import React, { ComponentType } from 'react';
 import { Route, RouteProps } from 'react-router-dom';
 
 import BetaCautionAlert from '~core/BetaCautionAlert';
+import FeedbackWidget from '~core/FeedbackWidget';
 import { RouteComponentProps } from '~pages/RouteLayouts';
 
 type routePropsFn = (params: any) => RouteComponentProps;
@@ -30,6 +31,7 @@ const AlwaysAccesibleRoute = ({
         <Layout routeProps={passedDownRouteProps} {...props}>
           <Component routeProps={passedDownRouteProps} {...props} />
           <BetaCautionAlert />
+          <FeedbackWidget />
         </Layout>
       );
     }}

--- a/src/routes/WalletRequiredRoute.tsx
+++ b/src/routes/WalletRequiredRoute.tsx
@@ -9,6 +9,7 @@ import { Location } from 'history';
 import { StaticContext } from 'react-router';
 
 import BetaCautionAlert from '~core/BetaCautionAlert';
+import FeedbackWidget from '~core/FeedbackWidget';
 import { RouteComponentProps } from '~pages/RouteLayouts';
 
 import {
@@ -44,6 +45,7 @@ const WalletRequiredRoute = ({
     <Layout routeProps={routeProps} {...props}>
       <Component routeProps={routeProps} {...props} />
       <BetaCautionAlert />
+      <FeedbackWidget />
     </Layout>
   );
   const locationPath = location && `${location.pathname}${location.search}`;
@@ -126,6 +128,7 @@ const WalletRequiredRoute = ({
               <Layout routeProps={routeProps} {...props}>
                 <Component routeProps={routeProps} {...props} />
                 <BetaCautionAlert />
+                <FeedbackWidget />
               </Layout>
             );
           }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -56,7 +56,6 @@ textarea {
 
 img,
 embed,
-iframe,
 object,
 audio,
 video {
@@ -65,6 +64,7 @@ video {
 }
 
 iframe {
+  max-width: 100%;
   border: 0;
 }
 


### PR DESCRIPTION
## Description

This is to add a link to an external tracking service called feedback.fish

This is integrated by having a button in the bottom right corner, and, upon clicking it, the  feedback.fish widget will show.

**New stuff** ✨

- add `@feedback-fish/react` package
- add `FeedbackWidget` component that integrates the service
- create `FEEDBACK_FISH_PROJECT_ID` env variable (so far empty)

**Changes** 🏗

none

**Deletions** ⚰️

- delete `height: auto` for `iframe` in `main.css` so that the external component can be displayed properly

## TODO

- To create a corporate account with Feedback.fish and add the project ID to the env variable

Resolves DEV-198

<img width="379" alt="Screenshot 2021-02-11 at 11 51 52" src="https://user-images.githubusercontent.com/34057551/107633762-70334300-6c60-11eb-9ad9-9865ebb21742.png">

