### PR TITLE
Display wallet address instead of colony address in membersListItem

### DIFF
--- a/src/modules/core/components/MembersList/MembersListItem.tsx
+++ b/src/modules/core/components/MembersList/MembersListItem.tsx
@@ -2,6 +2,7 @@ import React, { KeyboardEvent, ReactNode, useCallback, useMemo } from 'react';
 
 import { defineMessages } from 'react-intl';
 import { bigNumberify } from 'ethers/utils';
+import { createAddress } from '~utils/web3';
 import UserMention from '~core/UserMention';
 import { ListGroupItem } from '~core/ListGroup';
 import CopyableAddress from '~core/CopyableAddress';
@@ -93,7 +94,7 @@ const MembersListItem = <U extends AnyUser = AnyUser>(props: Props<U>) => {
     profile: { walletAddress },
   } = user;
 
-  const userProfile = useUser(walletAddress);
+  const userProfile = useUser(createAddress(walletAddress));
 
   const { data: userReputationData } = useUserReputationQuery({
     variables: { address: walletAddress, colonyAddress, domainId },

--- a/src/modules/core/components/MembersList/MembersListItem.tsx
+++ b/src/modules/core/components/MembersList/MembersListItem.tsx
@@ -1,4 +1,5 @@
 import React, { KeyboardEvent, ReactNode, useCallback, useMemo } from 'react';
+import { AddressZero } from 'ethers/constants';
 
 import { defineMessages } from 'react-intl';
 import { bigNumberify } from 'ethers/utils';
@@ -94,7 +95,7 @@ const MembersListItem = <U extends AnyUser = AnyUser>(props: Props<U>) => {
     profile: { walletAddress },
   } = user;
 
-  const userProfile = useUser(createAddress(walletAddress));
+  const userProfile = useUser(createAddress(walletAddress || AddressZero));
 
   const { data: userReputationData } = useUserReputationQuery({
     variables: { address: walletAddress, colonyAddress, domainId },

--- a/src/modules/core/components/MembersList/MembersListItem.tsx
+++ b/src/modules/core/components/MembersList/MembersListItem.tsx
@@ -194,7 +194,7 @@ const MembersListItem = <U extends AnyUser = AnyUser>(props: Props<U>) => {
             </span>
           )}
           <div className={styles.address}>
-            <CopyableAddress>{colonyAddress}</CopyableAddress>
+            <CopyableAddress>{walletAddress}</CopyableAddress>
           </div>
         </div>
         {renderedExtraItemContent && <div>{renderedExtraItemContent}</div>}


### PR DESCRIPTION
## Description

This PR fixes wrong displaying address in MembersListItem

**Changes** 🏗

* colonyAddress changed to walletAddress
* Use createAddress util before fetching user profile

Resolves DEV-242
