### PR TITLE
Fix "All Teams" reputation display

### DIFF
--- a/src/data/resolvers/user.ts
+++ b/src/data/resolvers/user.ts
@@ -19,6 +19,7 @@ import {
   SubgraphColoniesQueryVariables,
   SubgraphColoniesDocument,
 } from '~data/index';
+import { COLONY_TOTAL_BALANCE_DOMAIN_ID } from '~constants';
 
 import { getToken } from './token';
 import { getProcessedColony } from './colony';
@@ -33,7 +34,12 @@ const getUserReputation = async (
     ClientType.ColonyClient,
     colonyAddress,
   );
-  const { skillId } = await colonyClient.getDomain(domainId);
+  const { skillId } = await colonyClient.getDomain(
+    /*
+     * If we have the "All Teams" domain selected, fetch reputation values from "Root"
+     */
+    domainId === COLONY_TOTAL_BALANCE_DOMAIN_ID ? ROOT_DOMAIN_ID : domainId,
+  );
   const { reputationAmount } = await colonyClient.getReputation(
     skillId,
     address,


### PR DESCRIPTION
This PR fixes the reputation display on the "All Teams" domain selection, by fetching it from the root domain.

This was an issue we didn't catch in local testing since our mock-oracle was wrongly returning reputation values for domain id `0` as well. This does not happen in production

**Changes**

- Refactored `getUserReputation` resolver helper so that it fetches reputation from the "Root" domain if the "All Teams" selection is currently set

Resolves DEV-243