### PR TITLE
Colony Title aligned with Colony Navigation

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyHomeLayout.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHomeLayout.css
@@ -30,7 +30,7 @@
 }
 
 .leftAside {
-  padding-top: 0px;
+  padding-top: 0;
   text-align: right;
 }
 

--- a/src/modules/dashboard/components/ColonyHome/ColonyHomeLayout.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHomeLayout.css
@@ -30,12 +30,12 @@
 }
 
 .leftAside {
-  padding-top: 60px;
+  padding-top: 0px;
   text-align: right;
 }
 
 .mainContent {
-  padding: 30px 0;
+  padding: 100px 0 30px;
 }
 
 .domainsDropdownContainer {
@@ -55,7 +55,7 @@
 }
 
 .rightAside {
-  padding-top: 155px;
+  padding-top: 225px;
   text-align: left;
 }
 

--- a/src/modules/dashboard/components/ColonyHome/ColonyHomeLayout.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHomeLayout.tsx
@@ -43,9 +43,9 @@ const ColonyHomeLayout = ({
   onDomainChange = () => null,
 }: Props) => (
   <div className={styles.main}>
-    <ColonyTitle colony={colony} />
     <div className={showSidebar ? styles.mainContentGrid : styles.minimalGrid}>
       <aside className={styles.leftAside}>
+        <ColonyTitle colony={colony} />
         {showNavigation && <ColonyNavigation />}
       </aside>
       <div className={styles.mainContent}>

--- a/src/modules/dashboard/components/ColonyHome/ColonyTitle/ColonyTitle.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyTitle/ColonyTitle.css
@@ -1,11 +1,18 @@
 .main {
   display: block;
-  margin: 0 0 0 82px;
+  margin: 0 -40px 50px;
   padding-top: 15px;
+  text-align: right;
+}
+
+.wrapper {
+  display: inline-block;
+  width: 225px;
+  text-align: left;
 }
 
 .colonyTitle {
-  padding-right: 40px;
+  padding: 0 0 0 4px;
 }
 
 .colonyTitle h3 {

--- a/src/modules/dashboard/components/ColonyHome/ColonyTitle/ColonyTitle.css.d.ts
+++ b/src/modules/dashboard/components/ColonyHome/ColonyTitle/ColonyTitle.css.d.ts
@@ -1,3 +1,4 @@
 export const main: string;
+export const wrapper: string;
 export const colonyTitle: string;
 export const colonyAddress: string;

--- a/src/modules/dashboard/components/ColonyHome/ColonyTitle/ColonyTitle.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyTitle/ColonyTitle.tsx
@@ -32,28 +32,30 @@ const ColonyTitle = ({
 }: Props) => {
   return (
     <div className={styles.main}>
-      <div className={styles.colonyTitle}>
-        <Heading
-          appearance={{
-            size: 'medium',
-            weight: 'thin',
-            margin: 'none',
-          }}
-          text={colonyDisplayName || colonyName || MSG.fallbackColonyName}
-        />
-      </div>
-      <div>
-        {colonyAddress && (
-          <InvisibleCopyableAddress
-            address={colonyAddress}
-            copyMessage={MSG.copyMessage}
-          >
-            <div className={styles.colonyAddress}>
-              <MaskedAddress address={colonyAddress} />
-            </div>
-          </InvisibleCopyableAddress>
-        )}
-        <ColonySubscription colony={colony} />
+      <div className={styles.wrapper}>
+        <div className={styles.colonyTitle}>
+          <Heading
+            appearance={{
+              size: 'medium',
+              weight: 'thin',
+              margin: 'none',
+            }}
+            text={colonyDisplayName || colonyName || MSG.fallbackColonyName}
+          />
+        </div>
+        <div>
+          {colonyAddress && (
+            <InvisibleCopyableAddress
+              address={colonyAddress}
+              copyMessage={MSG.copyMessage}
+            >
+              <div className={styles.colonyAddress}>
+                <MaskedAddress address={colonyAddress} />
+              </div>
+            </InvisibleCopyableAddress>
+          )}
+          <ColonySubscription colony={colony} />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
This PR refactors the colony home page so that the Colony Title will be aligned vertically with the colony navigation list

**Changes**

- `ColonyHomeLayout` move `ColonyTitle` to grid
- `ColonyTitle` align with `ColonyNavigation` 

**Screenshots**
![Screenshot from 2021-03-22 21-47-50](https://user-images.githubusercontent.com/1193222/112050699-d6fa2500-8b59-11eb-9ccb-b2452da3e10b.png)
![Screenshot from 2021-03-22 21-47-56](https://user-images.githubusercontent.com/1193222/112050706-d792bb80-8b59-11eb-8824-3c1e672603f5.png)

Resolves DEV-262