### PR TITLE
Create tag components variants

### DIFF
--- a/src/modules/core/components/Tag/Tag.css
+++ b/src/modules/core/components/Tag/Tag.css
@@ -3,6 +3,7 @@
   border-radius: var(--radius-large);
   font-size: 0.8rem;
   font-weight: var(--weight-bold);
+  color: var(--colony-white);
 }
 
 .baseStyles + .baseStyles {
@@ -12,36 +13,32 @@
 .themePrimary {
   composes: baseStyles;
   background-color: var(--primary);
-  color: var(--colony-white);
 }
 
 .themeLight {
   composes: baseStyles;
   background-color: var(--grey-blue-1);
+  color: var(--grey-dark);
 }
 
 .themeGolden {
   composes: baseStyles;
   background-color: var(--golden);
-  color: white;
 }
 
 .themeDanger {
   composes: baseStyles;
   background-color: var(--danger);
-  color: white;
 }
 
 .themePink {
   composes: baseStyles;
   background-color: var(--pink);
-  color: white;
 }
 
 .themeBlue {
   composes: baseStyles;
   background-color: var(--action-secondary);
-  color: white;
 }
 
 .themePrimary.colorSchemaInverted {

--- a/src/modules/core/components/Tag/Tag.css
+++ b/src/modules/core/components/Tag/Tag.css
@@ -1,4 +1,5 @@
 .baseStyles {
+  display: inline-block;
   padding: 1px 8px 2px;
   border-radius: var(--radius-large);
   font-size: 0.8rem;
@@ -41,63 +42,57 @@
   background-color: var(--action-secondary);
 }
 
-.themePrimary.colorSchemaInverted {
-  border: 1px solid var(--primary);
+.colorSchemaInverted {
   background-color: transparent;
-  color: var(--primary);
 }
 
-.themePrimary.colorSchemaPlain {
+.colorSchemaPlain {
   border: none;
   background-color: var(--temp-grey-blue-8);
+}
+
+.themePrimary.colorSchemaInverted {
+  border: 1px solid var(--primary);
   color: var(--primary);
 }
 
 .themeGolden.colorSchemaInverted {
   border: 1px solid var(--golden);
-  background-color: transparent;
-  color: var(--golden);
-}
-
-.themeGolden.colorSchemaPlain {
-  border: none;
-  background-color: var(--temp-grey-blue-8);
   color: var(--golden);
 }
 
 .themePink.colorSchemaInverted {
   border: 1px solid var(--pink);
-  background-color: transparent;
-  color: var(--pink);
-}
-
-.themePink.colorSchemaPlain {
-  border: none;
-  background-color: var(--temp-grey-blue-8);
   color: var(--pink);
 }
 
 .themeBlue.colorSchemaInverted {
   border: 1px solid var(--action-secondary);
-  background-color: transparent;
-  color: var(--action-secondary);
-}
-
-.themeBlue.colorSchemaPlain {
-  border: none;
-  background-color: var(--temp-grey-blue-8);
   color: var(--action-secondary);
 }
 
 .themeDanger.colorSchemaInverted {
   border: 1px solid var(--danger);
-  background-color: transparent;
   color: var(--danger);
 }
 
+.themeGolden.colorSchemaPlain {
+  color: var(--golden);
+}
+
+.themePrimary.colorSchemaPlain {
+  color: var(--primary);
+}
+
+.themePink.colorSchemaPlain {
+  color: var(--pink);
+}
+
+.themeBlue.colorSchemaPlain {
+  color: var(--action-secondary);
+}
+
 .themeDanger.colorSchemaPlain {
-  border: none;
-  background-color: var(--temp-grey-blue-8);
   color: var(--danger);
 }
 

--- a/src/modules/core/components/Tag/Tag.css
+++ b/src/modules/core/components/Tag/Tag.css
@@ -1,5 +1,5 @@
 .baseStyles {
-  padding: 1px 10px 2px;
+  padding: 1px 8px 2px;
   border-radius: var(--radius-large);
   font-size: 0.8rem;
   font-weight: var(--weight-bold);

--- a/src/modules/core/components/Tag/Tag.css
+++ b/src/modules/core/components/Tag/Tag.css
@@ -44,11 +44,64 @@
   color: white;
 }
 
-.themeInversePrimary {
-  composes: baseStyles;
+.themePrimary.colorSchemaInverted {
   border: 1px solid var(--primary);
   background-color: transparent;
   color: var(--primary);
+}
+
+.themePrimary.colorSchemaPlain {
+  border: none;
+  background-color: var(--temp-grey-blue-8);
+  color: var(--primary);
+}
+
+.themeGolden.colorSchemaInverted {
+  border: 1px solid var(--golden);
+  background-color: transparent;
+  color: var(--golden);
+}
+
+.themeGolden.colorSchemaPlain {
+  border: none;
+  background-color: var(--temp-grey-blue-8);
+  color: var(--golden);
+}
+
+.themePink.colorSchemaInverted {
+  border: 1px solid var(--pink);
+  background-color: transparent;
+  color: var(--pink);
+}
+
+.themePink.colorSchemaPlain {
+  border: none;
+  background-color: var(--temp-grey-blue-8);
+  color: var(--pink);
+}
+
+.themeBlue.colorSchemaInverted {
+  border: 1px solid var(--action-secondary);
+  background-color: transparent;
+  color: var(--action-secondary);
+}
+
+.themeBlue.colorSchemaPlain {
+  border: none;
+  background-color: var(--temp-grey-blue-8);
+  color: var(--action-secondary);
+}
+
+.themeDanger.colorSchemaInverted {
+  border: 1px solid var(--danger);
+  background-color: transparent;
+  color: var(--danger);
+}
+
+.themeDanger.colorSchemaPlain {
+  border: none;
+  background-color: var(--temp-grey-blue-8);
+  color: var(--danger);
 }
 
 .fontSizeTiny {

--- a/src/modules/core/components/Tag/Tag.css
+++ b/src/modules/core/components/Tag/Tag.css
@@ -32,6 +32,29 @@
   color: white;
 }
 
+.themePink {
+  composes: baseStyles;
+  background-color: var(--pink);
+  color: white;
+}
+
+.themeBlue {
+  composes: baseStyles;
+  background-color: var(--action-secondary);
+  color: white;
+}
+
+.themeInversePrimary {
+  composes: baseStyles;
+  border: 1px solid var(--primary);
+  background-color: transparent;
+  color: var(--primary);
+}
+
+.fontSizeTiny {
+  font-size: 9px;
+}
+
 .main {
   composes: themeLight;
 }

--- a/src/modules/core/components/Tag/Tag.css.d.ts
+++ b/src/modules/core/components/Tag/Tag.css.d.ts
@@ -3,4 +3,8 @@ export const themePrimary: string;
 export const themeLight: string;
 export const themeGolden: string;
 export const themeDanger: string;
+export const themePink: string;
+export const themeBlue: string;
+export const themeInversePrimary: string;
+export const fontSizeTiny: string;
 export const main: string;

--- a/src/modules/core/components/Tag/Tag.css.d.ts
+++ b/src/modules/core/components/Tag/Tag.css.d.ts
@@ -5,6 +5,7 @@ export const themeGolden: string;
 export const themeDanger: string;
 export const themePink: string;
 export const themeBlue: string;
-export const themeInversePrimary: string;
+export const colorSchemaInverted: string;
+export const colorSchemaPlain: string;
 export const fontSizeTiny: string;
 export const main: string;

--- a/src/modules/core/components/Tag/Tag.tsx
+++ b/src/modules/core/components/Tag/Tag.tsx
@@ -6,7 +6,15 @@ import { useMainClasses } from '~utils/hooks';
 import styles from './Tag.css';
 
 interface Appearance {
-  theme: 'primary' | 'light' | 'golden' | 'danger';
+  theme:
+    | 'primary'
+    | 'light'
+    | 'golden'
+    | 'danger'
+    | 'pink'
+    | 'blue'
+    | 'inversePrimary';
+  fontSize?: 'tiny';
 }
 
 interface Props extends HTMLAttributes<HTMLSpanElement> {

--- a/src/modules/core/components/Tag/Tag.tsx
+++ b/src/modules/core/components/Tag/Tag.tsx
@@ -6,9 +6,11 @@ import { useMainClasses } from '~utils/hooks';
 import styles from './Tag.css';
 
 interface Appearance {
+  /* "light" is default */
   theme: 'primary' | 'light' | 'golden' | 'danger' | 'pink' | 'blue';
   fontSize?: 'tiny';
-  colorSchema?: 'inverted' | 'plain';
+  /* "fullColor" is default */
+  colorSchema?: 'fullColor' | 'inverted' | 'plain';
 }
 
 interface Props extends HTMLAttributes<HTMLSpanElement> {

--- a/src/modules/core/components/Tag/Tag.tsx
+++ b/src/modules/core/components/Tag/Tag.tsx
@@ -6,15 +6,9 @@ import { useMainClasses } from '~utils/hooks';
 import styles from './Tag.css';
 
 interface Appearance {
-  theme:
-    | 'primary'
-    | 'light'
-    | 'golden'
-    | 'danger'
-    | 'pink'
-    | 'blue'
-    | 'inversePrimary';
+  theme: 'primary' | 'light' | 'golden' | 'danger' | 'pink' | 'blue';
   fontSize?: 'tiny';
+  colorSchema?: 'inverted' | 'plain';
 }
 
 interface Props extends HTMLAttributes<HTMLSpanElement> {

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -10,7 +10,7 @@
   --danger: rgb(248, 43, 101); /* user mentions color */
   --violet: rgb(89, 100, 240);
   --pink: rgb(254, 94, 124);
-  --golden: rgb(238, 179, 0); /* Think pending states (golden yellow) */
+  --golden: rgba(255, 176, 0); /* Think pending states (golden yellow) */
   --dark: rgb(60, 68, 77); /* Used for colony name display (colony simplified) */
   --grey-dark: rgb(47, 47, 47);
   --grey-1: rgb(58, 58, 58);


### PR DESCRIPTION
## Description

Create variants for all tags used in Motion flow.

To test - add the code below wherever you want to see the tag and change the prop values:
`<Tag text="Text" appearance={{ theme: 'blue', colorSchema: 'plain', fontSize: 'tiny' }} />`

**New stuff** ✨

- added new themes to `Tag` component
- added `fontSize` tiny prop value and css
- add `colorSchema` plain & inverted

**Changes** 🏗

- updated golden color variable (also done in token activation popover but it's not yet merged into master)
- change padding left & right from `10px` to `8px` as agreed with Karol

**Deletions** ⚰️

none

## TODO

none

Resolves DEV-235
