### PR TITLE
Add TotalStakeWidget to motion action page

### DIFF
--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -505,7 +505,7 @@ export type QueryStakeAmountsForMotionArgs = {
   colonyAddress: Scalars['String'];
   userAddress: Scalars['String'];
   motionId: Scalars['Int'];
-  isObjectionStake: Scalars['Boolean'];
+  stakeSide: Scalars['String'];
 };
 
 
@@ -887,9 +887,14 @@ export type MotionVoteResults = {
   nayVoters: Array<Scalars['String']>;
 }
 
+export type TotalStakedAmounts = {
+  YAY?: Maybe<Scalars['String']>;
+  NAY?: Maybe<Scalars['String']>;
+};
+
 export type StakeAmounts = {
-  totalStaked: Scalars['String'];
-  userStake: Scalars['String'];
+  totalStaked: TotalStakedAmounts;
+  userStake?: Maybe<Scalars['String']>;
   requiredStake: Scalars['String'];
 };
 
@@ -1600,11 +1605,14 @@ export type StakeAmountsForMotionQueryVariables = Exact<{
   colonyAddress: Scalars['String'];
   userAddress: Scalars['String'];
   motionId: Scalars['Int'];
-  isObjectionStake: Scalars['Boolean'];
+  stakeSide: Scalars['String'];
 }>;
 
 
