### PR TITLE
Fix Payment Action Roles in Static Map

### DIFF
--- a/src/modules/dashboard/components/ActionsPage/staticMaps.ts
+++ b/src/modules/dashboard/components/ActionsPage/staticMaps.ts
@@ -37,7 +37,10 @@ type ActionsDetailsMap = Partial<
  * Containing the actual event, and the role(s)
  */
 export const EVENT_ROLES_MAP: EventRolesMap = {
-  [ColonyAndExtensionsEvents.OneTxPaymentMade]: [ColonyRole.Administration],
+  [ColonyAndExtensionsEvents.OneTxPaymentMade]: [
+    ColonyRole.Administration,
+    ColonyRole.Funding,
+  ],
   [ColonyAndExtensionsEvents.ColonyFundsMovedBetweenFundingPots]: [
     ColonyRole.Funding,
   ],


### PR DESCRIPTION
This PR updates the payment action static map so that it shows the correct permissions, both `Administration` and `Funding` on the action page's event entry

**Changes** 

- Added `Funding` role to `OneTxPaymentMade` static map

**Screenshots**

![Screenshot from 2021-03-22 22-06-19](https://user-images.githubusercontent.com/1193222/112051913-25f48a00-8b5b-11eb-8f7c-67103ae770b6.png)

![Screenshot from 2021-03-22 22-08-39](https://user-images.githubusercontent.com/1193222/112051942-2db42e80-8b5b-11eb-8b27-9cdf5d75df87.png)


Resolves DEV-261