### PR TITLE
Permissions Modal rename Domain to Team

### DIFF
--- a/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementCheckbox.tsx
+++ b/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementCheckbox.tsx
@@ -26,12 +26,12 @@ const MSG = defineMessages({
   },
   roleDescription3: {
     id: `dashboard.PermissionManagementDialog.PermissionManagementCheckbox.roleDescription3`,
-    defaultMessage: 'Set permissions in the active domain, and any subdomain.',
+    defaultMessage: 'Set permissions in the active team, and any sub-team.',
   },
   // We don't have architecture_subdomain (which would be 4)
   roleDescription5: {
     id: `dashboard.PermissionManagementDialog.PermissionManagementCheckbox.roleDescription5`,
-    defaultMessage: 'Fund expenditures and transfer funds between domains.',
+    defaultMessage: 'Fund expenditures and transfer funds between teams.',
   },
   roleDescription6: {
     id: `dashboard.PermissionManagementDialog.PermissionManagementCheckbox.roleDescription6`,
@@ -43,7 +43,7 @@ const MSG = defineMessages({
   },
   tooltipNoRootDomainSelected: {
     id: `dashboard.PermissionManagementDialog.PermissionManagementCheckbox.tooltipNoRootDomainSelected`,
-    defaultMessage: 'Switch domain to #Root to set the root role.',
+    defaultMessage: 'Switch team to Root to set the root role.',
   },
 });
 

--- a/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementForm.tsx
+++ b/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementForm.tsx
@@ -15,7 +15,7 @@ import styles from './PermissionManagementDialog.css';
 const MSG = defineMessages({
   domain: {
     id: 'dashboard.PermissionManagementDialog.PermissionManagementForm.domain',
-    defaultMessage: 'Domain',
+    defaultMessage: 'Team',
   },
   permissionsLabel: {
     id: `dashboard


### PR DESCRIPTION
This PR renames the leftover instances of _"Domain"_ into _"Team"_, inside the Permissions Action Modal, since apparently we missed them the first time around.

**Changes** 

- Rename all instaces of `Domain` to `Team` in `PermissionsManagementDialog`

**Screenshot**

![Screenshot from 2021-03-22 22-20-24](https://user-images.githubusercontent.com/1193222/112053509-1b3af480-8b5d-11eb-9a26-09a082e4a667.png)

Resolves DEV-266