-export type StakeAmountsForMotionQuery = { stakeAmountsForMotion: Pick<StakeAmounts, 'totalStaked' | 'userStake' | 'requiredStake'> };
+export type StakeAmountsForMotionQuery = { stakeAmountsForMotion: (
+    Pick<StakeAmounts, 'userStake' | 'requiredStake'>
+    & { totalStaked: Pick<TotalStakedAmounts, 'YAY' | 'NAY'> }
+  ) };
 
 export type MotionUserVoteRevealedQueryVariables = Exact<{
   motionId: Scalars['Int'];

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -1601,6 +1601,7 @@ export type MotionVoterRewardQueryVariables = Exact<{
 
 
 export type MotionsVoterRewardQuery = Pick<Query, 'motionVoterReward'>;
+
 export type StakeAmountsForMotionQueryVariables = Exact<{
   colonyAddress: Scalars['String'];
   userAddress: Scalars['String'];
@@ -3829,10 +3830,6 @@ export const MotionVoterRewardDocument = gql`
  *
  * To run a query within a React component, call `useMotionsVoterRewardQuery` and pass it any options that fit your needs.
  * When your component renders, `useMotionsVoterRewardQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * __useStakeAmountsForMotionQuery__
- *
- * To run a query within a React component, call `useStakeAmountsForMotionQuery` and pass it any options that fit your needs.
- * When your component renders, `useStakeAmountsForMotionQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -504,9 +504,8 @@ export type QueryRecoverySystemMessagesForSessionArgs = {
 export type QueryStakeAmountsForMotionArgs = {
   colonyAddress: Scalars['String'];
   userAddress: Scalars['String'];
-  motionId: Scalars['String'];
+  motionId: Scalars['Int'];
   isObjectionStake: Scalars['Boolean'];
-  tokenDecimals: Scalars['Int'];
 };
 
 
@@ -738,7 +737,7 @@ export type ColonyAction = {
   domainPurpose: Scalars['String'];
   domainColor: Scalars['String'];
   blockNumber: Scalars['Int'];
-  motionId: Scalars['String'];
+  motionNAYStake?: Maybe<Scalars['String']>;
   motionState?: Maybe<Scalars['String']>;
   motionDomain: Scalars['Int'];
 };
@@ -1596,7 +1595,16 @@ export type MotionVoterRewardQueryVariables = Exact<{
 }>;
 
 
-export type MotionVoterRewardQuery = Pick<Query, 'motionVoterReward'>;
+export type MotionsVoterRewardQuery = Pick<Query, 'motionVoterReward'>;
+export type StakeAmountsForMotionQueryVariables = Exact<{
+  colonyAddress: Scalars['String'];
+  userAddress: Scalars['String'];
+  motionId: Scalars['Int'];
+  isObjectionStake: Scalars['Boolean'];
+}>;
+
+
+export type StakeAmountsForMotionQuery = { stakeAmountsForMotion: Pick<StakeAmounts, 'totalStaked' | 'userStake' | 'requiredStake'> };
 
 export type MotionUserVoteRevealedQueryVariables = Exact<{
   motionId: Scalars['Int'];
@@ -3215,7 +3223,7 @@ export const ColonyActionDocument = gql`
     domainName
     domainPurpose
     domainColor
-    motionId
+    motionNAYStake
     motionState
     motionDomain
     roles {
@@ -3811,8 +3819,12 @@ export const MotionVoterRewardDocument = gql`
 /**
  * __useMotionVoterRewardQuery__
  *
- * To run a query within a React component, call `useMotionVoterRewardQuery` and pass it any options that fit your needs.
- * When your component renders, `useMotionVoterRewardQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useMotionsVoterRewardQuery` and pass it any options that fit your needs.
+ * When your component renders, `useMotionsVoterRewardQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * __useStakeAmountsForMotionQuery__
+ *
+ * To run a query within a React component, call `useStakeAmountsForMotionQuery` and pass it any options that fit your needs.
+ * When your component renders, `useStakeAmountsForMotionQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -505,6 +505,8 @@ export type QueryStakeAmountsForMotionArgs = {
   colonyAddress: Scalars['String'];
   userAddress: Scalars['String'];
   motionId: Scalars['String'];
+  isObjectionStake: Scalars['Boolean'];
+  tokenDecimals: Scalars['Int'];
 };
 
 
@@ -736,6 +738,7 @@ export type ColonyAction = {
   domainPurpose: Scalars['String'];
   domainColor: Scalars['String'];
   blockNumber: Scalars['Int'];
+  motionId: Scalars['String'];
   motionState?: Maybe<Scalars['String']>;
   motionDomain: Scalars['Int'];
 };
@@ -3212,6 +3215,7 @@ export const ColonyActionDocument = gql`
     domainName
     domainPurpose
     domainColor
+    motionId
     motionState
     motionDomain
     roles {

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -887,6 +887,14 @@ export type MotionVoteResults = {
   nayVoters: Array<Scalars['String']>;
 };
 
+export type MotionStakerRewards = {
+  stakingRewardYay: Scalars['String'];
+  stakingRewardNay: Scalars['String'];
+  stakesYay: Scalars['String'];
+  stakesNay: Scalars['String'];
+  claimedReward: Scalars['Boolean'];
+};
+
 export type TotalStakedAmounts = {
   YAY?: Maybe<Scalars['String']>;
   NAY?: Maybe<Scalars['String']>;
@@ -896,14 +904,6 @@ export type StakeAmounts = {
   totalStaked: TotalStakedAmounts;
   userStake?: Maybe<Scalars['String']>;
   requiredStake: Scalars['String'];
-};
-
-export type MotionStakerRewards = {
-  stakingRewardYay: Scalars['String'];
-  stakingRewardNay: Scalars['String'];
-  stakesYay: Scalars['String'];
-  stakesNay: Scalars['String'];
-  claimedReward: Scalars['Boolean'];
 };
 
 export type ByColonyFilter = {
@@ -1600,7 +1600,7 @@ export type MotionVoterRewardQueryVariables = Exact<{
 }>;
 
 
-export type MotionsVoterRewardQuery = Pick<Query, 'motionVoterReward'>;
+export type MotionVoterRewardQuery = Pick<Query, 'motionVoterReward'>;
 
 export type MotionUserVoteRevealedQueryVariables = Exact<{
   motionId: Scalars['Int'];
@@ -1645,6 +1645,7 @@ export type MotionStakerRewardQueryVariables = Exact<{
 
 
 export type MotionStakerRewardQuery = { motionStakerReward: Pick<MotionStakerRewards, 'stakingRewardYay' | 'stakingRewardNay' | 'stakesYay' | 'stakesNay' | 'claimedReward'> };
+
 export type StakeAmountsForMotionQueryVariables = Exact<{
   colonyAddress: Scalars['String'];
   userAddress: Scalars['String'];
@@ -3827,8 +3828,8 @@ export const MotionVoterRewardDocument = gql`
 /**
  * __useMotionVoterRewardQuery__
  *
- * To run a query within a React component, call `useMotionsVoterRewardQuery` and pass it any options that fit your needs.
- * When your component renders, `useMotionsVoterRewardQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useMotionVoterRewardQuery` and pass it any options that fit your needs.
+ * When your component renders, `useMotionVoterRewardQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
@@ -3999,15 +4000,6 @@ export const MotionStakerRewardDocument = gql`
     stakesYay
     stakesNay
     claimedReward
-export const StakeAmountsForMotionDocument = gql`
-    query StakeAmountsForMotion($colonyAddress: String!, $userAddress: String!, $motionId: Int!, $stakeSide: String!) {
-  stakeAmountsForMotion(colonyAddress: $colonyAddress, userAddress: $userAddress, motionId: $motionId, stakeSide: $stakeSide) @client {
-    totalStaked {
-      YAY
-      NAY
-    }
-    userStake
-    requiredStake
   }
 }
     `;
@@ -4017,10 +4009,6 @@ export const StakeAmountsForMotionDocument = gql`
  *
  * To run a query within a React component, call `useMotionStakerRewardQuery` and pass it any options that fit your needs.
  * When your component renders, `useMotionStakerRewardQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * __useStakeAmountsForMotionQuery__
- *
- * To run a query within a React component, call `useStakeAmountsForMotionQuery` and pass it any options that fit your needs.
- * When your component renders, `useStakeAmountsForMotionQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
@@ -4043,6 +4031,29 @@ export function useMotionStakerRewardLazyQuery(baseOptions?: Apollo.LazyQueryHoo
 export type MotionStakerRewardQueryHookResult = ReturnType<typeof useMotionStakerRewardQuery>;
 export type MotionStakerRewardLazyQueryHookResult = ReturnType<typeof useMotionStakerRewardLazyQuery>;
 export type MotionStakerRewardQueryResult = Apollo.QueryResult<MotionStakerRewardQuery, MotionStakerRewardQueryVariables>;
+export const StakeAmountsForMotionDocument = gql`
+    query StakeAmountsForMotion($colonyAddress: String!, $userAddress: String!, $motionId: Int!, $stakeSide: String!) {
+  stakeAmountsForMotion(colonyAddress: $colonyAddress, userAddress: $userAddress, motionId: $motionId, stakeSide: $stakeSide) @client {
+    totalStaked {
+      YAY
+      NAY
+    }
+    userStake
+    requiredStake
+  }
+}
+    `;
+
+/**
+ * __useStakeAmountsForMotionQuery__
+ *
+ * To run a query within a React component, call `useStakeAmountsForMotionQuery` and pass it any options that fit your needs.
+ * When your component renders, `useStakeAmountsForMotionQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
  * const { data, loading, error } = useStakeAmountsForMotionQuery({
  *   variables: {
  *      colonyAddress: // value for 'colonyAddress'

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -885,7 +885,7 @@ export type MotionVoteResults = {
   yayVoters: Array<Scalars['String']>;
   nayVotes: Scalars['String'];
   nayVoters: Array<Scalars['String']>;
-}
+};
 
 export type TotalStakedAmounts = {
   YAY?: Maybe<Scalars['String']>;
@@ -1466,7 +1466,7 @@ export type ColonyActionQueryVariables = Exact<{
 
 
 export type ColonyActionQuery = { colonyAction: (
-    Pick<ColonyAction, 'hash' | 'actionInitiator' | 'fromDomain' | 'toDomain' | 'recipient' | 'status' | 'createdAt' | 'actionType' | 'amount' | 'tokenAddress' | 'annotationHash' | 'newVersion' | 'oldVersion' | 'colonyDisplayName' | 'colonyAvatarHash' | 'colonyTokens' | 'domainName' | 'domainPurpose' | 'domainColor' | 'motionState' | 'motionDomain' | 'blockNumber'>
+    Pick<ColonyAction, 'hash' | 'actionInitiator' | 'fromDomain' | 'toDomain' | 'recipient' | 'status' | 'createdAt' | 'actionType' | 'amount' | 'tokenAddress' | 'annotationHash' | 'newVersion' | 'oldVersion' | 'colonyDisplayName' | 'colonyAvatarHash' | 'colonyTokens' | 'domainName' | 'domainPurpose' | 'domainColor' | 'motionNAYStake' | 'motionState' | 'motionDomain' | 'blockNumber'>
     & { events: Array<Pick<ParsedEvent, 'type' | 'name' | 'values' | 'createdAt' | 'emmitedBy' | 'transactionHash'>>, roles: Array<Pick<ColonyActionRoles, 'id' | 'setTo'>> }
   ) };
 
@@ -1602,19 +1602,6 @@ export type MotionVoterRewardQueryVariables = Exact<{
 
 export type MotionsVoterRewardQuery = Pick<Query, 'motionVoterReward'>;
 
-export type StakeAmountsForMotionQueryVariables = Exact<{
-  colonyAddress: Scalars['String'];
-  userAddress: Scalars['String'];
-  motionId: Scalars['Int'];
-  stakeSide: Scalars['String'];
-}>;
-
-
-export type StakeAmountsForMotionQuery = { stakeAmountsForMotion: (
-    Pick<StakeAmounts, 'userStake' | 'requiredStake'>
-    & { totalStaked: Pick<TotalStakedAmounts, 'YAY' | 'NAY'> }
-  ) };
-
 export type MotionUserVoteRevealedQueryVariables = Exact<{
   motionId: Scalars['Int'];
   colonyAddress: Scalars['String'];
@@ -1658,6 +1645,18 @@ export type MotionStakerRewardQueryVariables = Exact<{
 
 
 export type MotionStakerRewardQuery = { motionStakerReward: Pick<MotionStakerRewards, 'stakingRewardYay' | 'stakingRewardNay' | 'stakesYay' | 'stakesNay' | 'claimedReward'> };
+export type StakeAmountsForMotionQueryVariables = Exact<{
+  colonyAddress: Scalars['String'];
+  userAddress: Scalars['String'];
+  motionId: Scalars['Int'];
+  stakeSide: Scalars['String'];
+}>;
+
+
+export type StakeAmountsForMotionQuery = { stakeAmountsForMotion: (
+    Pick<StakeAmounts, 'userStake' | 'requiredStake'>
+    & { totalStaked: Pick<TotalStakedAmounts, 'YAY' | 'NAY'> }
+  ) };
 
 export type SubgraphDomainsQueryVariables = Exact<{
   colonyAddress: Scalars['String'];
@@ -4000,6 +3999,15 @@ export const MotionStakerRewardDocument = gql`
     stakesYay
     stakesNay
     claimedReward
+export const StakeAmountsForMotionDocument = gql`
+    query StakeAmountsForMotion($colonyAddress: String!, $userAddress: String!, $motionId: Int!, $stakeSide: String!) {
+  stakeAmountsForMotion(colonyAddress: $colonyAddress, userAddress: $userAddress, motionId: $motionId, stakeSide: $stakeSide) @client {
+    totalStaked {
+      YAY
+      NAY
+    }
+    userStake
+    requiredStake
   }
 }
     `;
@@ -4009,6 +4017,10 @@ export const MotionStakerRewardDocument = gql`
  *
  * To run a query within a React component, call `useMotionStakerRewardQuery` and pass it any options that fit your needs.
  * When your component renders, `useMotionStakerRewardQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * __useStakeAmountsForMotionQuery__
+ *
+ * To run a query within a React component, call `useStakeAmountsForMotionQuery` and pass it any options that fit your needs.
+ * When your component renders, `useStakeAmountsForMotionQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
@@ -4031,6 +4043,24 @@ export function useMotionStakerRewardLazyQuery(baseOptions?: Apollo.LazyQueryHoo
 export type MotionStakerRewardQueryHookResult = ReturnType<typeof useMotionStakerRewardQuery>;
 export type MotionStakerRewardLazyQueryHookResult = ReturnType<typeof useMotionStakerRewardLazyQuery>;
 export type MotionStakerRewardQueryResult = Apollo.QueryResult<MotionStakerRewardQuery, MotionStakerRewardQueryVariables>;
+ * const { data, loading, error } = useStakeAmountsForMotionQuery({
+ *   variables: {
+ *      colonyAddress: // value for 'colonyAddress'
+ *      userAddress: // value for 'userAddress'
+ *      motionId: // value for 'motionId'
+ *      stakeSide: // value for 'stakeSide'
+ *   },
+ * });
+ */
+export function useStakeAmountsForMotionQuery(baseOptions?: Apollo.QueryHookOptions<StakeAmountsForMotionQuery, StakeAmountsForMotionQueryVariables>) {
+        return Apollo.useQuery<StakeAmountsForMotionQuery, StakeAmountsForMotionQueryVariables>(StakeAmountsForMotionDocument, baseOptions);
+      }
+export function useStakeAmountsForMotionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<StakeAmountsForMotionQuery, StakeAmountsForMotionQueryVariables>) {
+          return Apollo.useLazyQuery<StakeAmountsForMotionQuery, StakeAmountsForMotionQueryVariables>(StakeAmountsForMotionDocument, baseOptions);
+        }
+export type StakeAmountsForMotionQueryHookResult = ReturnType<typeof useStakeAmountsForMotionQuery>;
+export type StakeAmountsForMotionLazyQueryHookResult = ReturnType<typeof useStakeAmountsForMotionLazyQuery>;
+export type StakeAmountsForMotionQueryResult = Apollo.QueryResult<StakeAmountsForMotionQuery, StakeAmountsForMotionQueryVariables>;
 export const SubgraphDomainsDocument = gql`
     query SubgraphDomains($colonyAddress: String!) {
   domains(where: {colonyAddress: $colonyAddress}) {

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -302,6 +302,7 @@ export type Query = {
   recoveryRolesAndApprovalsForSession: Array<UsersAndRecoveryApprovals>;
   recoveryRolesUsers: Array<User>;
   recoverySystemMessagesForSession: Array<SystemMessage>;
+  stakeAmountsForMotion: StakeAmounts;
   subscribedUsers: Array<User>;
   systemInfo: SystemInfo;
   token: Token;
@@ -497,6 +498,13 @@ export type QueryRecoveryRolesUsersArgs = {
 export type QueryRecoverySystemMessagesForSessionArgs = {
   blockNumber: Scalars['Int'];
   colonyAddress: Scalars['String'];
+};
+
+
+export type QueryStakeAmountsForMotionArgs = {
+  colonyAddress: Scalars['String'];
+  userAddress: Scalars['String'];
+  motionId: Scalars['String'];
 };
 
 
@@ -875,6 +883,12 @@ export type MotionVoteResults = {
   yayVoters: Array<Scalars['String']>;
   nayVotes: Scalars['String'];
   nayVoters: Array<Scalars['String']>;
+}
+
+export type StakeAmounts = {
+  totalStaked: Scalars['Int'];
+  userStake: Scalars['Int'];
+  requiredStake: Scalars['Int'];
 };
 
 export type MotionStakerRewards = {

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -889,9 +889,9 @@ export type MotionVoteResults = {
 }
 
 export type StakeAmounts = {
-  totalStaked: Scalars['Int'];
-  userStake: Scalars['Int'];
-  requiredStake: Scalars['Int'];
+  totalStaked: Scalars['String'];
+  userStake: Scalars['String'];
+  requiredStake: Scalars['String'];
 };
 
 export type MotionStakerRewards = {

--- a/src/data/graphql/queries.graphql
+++ b/src/data/graphql/queries.graphql
@@ -248,6 +248,7 @@ query ColonyAction($transactionHash: String!, $colonyAddress: String!) {
     domainName
     domainPurpose
     domainColor
+    motionId
     motionState
     motionDomain
     roles {

--- a/src/data/graphql/queries.graphql
+++ b/src/data/graphql/queries.graphql
@@ -436,9 +436,12 @@ query MotionStakerReward($motionId: Int!, $colonyAddress: String!, $userAddress:
   }
 }
 
-query StakeAmountsForMotion($colonyAddress: String!, $userAddress: String!, $motionId: Int! $isObjectionStake: Boolean!) {
-  stakeAmountsForMotion(colonyAddress: $colonyAddress, userAddress: $userAddress, motionId: $motionId, isObjectionStake: $isObjectionStake) @client {
-    totalStaked
+query StakeAmountsForMotion($colonyAddress: String!, $userAddress: String!, $motionId: Int! $stakeSide: String!) {
+  stakeAmountsForMotion(colonyAddress: $colonyAddress, userAddress: $userAddress, motionId: $motionId, stakeSide: $stakeSide) @client {
+    totalStaked {
+      YAY
+      NAY
+    }
     userStake
     requiredStake
   }

--- a/src/data/graphql/queries.graphql
+++ b/src/data/graphql/queries.graphql
@@ -435,6 +435,14 @@ query MotionStakerReward($motionId: Int!, $colonyAddress: String!, $userAddress:
   }
 }
 
+query StakeAmountsForMotion($colonyAddress: String!, $userAddress: String!, $motionId: String!) {
+  stakeAmountsForMotion(colonyAddress: $colonyAddress, userAddress: $userAddress, motionId: $motionId) @client {
+    totalStaked
+    userStake
+    requiredStake
+  }
+}
+
 # The Graph
 #
 # @NOTE All queries meant for the subgraph should be prepended with `Subgraph`

--- a/src/data/graphql/queries.graphql
+++ b/src/data/graphql/queries.graphql
@@ -248,7 +248,7 @@ query ColonyAction($transactionHash: String!, $colonyAddress: String!) {
     domainName
     domainPurpose
     domainColor
-    motionId
+    motionNAYStake
     motionState
     motionDomain
     roles {
@@ -436,8 +436,8 @@ query MotionStakerReward($motionId: Int!, $colonyAddress: String!, $userAddress:
   }
 }
 
-query StakeAmountsForMotion($colonyAddress: String!, $userAddress: String!, $motionId: String!) {
-  stakeAmountsForMotion(colonyAddress: $colonyAddress, userAddress: $userAddress, motionId: $motionId) @client {
+query StakeAmountsForMotion($colonyAddress: String!, $userAddress: String!, $motionId: Int! $isObjectionStake: Boolean!) {
+  stakeAmountsForMotion(colonyAddress: $colonyAddress, userAddress: $userAddress, motionId: $motionId, isObjectionStake: $isObjectionStake) @client {
     totalStaked
     userStake
     requiredStake

--- a/src/data/graphql/typeDefs.ts
+++ b/src/data/graphql/typeDefs.ts
@@ -232,6 +232,12 @@ export default gql`
     claimedReward: Boolean!
   }
 
+  type StakeAmounts {
+    totalStaked: Int!
+    userStake: Int!
+    requiredStake: Int!
+  }
+
   extend type Query {
     loggedInUser: LoggedInUser!
     colonyAddress(name: String!): String!
@@ -327,6 +333,11 @@ export default gql`
       colonyAddress: String!
       userAddress: String!
     ): MotionStakerRewards!
+    stakeAmountsForMotion(
+      colonyAddress: String!
+      userAddress: String!
+      motionId: String!
+    ): StakeAmounts!
   }
 
   extend type Mutation {

--- a/src/data/graphql/typeDefs.ts
+++ b/src/data/graphql/typeDefs.ts
@@ -62,7 +62,7 @@ export default gql`
     domainPurpose: String!
     domainColor: String!
     blockNumber: Int!
-    motionId: String!
+    motionNAYStake: String
     motionState: String
     motionDomain: Int!
   }
@@ -337,9 +337,8 @@ export default gql`
     stakeAmountsForMotion(
       colonyAddress: String!
       userAddress: String!
-      motionId: String!
+      motionId: Int!
       isObjectionStake: Boolean!
-      tokenDecimals: Int!
     ): StakeAmounts!
   }
 

--- a/src/data/graphql/typeDefs.ts
+++ b/src/data/graphql/typeDefs.ts
@@ -234,9 +234,9 @@ export default gql`
   }
 
   type StakeAmounts {
-    totalStaked: Int!
-    userStake: Int!
-    requiredStake: Int!
+    totalStaked: String!
+    userStake: String!
+    requiredStake: String!
   }
 
   extend type Query {

--- a/src/data/graphql/typeDefs.ts
+++ b/src/data/graphql/typeDefs.ts
@@ -233,9 +233,14 @@ export default gql`
     claimedReward: Boolean!
   }
 
+  type TotalStakedAmounts {
+    YAY: String
+    NAY: String
+  }
+
   type StakeAmounts {
-    totalStaked: String!
-    userStake: String!
+    totalStaked: TotalStakedAmounts!
+    userStake: String
     requiredStake: String!
   }
 
@@ -338,7 +343,7 @@ export default gql`
       colonyAddress: String!
       userAddress: String!
       motionId: Int!
-      isObjectionStake: Boolean!
+      stakeSide: String!
     ): StakeAmounts!
   }
 

--- a/src/data/graphql/typeDefs.ts
+++ b/src/data/graphql/typeDefs.ts
@@ -62,6 +62,7 @@ export default gql`
     domainPurpose: String!
     domainColor: String!
     blockNumber: Int!
+    motionId: String!
     motionState: String
     motionDomain: Int!
   }
@@ -337,6 +338,8 @@ export default gql`
       colonyAddress: String!
       userAddress: String!
       motionId: String!
+      isObjectionStake: Boolean!
+      tokenDecimals: Int!
     ): StakeAmounts!
   }
 

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -39,6 +39,7 @@ import { eventsResolvers } from './resolvers/events';
 import { recoveryModeResolvers } from './resolvers/recovery';
 import { extensionsResolvers } from './resolvers/extensions';
 import { motionsResolvers } from './resolvers/motions';
+import { stakesResolvers } from './resolvers/stakes';
 
 import { FixedToken } from '../types';
 
@@ -66,6 +67,7 @@ export const resolvers: ResolverFactory[] = [
   recoveryModeResolvers,
   extensionsResolvers,
   motionsResolvers,
+  stakesResolvers,
 ];
 
 // export all the generated types and helpers

--- a/src/data/resolvers/colonyActions.ts
+++ b/src/data/resolvers/colonyActions.ts
@@ -241,6 +241,7 @@ export const colonyActionsResolvers = ({
           domainPurpose: null,
           domainColor: null,
           blockNumber,
+          motionId: null,
           motionState: null,
           motionDomain: null,
           ...actionValues,

--- a/src/data/resolvers/colonyActions.ts
+++ b/src/data/resolvers/colonyActions.ts
@@ -241,7 +241,6 @@ export const colonyActionsResolvers = ({
           domainPurpose: null,
           domainColor: null,
           blockNumber,
-          motionId: null,
           motionState: null,
           motionDomain: null,
           ...actionValues,

--- a/src/data/resolvers/colonyActions.ts
+++ b/src/data/resolvers/colonyActions.ts
@@ -243,6 +243,7 @@ export const colonyActionsResolvers = ({
           blockNumber,
           motionState: null,
           motionDomain: null,
+          motionNAYStake: null,
           ...actionValues,
         };
       }

--- a/src/data/resolvers/stakes.ts
+++ b/src/data/resolvers/stakes.ts
@@ -11,7 +11,7 @@ export const stakesResolvers = ({
   Query: {
     async stakeAmountsForMotion(
       _,
-      { colonyAddress, userAddress, motionId, isObjectionStake, tokenDecimals },
+      { colonyAddress, userAddress, motionId, isObjectionStake },
     ) {
       try {
         const supportedSide = isObjectionStake
@@ -21,6 +21,7 @@ export const stakesResolvers = ({
           ClientType.ColonyClient,
           colonyAddress,
         );
+        const tokenDecimals = await colonyClient.tokenClient.decimals();
         const votingReputationClient = await colonyClient.getExtensionClient(
           Extension.VotingReputation,
         );

--- a/src/data/resolvers/stakes.ts
+++ b/src/data/resolvers/stakes.ts
@@ -39,9 +39,9 @@ export const stakesResolvers = ({
           .mul(totalStakeFraction)
           .div(bigNumberify(10).pow(tokenDecimals * 2))
           .toString();
-        const totalStaked = stakes[supportedSide].div(
-          bigNumberify(10).pow(tokenDecimals),
-        );
+        const totalStaked = stakes[supportedSide]
+          .div(bigNumberify(10).pow(tokenDecimals))
+          .toString();
         const userStakeAmount = userStake
           .div(bigNumberify(10).pow(tokenDecimals))
           .toString();

--- a/src/data/resolvers/stakes.ts
+++ b/src/data/resolvers/stakes.ts
@@ -1,9 +1,8 @@
 import { Resolvers } from '@apollo/client';
 import { ClientType, Extension } from '@colony/colony-js';
-import { bigNumberify } from 'ethers/utils';
 
 import { Context } from '~context/index';
-import { MotionVote } from '~utils/colonyMotions';
+import { getMotionRequiredStake, MotionVote } from '~utils/colonyMotions';
 
 export const stakesResolvers = ({
   colonyManager,
@@ -21,7 +20,6 @@ export const stakesResolvers = ({
           ClientType.ColonyClient,
           colonyAddress,
         );
-        const tokenDecimals = await colonyClient.tokenClient.decimals();
         const votingReputationClient = await colonyClient.getExtensionClient(
           Extension.VotingReputation,
         );
@@ -36,16 +34,13 @@ export const stakesResolvers = ({
         // @NOTE There's no prettier compatible solution to this :(
         // eslint-disable-next-line max-len
         const totalStakeFraction = await votingReputationClient.getTotalStakeFraction();
-        const requiredStake = skillRep
-          .mul(totalStakeFraction)
-          .div(bigNumberify(10).pow(tokenDecimals * 2))
-          .toString();
-        const totalStaked = stakes[supportedSide]
-          .div(bigNumberify(10).pow(tokenDecimals))
-          .toString();
-        const userStakeAmount = userStake
-          .div(bigNumberify(10).pow(tokenDecimals))
-          .toString();
+        const requiredStake = getMotionRequiredStake(
+          skillRep,
+          totalStakeFraction,
+          18,
+        ).toString();
+        const totalStaked = stakes[supportedSide].toString();
+        const userStakeAmount = userStake.toString();
 
         return {
           totalStaked,

--- a/src/data/resolvers/stakes.ts
+++ b/src/data/resolvers/stakes.ts
@@ -1,0 +1,41 @@
+import { Resolvers } from '@apollo/client';
+import { ClientType, ColonyClientV6, Extension } from '@colony/colony-js';
+
+import { Context } from '~context/index';
+
+export const stakesResolvers = ({
+  colonyManager,
+}: Required<Context>): Resolvers => ({
+  Query: {
+    async stakeAmountsForMotion(_, { colonyAddress, userAddress, motionId }) {
+      try {
+        const colonyClient = (await colonyManager.getClient(
+          ClientType.ColonyClient,
+          colonyAddress,
+        )) as ColonyClientV6;
+        const votingReputationClient = colonyClient.getExtensionClient(
+          Extension.VotingReputation,
+        );
+        const motionData = (await votingReputationClient).getMotion(motionId);
+        const totalStaked = motionData.stakes[1];
+        const userStake = (await votingReputationClient).getStake(
+          motionId,
+          userAddress,
+          1,
+        );
+        const requiredStake = (await votingReputationClient).getRequiredStake(
+          motionId,
+        );
+
+        return {
+          totalStaked,
+          userStake,
+          requiredStake,
+        };
+      } catch (error) {
+        console.error(error);
+        return null;
+      }
+    },
+  },
+});

--- a/src/data/resolvers/stakes.ts
+++ b/src/data/resolvers/stakes.ts
@@ -3,6 +3,7 @@ import { ClientType, Extension } from '@colony/colony-js';
 import { bigNumberify } from 'ethers/utils';
 
 import { Context } from '~context/index';
+import { MotionVote } from '~utils/colonyMotions';
 
 export const stakesResolvers = ({
   colonyManager,
@@ -13,7 +14,9 @@ export const stakesResolvers = ({
       { colonyAddress, userAddress, motionId, isObjectionStake, tokenDecimals },
     ) {
       try {
-        const supportedSide = isObjectionStake ? 0 : 1;
+        const supportedSide = isObjectionStake
+          ? MotionVote.NAY
+          : MotionVote.YAY;
         const colonyClient = await colonyManager.getClient(
           ClientType.ColonyClient,
           colonyAddress,

--- a/src/data/resolvers/stakes.ts
+++ b/src/data/resolvers/stakes.ts
@@ -28,7 +28,7 @@ export const stakesResolvers = ({
 
         if (stakeSide !== StakeSide.Both) {
           const supportedSide =
-            stakeSide === StakeSide.Objection ? MotionVote.NAY : MotionVote.YAY;
+            stakeSide === StakeSide.Objection ? MotionVote.Nay : MotionVote.Yay;
 
           const userStake = await votingReputationClient.getStake(
             motionId,
@@ -52,8 +52,8 @@ export const stakesResolvers = ({
           NAY: string | null;
         } = {
           YAY:
-            stakeSide !== StakeSide.Objection ? stakes[MotionVote.YAY] : null,
-          NAY: stakeSide !== StakeSide.Motion ? stakes[MotionVote.NAY] : null,
+            stakeSide !== StakeSide.Objection ? stakes[MotionVote.Yay] : null,
+          NAY: stakeSide !== StakeSide.Motion ? stakes[MotionVote.Nay] : null,
         };
 
         return {

--- a/src/data/resolvers/stakes.ts
+++ b/src/data/resolvers/stakes.ts
@@ -38,13 +38,13 @@ export const stakesResolvers = ({
         const requiredStake = skillRep
           .mul(totalStakeFraction)
           .div(bigNumberify(10).pow(tokenDecimals * 2))
-          .toNumber();
-        const totalStaked = stakes[supportedSide]
-          .div(bigNumberify(10).pow(tokenDecimals))
-          .toNumber();
+          .toString();
+        const totalStaked = stakes[supportedSide].div(
+          bigNumberify(10).pow(tokenDecimals),
+        );
         const userStakeAmount = userStake
           .div(bigNumberify(10).pow(tokenDecimals))
-          .toNumber();
+          .toString();
 
         return {
           totalStaked,

--- a/src/modules/core/components/Fields/Radio/CustomRadio.css
+++ b/src/modules/core/components/Fields/Radio/CustomRadio.css
@@ -44,11 +44,17 @@
 }
 
 .main.stateIsChecked .description {
+  color: var(--temp-grey-blue-7);
   opacity: 0.85;
 }
 
 .main.stateIsDisabled .description {
+  color: var(--temp-grey-blue-7);
   opacity: 0.85;
+}
+
+.main.stateIsDisabled .label {
+  color: var(--temp-grey-blue-7);
 }
 
 .main.stateIsDisabled {
@@ -65,7 +71,8 @@
   gap: 6px;
 }
 
-.description {
+.description,
+.description span {
   margin-left: auto;
   font-size: var(--size-tiny);
   font-weight: var(--weight-bold);

--- a/src/modules/core/components/Fields/Radio/CustomRadio.tsx
+++ b/src/modules/core/components/Fields/Radio/CustomRadio.tsx
@@ -1,11 +1,11 @@
 import React, { useRef } from 'react';
-import { MessageDescriptor, useIntl, FormattedMessage } from 'react-intl';
+import { MessageDescriptor, FormattedMessage } from 'react-intl';
 import { nanoid } from 'nanoid';
 import { useField } from 'formik';
 
 import { getMainClasses } from '~utils/css';
 import Icon from '~core/Icon';
-import { SimpleMessageValues, UniversalMessageValues } from '~types/index';
+import { UniversalMessageValues } from '~types/index';
 
 import styles from './CustomRadio.css';
 
@@ -24,15 +24,13 @@ export interface Props {
   /** Label text */
   label: string | MessageDescriptor;
   /** Description text values for intl interpolation */
-  labelValues?: SimpleMessageValues;
+  labelValues?: UniversalMessageValues;
   /** Button description */
   description?: string | MessageDescriptor;
   /** Description text values for intl interpolation */
   descriptionValues?: UniversalMessageValues;
   /** Button icon */
   icon?: string;
-  /** Button sufix label icon */
-  labelIcon?: string | null;
   /** If the input is checked */
   checked: boolean;
   /** Radio button name attribute */
@@ -55,13 +53,10 @@ const CustomRadio = ({
   description,
   descriptionValues,
   icon,
-  labelIcon,
 }: Props) => {
   const [, { error }, { setValue }] = useField(name);
-  const { formatMessage } = useIntl();
   const inputRef = useRef<string>(inputId || nanoid());
-  const labelText =
-    typeof label === 'object' ? formatMessage(label, labelValues) : label;
+
   return (
     <label
       className={getMainClasses(appearance, styles, {
@@ -88,15 +83,12 @@ const CustomRadio = ({
         </div>
       )}
       <div className={styles.content}>
-        {labelText && (
+        {label && (
           <span className={styles.label}>
-            {labelText}
-            {labelIcon && (
-              <Icon
-                appearance={{ size: 'normal' }}
-                name={labelIcon}
-                title={labelIcon}
-              />
+            {label === 'string' ? (
+              label
+            ) : (
+              <FormattedMessage {...label} values={labelValues} />
             )}
           </span>
         )}

--- a/src/modules/core/components/Fields/Radio/CustomRadio.tsx
+++ b/src/modules/core/components/Fields/Radio/CustomRadio.tsx
@@ -100,13 +100,15 @@ const CustomRadio = ({
             )}
           </span>
         )}
-        <span className={styles.description}>
-          {description && description === 'string' ? (
-            description
-          ) : (
-            <FormattedMessage {...description} values={descriptionValues} />
-          )}
-        </span>
+        {description && (
+          <span className={styles.description}>
+            {description === 'string' ? (
+              description
+            ) : (
+              <FormattedMessage {...description} values={descriptionValues} />
+            )}
+          </span>
+        )}
       </div>
     </label>
   );

--- a/src/modules/core/components/Fields/Radio/CustomRadio.tsx
+++ b/src/modules/core/components/Fields/Radio/CustomRadio.tsx
@@ -1,11 +1,11 @@
 import React, { useRef } from 'react';
-import { MessageDescriptor, useIntl } from 'react-intl';
+import { MessageDescriptor, useIntl, FormattedMessage } from 'react-intl';
 import { nanoid } from 'nanoid';
 import { useField } from 'formik';
 
 import { getMainClasses } from '~utils/css';
 import Icon from '~core/Icon';
-import { SimpleMessageValues } from '~types/index';
+import { SimpleMessageValues, UniversalMessageValues } from '~types/index';
 
 import styles from './CustomRadio.css';
 
@@ -28,9 +28,11 @@ export interface Props {
   /** Button description */
   description?: string | MessageDescriptor;
   /** Description text values for intl interpolation */
-  descriptionValues?: SimpleMessageValues;
+  descriptionValues?: UniversalMessageValues;
   /** Button icon */
   icon?: string;
+  /** Button sufix label icon */
+  labelIcon?: string | null;
   /** If the input is checked */
   checked: boolean;
   /** Radio button name attribute */
@@ -53,16 +55,13 @@ const CustomRadio = ({
   description,
   descriptionValues,
   icon,
+  labelIcon,
 }: Props) => {
   const [, { error }, { setValue }] = useField(name);
   const { formatMessage } = useIntl();
   const inputRef = useRef<string>(inputId || nanoid());
   const labelText =
     typeof label === 'object' ? formatMessage(label, labelValues) : label;
-  const descriptionText =
-    typeof description === 'object'
-      ? formatMessage(description, descriptionValues)
-      : description;
   return (
     <label
       className={getMainClasses(appearance, styles, {
@@ -89,10 +88,25 @@ const CustomRadio = ({
         </div>
       )}
       <div className={styles.content}>
-        {labelText && <span className={styles.label}>{labelText}</span>}
-        {descriptionText && (
-          <span className={styles.description}>{descriptionText}</span>
+        {labelText && (
+          <span className={styles.label}>
+            {labelText}
+            {labelIcon && (
+              <Icon
+                appearance={{ size: 'normal' }}
+                name={labelIcon}
+                title={labelIcon}
+              />
+            )}
+          </span>
         )}
+        <span className={styles.description}>
+          {description && description === 'string' ? (
+            description
+          ) : (
+            <FormattedMessage {...description} values={descriptionValues} />
+          )}
+        </span>
       </div>
     </label>
   );

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
@@ -209,6 +209,13 @@ const MintTokenMotion = ({
           )}
         </div>
         <div className={styles.details}>
+          {motionState === MotionState.StakeRequired && (
+            <TotalStakeWidget
+              colonyAddress={colony.colonyAddress}
+              tokenDecimals={decimals}
+              motionId={motionId}
+            />
+          )}
           {(motionState === MotionState.StakeRequired ||
             motionState === MotionState.Motion ||
             motionState === MotionState.Objection) && (
@@ -251,13 +258,6 @@ const MintTokenMotion = ({
             transactionHash={transactionHash}
             colony={colony}
           />
-          {motionState === MotionState.StakeRequired && (
-            <TotalStakeWidget
-              colonyAddress={colony.colonyAddress}
-              tokenDecimals={decimals}
-              motionId={motionId}
-            />
-          )}
         </div>
       </div>
     </div>

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
@@ -24,6 +24,7 @@ import CountDownTimer from '~core/CountDownTimer';
 import { getTokenDecimalsWithFallback } from '~utils/tokens';
 import { MotionState, MOTION_TAG_MAP } from '~utils/colonyMotions';
 
+import TotalStakeWidget from '../TotalStakeWidget';
 import DetailsWidget from '../DetailsWidget';
 import StakingWidget from '../StakingWidget';
 import VoteWidget from '../VoteWidget';
@@ -59,6 +60,7 @@ const MintTokenMotion = ({
     annotationHash,
     colonyDisplayName,
     amount,
+    motionId,
     motionState,
     motionDomain,
     actionInitiator,
@@ -249,6 +251,13 @@ const MintTokenMotion = ({
             transactionHash={transactionHash}
             colony={colony}
           />
+          {motionState === MotionState.StakeRequired && (
+            <TotalStakeWidget
+              colonyAddress={colony.colonyAddress}
+              tokenDecimals={decimals}
+              motionId={motionId}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
@@ -161,7 +161,7 @@ const MintTokenMotion = ({
   );
 
   const stakeShownSide = getStakeShownSide();
-  const isOnStakingPhase =
+  const isStakingPhase =
     motionState === MotionState.StakeRequired ||
     motionState === MotionState.Motion ||
     motionState === MotionState.Objection;
@@ -236,7 +236,7 @@ const MintTokenMotion = ({
           )}
         </div>
         <div className={styles.details}>
-          {isOnStakingPhase && (
+          {isStakingPhase && (
             <TotalStakeWidget
               colonyAddress={colony.colonyAddress}
               motionId={motionId}
@@ -244,7 +244,7 @@ const MintTokenMotion = ({
               handleStakeSideSelect={setSelectedStakeSide}
             />
           )}
-          {isOnStakingPhase && stakeShownSide === StakeSide.Motion && (
+          {isStakingPhase && stakeShownSide === StakeSide.Motion && (
             <StakingWidget
               motionId={motionId}
               colony={colony}

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useRef } from 'react';
 import { FormattedMessage } from 'react-intl';
 
+import { bigNumberify } from 'ethers/utils';
 import Numeral from '~core/Numeral';
 import ActionsPageFeed, {
   ActionsPageFeedItem,
@@ -60,7 +61,7 @@ const MintTokenMotion = ({
     annotationHash,
     colonyDisplayName,
     amount,
-    motionId,
+    motionNAYStake,
     motionState,
     motionDomain,
     actionInitiator,
@@ -209,12 +210,20 @@ const MintTokenMotion = ({
           )}
         </div>
         <div className={styles.details}>
-          {motionState === MotionState.StakeRequired && (
-            <TotalStakeWidget
-              colonyAddress={colony.colonyAddress}
-              tokenDecimals={decimals}
-              motionId={motionId}
-            />
+          {motionState !== MotionState.StakeRequired && (
+            <>
+              <TotalStakeWidget
+                colonyAddress={colony.colonyAddress}
+                motionId={motionId}
+              />
+              {!bigNumberify(motionNAYStake || 0).eq(0) && (
+                <TotalStakeWidget
+                  colonyAddress={colony.colonyAddress}
+                  motionId={motionId}
+                  isObjectionStake
+                />
+              )}
+            </>
           )}
           {(motionState === MotionState.StakeRequired ||
             motionState === MotionState.Motion ||

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useCallback } from 'react';
+import React, { useMemo, useRef, useCallback, useState } from 'react';
 
 import { FormattedMessage } from 'react-intl';
 
@@ -91,7 +91,9 @@ const MintTokenMotion = ({
 
   const { username: currentUserName, ethereal } = useLoggedInUser();
 
-  const [selectedStakeSide, setSelectedStakeSide] = useState<StakeSide>();
+  const [selectedStakeSide, setSelectedStakeSide] = useState<StakeSide | null>(
+    null,
+  );
   const { data: motionsSystemMessagesData } = useMotionsSystemMessagesQuery({
     variables: {
       motionId,
@@ -142,7 +144,7 @@ const MintTokenMotion = ({
   };
   const motionStyles = MOTION_TAG_MAP[motionState || MotionState.Invalid];
 
-  const getStakeSide = useCallback((): StakeSide => {
+  const getStakeShownSide = useCallback((): StakeSide => {
     if (selectedStakeSide) {
       return selectedStakeSide;
     }
@@ -153,6 +155,16 @@ const MintTokenMotion = ({
 
     return StakeSide.Both;
   }, [selectedStakeSide, motionNAYStake]);
+  const previousTotalStakeStep = useCallback(
+    () => setSelectedStakeSide(null),
+    [],
+  );
+
+  const stakeShownSide = getStakeShownSide();
+  const isOnStakingPhase =
+    motionState === MotionState.StakeRequired ||
+    motionState === MotionState.Motion ||
+    motionState === MotionState.Objection;
 
   return (
     <div className={styles.main}>
@@ -224,24 +236,23 @@ const MintTokenMotion = ({
           )}
         </div>
         <div className={styles.details}>
-          {(motionState === MotionState.StakeRequired ||
-            motionState === MotionState.Motion ||
-            motionState === MotionState.Objection) && (
+          {isOnStakingPhase && (
             <TotalStakeWidget
               colonyAddress={colony.colonyAddress}
               motionId={motionId}
-              stakeSide={getStakeSide()}
+              stakeSide={stakeShownSide}
               handleStakeSideSelect={setSelectedStakeSide}
             />
           )}
-          {(motionState === MotionState.StakeRequired ||
-            motionState === MotionState.Motion ||
-            motionState === MotionState.Objection) && (
+          {isOnStakingPhase && stakeShownSide === StakeSide.Motion && (
             <StakingWidget
               motionId={motionId}
               colony={colony}
               scrollToRef={bottomElementRef}
               transactionHash={transactionHash}
+              previousTotalStakeStep={
+                selectedStakeSide && previousTotalStakeStep
+              }
             />
           )}
           {motionState === MotionState.Voting && (

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
@@ -25,7 +25,7 @@ import CountDownTimer from '~core/CountDownTimer';
 import { getTokenDecimalsWithFallback } from '~utils/tokens';
 import { MotionState, MOTION_TAG_MAP } from '~utils/colonyMotions';
 
-import TotalStakeWidget from '../TotalStakeWidget';
+import TotalStakeWidget, { StakeSide } from '../TotalStakeWidget';
 import DetailsWidget from '../DetailsWidget';
 import StakingWidget from '../StakingWidget';
 import VoteWidget from '../VoteWidget';
@@ -210,20 +210,16 @@ const MintTokenMotion = ({
           )}
         </div>
         <div className={styles.details}>
-          {motionState !== MotionState.StakeRequired && (
-            <>
-              <TotalStakeWidget
-                colonyAddress={colony.colonyAddress}
-                motionId={motionId}
-              />
-              {!bigNumberify(motionNAYStake || 0).eq(0) && (
-                <TotalStakeWidget
-                  colonyAddress={colony.colonyAddress}
-                  motionId={motionId}
-                  isObjectionStake
-                />
-              )}
-            </>
+          {motionState === MotionState.StakeRequired && (
+            <TotalStakeWidget
+              colonyAddress={colony.colonyAddress}
+              motionId={motionId}
+              stakeSide={
+                bigNumberify(motionNAYStake || 0).eq(0)
+                  ? StakeSide.Motion
+                  : StakeSide.Both
+              }
+            />
           )}
           {(motionState === MotionState.StakeRequired ||
             motionState === MotionState.Motion ||

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
@@ -28,6 +28,7 @@ type Props = {
   motionId: number;
   scrollToRef?: RefObject<HTMLInputElement>;
   transactionHash: string;
+  previousTotalStakeStep: (() => void) | null;
 };
 
 const displayName = 'StakingWidget';
@@ -49,6 +50,10 @@ const MSG = defineMessages({
     id: 'dashboard.ActionsPage.StakingWidget.objectButton',
     defaultMessage: 'Object',
   },
+  backButton: {
+    id: 'dashboard.ActionsPage.StakingWidget.backButton',
+    defaultMessage: 'Back',
+  },
   stakingTooltip: {
     id: 'dashboard.ActionsPage.StakingWidget.stakingTooltip',
     defaultMessage: '[TO BE ADDED]',
@@ -68,6 +73,7 @@ const StakingWidget = ({
   motionId,
   scrollToRef,
   transactionHash,
+  previousTotalStakeStep,
 }: Props) => {
   const { walletAddress, username, ethereal } = useLoggedInUser();
 
@@ -282,9 +288,15 @@ const StakingWidget = ({
                 text={MSG.stakeButton}
               />
               <Button
-                appearance={{ theme: 'danger', size: 'medium' }}
-                text={MSG.objectButton}
-                disabled={!canUserStake}
+                appearance={{
+                  theme: previousTotalStakeStep ? 'ghost' : 'danger',
+                  size: 'medium',
+                }}
+                text={
+                  previousTotalStakeStep ? MSG.backButton : MSG.objectButton
+                }
+                disabled={!previousTotalStakeStep && !canUserStake}
+                onClick={previousTotalStakeStep || undefined}
               />
             </div>
           </div>

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
@@ -50,10 +50,6 @@ const MSG = defineMessages({
     id: 'dashboard.ActionsPage.StakingWidget.objectButton',
     defaultMessage: 'Object',
   },
-  backButton: {
-    id: 'dashboard.ActionsPage.StakingWidget.backButton',
-    defaultMessage: 'Back',
-  },
   stakingTooltip: {
     id: 'dashboard.ActionsPage.StakingWidget.stakingTooltip',
     defaultMessage: '[TO BE ADDED]',
@@ -293,7 +289,9 @@ const StakingWidget = ({
                   size: 'medium',
                 }}
                 text={
-                  previousTotalStakeStep ? MSG.backButton : MSG.objectButton
+                  previousTotalStakeStep
+                    ? { id: 'button.back' }
+                    : MSG.objectButton
                 }
                 disabled={!previousTotalStakeStep && !canUserStake}
                 onClick={previousTotalStakeStep || undefined}

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/GroupedTotalStake.tsx
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/GroupedTotalStake.tsx
@@ -20,7 +20,7 @@ type Props = {
   isUserLoggedIn: boolean;
   formattedTotalYAYStakedPercentage: string;
   formattedTotalNAYStakedPercentage: string;
-  handleStakeSideSelect: Dispatch<SetStateAction<StakeSide | undefined>>;
+  handleStakeSideSelect: Dispatch<SetStateAction<StakeSide | null>>;
   tokenDecimals?: number;
   tokenSymbol?: string;
 };
@@ -156,15 +156,17 @@ const GroupedTotalStake = ({
               }}
               appearance={{ theme: 'danger' }}
               checked={values.stakeSide === StakeSide.Objection}
-              disabled={!isNAYSideFullyStaked || !isUserLoggedIn}
+              disabled={isNAYSideFullyStaked || !isUserLoggedIn}
             />
           </div>
-          <Button
-            type="submit"
-            appearance={{ theme: 'primary', size: 'medium' }}
-            text={MSG.nextButton}
-            disabled={!isValid || !isUserLoggedIn}
-          />
+          <div className={styles.submitButtonContainer}>
+            <Button
+              type="submit"
+              appearance={{ theme: 'primary', size: 'medium' }}
+              text={MSG.nextButton}
+              disabled={!isValid || !isUserLoggedIn || !values.stakeSide}
+            />
+          </div>
         </>
       )}
     </Form>

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/GroupedTotalStake.tsx
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/GroupedTotalStake.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { defineMessages } from 'react-intl';
+
+import Heading from '~core/Heading';
+import { CustomRadio } from '~core/Fields/Radio';
+import Numeral from '~core/Numeral';
+import { Form } from '~core/Fields';
+
+import { getTokenDecimalsWithFallback } from '~utils/tokens';
+
+import styles from './TotalStakeWidget.css';
+
+type Props = {
+  requiredStake: string | number;
+  formattedTotalYAYStakedPercentage: string;
+  formattedTotalNAYStakedPercentage: string;
+  tokenDecimals?: number;
+  tokenSymbol?: string;
+};
+
+const MSG = defineMessages({
+  stakeProgress: {
+    id:
+      'dashboard.ActionsPage.TotalStakeWidget.GroupedTotalStake.stakeProgress',
+    defaultMessage: '{totalPercentage}% of {requiredStake}',
+  },
+  crowdfundStakeTitle: {
+    id: `dashboard.ActionsPage.TotalStakeWidget.GroupedTotalStake.crowdfundStakeTitle`,
+    defaultMessage: 'Crowdfund stakes',
+  },
+  YAYName: {
+    id: 'dashboard.ActionsPage.TotalStakeWidget.GroupedTotalStake.YAYName',
+    defaultMessage: 'Motion',
+  },
+  NAYName: {
+    id: 'dashboard.ActionsPage.TotalStakeWidget.GroupedTotalStake.NAYName',
+    defaultMessage: 'Objection',
+  },
+  fullyStaked: {
+    id: 'dashboard.ActionsPage.TotalStakeWidget.GroupedTotalStake.fullyStaked',
+    defaultMessage: 'Fully staked',
+  },
+});
+
+const GroupedTotalStake = ({
+  requiredStake,
+  formattedTotalYAYStakedPercentage,
+  formattedTotalNAYStakedPercentage,
+  tokenDecimals,
+  tokenSymbol,
+}: Props) => {
+  const isYAYSideFullyStaked = formattedTotalYAYStakedPercentage === '100';
+  const isNAYSideFullyStaked = formattedTotalNAYStakedPercentage === '100';
+
+  /*
+   * @NOTE
+   *
+   * A Form component is added here just to make CustomRadio happy.
+   *
+   * This isn't really a Form, and those are not really Radio buttons.
+   *
+   * The CustomRadio are just there for the visuals.
+   */
+  // eslint-disable-next-line no-console
+  const handleSubmit = () => console.log('Time to submit');
+
+  return (
+    <Form initialValues={{}} onSubmit={handleSubmit}>
+      <div className={styles.widgetHeading}>
+        <Heading
+          appearance={{
+            theme: 'dark',
+            size: 'small',
+            weight: 'bold',
+            margin: 'none',
+          }}
+          text={MSG.crowdfundStakeTitle}
+          className={styles.title}
+        />
+      </div>
+      <div className={styles.totalStakeRadio}>
+        <CustomRadio
+          value=""
+          name="stakeYAY"
+          description={
+            isYAYSideFullyStaked ? MSG.fullyStaked : MSG.stakeProgress
+          }
+          descriptionValues={{
+            totalPercentage: formattedTotalYAYStakedPercentage,
+            requiredStake: (
+              <Numeral
+                value={requiredStake}
+                unit={getTokenDecimalsWithFallback(tokenDecimals)}
+                suffix={` ${tokenSymbol}`}
+                truncate={2}
+              />
+            ),
+          }}
+          label={MSG.YAYName}
+          labelIcon={isYAYSideFullyStaked ? 'circle-check-primary' : null}
+          appearance={{ theme: 'primary' }}
+          checked
+          disabled={isYAYSideFullyStaked}
+        />
+      </div>
+      <div className={styles.totalStakeRadio}>
+        <CustomRadio
+          value=""
+          name="stakeNAY"
+          description={
+            isNAYSideFullyStaked ? MSG.fullyStaked : MSG.stakeProgress
+          }
+          descriptionValues={{
+            totalPercentage: formattedTotalNAYStakedPercentage,
+            requiredStake: (
+              <Numeral
+                value={requiredStake}
+                unit={getTokenDecimalsWithFallback(tokenDecimals)}
+                suffix={` ${tokenSymbol}`}
+                truncate={2}
+              />
+            ),
+          }}
+          label={MSG.NAYName}
+          labelIcon={isNAYSideFullyStaked ? 'circle-check-primary' : null}
+          appearance={{ theme: 'danger' }}
+          checked
+          disabled={isNAYSideFullyStaked}
+        />
+      </div>
+    </Form>
+  );
+};
+
+export default GroupedTotalStake;

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/GroupedTotalStake.tsx
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/GroupedTotalStake.tsx
@@ -5,6 +5,7 @@ import Heading from '~core/Heading';
 import { CustomRadio } from '~core/Fields/Radio';
 import Numeral from '~core/Numeral';
 import { Form } from '~core/Fields';
+import QuestionMarkTooltip from '~core/QuestionMarkTooltip';
 
 import { getTokenDecimalsWithFallback } from '~utils/tokens';
 
@@ -39,6 +40,10 @@ const MSG = defineMessages({
   fullyStaked: {
     id: 'dashboard.ActionsPage.TotalStakeWidget.GroupedTotalStake.fullyStaked',
     defaultMessage: 'Fully staked',
+  },
+  totalStakeTooltip: {
+    id: `dashboard.ActionsPage.TotalStakeWidget.GroupedTotalStake.totalStakeTooltip`,
+    defaultMessage: `[TO BE ADDED WHEN AVAILABLE]`,
   },
 });
 
@@ -76,6 +81,13 @@ const GroupedTotalStake = ({
           }}
           text={MSG.crowdfundStakeTitle}
           className={styles.title}
+        />
+        <QuestionMarkTooltip
+          className={styles.tooltip}
+          tooltipText={MSG.totalStakeTooltip}
+          tooltipPopperProps={{
+            placement: 'right',
+          }}
         />
       </div>
       <div className={styles.totalStakeRadio}>

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/GroupedTotalStake.tsx
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/GroupedTotalStake.tsx
@@ -6,6 +6,7 @@ import { CustomRadio } from '~core/Fields/Radio';
 import Numeral from '~core/Numeral';
 import { Form } from '~core/Fields';
 import QuestionMarkTooltip from '~core/QuestionMarkTooltip';
+import Icon from '~core/Icon';
 
 import { getTokenDecimalsWithFallback } from '~utils/tokens';
 
@@ -31,11 +32,11 @@ const MSG = defineMessages({
   },
   YAYName: {
     id: 'dashboard.ActionsPage.TotalStakeWidget.GroupedTotalStake.YAYName',
-    defaultMessage: 'Motion',
+    defaultMessage: 'Motion {fullyStakedEmoji}',
   },
   NAYName: {
     id: 'dashboard.ActionsPage.TotalStakeWidget.GroupedTotalStake.NAYName',
-    defaultMessage: 'Objection',
+    defaultMessage: 'Objection {fullyStakedEmoji}',
   },
   fullyStaked: {
     id: 'dashboard.ActionsPage.TotalStakeWidget.GroupedTotalStake.fullyStaked',
@@ -109,7 +110,11 @@ const GroupedTotalStake = ({
             ),
           }}
           label={MSG.YAYName}
-          labelIcon={isYAYSideFullyStaked ? 'circle-check-primary' : null}
+          labelValues={{
+            fullyStakedEmoji: isYAYSideFullyStaked ? (
+              <Icon name="circle-check-primary" title={MSG.fullyStaked} />
+            ) : null,
+          }}
           appearance={{ theme: 'primary' }}
           checked
           disabled={isYAYSideFullyStaked}
@@ -134,7 +139,11 @@ const GroupedTotalStake = ({
             ),
           }}
           label={MSG.NAYName}
-          labelIcon={isNAYSideFullyStaked ? 'circle-check-primary' : null}
+          labelValues={{
+            fullyStakedEmoji: isNAYSideFullyStaked ? (
+              <Icon name="circle-check-primary" title={MSG.fullyStaked} />
+            ) : null,
+          }}
           appearance={{ theme: 'danger' }}
           checked
           disabled={isNAYSideFullyStaked}

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/SingleTotalStake.tsx
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/SingleTotalStake.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import formatNumber from 'format-number';
+import { bigNumberify } from 'ethers/utils';
+
+import Heading from '~core/Heading';
+import ProgressBar from '~core/ProgressBar';
+import Numeral from '~core/Numeral';
+import { getTokenDecimalsWithFallback } from '~utils/tokens';
+
+import { StakeSide } from './TotalStakeWidget';
+import styles from './TotalStakeWidget.css';
+
+type Props = {
+  requiredStake: string | number;
+  stakeSide: string;
+  totalPercentage: number;
+  formattedTotalPercentage: string;
+  userStake?: string | null;
+  tokenDecimals?: number;
+  tokenSymbol?: string;
+};
+
+const MSG = defineMessages({
+  motionTitle: {
+    id: 'dashboard.ActionsPage.TotalStakeWidget.SingleTotalStake.motionTitle',
+    defaultMessage: 'Stake',
+  },
+  objectionTitle: {
+    id:
+      'dashboard.ActionsPage.TotalStakeWidget.SingleTotalStake.objectionTitle',
+    defaultMessage: 'Goal',
+  },
+  stakeProgress: {
+    id: 'dashboard.ActionsPage.TotalStakeWidget.SingleTotalStake.stakeProgress',
+    defaultMessage: '{totalPercentage}% of {requiredStake}',
+  },
+  userStake: {
+    id: 'dashboard.ActionsPage.TotalStakeWidget.SingleTotalStake.userStake',
+    defaultMessage: `You staked {userPercentage}% of this motion ({userStake}).`,
+  },
+});
+
+const SingleTotalStake = ({
+  userStake,
+  requiredStake,
+  stakeSide,
+  totalPercentage,
+  formattedTotalPercentage,
+  tokenDecimals,
+  tokenSymbol,
+}: Props) => {
+  const userStakePercentage = bigNumberify(userStake || 0)
+    .mul(100)
+    .div(requiredStake)
+    .toNumber();
+  const formattedUserStakePercentage = formatNumber({
+    truncate: 2,
+  })(userStakePercentage);
+
+  return (
+    <>
+      <div className={styles.widgetHeading}>
+        <Heading
+          appearance={{
+            theme: 'dark',
+            size: 'small',
+            weight: 'bold',
+            margin: 'none',
+          }}
+          text={
+            stakeSide === StakeSide.Objection
+              ? MSG.objectionTitle
+              : MSG.motionTitle
+          }
+          className={styles.title}
+        />
+        <span className={styles.stakeProgress}>
+          <FormattedMessage
+            {...MSG.stakeProgress}
+            values={{
+              totalPercentage: formattedTotalPercentage,
+              requiredStake: (
+                <Numeral
+                  value={requiredStake}
+                  unit={getTokenDecimalsWithFallback(tokenDecimals)}
+                  suffix={tokenSymbol && ` ${tokenSymbol}`}
+                  truncate={2}
+                />
+              ),
+            }}
+          />
+        </span>
+      </div>
+      <ProgressBar
+        value={totalPercentage}
+        max={100}
+        appearance={{
+          barTheme: stakeSide === StakeSide.Objection ? 'danger' : 'primary',
+          backgroundTheme: 'default',
+        }}
+      />
+      {userStake && userStake !== '0' && (
+        <p className={styles.userStake}>
+          <FormattedMessage
+            {...MSG.userStake}
+            values={{
+              userPercentage: formattedUserStakePercentage,
+              userStake: (
+                <Numeral
+                  value={userStake}
+                  unit={getTokenDecimalsWithFallback(tokenDecimals)}
+                  suffix={tokenSymbol && ` ${tokenSymbol}`}
+                  truncate={2}
+                />
+              ),
+            }}
+          />
+        </p>
+      )}
+    </>
+  );
+};
+
+export default SingleTotalStake;

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css
@@ -1,0 +1,18 @@
+.widgetHeading {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 7px;
+}
+
+.stakeProgress {
+  font-size: var(--size-tiny);
+  font-weight: var(--weight-bold);
+  color: var(--dark);
+}
+
+.userStake {
+  margin-top: 16px;
+  font-size: var(--size-tiny);
+  font-weight: var(--weight-bold);
+  color: var(--temp-grey-blue-7);
+}

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css
@@ -9,6 +9,11 @@
   margin-bottom: 7px;
 }
 
+.title {
+  font-size: var(--size-smallish);
+  color: var(--dark);
+}
+
 .stakeProgress {
   font-size: var(--size-tiny);
   font-weight: var(--weight-bold);

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css
@@ -22,9 +22,14 @@
   color: var(--dark);
 }
 
-.userStake {
+.userStake,
+.userStake span {
   margin-top: 16px;
   font-size: var(--size-tiny);
   font-weight: var(--weight-bold);
   color: var(--temp-grey-blue-7);
+}
+
+.totalStakeRadio + .totalStakeRadio {
+  margin-top: 6px;
 }

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css
@@ -1,3 +1,8 @@
+.widget {
+  margin-top: 17px;
+  margin-bottom: 35px;
+}
+
 .widgetHeading {
   display: flex;
   justify-content: space-between;

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css
@@ -54,3 +54,9 @@
   margin-left: auto;
   width: fit-content;
 }
+
+.submitButtonContainer > button {
+  padding: 2px 35px;
+  font-size: var(--size-small);
+  font-weight: var(--weight-bold);
+}

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css
@@ -1,5 +1,5 @@
 .widget {
-  margin-top: 17px;
+  margin-top: 20px;
   margin-bottom: 35px;
 }
 
@@ -11,10 +11,12 @@
 
 .title {
   font-size: var(--size-smallish);
+  font-weight: var(--weight-bold);
   color: var(--dark);
 }
 
-.stakeProgress {
+.stakeProgress,
+.stakeProgress span {
   font-size: var(--size-tiny);
   font-weight: var(--weight-bold);
   color: var(--dark);

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css
@@ -33,3 +33,8 @@
 .totalStakeRadio + .totalStakeRadio {
   margin-top: 6px;
 }
+
+.tooltip {
+  margin-right: auto;
+  margin-left: 8px;
+}

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css
@@ -34,7 +34,17 @@
   margin-top: 6px;
 }
 
-.tooltip {
+.totalStakeRadio > label {
+  padding: 7px 10px 7px 16px;
+}
+
+.help {
   margin-right: auto;
   margin-left: 8px;
+}
+
+.tooltip {
+  margin-left: 10px;
+  padding: 10px;
+  width: 220px;
 }

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css
@@ -1,6 +1,5 @@
 .widget {
   margin-top: 20px;
-  margin-bottom: 35px;
 }
 
 .widgetHeading {
@@ -47,4 +46,11 @@
   margin-left: 10px;
   padding: 10px;
   width: 220px;
+}
+
+.submitButtonContainer {
+  margin-top: 10px;
+  margin-bottom: 105px;
+  margin-left: auto;
+  width: fit-content;
 }

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css.d.ts
@@ -3,3 +3,4 @@ export const widgetHeading: string;
 export const title: string;
 export const stakeProgress: string;
 export const userStake: string;
+export const totalStakeRadio: string;

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css.d.ts
@@ -6,3 +6,4 @@ export const userStake: string;
 export const totalStakeRadio: string;
 export const help: string;
 export const tooltip: string;
+export const submitButtonContainer: string;

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css.d.ts
@@ -1,0 +1,3 @@
+export const widgetHeading: string;
+export const stakeProgress: string;
+export const userStake: string;

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css.d.ts
@@ -4,3 +4,4 @@ export const title: string;
 export const stakeProgress: string;
 export const userStake: string;
 export const totalStakeRadio: string;
+export const tooltip: string;

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css.d.ts
@@ -1,3 +1,4 @@
+export const widget: string;
 export const widgetHeading: string;
 export const stakeProgress: string;
 export const userStake: string;

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css.d.ts
@@ -4,4 +4,5 @@ export const title: string;
 export const stakeProgress: string;
 export const userStake: string;
 export const totalStakeRadio: string;
+export const help: string;
 export const tooltip: string;

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css.d.ts
@@ -1,4 +1,5 @@
 export const widget: string;
 export const widgetHeading: string;
+export const title: string;
 export const stakeProgress: string;
 export const userStake: string;

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import Heading from '~core/Heading';
+import ProgressBar from '~core/ProgressBar';
+
+import styles from './TotalStakeWidget.css';
+
+const displayName = 'TotalStakeWidget';
+
+const MSG = defineMessages({
+  title: {
+    id: 'dashboard.ActionsPage.TotalStakeWidget.title',
+    defaultMessage: 'Stake',
+  },
+  stakeProgress: {
+    id: 'dashboard.ActionsPage.TotalStakeWidget.stakeProgress',
+    defaultMessage: '20% of 100.00 CLNY',
+  },
+  userStake: {
+    id: 'dashboard.ActionsPage.TotalStakeWidget.userStake',
+    defaultMessage: 'You staked 20% of this motion (20.000 CLNY).',
+  },
+});
+
+const TotalStakeWidget = () => {
+  return (
+    <div>
+      <div className={styles.widgetHeading}>
+        <Heading
+          appearance={{
+            theme: 'dark',
+            size: 'small',
+            weight: 'bold',
+            margin: 'none',
+          }}
+          text={MSG.title}
+        />
+        <span className={styles.stakeProgress}>
+          <FormattedMessage {...MSG.stakeProgress} />
+        </span>
+      </div>
+      <ProgressBar value={20} max={100} />
+      <p className={styles.userStake}>
+        <FormattedMessage {...MSG.userStake} />
+      </p>
+    </div>
+  );
+};
+
+TotalStakeWidget.displayName = displayName;
+
+export default TotalStakeWidget;

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.tsx
@@ -59,7 +59,6 @@ const TotalStakeWidget = ({
       tokenDecimals,
     },
   });
-  const { totalStaked, userStake, requiredStake } = data.stakeAmountsForMotion;
   const {
     data: nativeTokenAddressData,
     loading: loadingNativeTokenAddress,
@@ -84,13 +83,15 @@ const TotalStakeWidget = ({
     return null;
   }
 
+  const { totalStaked, userStake, requiredStake } = data.stakeAmountsForMotion;
+  const divisibleRequiredStake = requiredStake !== '0' ? requiredStake : 1;
   const totalStakedPercentage = bigNumberify(totalStaked)
     .mul(100)
-    .div(requiredStake || 1)
+    .div(divisibleRequiredStake)
     .toNumber();
   const userStakePercentage = bigNumberify(userStake)
     .mul(100)
-    .div(requiredStake || 1)
+    .div(divisibleRequiredStake)
     .toNumber();
   const formattedTotalStakedPercentage = formatNumber({
     truncate: 2,
@@ -100,7 +101,7 @@ const TotalStakeWidget = ({
   })(userStakePercentage);
 
   return (
-    <div>
+    <div className={styles.widget}>
       <div className={styles.widgetHeading}>
         <Heading
           appearance={{
@@ -132,7 +133,7 @@ const TotalStakeWidget = ({
           backgroundTheme: 'default',
         }}
       />
-      {userStake !== 0 && (
+      {userStake !== '0' && (
         <p className={styles.userStake}>
           {!loadingTokenInfoData && !loadingNativeTokenAddress && (
             <FormattedMessage

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.tsx
@@ -18,9 +18,8 @@ import styles from './TotalStakeWidget.css';
 const displayName = 'TotalStakeWidget';
 
 type Props = {
-  tokenDecimals: number;
   colonyAddress: Address;
-  motionId: string;
+  motionId: number;
   isObjectionStake?: boolean;
 };
 
@@ -44,7 +43,6 @@ const MSG = defineMessages({
 });
 
 const TotalStakeWidget = ({
-  tokenDecimals,
   colonyAddress,
   motionId,
   isObjectionStake = false,
@@ -56,7 +54,6 @@ const TotalStakeWidget = ({
       userAddress: walletAddress,
       motionId,
       isObjectionStake,
-      tokenDecimals,
     },
   });
   const {

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.tsx
@@ -111,6 +111,7 @@ const TotalStakeWidget = ({
             margin: 'none',
           }}
           text={isObjectionStake ? MSG.objectionTitle : MSG.motionTitle}
+          className={styles.title}
         />
         <span className={styles.stakeProgress}>
           {!loadingTokenInfoData && !loadingNativeTokenAddress && (

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.tsx
@@ -26,7 +26,7 @@ export enum StakeSide {
 type Props = {
   colonyAddress: Address;
   motionId: number;
-  handleStakeSideSelect: Dispatch<SetStateAction<StakeSide | undefined>>;
+  handleStakeSideSelect: Dispatch<SetStateAction<StakeSide | null>>;
   stakeSide?: StakeSide;
 };
 

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, Dispatch, SetStateAction } from 'react';
 import formatNumber from 'format-number';
 import { bigNumberify } from 'ethers/utils';
 
@@ -26,15 +26,17 @@ export enum StakeSide {
 type Props = {
   colonyAddress: Address;
   motionId: number;
-  stakeSide?: string;
+  handleStakeSideSelect: Dispatch<SetStateAction<StakeSide | undefined>>;
+  stakeSide?: StakeSide;
 };
 
 const TotalStakeWidget = ({
   colonyAddress,
   motionId,
   stakeSide = StakeSide.Motion,
+  handleStakeSideSelect,
 }: Props) => {
-  const { walletAddress } = useLoggedInUser();
+  const { walletAddress, username, ethereal } = useLoggedInUser();
   const { data, loading } = useStakeAmountsForMotionQuery({
     variables: {
       colonyAddress,
@@ -109,6 +111,8 @@ const TotalStakeWidget = ({
           formattedTotalYAYStakedPercentage={formattedTotalYAYStakedPercentage}
           tokenDecimals={tokenInfoData?.tokenInfo.decimals}
           tokenSymbol={tokenInfoData?.tokenInfo.symbol}
+          isUserLoggedIn={!!(username && !ethereal)}
+          handleStakeSideSelect={handleStakeSideSelect}
         />
       )}
     </div>

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.tsx
@@ -44,6 +44,7 @@ const TotalStakeWidget = ({
       motionId,
       stakeSide,
     },
+    fetchPolicy: 'network-only',
   });
   const { data: nativeTokenAddressData } = useColonyNativeTokenQuery({
     variables: { address: colonyAddress },

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/index.ts
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TotalStakeWidget';

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/index.ts
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/index.ts
@@ -1,1 +1,1 @@
-export { default } from './TotalStakeWidget';
+export { default, StakeSide } from './TotalStakeWidget';

--- a/src/modules/dashboard/sagas/motions/stakeMotion.ts
+++ b/src/modules/dashboard/sagas/motions/stakeMotion.ts
@@ -5,6 +5,8 @@ import { Action, ActionTypes, AllActions } from '~redux/index';
 import { TEMP_getContext, ContextModule } from '~context/index';
 import { putError, takeFrom } from '~utils/saga/effects';
 
+import { StakeSide } from '~dashboard/ActionsPage/TotalStakeWidget';
+
 import {
   createTransaction,
   createTransactionChannels,
@@ -119,6 +121,7 @@ function* stakeMotion({
       userAddress,
       motionId,
       transactionHash,
+      StakeSide.Motion,
     );
 
     yield put<AllActions>({

--- a/src/modules/dashboard/sagas/utils/updateMotionValues.ts
+++ b/src/modules/dashboard/sagas/utils/updateMotionValues.ts
@@ -31,7 +31,7 @@ export function* updateMotionValues(
   userAddress: Address,
   motionId: BigNumber,
   transactionHash: string,
-  stakeSide: string,
+  stakeSide?: string,
 ) {
   const apolloClient = TEMP_getContext(ContextModule.ApolloClient);
 
@@ -80,22 +80,24 @@ export function* updateMotionValues(
     fetchPolicy: 'network-only',
   });
 
-  /*
-   * Total stake widget values
-   */
-  yield apolloClient.query<
-    StakeAmountsForMotionQuery,
-    StakeAmountsForMotionQueryVariables
-  >({
-    query: StakeAmountsForMotionDocument,
-    variables: {
-      colonyAddress,
-      userAddress,
-      motionId: motionId.toNumber(),
-      stakeSide,
-    },
-    fetchPolicy: 'network-only',
-  });
+  if (stakeSide) {
+    /*
+     * Total stake widget values
+     */
+    yield apolloClient.query<
+      StakeAmountsForMotionQuery,
+      StakeAmountsForMotionQueryVariables
+    >({
+      query: StakeAmountsForMotionDocument,
+      variables: {
+        colonyAddress,
+        userAddress,
+        motionId: motionId.toNumber(),
+        stakeSide,
+      },
+      fetchPolicy: 'network-only',
+    });
+  }
 
   /*
    * Motion Events

--- a/src/modules/dashboard/sagas/utils/updateMotionValues.ts
+++ b/src/modules/dashboard/sagas/utils/updateMotionValues.ts
@@ -21,6 +21,9 @@ import {
   MotionCurrentUserVotedQuery,
   MotionCurrentUserVotedQueryVariables,
   MotionCurrentUserVotedDocument,
+  StakeAmountsForMotionQuery,
+  StakeAmountsForMotionQueryVariables,
+  StakeAmountsForMotionDocument,
 } from '~data/index';
 
 export function* updateMotionValues(
@@ -28,6 +31,7 @@ export function* updateMotionValues(
   userAddress: Address,
   motionId: BigNumber,
   transactionHash: string,
+  stakeSide: string,
 ) {
   const apolloClient = TEMP_getContext(ContextModule.ApolloClient);
 
@@ -72,6 +76,23 @@ export function* updateMotionValues(
       colonyAddress,
       userAddress,
       motionId: motionId.toNumber(),
+    },
+    fetchPolicy: 'network-only',
+  });
+
+  /*
+   * Total stake widget values
+   */
+  yield apolloClient.query<
+    StakeAmountsForMotionQuery,
+    StakeAmountsForMotionQueryVariables
+  >({
+    query: StakeAmountsForMotionDocument,
+    variables: {
+      colonyAddress,
+      userAddress,
+      motionId: motionId.toNumber(),
+      stakeSide,
     },
     fetchPolicy: 'network-only',
   });

--- a/src/utils/colonyMotions.ts
+++ b/src/utils/colonyMotions.ts
@@ -1,5 +1,10 @@
 import { defineMessage } from 'react-intl';
 
+export enum MotionVote {
+  NAY = 0,
+  YAY = 1,
+}
+
 export enum MotionState {
   Motion = 'Motion',
   StakeRequired = 'StakeRequired',

--- a/src/utils/colonyMotions.ts
+++ b/src/utils/colonyMotions.ts
@@ -1,4 +1,5 @@
 import { defineMessage } from 'react-intl';
+import { BigNumber, bigNumberify } from 'ethers/utils';
 
 export enum MotionVote {
   NAY = 0,
@@ -105,4 +106,16 @@ export const MOTION_TAG_MAP = {
     name: MSG.invalidTag,
     tagName: 'invalidTag',
   },
+};
+
+export const getMotionRequiredStake = (
+  skillRep: BigNumber,
+  totalStakeFraction: BigNumber,
+  decimals: number,
+): BigNumber => {
+  const requiredStake = skillRep
+    .mul(totalStakeFraction)
+    .div(bigNumberify(10).pow(decimals));
+
+  return requiredStake;
 };

--- a/src/utils/colonyMotions.ts
+++ b/src/utils/colonyMotions.ts
@@ -1,11 +1,6 @@
 import { defineMessage } from 'react-intl';
 import { BigNumber, bigNumberify } from 'ethers/utils';
 
-export enum MotionVote {
-  NAY = 0,
-  YAY = 1,
-}
-
 export enum MotionState {
   Motion = 'Motion',
   StakeRequired = 'StakeRequired',

--- a/src/utils/events/index.ts
+++ b/src/utils/events/index.ts
@@ -583,6 +583,7 @@ const getMintTokensMotionValues = async (
   const tokenAddress = await colonyClient.getToken();
 
   const mintTokensMotionValues: {
+    motionId: string;
     motionState: MotionState;
     address: Address;
     amount: string;
@@ -591,6 +592,7 @@ const getMintTokensMotionValues = async (
     tokenAddress: Address;
     motionDomain: number;
   } = {
+    motionId,
     motionState,
     address: motionCreatedEvent.address,
     recipient: motion.altTarget,

--- a/src/utils/events/index.ts
+++ b/src/utils/events/index.ts
@@ -583,7 +583,7 @@ const getMintTokensMotionValues = async (
   const tokenAddress = await colonyClient.getToken();
 
   const mintTokensMotionValues: {
-    motionId: string;
+    motionNAYStake: string;
     motionState: MotionState;
     address: Address;
     amount: string;
@@ -592,7 +592,7 @@ const getMintTokensMotionValues = async (
     tokenAddress: Address;
     motionDomain: number;
   } = {
-    motionId,
+    motionNAYStake: motion.stakes[0].toString(),
     motionState,
     address: motionCreatedEvent.address,
     recipient: motion.altTarget,

--- a/src/utils/events/index.ts
+++ b/src/utils/events/index.ts
@@ -30,7 +30,7 @@ import ipfs from '~context/ipfsWithFallbackContext';
 import { log } from '~utils/debug';
 
 import { getSetUserRolesMessageDescriptorsIds } from '../colonyActions';
-import { MotionState } from '../colonyMotions';
+import { getMotionRequiredStake, MotionState } from '../colonyMotions';
 
 interface ActionValues {
   recipient: Address;
@@ -507,9 +507,11 @@ export const getMotionState = async (
   motion,
 ): Promise<MotionState> => {
   const totalStakeFraction = await votingClient.getTotalStakeFraction();
-  const requiredStakes = bigNumberify(motion.skillRep)
-    .mul(totalStakeFraction)
-    .div(bigNumberify(10).pow(18));
+  const requiredStakes = getMotionRequiredStake(
+    motion.skillRep,
+    totalStakeFraction,
+    18,
+  );
   switch (motionNetworkState) {
     case NetworkMotionState.Staking:
       return bigNumberify(motion.stakes[0]).gt(bigNumberify(0)) ||


### PR DESCRIPTION
Added TotalStakeWidget with reducers included

**New stuff** ✨

* Added TotalStakeWidget to show the total staked for/against the motion
* Added TotalStakeWidget subcomponent to allow the user to select the side to stake on
* Added query with a local resolver to get the user stake, total stake, and required stake
* Added getMotionRequiredStake function

**Changes** 🏗

* Integrated StakingWidget with TotalStakeWidget

**When there's no stake on the NAY side**
![FireShot Capture 239 - Colony - localhost](https://user-images.githubusercontent.com/18473896/116252071-9d629e00-a745-11eb-8f44-b282197c6a35.png)

**When there's a stake on the NAY side but the user is not logged in**
![FireShot Capture 242 - Colony - localhost](https://user-images.githubusercontent.com/18473896/116252081-9f2c6180-a745-11eb-8a8a-85e08b67e499.png)

**When there's a stake on the NAY side and the user is logged in**
![FireShot Capture 245 - Colony - localhost](https://user-images.githubusercontent.com/18473896/116252087-a05d8e80-a745-11eb-940d-0f95d5216320.png)

**When there's a stake on the NAY side and the user selected a side to stake in**
![FireShot Capture 248 - Colony - localhost](https://user-images.githubusercontent.com/18473896/116252092-a2275200-a745-11eb-9266-ac3ac8406305.png)

**When you choose a side to stake on, a StakingWidget will appear but with a `Back` button**
![FireShot Capture 251 - Colony - localhost](https://user-images.githubusercontent.com/18473896/116252103-a489ac00-a745-11eb-8954-c67be3935025.png)

**When you choose the NAY side. TODO: Add Objection StakingWidget**
![FireShot Capture 254 - Colony - localhost](https://user-images.githubusercontent.com/18473896/116252111-a5bad900-a745-11eb-80c1-5865507bfcf3.png)


Resolves DEV-255
