### PR TITLE
Fix Token Management Modal Back Button

### DIFF
--- a/src/modules/core/components/TokenEditDialog/TokenEditDialog.tsx
+++ b/src/modules/core/components/TokenEditDialog/TokenEditDialog.tsx
@@ -68,6 +68,7 @@ interface Props {
   // Token list from json file. Not supported on local env
   tokensList?: AnyToken[];
   colony: Colony;
+  back?: () => void;
 }
 
 interface FormValues {
@@ -88,6 +89,7 @@ const TokenEditDialog = ({
   tokensList = [],
   colony: { tokens = [], nativeTokenAddress, tokenAddresses },
   colony,
+  back,
 }: Props) => {
   const { walletAddress, username, ethereal } = useLoggedInUser();
 
@@ -258,8 +260,10 @@ const TokenEditDialog = ({
             <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
               <Button
                 appearance={{ theme: 'secondary', size: 'large' }}
-                text={{ id: 'button.cancel' }}
-                onClick={close}
+                text={{
+                  id: back === undefined ? 'button.cancel' : 'button.back',
+                }}
+                onClick={back === undefined ? close : back}
               />
               <Button
                 appearance={{ theme: 'primary', size: 'large' }}

--- a/src/modules/dashboard/components/ColonyTokenManagementDialog/ColonyTokenManagementDialog.tsx
+++ b/src/modules/dashboard/components/ColonyTokenManagementDialog/ColonyTokenManagementDialog.tsx
@@ -13,6 +13,8 @@ interface Props {
   colony: Colony;
   cancel: () => void;
   close: () => void;
+  prevStep?: string;
+  callStep?: (dialogName: string) => void;
 }
 
 const displayName = 'dashboard.ColonyTokenManagementDialog';
@@ -34,6 +36,8 @@ const ColonyTokenManagementDialog = ({
   colony,
   cancel,
   close,
+  callStep,
+  prevStep,
 }: Props) => {
   const history = useHistory();
 
@@ -66,6 +70,11 @@ const ColonyTokenManagementDialog = ({
       colony={colony}
       updateTokens={updateTokens}
       tokensList={getTokenList}
+      back={
+        prevStep === undefined || callStep === undefined
+          ? undefined
+          : () => callStep(prevStep)
+      }
     />
   );
 };

--- a/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementDialog.tsx
+++ b/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementDialog.tsx
@@ -65,6 +65,8 @@ interface Props {
   cancel: () => void;
   close: () => void;
   colonyAddress: string;
+  prevStep?: string;
+  callStep?: (dialogName: string) => void;
 }
 
 const UserAvatar = HookedUserAvatar({ fetchUser: false });
@@ -77,6 +79,8 @@ const PermissionManagementDialog = ({
   colonyAddress,
   cancel,
   close,
+  callStep,
+  prevStep,
 }: Props) => {
   const history = useHistory();
   const { walletAddress: loggedInUserWalletAddress } = useLoggedInUser();
@@ -297,8 +301,17 @@ const PermissionManagementDialog = ({
               <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
                 <Button
                   appearance={{ theme: 'secondary', size: 'large' }}
-                  onClick={cancel}
-                  text={{ id: 'button.cancel' }}
+                  onClick={
+                    prevStep === undefined || callStep === undefined
+                      ? cancel
+                      : () => callStep(prevStep)
+                  }
+                  text={{
+                    id:
+                      prevStep === undefined || callStep === undefined
+                        ? 'button.cancel'
+                        : 'button.back',
+                  }}
                 />
                 <Button
                   appearance={{ theme: 'primary', size: 'large' }}


### PR DESCRIPTION
## Description

Due to some oversight, the back button for the Token Management modal is actually a "Cancel" button, and breaks out of the wizard flow.

I think the reason is that we have the same dialog open from the funding page and there is no back there, only cancel. So I just did back button depending on the passed props.

**New stuff** ✨

none

**Changes** 🏗

- add option back prop to the dialog & invoke it if it's passed

**Deletions** ⚰️

none

## TODO

none

Resolves DEV-229

![token-mngt-dialog2](https://user-images.githubusercontent.com/34057551/109495403-22537300-7a87-11eb-986c-23e913b044fd.gif)


![token-mngt-dialog](https://user-images.githubusercontent.com/34057551/109495382-1b2c6500-7a87-11eb-9ee5-ae07c9a1f38c.gif)

