### PR TITLE
Display correct block explorer name in Transaction Meta

### DIFF
--- a/src/modules/dashboard/components/ActionsPage/TransactionMeta/TransactionMeta.tsx
+++ b/src/modules/dashboard/components/ActionsPage/TransactionMeta/TransactionMeta.tsx
@@ -9,9 +9,9 @@ import { STATUS } from '../types';
 import styles from './TransactionMeta.css';
 
 const MSG = defineMessages({
-  blockscout: {
-    id: 'dashboard.ActionsPage.TransactionMeta.blockscout',
-    defaultMessage: 'Etherscan',
+  blockExplorer: {
+    id: 'dashboard.ActionsPage.TransactionMeta.blockExplorer',
+    defaultMessage: '{blockExplorerName}',
   },
   transactionStatus: {
     id: 'dashboard.ColonyHome.ColonyTitle.transactionStatus',
@@ -43,7 +43,7 @@ const TransactionMeta = ({ createdAt, transactionHash, status }: Props) => (
         <TransactionLink
           className={styles.blockscoutLink}
           hash={transactionHash}
-          text={MSG.blockscout}
+          text={MSG.blockExplorer}
           textValues={{
             blockExplorerName: DEFAULT_NETWORK_INFO.blockExplorerName,
           }}


### PR DESCRIPTION
## Description

This PR fixes an issue reported on the xdai mainnet where the block explorer, on the action page, would still show up as Etherescan, despite xdai using Blockscout as it's explorer.

The link to the specific transaction was created correctly, it was just the name that was at fault here.

This was due to a message descriptor, to which we would pass a correct block explorer value, but since it was hard-coded it didn't actually display it.

**Changes** 

- [x] Fixed message descriptor in `TransactionMeta` to actually display values

Resolves DEV-217
