### PR TITLE
Fix Permission Modal bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1483,9 +1483,9 @@
       }
     },
     "@colony/colony-js": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-3.1.0.tgz",
-      "integrity": "sha512-8k/oUkhlUenS2O9OWh7sRg7aClBIez+LrNhFOCWxAZTucO9wIZGmW+s87JZipfKM1c/dBLC0yLh9qQOghOxR8g==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-3.1.1.tgz",
+      "integrity": "sha512-SZ7JWPD/DPCPLmeOTm9Hefka9Wjs3AzPRfD2Ld4MXmCCXkywKAx5Qs425ETKO2g4Rc5VVZrjpNCDZZpr5BkVOw==",
       "requires": {
         "isomorphic-fetch": "^2.2.1",
         "lodash.isequal": "^4.5.0"

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.0.2",
-    "@colony/colony-js": "^3.1.0",
+    "@colony/colony-js": "^3.1.1",
     "@colony/redux-promise-listener": "^1.2.0",
     "@feedback-fish/react": "^1.2.1",
     "@formatjs/intl-pluralrules": "^1.5.7",

--- a/src/modules/dashboard/components/AdvancedDialog/AdvancedDialog.tsx
+++ b/src/modules/dashboard/components/AdvancedDialog/AdvancedDialog.tsx
@@ -124,7 +124,7 @@ const AdvancedDialog = ({
     parseInt(colonyVersion, 10) > ColonyVersion.LightweightSpaceship;
 
   const canEnterPermissionManagement =
-    hasRegisteredProfile && canArchitect(allUserRoles);
+    (hasRegisteredProfile && canArchitect(allUserRoles)) || hasRootPermission;
 
   const items = [
     {

--- a/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementCheckbox.tsx
+++ b/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementCheckbox.tsx
@@ -26,7 +26,7 @@ const MSG = defineMessages({
   },
   roleDescription3: {
     id: `dashboard.PermissionManagementDialog.PermissionManagementCheckbox.roleDescription3`,
-    defaultMessage: 'Set permissions for your team.',
+    defaultMessage: 'Set permissions in any sub-team.',
   },
   // We don't have architecture_subdomain (which would be 4)
   roleDescription5: {

--- a/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementCheckbox.tsx
+++ b/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementCheckbox.tsx
@@ -26,7 +26,7 @@ const MSG = defineMessages({
   },
   roleDescription3: {
     id: `dashboard.PermissionManagementDialog.PermissionManagementCheckbox.roleDescription3`,
-    defaultMessage: 'Set permissions in the active team, and any sub-team.',
+    defaultMessage: 'Set permissions for your team.',
   },
   // We don't have architecture_subdomain (which would be 4)
   roleDescription5: {

--- a/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementDialog.tsx
+++ b/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementDialog.tsx
@@ -38,7 +38,6 @@ import {
   getAllRootAccounts,
   getAllUserRolesForDomain,
 } from '../../../transformers';
-import { userHasRole } from '../../../users/checks';
 import PermissionManagementForm from './PermissionManagementForm';
 import { availableRoles } from './constants';
 
@@ -210,7 +209,10 @@ const PermissionManagementDialog = ({
     };
   });
 
-  const userHasPermission = selectedDomainId === ROOT_DOMAIN_ID && currentUserRolesInRoot.includes(ColonyRole.Root) || currentUserRolesInRoot.includes(ColonyRole.Architecture);
+  const userHasPermission =
+    (selectedDomainId === ROOT_DOMAIN_ID &&
+      currentUserRolesInRoot.includes(ColonyRole.Root)) ||
+    currentUserRolesInRoot.includes(ColonyRole.Architecture);
   const requiredRoles: ColonyRole[] = [ColonyRole.Architecture];
 
   return (

--- a/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementDialog.tsx
+++ b/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementDialog.tsx
@@ -109,6 +109,12 @@ const PermissionManagementDialog = ({
     selectedDomainId,
   ]);
 
+  const currentUserRolesInRoot = useTransformer(getUserRolesForDomain, [
+    colony,
+    loggedInUserWalletAddress,
+    ROOT_DOMAIN_ID,
+  ]);
+
   const userDirectRoles = useTransformer(getUserRolesForDomain, [
     colony,
     // USER TO SET PERMISSIONS FOR!
@@ -204,10 +210,7 @@ const PermissionManagementDialog = ({
     };
   });
 
-  const userHasPermission = userHasRole(
-    currentUserRoles,
-    ColonyRole.Architecture,
-  );
+  const userHasPermission = selectedDomainId === ROOT_DOMAIN_ID && currentUserRolesInRoot.includes(ColonyRole.Root) || currentUserRolesInRoot.includes(ColonyRole.Architecture);
   const requiredRoles: ColonyRole[] = [ColonyRole.Architecture];
 
   return (
@@ -268,6 +271,7 @@ const PermissionManagementDialog = ({
                   domainId={selectedDomainId}
                   rootAccounts={rootAccounts}
                   userDirectRoles={userDirectRoles}
+                  currentUserRolesInRoot={currentUserRolesInRoot}
                   userInheritedRoles={userInheritedRoles}
                   colonyDomains={domains}
                   onDomainSelected={setSelectedDomainId}

--- a/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementForm.tsx
+++ b/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementForm.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { defineMessages } from 'react-intl';
 import { ColonyRole, ROOT_DOMAIN_ID } from '@colony/colony-js';
 import sortBy from 'lodash/sortBy';
@@ -114,6 +114,16 @@ const PermissionManagementForm = ({
     [onDomainSelected],
   );
 
+  const filteredRoles = useMemo(
+    () =>
+      domainId !== ROOT_DOMAIN_ID
+        ? availableRoles.filter(
+            (role) => role !== ColonyRole.Root && role !== ColonyRole.Recovery,
+          )
+        : availableRoles,
+    [availableRoles, domainId],
+  );
+
   return (
     <>
       <div className={styles.domainSelectContainer}>
@@ -130,7 +140,7 @@ const PermissionManagementForm = ({
         appearance={{ colorSchema: 'grey' }}
       />
       <div className={styles.permissionChoiceContainer}>
-        {availableRoles.map((role) => {
+        {filteredRoles.map((role) => {
           const roleIsInherited =
             !userDirectRoles.includes(role) &&
             userInheritedRoles.includes(role);

--- a/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementForm.tsx
+++ b/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementForm.tsx
@@ -90,15 +90,7 @@ const PermissionManagementForm = ({
           return false;
       }
     },
-    [
-      currentUserRoles,
-      domainId,
-      rootAccounts,
-      userDirectRoles,
-      canSetPermissionsInRoot,
-      hasArchitectureInRoot,
-      hasRoot,
-    ],
+    [domainId, canSetPermissionsInRoot, hasArchitectureInRoot, hasRoot],
   );
 
   const domainSelectOptions = sortBy(
@@ -121,7 +113,7 @@ const PermissionManagementForm = ({
             (role) => role !== ColonyRole.Root && role !== ColonyRole.Recovery,
           )
         : availableRoles,
-    [availableRoles, domainId],
+    [domainId],
   );
 
   return (


### PR DESCRIPTION
## Description

- This PR adds fixes bugs related to setting permissions in management modal

**Changes** 🏗

* Updated architecture description to be more general
* Fixed advanced dialog to let user with root (and only root) permission to enter Permission Management dialog
* Fixed userHasPermissions flag in PermissionManagementDialog
* Fixed canRoleBeSet callback in PermissionManagementForm
* Hide root and recovery permission checkboxes from subdomains

**Notes** 🏗
* Run npm install before QA
* To change root domain permissions you need to have ROOT
* To change any permission in subdomain, you need to have architecture
* If you have architecture permission in subdomain, you CANNOT change anything in this domain -> only in future sub domains

Resolves DEV-259
