### PR TITLE
Allow users to create payments in subdomains

### DIFF
--- a/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialogForm.tsx
+++ b/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialogForm.tsx
@@ -225,6 +225,8 @@ const CreatePaymentDialogForm = ({
          * to Formik's error state.
          */
         setCustomAmountError(MSG.noBalance);
+      } else {
+        setCustomAmountError(undefined);
       }
     }
   }, [

--- a/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialogForm.tsx
+++ b/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialogForm.tsx
@@ -273,7 +273,6 @@ const CreatePaymentDialogForm = ({
               label={MSG.from}
               name="domainId"
               appearance={{ theme: 'grey', width: 'fluid' }}
-              disabled={!userHasPermission || !canMakePayment}
             />
             {!!tokenAddress && (
               <div className={styles.domainPotBalance}>
@@ -418,7 +417,12 @@ const CreatePaymentDialogForm = ({
            * Disable Form submissions if either the form is invalid, or
            * if our custom state was triggered.
            */
-          disabled={!isValid || !!customAmountError || !canMakePayment}
+          disabled={
+            !isValid ||
+            !!customAmountError ||
+            !canMakePayment ||
+            !userHasPermission
+          }
           style={{ width: styles.wideButton }}
         />
       </DialogSection>

--- a/src/modules/dashboard/components/ExpendituresDialog/ExpendituresDialog.tsx
+++ b/src/modules/dashboard/components/ExpendituresDialog/ExpendituresDialog.tsx
@@ -7,7 +7,7 @@ import IndexModal from '~core/IndexModal';
 import { WizardDialogType, useTransformer } from '~utils/hooks';
 import { useLoggedInUser, Colony } from '~data/index';
 import { getAllUserRoles } from '../../../transformers';
-import { canArchitect, canFund } from '../../../users/checks';
+import { canAdminister, canFund } from '../../../users/checks';
 
 const MSG = defineMessages({
   dialogHeader: {
@@ -80,7 +80,9 @@ const ExpendituresDialog = ({
 
   const hasRegisteredProfile = !!username && !ethereal;
   const canCreatePayment =
-    hasRegisteredProfile && canArchitect(allUserRoles) && canFund(allUserRoles);
+    hasRegisteredProfile &&
+    canAdminister(allUserRoles) &&
+    canFund(allUserRoles);
 
   const items = [
     {

--- a/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementForm.tsx
+++ b/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementForm.tsx
@@ -104,7 +104,6 @@ const PermissionManagementForm = ({
           name="domainId"
           appearance={{ theme: 'grey' }}
           onChange={handleDomainChange}
-          disabled={!userHasPermission}
         />
       </div>
       <InputLabel


### PR DESCRIPTION
This PR fixes the issue where a user, even with the correct permissions, could not create a payment in a subdomain.

This was because the domain dropdown was disabled unless you had permissions in "Root".

To fix this, I've enabled the dropdown for all access levels so that you can get to the domain you have permissions in. While I was at it I've fixed a bug where the custom error validation was not resetting properly.

![fix-subdomain-payment](https://user-images.githubusercontent.com/1193222/108064987-12d73180-7066-11eb-818f-58f07d7919ca.gif)

As a future improvement, we could remove all domains from the list, in which the user doesn't have permissions.

Resolves DEV-211