### PR TITLE
Fix `useColonyFromNameQuery` not returning token balances for all domains

### DIFF
--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -1207,11 +1207,11 @@ export type ProcessedTokens = {
   decimals: Scalars['Int'];
   name: Scalars['String'];
   symbol: Scalars['String'];
-  balances: Array<ProcessedTokenBalances>;
+  processedBalances: Array<ProcessedTokenBalances>;
 };
 
 
-export type ProcessedTokensBalancesArgs = {
+export type ProcessedTokensProcessedBalancesArgs = {
   colonyAddress: Scalars['String'];
 };
 
@@ -1319,7 +1319,7 @@ export type TokensFragment = (
   Pick<ProcessedColony, 'nativeTokenAddress' | 'tokenAddresses'>
   & { tokens: Array<(
     Pick<ProcessedTokens, 'id' | 'address' | 'iconHash' | 'decimals' | 'name' | 'symbol'>
-    & { balances: Array<Pick<ProcessedTokenBalances, 'domainId' | 'amount'>> }
+    & { processedBalances: Array<Pick<ProcessedTokenBalances, 'domainId' | 'amount'>> }
   )> }
 );
 
@@ -2152,7 +2152,7 @@ export const TokensFragmentDoc = gql`
     decimals
     name
     symbol
-    balances(colonyAddress: $address) {
+    processedBalances(colonyAddress: $address) {
       domainId
       amount
     }

--- a/src/data/graphql/fragments.graphql
+++ b/src/data/graphql/fragments.graphql
@@ -50,7 +50,7 @@ fragment Tokens on ProcessedColony {
     decimals
     name
     symbol
-    balances(colonyAddress: $address) {
+    processedBalances(colonyAddress: $address) {
       domainId
       amount
     }

--- a/src/data/graphql/typeDefs.ts
+++ b/src/data/graphql/typeDefs.ts
@@ -306,7 +306,7 @@ export default gql`
     decimals: Int!
     name: String!
     symbol: String!
-    balances(colonyAddress: String!): [ProcessedTokenBalances!]!
+    processedBalances(colonyAddress: String!): [ProcessedTokenBalances!]!
   }
 
   type ProcessedColony {

--- a/src/modules/dashboard/components/ColonyFunding/ColonyFunding.tsx
+++ b/src/modules/dashboard/components/ColonyFunding/ColonyFunding.tsx
@@ -29,6 +29,10 @@ const MSG = defineMessages({
     id: 'dashboard.ColonyFunding.loadingText',
     defaultMessage: 'Loading Colony',
   },
+  loading: {
+    id: 'dashboard.ColonyFunding.loading',
+    defaultMessage: `Loading Tokens`,
+  },
 });
 
 type Props = RouteChildrenProps<{ colonyName: string }>;

--- a/src/modules/dashboard/components/ColonyFunding/ColonyFunding.tsx
+++ b/src/modules/dashboard/components/ColonyFunding/ColonyFunding.tsx
@@ -29,10 +29,6 @@ const MSG = defineMessages({
     id: 'dashboard.ColonyFunding.loadingText',
     defaultMessage: 'Loading Colony',
   },
-  loading: {
-    id: 'dashboard.ColonyFunding.loading',
-    defaultMessage: `Loading Tokens`,
-  },
 });
 
 type Props = RouteChildrenProps<{ colonyName: string }>;

--- a/src/modules/dashboard/components/ColonyHome/ColonyFunding/TokenItem.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyFunding/TokenItem.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
 import Numeral from '~core/Numeral';
-import { Colony } from '~data/index';
+import { TokenBalancesForDomainsQuery } from '~data/index';
 import { getTokenDecimalsWithFallback } from '~utils/tokens';
 
 interface Props {
   currentDomainId: number;
-  token: Colony['tokens'][0];
+  token: TokenBalancesForDomainsQuery['tokens'][0];
 }
 
 const displayName = 'dashboard.ColonyHome.ColonyFunding.TokenItem';

--- a/src/modules/dashboard/components/ColonyTotalFunds/ColonyTotalFundsPopover.tsx
+++ b/src/modules/dashboard/components/ColonyTotalFunds/ColonyTotalFundsPopover.tsx
@@ -3,7 +3,7 @@ import React, { ReactNode, Dispatch, SetStateAction } from 'react';
 import Popover from '~core/Popover';
 import TokenIcon from '~dashboard/HookedTokenIcon';
 import Numeral from '~core/Numeral';
-import { Colony } from '~data/index';
+import { TokenBalancesForDomainsQuery } from '~data/index';
 import { Address } from '~types/index';
 import { COLONY_TOTAL_BALANCE_DOMAIN_ID } from '~constants';
 import { getTokenDecimalsWithFallback } from '~utils/tokens';
@@ -12,7 +12,7 @@ import styles from './ColonyTotalFundsPopover.css';
 
 interface Props {
   onSelectToken?: Dispatch<SetStateAction<Address>>;
-  tokens?: Colony['tokens'][0][];
+  tokens?: TokenBalancesForDomainsQuery['tokens'][0][];
   children?: ReactNode;
   currentTokenAddress?: Address;
 }

--- a/src/modules/dashboard/components/TokenCardList/TokenCardList.tsx
+++ b/src/modules/dashboard/components/TokenCardList/TokenCardList.tsx
@@ -37,6 +37,13 @@ const TokenCardList = ({
     <CardList appearance={appearance}>
       {tokens.map((token) => (
         <div key={token.address}>
+          {'processedBalances' in token && (
+            <TokenCard
+              domainId={domainId}
+              nativeTokenAddress={nativeTokenAddress}
+              token={token}
+            />
+          )}
           {'balances' in token && (
             <TokenCard
               domainId={domainId}

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -14,6 +14,11 @@ export const getBalanceFromToken = (
       ({ domainId }) => domainId === tokenDomainId,
     );
     result = domainBalance ? domainBalance.amount : 0;
+  } else if ('processedBalances' in token) {
+    const domainBalance = token.processedBalances.find(
+      ({ domainId }) => domainId === tokenDomainId,
+    );
+    result = domainBalance ? domainBalance.amount : 0;
   } else if ('balance' in token) {
     result = token.balance;
   } else {


### PR DESCRIPTION
## Description

- [] TODO write description

**New stuff** ✨

- add `processedBalances` in token resolver, `ProcessedTokens` & `ProcessedColony`
- add `Spinner` to `ColonyFunding`

**Changes** 🏗

- changed token types in `TokenItem` & `ColonyTotalFundsPopover`

**Deletions** ⚰️

- none

## TODO

- maybe remove my spinner during rebase as it seems Raul added one as well

Resolves DEV-199

![funds-by-team](https://user-images.githubusercontent.com/34057551/107933473-b1846500-6f76-11eb-93f8-ce9ef3414ee3.gif)

