### PR TITLE
Hide Coin Machine Extensions

### DIFF
--- a/src/modules/dashboard/components/Extensions/Extensions.tsx
+++ b/src/modules/dashboard/components/Extensions/Extensions.tsx
@@ -45,6 +45,17 @@ const Extensions = ({ colonyAddress }: Props) => {
     variables: { address: colonyAddress },
   });
 
+  const installedExtensionsData = useMemo(() => {
+    if (data?.processedColony?.installedExtensions) {
+      const { installedExtensions } = data.processedColony;
+      return installedExtensions.map(({ extensionId, address }) => ({
+        ...extensionData[extensionId],
+        address,
+      }));
+    }
+    return [];
+  }, [data]);
+
   const availableExtensionsData = useMemo(() => {
     if (data?.processedColony?.installedExtensions) {
       const { installedExtensions } = data.processedColony;
@@ -80,13 +91,6 @@ const Extensions = ({ colonyAddress }: Props) => {
   const installedExtensions = data
     ? data.processedColony.installedExtensions
     : [];
-
-  const installedExtensionsData = installedExtensions.map(
-    ({ extensionId, address }) => ({
-      ...extensionData[extensionId],
-      address,
-    }),
-  );
 
   return (
     <div className={styles.main}>

--- a/src/modules/dashboard/components/Extensions/Extensions.tsx
+++ b/src/modules/dashboard/components/Extensions/Extensions.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { extensions } from '@colony/colony-js';
 
@@ -45,6 +45,27 @@ const Extensions = ({ colonyAddress }: Props) => {
     variables: { address: colonyAddress },
   });
 
+  const availableExtensionsData = useMemo(() => {
+    if (data?.processedColony?.installedExtensions) {
+      const { installedExtensions } = data.processedColony;
+      return extensions.reduce((availableExtensions, extensionName) => {
+        const installedExtension = installedExtensions.find(
+          ({ extensionId }) => extensionName === extensionId,
+        );
+        if (!installedExtension) {
+          return [
+            ...availableExtensions,
+            {
+              ...extensionData[extensionName],
+            },
+          ];
+        }
+        return availableExtensions;
+      }, []);
+    }
+    return [];
+  }, [data]);
+
   if (loading) {
     return (
       <div className={styles.loadingSpinner}>
@@ -66,14 +87,7 @@ const Extensions = ({ colonyAddress }: Props) => {
       address,
     }),
   );
-  const availableExtensionsData = extensions
-    .filter(
-      (name: string) =>
-        !installedExtensions.find(({ extensionId }) => name === extensionId),
-    )
-    .map((id: string) => ({
-      ...extensionData[id],
-    }));
+
   return (
     <div className={styles.main}>
       <div className={styles.content}>

--- a/src/modules/dashboard/components/Extensions/Extensions.tsx
+++ b/src/modules/dashboard/components/Extensions/Extensions.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
-import { extensions } from '@colony/colony-js';
+import { extensions, Extension } from '@colony/colony-js';
 
 import BreadCrumb from '~core/BreadCrumb';
 import Heading from '~core/Heading';
@@ -63,7 +63,12 @@ const Extensions = ({ colonyAddress }: Props) => {
         const installedExtension = installedExtensions.find(
           ({ extensionId }) => extensionName === extensionId,
         );
-        if (!installedExtension) {
+        /*
+         * @NOTE Temporary disable the coin machine extension in the list
+         *
+         * This will be re-enabled in the Coin Machine feature branch
+         */
+        if (!installedExtension && extensionName !== Extension.CoinMachine) {
           return [
             ...availableExtensions,
             {


### PR DESCRIPTION
## Description

This PR hides the Coin Machine extension in the listing so it can't be installed from the dapp _(it can still be installed and configured from the contracts side)_

It will be re-enable once we ship the Coin Machine feature... _soon™_

**Changes** 

- Refactored `Extensions` `availableExtensionsData` method 
- Refactored `Extensions` `installedExtensionsData` method 

Resolves DEV-241
