### PR TITLE
ColonyUpgrade add optional upgrade styles

### DIFF
--- a/src/modules/constants.ts
+++ b/src/modules/constants.ts
@@ -141,3 +141,5 @@ export const ALLDOMAINS_DOMAIN_SELECTION = {
 export const TOKEN_LOGOS_REPO_URL =
   'https://raw.githubusercontent.com/trustwallet' +
   '/assets/master/blockchains/ethereum/';
+
+export const NETWORK_RELEASES_URL = `https://github.com/JoinColony/colonyNetwork/releases/tag`;

--- a/src/modules/core/components/Alert/Alert.css
+++ b/src/modules/core/components/Alert/Alert.css
@@ -1,3 +1,5 @@
+@value newInfoBlue: rgb(0, 40, 75);
+
 .main {
   margin: 10px 0;
   padding: 5px 15px;
@@ -27,7 +29,7 @@
 
 .themeInfo {
   composes: main;
-  background-color: var(--sky-blue);
+  background-color: newInfoBlue;
   color: var(--colony-white);
 }
 

--- a/src/modules/core/components/Alert/Alert.css.d.ts
+++ b/src/modules/core/components/Alert/Alert.css.d.ts
@@ -1,3 +1,4 @@
+export const newInfoBlue: string;
 export const main: string;
 export const closeButton: string;
 export const themePrimary: string;

--- a/src/modules/core/components/Alert/Alert.tsx
+++ b/src/modules/core/components/Alert/Alert.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode, useCallback, useState } from 'react';
 import { MessageDescriptor, useIntl } from 'react-intl';
 
-import Icon from '~core/Icon';
 import { SimpleMessageValues } from '~types/index';
 import { getMainClasses } from '~utils/css';
 
@@ -14,21 +13,20 @@ interface Appearance {
   margin?: 'none' | 'default';
 }
 
+type childrenFn = (handleDismissed: any) => void;
+
 interface Props {
   /** Appearance object */
   appearance?: Appearance;
 
   /** `children` to render (only works if `text` is not set) */
-  children?: ReactNode;
+  children?: ReactNode | childrenFn;
 
   /** A string or a `messageDescriptor` that make up the alert's content */
   text?: MessageDescriptor | string;
 
   /** Values for loading text (react-intl interpolation) */
   textValues?: SimpleMessageValues;
-
-  /** Should the alert be dismissible */
-  isDismissible?: boolean;
 
   /** Callback after alert is dismissed (only if `isDismissible` is `true`) */
   onAlertDismissed?: () => void;
@@ -39,7 +37,6 @@ const displayName = 'Alert';
 const Alert = ({
   appearance = { theme: 'danger', margin: 'default' },
   onAlertDismissed: callback,
-  isDismissible = false,
   children,
   text,
   textValues,
@@ -49,14 +46,11 @@ const Alert = ({
   const { formatMessage } = useIntl();
 
   const handleDismiss = useCallback(() => {
-    if (!isDismissible) {
-      return;
-    }
     setIsOpen(false);
     if (typeof callback === 'function') {
       callback();
     }
-  }, [callback, isDismissible]);
+  }, [callback]);
 
   if (!isOpen) return null;
 
@@ -64,20 +58,11 @@ const Alert = ({
     typeof text === 'string' ? text : text && formatMessage(text, textValues);
   return (
     <div className={getMainClasses(appearance, styles)}>
-      {isDismissible && (
-        <button
-          className={styles.closeButton}
-          type="button"
-          onClick={handleDismiss}
-        >
-          <Icon
-            appearance={{ size: 'small' }}
-            name="close"
-            title={{ id: 'button.close' }}
-          />
-        </button>
-      )}
-      {alertText || children}
+      <>
+        {alertText || typeof children === 'function'
+          ? (children as childrenFn)(handleDismiss)
+          : children}
+      </>
     </div>
   );
 };

--- a/src/modules/core/sagas/setupUserContext.ts
+++ b/src/modules/core/sagas/setupUserContext.ts
@@ -164,11 +164,6 @@ export default function* setupUserContext(
      */
     yield fork(setupContextDependentSagas);
 
-    /*
-     * Get the network contract values from the resolver
-     */
-    yield updateNetworkContracts();
-
     // Start a forked task to listen for user balance events
     yield fork(setupUserBalanceListener, walletAddress);
 
@@ -220,6 +215,11 @@ export default function* setupUserContext(
       // @ts-ignore
       update: cacheUpdates.setNativeTokenPermissions(),
     });
+
+    /*
+     * Get the network contract values from the resolver
+     */
+    yield updateNetworkContracts();
 
     setupOnBeforeUnload();
 

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageSystemInfo/ActionsPageSystemInfo.css
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageSystemInfo/ActionsPageSystemInfo.css
@@ -1,5 +1,5 @@
 .main {
-  margin: 16px 0;
+  margin: 15px 0 16px;
   padding: 50px;
   border-radius: var(--radius-large);
   font-size: var(--size-normal);

--- a/src/modules/dashboard/components/ColonyHome/ColonyUpgrade/ColonyUpgrade.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyUpgrade/ColonyUpgrade.css
@@ -8,9 +8,19 @@
   text-align: center;
 }
 
-.upgradeBannerContainer button {
+.controls {
   margin-top: -38px;
   float: right;
+}
+
+.controls button {
+  margin: 0;
+  width: 100px;
+  font-size: var(--size-small);
+}
+
+.controls button:nth-child(2) {
+  margin-left: 20px;
 }
 
 .upgradeBanner {

--- a/src/modules/dashboard/components/ColonyHome/ColonyUpgrade/ColonyUpgrade.css.d.ts
+++ b/src/modules/dashboard/components/ColonyHome/ColonyUpgrade/ColonyUpgrade.css.d.ts
@@ -1,2 +1,3 @@
 export const upgradeBannerContainer: string;
+export const controls: string;
 export const upgradeBanner: string;

--- a/src/modules/dashboard/components/ColonyHome/ColonyUpgrade/ColonyUpgrade.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyUpgrade/ColonyUpgrade.tsx
@@ -1,15 +1,18 @@
 import React, { useCallback } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
+import { ColonyVersion } from '@colony/colony-js';
 
 import { useDialog } from '~core/Dialog';
 import NetworkContractUpgradeDialog from '~dashboard/NetworkContractUpgradeDialog';
 import Alert from '~core/Alert';
 import Button from '~core/Button';
+import ExternalLink from '~core/ExternalLink';
 
 import { Colony, useNetworkContracts } from '~data/index';
 import { useLoggedInUser } from '~data/helpers';
 import { useTransformer } from '~utils/hooks';
-import { canBeUpgraded } from '../../../checks';
+import { getNetworkRelaseLink } from '~utils/external';
+import { mustBeUpgraded, shouldBeUpgraded } from '../../../checks';
 import { hasRoot } from '../../../../users/checks';
 import { getAllUserRoles } from '../../../../transformers';
 
@@ -20,6 +23,14 @@ const MSG = defineMessages({
     id: `dashboard.ColonyHome.ColonyUpgrade.upgradeRequired`,
     defaultMessage: `This colony uses a version of the network that is no
       longer supported. You must upgrade to continue using this application.`,
+  },
+  upgradeSuggested: {
+    id: `dashboard.ColonyHome.ColonyUpgrade.upgradeSuggested`,
+    defaultMessage: `A new version of the Colony Network is available! {linkToRelease}`,
+  },
+  learnMore: {
+    id: `dashboard.ColonyHome.ColonyUpgrade.learnMore`,
+    defaultMessage: `Learn More`,
   },
 });
 
@@ -47,29 +58,83 @@ const ColonyUpgrade = ({ colony }: Props) => {
   const hasRegisteredProfile = !!username && !ethereal;
   const canUpgradeColony = hasRegisteredProfile && hasRoot(allUserRoles);
 
-  const canUpgrade = canBeUpgraded(colony, networkVersion as string);
+  const mustUpgrade = mustBeUpgraded(colony, networkVersion as string);
+  const shouldUpdgrade = shouldBeUpgraded(colony, networkVersion as string);
 
-  return canUpgrade ? (
-    <div className={styles.upgradeBannerContainer}>
-      <Alert
-        appearance={{
-          theme: 'danger',
-          margin: 'none',
-          borderRadius: 'none',
-        }}
-      >
-        <div className={styles.upgradeBanner}>
-          <FormattedMessage {...MSG.upgradeRequired} />
-        </div>
-        <Button
-          appearance={{ theme: 'primary', size: 'medium' }}
-          text={{ id: 'button.upgrade' }}
-          onClick={handleUpgradeColony}
-          disabled={!canUpgradeColony}
-        />
-      </Alert>
-    </div>
-  ) : null;
+  if (mustUpgrade) {
+    return (
+      <div className={styles.upgradeBannerContainer}>
+        <Alert
+          appearance={{
+            theme: 'danger',
+            margin: 'none',
+            borderRadius: 'none',
+          }}
+        >
+          <div className={styles.upgradeBanner}>
+            <FormattedMessage {...MSG.upgradeRequired} />
+          </div>
+          <div className={styles.controls}>
+            <Button
+              appearance={{ theme: 'primary', size: 'medium' }}
+              text={{ id: 'button.upgrade' }}
+              onClick={handleUpgradeColony}
+              disabled={!canUpgradeColony}
+            />
+          </div>
+        </Alert>
+      </div>
+    );
+  }
+
+  if (shouldUpdgrade) {
+    return (
+      <div className={styles.upgradeBannerContainer}>
+        <Alert
+          appearance={{
+            theme: 'info',
+            margin: 'none',
+            borderRadius: 'none',
+          }}
+        >
+          {(handleDismissed) => (
+            <>
+              <div className={styles.upgradeBanner}>
+                <FormattedMessage
+                  {...MSG.upgradeSuggested}
+                  values={{
+                    linkToRelease: (
+                      <ExternalLink
+                        text={MSG.learnMore}
+                        href={getNetworkRelaseLink(
+                          (colony.version as unknown) as ColonyVersion,
+                        )}
+                      />
+                    ),
+                  }}
+                />
+              </div>
+              <div className={styles.controls}>
+                <Button
+                  appearance={{ theme: 'danger', size: 'medium' }}
+                  text={{ id: 'button.dismiss' }}
+                  onClick={handleDismissed}
+                />
+                <Button
+                  appearance={{ theme: 'primary', size: 'medium' }}
+                  text={{ id: 'button.upgrade' }}
+                  onClick={handleUpgradeColony}
+                  disabled={!canUpgradeColony}
+                />
+              </div>
+            </>
+          )}
+        </Alert>
+      </div>
+    );
+  }
+
+  return null;
 };
 
 ColonyUpgrade.displayName = displayName;

--- a/src/utils/external/index.ts
+++ b/src/utils/external/index.ts
@@ -1,7 +1,7 @@
 import { BigNumber, formatUnits } from 'ethers/utils';
-import { Network } from '@colony/colony-js';
+import { Network, ColonyVersion, releaseMap } from '@colony/colony-js';
 
-import { DEFAULT_NETWORK } from '~constants';
+import { DEFAULT_NETWORK, NETWORK_RELEASES_URL } from '~constants';
 
 interface EthUsdResponse {
   status: string;
@@ -110,3 +110,6 @@ export const getBlockExplorerLink = ({
     network === 'homestead' || network === Network.Mainnet ? '' : `${network}.`;
   return `https://${networkSubdomain}etherscan.${tld}/${linkType}/${addressOrHash}`;
 };
+
+export const getNetworkRelaseLink = (version: ColonyVersion) =>
+  `${NETWORK_RELEASES_URL}/${releaseMap[version]}`;


### PR DESCRIPTION
## Description

This PR adds in styles and some logic for the `ColonyUpgrade` component to show a different styled banner for versions of the network contracts that are available for upgrade, but that are not strictly required

**Changes**

- Refactored core `Alert` to pass down the dismissal handler
- Refactored core `Alert` info theme
- Added `getNetworkReleaseLink` util
- `setupUserContext` fixed network version not being set for an ethereal wallet
- `ColoynUpgrade` show optional upgrade banner

**Note that the actual "Learn More" link is currently broken, since the new network version doesn't really have a release yet**

**Demo**

![Screenshot from 2021-03-05 00-26-24](https://user-images.githubusercontent.com/1193222/110039414-da17a780-7d49-11eb-81d5-e9e95ab87923.png)


Resolves DEV-240
Resolves DEV-157
