### PR TITLE
Fixed UserPermissions headRole conditional

### DIFF
--- a/src/modules/dashboard/components/UserPermissions/UserPermissions.tsx
+++ b/src/modules/dashboard/components/UserPermissions/UserPermissions.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { ColonyRole } from '@colony/colony-js';
+import { isNil } from 'lodash';
+
 import PermissionsLabel from '~core/PermissionsLabel';
 import { permissionsObject } from '~core/PermissionsLabel/permissions';
 import { getMainClasses } from '~utils/css';
@@ -34,7 +36,7 @@ const UserPermissions = ({ roles, directRoles, appearance }: Props) => {
   const [headRole, ...restRoles] = sortedRoles;
   return (
     <div className={getMainClasses(appearance, styles)}>
-      {headRole && (
+      {!isNil(headRole) && (
         <PermissionsLabel
           permission={headRole}
           key={headRole}


### PR DESCRIPTION
Fixed Recovery role not showing because the previous conditional checked if the value of the headRole is a falsey value (like `0`, which is the role id of Recovery). Now it only checks if it's `null` or `undefined`

![FireShot Capture 155 - Colony - localhost](https://user-images.githubusercontent.com/18473896/109323359-22a70080-7832-11eb-8f5a-0c7367240ae0.png)


Resolves DEV-226
