### PR TITLE
Fix ERC20 unclaimed transfers to show up properly

### DIFF
--- a/src/modules/dashboard/components/UnclaimedTransfers/UnclaimedTransfers.css
+++ b/src/modules/dashboard/components/UnclaimedTransfers/UnclaimedTransfers.css
@@ -1,5 +1,5 @@
 .main {
-  margin-bottom: 30px;
+  margin: 30px 0;
 }
 
 .title {
@@ -7,4 +7,12 @@
   font-size: var(--size-smallish);
   font-weight: var(--weight-bold);
   color: var(--dark);
+}
+
+.loadingText {
+  display: inline-block;
+  margin: -8px 0 0 5px;
+  vertical-align: middle;
+  font-size: var(--size-small);
+  letter-spacing: initial;
 }

--- a/src/modules/dashboard/components/UnclaimedTransfers/UnclaimedTransfers.css.d.ts
+++ b/src/modules/dashboard/components/UnclaimedTransfers/UnclaimedTransfers.css.d.ts
@@ -1,2 +1,3 @@
 export const main: string;
 export const title: string;
+export const loadingText: string;

--- a/src/modules/dashboard/components/UnclaimedTransfers/UnclaimedTransfers.tsx
+++ b/src/modules/dashboard/components/UnclaimedTransfers/UnclaimedTransfers.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { useColonyTransfersQuery, Colony } from '~data/index';
+
+import { SpinnerLoader } from '~core/Preloaders';
 import UnclaimedTransfersItem from './UnclaimedTransfersItem';
 
 import styles from './UnclaimedTransfers.css';
@@ -16,13 +18,28 @@ const MSG = defineMessages({
     id: 'dashboard.UnclaimedTransfers.title',
     defaultMessage: 'Incoming funds',
   },
+  loadingData: {
+    id: 'dashboard.UnclaimedTransfers.title',
+    defaultMessage: 'Loading token transfers...',
+  },
 });
 
 const UnclaimedTransfers = ({ colony: { colonyAddress }, colony }: Props) => {
-  const { data, error } = useColonyTransfersQuery({
+  const { data, error, loading } = useColonyTransfersQuery({
     variables: { address: colonyAddress },
   });
   if (error) console.warn(error);
+
+  if (loading) {
+    return (
+      <div className={styles.main}>
+        <SpinnerLoader appearance={{ size: 'small' }} />
+        <span className={styles.loadingText}>
+          <FormattedMessage {...MSG.loadingData} />
+        </span>
+      </div>
+    );
+  }
 
   return (
     <>


### PR DESCRIPTION
## Description

This PR fixes a urgent bug found in production where a colony could not claim their non-native token transfers.

This was due to the fact that our tokens differ from ERC20 ones in values named in the abi (check my comment), so that means that for ERC20 it could not fetch the correct values

**Changes** 

- [x] transfer resolvers handle ERC20 token values
- [x] `UnclaimedTransfer` add loading state

Resolves DEV-218