### PR TITLE
Show Colony Upgraded Actions

### DIFF
--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -1304,6 +1304,8 @@ export type EventProcessedValues = {
   user: Scalars['String'];
   role: Scalars['String'];
   setTo: Scalars['String'];
+  oldVersion: Scalars['String'];
+  newVersion: Scalars['String'];
 };
 
 export type SubscriptionEvent = {
@@ -2137,7 +2139,7 @@ export type SubscriptionSubgraphEventsThatAreActionsSubscription = { events: Arr
     ), transaction: (
       { hash: SubgraphTransaction['id'] }
       & { block: Pick<SubgraphBlock, 'timestamp'> }
-    ), processedValues: Pick<EventProcessedValues, 'agent' | 'who' | 'fromPot' | 'fromDomain' | 'toPot' | 'toDomain' | 'domainId' | 'amount' | 'token' | 'metadata' | 'user'> }
+    ), processedValues: Pick<EventProcessedValues, 'agent' | 'who' | 'fromPot' | 'fromDomain' | 'toPot' | 'toDomain' | 'domainId' | 'amount' | 'token' | 'metadata' | 'user' | 'oldVersion' | 'newVersion'> }
   )> };
 
 export const PayoutsFragmentDoc = gql`
@@ -5291,7 +5293,7 @@ export type SubscriptionSubgraphOneTxSubscriptionHookResult = ReturnType<typeof 
 export type SubscriptionSubgraphOneTxSubscriptionResult = Apollo.SubscriptionResult<SubscriptionSubgraphOneTxSubscription>;
 export const SubscriptionSubgraphEventsThatAreActionsDocument = gql`
     subscription SubscriptionSubgraphEventsThatAreActions($skip: Int!, $first: Int!, $colonyAddress: String!) {
-  events(skip: $skip, first: $first, where: {associatedColony_contains: $colonyAddress, name_in: ["TokensMinted(address,address,uint256)", "DomainAdded(address,uint256)", "ColonyMetadata(address,string)", "ColonyFundsMovedBetweenFundingPots(address,uint256,uint256,uint256,address)", "DomainMetadata(address,uint256,string)", "ColonyRoleSet(address,address,uint256,uint8,bool)"]}) {
+  events(skip: $skip, first: $first, where: {associatedColony_contains: $colonyAddress, name_in: ["TokensMinted(address,address,uint256)", "DomainAdded(address,uint256)", "ColonyMetadata(address,string)", "ColonyFundsMovedBetweenFundingPots(address,uint256,uint256,uint256,address)", "DomainMetadata(address,uint256,string)", "ColonyRoleSet(address,address,uint256,uint8,bool)", "ColonyUpgraded(address,uint256,uint256)", "ColonyUpgraded(uint256,uint256)"]}) {
     id
     address
     associatedColony {
@@ -5323,6 +5325,8 @@ export const SubscriptionSubgraphEventsThatAreActionsDocument = gql`
       token
       metadata
       user
+      oldVersion
+      newVersion
     }
   }
 }

--- a/src/data/graphql/subscriptions.graphql
+++ b/src/data/graphql/subscriptions.graphql
@@ -66,7 +66,9 @@ subscription SubscriptionSubgraphEventsThatAreActions($skip: Int!, $first: Int!,
         "ColonyMetadata(address,string)",
         "ColonyFundsMovedBetweenFundingPots(address,uint256,uint256,uint256,address)",
         "DomainMetadata(address,uint256,string)",
-        "ColonyRoleSet(address,address,uint256,uint8,bool)"
+        "ColonyRoleSet(address,address,uint256,uint8,bool)",
+        "ColonyUpgraded(address,uint256,uint256)",
+        "ColonyUpgraded(uint256,uint256)"
       ]
     }) {
     id
@@ -100,6 +102,8 @@ subscription SubscriptionSubgraphEventsThatAreActions($skip: Int!, $first: Int!,
       token
       metadata
       user
+      oldVersion
+      newVersion
     }
   }
 }

--- a/src/data/graphql/typeDefsSubscriptions.ts
+++ b/src/data/graphql/typeDefsSubscriptions.ts
@@ -32,6 +32,8 @@ export default gql`
     user: String!
     role: String!
     setTo: String!
+    oldVersion: String!
+    newVersion: String!
   }
 
   type SubscriptionEvent {

--- a/src/i18n/en-actions.ts
+++ b/src/i18n/en-actions.ts
@@ -9,7 +9,7 @@ const actionsMessageDescriptors = {
       ${ColonyActions.MoveFunds} {Move {amount} {tokenSymbol} from {fromDomain} to {toDomain}}
       ${ColonyActions.MintTokens} {Mint {amount} {tokenSymbol}}
       ${ColonyActions.CreateDomain} {New team: {fromDomain}}
-      ${ColonyActions.VersionUpgrade} {Upgrade Colony!}
+      ${ColonyActions.VersionUpgrade} {Upgrade Colony to Version {newVersion}!}
       ${ColonyActions.ColonyEdit} {Colony details changed}
       ${ColonyActions.EditDomain} {{fromDomain} team details edited}
       other {Generic action we don't have information about}

--- a/src/i18n/en-events.ts
+++ b/src/i18n/en-events.ts
@@ -50,6 +50,7 @@ const eventsMessageDescriptors = {
       ${ColonyAndExtensionsEvents.ExtensionDeprecated} {Extension was deprecated {extensionHash}}
       ${ColonyAndExtensionsEvents.ExtensionUpgraded} {Extension was upgraded to {extensionVersion} {extensionHash}}
       ${ColonyAndExtensionsEvents.ExtensionUninstalled} {Extension was uninstalled {extensionHash}}
+      ${ColonyAndExtensionsEvents.ColonyUpgraded} {Colony was upgraded from version {oldVersion} to {newVersion}}
       other {{eventName} emmited with values: {displayValues}}
     }`,
   [`eventList.${ColonyAndExtensionsEvents.ColonyRoleSet}.assign`]: `{agent} assigned the {role} permission in the {domain} team to {recipient}`,

--- a/src/modules/core/components/ActionsList/ActionsListItem.tsx
+++ b/src/modules/core/components/ActionsList/ActionsListItem.tsx
@@ -70,6 +70,7 @@ const ActionsListItem = ({
     commentCount = 0,
     metadata,
     roles,
+    newVersion,
   },
   colony,
   handleOnClick,
@@ -204,6 +205,7 @@ const ActionsListItem = ({
                 fromDomain: domainName || fromDomain?.name || '',
                 toDomain: toDomain?.name || '',
                 roles: roleTitle,
+                newVersion: newVersion || '0',
               }}
             />
           </div>

--- a/src/modules/dashboard/components/ColonyEvents/ColonyEventsListItem.tsx
+++ b/src/modules/dashboard/components/ColonyEvents/ColonyEventsListItem.tsx
@@ -61,6 +61,8 @@ const ColonyEventsListItem = ({
     setTo,
     extensionHash,
     extensionVersion,
+    oldVersion,
+    newVersion,
   },
   colony: { tokens, nativeTokenAddress },
   colony,
@@ -125,6 +127,8 @@ const ColonyEventsListItem = ({
     role: role ? getFormattedRole() : '',
     extensionHash,
     extensionVersion,
+    oldVersion,
+    newVersion,
   };
 
   return (

--- a/src/modules/dashboard/transformers.ts
+++ b/src/modules/dashboard/transformers.ts
@@ -290,6 +290,8 @@ export const getEventsListData = (
         user,
         extensionId,
         version,
+        oldVersion,
+        newVersion,
       } = JSON.parse(args || '{}');
       const checksummedColonyAddress = createAddress(colonyAddress);
       const getRecipient = () => {
@@ -323,6 +325,8 @@ export const getEventsListData = (
           setTo: setTo === 'true',
           extensionHash: extensionId,
           extensionVersion: version,
+          oldVersion: oldVersion || '0',
+          newVersion: newVersion || '0',
         },
       ];
     } catch (error) {

--- a/src/types/colonyActions.ts
+++ b/src/types/colonyActions.ts
@@ -128,6 +128,8 @@ export interface FormattedAction {
   commentCount: number;
   metadata?: string;
   roles: ActionUserRoles[];
+  oldVersion?: string;
+  newVersion?: string;
 }
 
 export interface FormattedEvent {
@@ -150,4 +152,6 @@ export interface FormattedEvent {
   setTo: boolean;
   extensionHash?: string;
   extensionVersion?: string;
+  oldVersion?: string;
+  newVersion?: string;
 }

--- a/src/utils/colonyActions.ts
+++ b/src/utils/colonyActions.ts
@@ -1,6 +1,7 @@
 import sortBy from 'lodash/sortBy';
 import isEqual from 'lodash/isEqual';
 import { ColonyRole } from '@colony/colony-js';
+import { AddressZero } from 'ethers/constants';
 
 import {
   ColonyActions,
@@ -96,6 +97,13 @@ export const getValuesForActionType = (
               setTo: values.setTo === 'true',
             },
           ],
+        };
+      }
+      case ColonyActions.VersionUpgrade: {
+        return {
+          initiator: values?.agent || AddressZero,
+          oldVersion: values.oldVersion,
+          newVersion: values.newVersion,
         };
       }
       default: {


### PR DESCRIPTION
## Description

This PR brings in from the subgraph, and shows, the colony upgraded events and actions.

_Note that this uses [subgraph#9](https://github.com/JoinColony/subgraph/pull/9) for the subgraph branch_

**Changes** 

- Added `ColonyUpgaded` event to subgraph subscriptions
- Added event message descriptors
- Added actions message descriptors
- Updated actions transformer and component
- Updated events transformer and component

**Demo**

![demo-colony-upgraded-actions](https://user-images.githubusercontent.com/1193222/109120242-63c5e480-774e-11eb-903e-e1c13796fce8.gif)


Resolves DEV-141