### PR TITLE
Fixed FriendlyName showing incorrect name/address

### DIFF
--- a/src/modules/core/components/FriendlyName/FriendlyName.tsx
+++ b/src/modules/core/components/FriendlyName/FriendlyName.tsx
@@ -86,9 +86,11 @@ const FriendlyName = ({
       addressRef.current.style.fontSize = `${inheritedFontSize - 1}px`;
     }
   }, [addressRef, autoShrinkAddress]);
+  const isColony = user?.profile.walletAddress === colony?.colonyAddress;
+
   return (
     <div className={styles.main}>
-      {userDisplay || colonyDisplay || (
+      {userDisplay || (isColony && colonyDisplay) || (
         <MaskedAddress
           address={userDisplayAddress || colonyDisplayAddress}
           full={!maskedAddress}


### PR DESCRIPTION
Fixes FriendlyName always showing the name of the colony when the initiator/recipient is not a member of the colony

Resolves DEV-183
