### PR TITLE
Show Join Colony Button for All Users

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonySubscription/ColonySubscription.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonySubscription/ColonySubscription.css
@@ -35,3 +35,14 @@
   background-color: color-mod(var(--colony-blue) alpha(10%));
   fill: var(--colony-blue);
 }
+
+.createUserRedirect {
+  font-size: var(--size-tiny);
+  font-weight: var(--weight-bold);
+  color: var(--colony-blue);
+}
+
+.createUserRedirect:hover {
+  text-decoration: underline;
+  color: var(--colony-blue);
+}

--- a/src/modules/dashboard/components/ColonyHome/ColonySubscription/ColonySubscription.css.d.ts
+++ b/src/modules/dashboard/components/ColonyHome/ColonySubscription/ColonySubscription.css.d.ts
@@ -3,3 +3,4 @@ export const joinColony: string;
 export const spinnerContainer: string;
 export const menuIconContainer: string;
 export const menuIcon: string;
+export const createUserRedirect: string;

--- a/src/modules/dashboard/components/ColonyHome/ColonySubscription/ColonySubscription.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonySubscription/ColonySubscription.tsx
@@ -4,6 +4,8 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 import { SpinnerLoader } from '~core/Preloaders';
 import Icon from '~core/Icon';
 import Button from '~core/Button';
+import Link from '~core/Link';
+
 import {
   useLoggedInUser,
   useSubscribeToColonyMutation,
@@ -12,8 +14,10 @@ import {
   cacheUpdates,
   Colony,
 } from '~data/index';
-import ColonySubscriptionInfoPopover from './ColonySubscriptionInfoPopover';
 import { ALLOWED_NETWORKS } from '~constants';
+import { CREATE_USER_ROUTE } from '~routes/index';
+
+import ColonySubscriptionInfoPopover from './ColonySubscriptionInfoPopover';
 
 import styles from './ColonySubscription.css';
 
@@ -54,13 +58,9 @@ const ColonySubscription = ({ colony: { colonyAddress }, colony }: Props) => {
     update: cacheUpdates.unsubscribeFromColony(colonyAddress),
   });
 
-  if (!username || !data) return null;
-
-  const {
-    user: { colonyAddresses },
-  } = data;
-
-  const isSubscribed = (colonyAddresses || []).includes(colonyAddress);
+  const isSubscribed = (data?.user?.colonyAddresses || []).includes(
+    colonyAddress,
+  );
 
   const isNetworkAllowed = !!ALLOWED_NETWORKS[networkId || 1];
 
@@ -72,13 +72,20 @@ const ColonySubscription = ({ colony: { colonyAddress }, colony }: Props) => {
             <SpinnerLoader appearance={{ theme: 'primary', size: 'small' }} />
           </div>
         ))}
-      {!isSubscribed && (
+      {!isSubscribed && username && (
         <Button
           onClick={() => subscribe()}
           appearance={{ theme: 'blue', size: 'small' }}
         >
           <FormattedMessage {...MSG.joinColony} />
         </Button>
+      )}
+      {!isSubscribed && !username && (
+        <Link
+          className={styles.createUserRedirect}
+          to={CREATE_USER_ROUTE}
+          text={MSG.joinColony}
+        />
       )}
       {isSubscribed && (
         <ColonySubscriptionInfoPopover


### PR DESCRIPTION
This PR refactors the `ColonySubscription` component to show the "Join" link for all users, but if the user doesn't have a username registered, then to the register user wizard flow

**Changes** 

- `ColonySubscription` show `Join` button or link for all users

**Screenshot**

![Screenshot from 2021-03-22 21-08-44](https://user-images.githubusercontent.com/1193222/112045296-5afcde80-8b53-11eb-9d78-7db21d6aa37e.png)

Resolves DEV-263
