### PR TITLE
Fix 404 redirection in ColonyHome page

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
@@ -97,7 +97,10 @@ const ColonyHome = ({ match, location }: Props) => {
    * This problem is made even worse in an production environment where loading
    * times are slow.
    */
-  if (loading || data?.processedColony?.colonyName !== colonyName) {
+  if (
+    loading ||
+    (data?.processedColony && data.processedColony.colonyName !== colonyName)
+  ) {
     return (
       <div className={styles.loadingWrapper}>
         <LoadingTemplate loadingText={MSG.loadingText} />
@@ -105,7 +108,12 @@ const ColonyHome = ({ match, location }: Props) => {
     );
   }
 
-  if (!colonyName || error || !data?.processedColony) {
+  if (
+    !colonyName ||
+    error ||
+    !data?.processedColony ||
+    (data?.colonyAddress as any) instanceof Error
+  ) {
     return <Redirect to={NOT_FOUND_ROUTE} />;
   }
 


### PR DESCRIPTION
* Fixed `data?.processedColony?.colonyName !== colonyName` always being true(and thus, always showing the loader) when `processedColony` arrives as `undefined`
* Added extra conditional for 404 redirection that checks for errors on the `data.colonyAddress` prop

Resolves DEV-210
