### PR TITLE
Add Tooltip to colony event list titles

### DIFF
--- a/src/modules/core/components/Fields/Checkbox/Checkbox.tsx
+++ b/src/modules/core/components/Fields/Checkbox/Checkbox.tsx
@@ -129,7 +129,7 @@ const Checkbox = ({
     <label className={classNames} htmlFor={elementOnly ? inputId : undefined}>
       {disabled && tooltipText ? (
         <Tooltip
-          darkTheme
+          appearance={{ theme: 'dark' }}
           content={tooltipText}
           placement="bottom"
           popperProps={tooltipPopperProps}

--- a/src/modules/core/components/IndexModal/IndexModalItem.css
+++ b/src/modules/core/components/IndexModal/IndexModalItem.css
@@ -106,6 +106,5 @@
 }
 
 .tooltip {
-  padding: 8px 4px;
   max-width: 200px;
 }

--- a/src/modules/core/components/IndexModal/IndexModalItem.tsx
+++ b/src/modules/core/components/IndexModal/IndexModalItem.tsx
@@ -81,6 +81,7 @@ const IndexModalItem = ({
            * need some heavy duty refactoring in order to make it play nicely with
            * the Popover / Tooltip component.
            */
+          appearance={{ size: 'medium' }}
           placement="right"
           trigger="hover"
           content={

--- a/src/modules/core/components/InvisibleCopyableAddress/InvisibleCopyableAddress.css
+++ b/src/modules/core/components/InvisibleCopyableAddress/InvisibleCopyableAddress.css
@@ -1,7 +1,3 @@
 .addressWrapper {
   display: inline-block;
 }
-
-.copyAddressTooltip {
-  padding: 8px 4px;
-}

--- a/src/modules/core/components/InvisibleCopyableAddress/InvisibleCopyableAddress.css.d.ts
+++ b/src/modules/core/components/InvisibleCopyableAddress/InvisibleCopyableAddress.css.d.ts
@@ -1,2 +1,1 @@
 export const addressWrapper: string;
-export const copyAddressTooltip: string;

--- a/src/modules/core/components/InvisibleCopyableAddress/InvisibleCopyableAddress.tsx
+++ b/src/modules/core/components/InvisibleCopyableAddress/InvisibleCopyableAddress.tsx
@@ -64,15 +64,14 @@ const InvisibleCopyableAddress = ({
     formatMessage(MSG.copyMessage);
   return (
     <Tooltip
+      appearance={{ size: 'medium' }}
       placement="right"
       trigger="hover"
       content={
-        <div className={styles.copyAddressTooltip}>
-          <FormattedMessage
-            {...MSG.copyAddressTooltip}
-            values={{ copied, tooltipMessage }}
-          />
-        </div>
+        <FormattedMessage
+          {...MSG.copyAddressTooltip}
+          values={{ copied, tooltipMessage }}
+        />
       }
     >
       <div className={styles.addressWrapper}>

--- a/src/modules/core/components/PermissionRequiredInfo/PermissionRequiredInfo.css
+++ b/src/modules/core/components/PermissionRequiredInfo/PermissionRequiredInfo.css
@@ -66,6 +66,5 @@
 }
 
 .tooltipContent {
-  padding: 8px 4px;
   max-width: 200px;
 }

--- a/src/modules/core/components/PermissionRequiredInfo/PermissionRequiredInfo.tsx
+++ b/src/modules/core/components/PermissionRequiredInfo/PermissionRequiredInfo.tsx
@@ -64,7 +64,11 @@ const PermissionRequiredInfo = ({ requiredRoles }: Props) => {
           <p className={styles.sectionLabel}>
             <FormattedMessage {...MSG.sectionLabel} />
           </p>
-          <Tooltip darkTheme content={tooltipText} placement="right">
+          <Tooltip
+            appearance={{ theme: 'dark', size: 'medium' }}
+            content={tooltipText}
+            placement="right"
+          >
             {({ close, open, ref }) => (
               <div
                 ref={ref}

--- a/src/modules/core/components/Popover/PopoverWrapper.css
+++ b/src/modules/core/components/Popover/PopoverWrapper.css
@@ -138,6 +138,10 @@
   color: var(--colony-white);
 }
 
+.sizeMedium {
+  padding: 8px 4px;
+}
+
 /*
  *  @NOTE On theme-ing arrows
  *

--- a/src/modules/core/components/Popover/PopoverWrapper.css.d.ts
+++ b/src/modules/core/components/Popover/PopoverWrapper.css.d.ts
@@ -22,6 +22,7 @@ export const leftArrow: string;
 export const leftEndArrow: string;
 export const leftStartArrow: string;
 export const themeDark: string;
+export const sizeMedium: string;
 export const themeDarkTopArrow: string;
 export const themeDarkTopEndArrow: string;
 export const themeDarkTopStartArrow: string;

--- a/src/modules/core/components/Popover/Tooltip.tsx
+++ b/src/modules/core/components/Popover/Tooltip.tsx
@@ -2,11 +2,18 @@ import React, { ReactNode, useMemo } from 'react';
 import { PopperProps } from 'react-popper';
 
 import Popover from './Popover';
-import { PopoverTriggerType, PopoverChildFn } from './types';
+import {
+  PopoverTriggerType,
+  PopoverChildFn,
+  PopoverAppearanceType,
+} from './types';
 
 import styles from './Tooltip.css';
 
 interface Props {
+  /** Appearance object */
+  appearance?: PopoverAppearanceType;
+
   /** Child element to trigger the popover */
   children: ReactNode | PopoverChildFn;
 
@@ -27,11 +34,10 @@ interface Props {
 
   /** Set the open state from outside */
   isOpen?: boolean;
-
-  darkTheme?: boolean;
 }
 
 const Tooltip = ({
+  appearance,
   children,
   content,
   placement = 'top',
@@ -39,7 +45,6 @@ const Tooltip = ({
   showArrow = true,
   trigger = 'hover',
   isOpen,
-  darkTheme = true,
 }: Props) => {
   const renderedContent = useMemo(
     () => <div className={styles.container}>{content}</div>,
@@ -47,7 +52,7 @@ const Tooltip = ({
   );
   return (
     <Popover
-      appearance={darkTheme ? { theme: 'dark' } : undefined}
+      appearance={appearance}
       trigger={content ? trigger : 'disabled'}
       openDelay={200}
       content={renderedContent}

--- a/src/modules/core/components/Popover/types.ts
+++ b/src/modules/core/components/Popover/types.ts
@@ -2,7 +2,8 @@ import { ReactNode, ReactElement } from 'react';
 import { MessageDescriptor } from 'react-intl';
 
 export type PopoverAppearanceType = {
-  theme: 'dark' | 'grey';
+  theme?: 'dark' | 'grey';
+  size?: 'medium';
 };
 
 export interface PopoverChildFnProps {

--- a/src/modules/dashboard/components/ActionsPage/TransactionStatus/TransactionStatus.css
+++ b/src/modules/dashboard/components/ActionsPage/TransactionStatus/TransactionStatus.css
@@ -21,10 +21,6 @@
   cursor: default;
 }
 
-.tooltip {
-  padding: 8px 4px;
-}
-
 .themeFailed {
   composes: statusTheme;
   background-color: var(--pink);

--- a/src/modules/dashboard/components/ActionsPage/TransactionStatus/TransactionStatus.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/TransactionStatus/TransactionStatus.css.d.ts
@@ -1,6 +1,5 @@
 export const main: string;
 export const statusTheme: string;
-export const tooltip: string;
 export const themeFailed: string;
 export const themePending: string;
 export const themeSucceeded: string;

--- a/src/modules/dashboard/components/ActionsPage/TransactionStatus/TransactionStatus.tsx
+++ b/src/modules/dashboard/components/ActionsPage/TransactionStatus/TransactionStatus.tsx
@@ -29,12 +29,11 @@ interface Props {
 
 const TransactionStatus = ({ status, showTooltip = true }: Props) => (
   <Tooltip
+    appearance={{ size: 'medium' }}
     placement="right"
     trigger={showTooltip ? 'hover' : 'disabled'}
     content={
-      <div className={styles.tooltip}>
-        <FormattedMessage {...MSG.transactionStatus} values={{ status }} />
-      </div>
+      <FormattedMessage {...MSG.transactionStatus} values={{ status }} />
     }
   >
     <div className={styles.main}>

--- a/src/modules/dashboard/components/ColonyEvents/ColonyEventsListItem.css
+++ b/src/modules/dashboard/components/ColonyEvents/ColonyEventsListItem.css
@@ -108,3 +108,8 @@
 .titleDecoration {
   color: var(--pink);
 }
+
+.tooltip span {
+  vertical-align: text-top;
+  font-size: var(--size-tiny);
+}

--- a/src/modules/dashboard/components/ColonyEvents/ColonyEventsListItem.css.d.ts
+++ b/src/modules/dashboard/components/ColonyEvents/ColonyEventsListItem.css.d.ts
@@ -13,3 +13,4 @@ export const commentCount: string;
 export const commentCountIcon: string;
 export const userMention: string;
 export const titleDecoration: string;
+export const tooltip: string;

--- a/src/modules/dashboard/components/ColonyEvents/ColonyEventsListItem.tsx
+++ b/src/modules/dashboard/components/ColonyEvents/ColonyEventsListItem.tsx
@@ -11,6 +11,7 @@ import HookedColonyAvatar from '~dashboard/HookedColonyAvatar';
 
 import Numeral from '~core/Numeral';
 import FriendlyName from '~core/FriendlyName';
+import { Tooltip } from '~core/Popover';
 
 import { removeValueUnits } from '~utils/css';
 import { getTokenDecimalsWithFallback } from '~utils/tokens';
@@ -178,20 +179,35 @@ const ColonyEventsListItem = ({
           )}
         </div>
         <div className={styles.content}>
-          <div
-            className={styles.title}
-            title={
-              formatMessage(
-                { id: getEventListTitleMessageDescriptor },
-                eventMessageValues,
-              ) as string
+          <Tooltip
+            placement="bottom-start"
+            showArrow={false}
+            content={
+              <div className={styles.tooltip}>
+                <FormattedMessage
+                  id={getEventListTitleMessageDescriptor}
+                  values={eventMessageValues}
+                />
+              </div>
             }
+            popperProps={{
+              modifiers: [
+                {
+                  name: 'offset',
+                  options: {
+                    offset: [0, 5],
+                  },
+                },
+              ],
+            }}
           >
-            <FormattedMessage
-              id={getEventListTitleMessageDescriptor}
-              values={eventMessageValues}
-            />
-          </div>
+            <div className={styles.title}>
+              <FormattedMessage
+                id={getEventListTitleMessageDescriptor}
+                values={eventMessageValues}
+              />
+            </div>
+          </Tooltip>
           <div className={styles.meta}>
             <FormattedDateParts value={createdAt} month="short" day="numeric">
               {(parts) => (

--- a/src/modules/dashboard/components/ColonyEvents/ColonyEventsListItem.tsx
+++ b/src/modules/dashboard/components/ColonyEvents/ColonyEventsListItem.tsx
@@ -180,6 +180,7 @@ const ColonyEventsListItem = ({
         </div>
         <div className={styles.content}>
           <Tooltip
+            appearance={{ size: 'medium', theme: 'dark' }}
             placement="bottom-start"
             showArrow={false}
             content={


### PR DESCRIPTION
This should stop the tooltip of the titles in the event list to display `[object object]` whenever a dynamic value is used

Resolves DEV-193
