### PR TITLE
Allow `HookedTokenIcon` to Fetch Token Images for More Networks

### DIFF
--- a/src/modules/constants.ts
+++ b/src/modules/constants.ts
@@ -138,8 +138,6 @@ export const ALLDOMAINS_DOMAIN_SELECTION = {
   description: '',
 };
 
-export const TOKEN_LOGOS_REPO_URL =
-  'https://raw.githubusercontent.com/trustwallet' +
-  '/assets/master/blockchains/ethereum/';
+export const TOKEN_LOGOS_REPO_URL = `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains`;
 
 export const NETWORK_RELEASES_URL = `https://github.com/JoinColony/colonyNetwork/releases/tag`;

--- a/src/modules/dashboard/components/HookedTokenIcon/HookedTokenIcon.tsx
+++ b/src/modules/dashboard/components/HookedTokenIcon/HookedTokenIcon.tsx
@@ -1,8 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Network } from '@colony/colony-js';
-
 import { AddressZero } from 'ethers/constants';
-import { TOKEN_LOGOS_REPO_URL, DEFAULT_NETWORK } from '~constants';
 
 import Avatar from '~core/Avatar';
 import { useDataFetcher } from '~utils/hooks';
@@ -10,6 +8,8 @@ import { AnyToken } from '~data/index';
 import { Address } from '~types/index';
 import Icon from '~core/Icon';
 import { getBase64image } from '~utils/dataReader';
+
+import { TOKEN_LOGOS_REPO_URL, DEFAULT_NETWORK } from '~constants';
 
 import { ipfsDataFetcher } from '../../../core/fetchers';
 
@@ -42,9 +42,11 @@ interface Props {
 const ICON_STORAGE = 'tokenImages';
 
 const loadTokenImages = async (address: Address): Promise<Response> => {
-  let tokenImageUrl = `${TOKEN_LOGOS_REPO_URL}${address}/logo.png`;
+  const network =
+    DEFAULT_NETWORK === Network.Mainnet ? 'ethereum' : DEFAULT_NETWORK;
+  let tokenImageUrl = `${TOKEN_LOGOS_REPO_URL}/${network}/${address}/logo.png`;
   if (address === AddressZero) {
-    tokenImageUrl = `${TOKEN_LOGOS_REPO_URL}info/logo.png`;
+    tokenImageUrl = `${TOKEN_LOGOS_REPO_URL}/${network}/info/logo.png`;
   }
   return fetch(tokenImageUrl);
 };
@@ -53,7 +55,8 @@ const HookedTokenIcon = ({
   name,
   token: { iconHash, address },
   iconName,
-  dontFetch = DEFAULT_NETWORK !== Network.Mainnet,
+  dontFetch = DEFAULT_NETWORK !== Network.Mainnet &&
+    DEFAULT_NETWORK !== Network.Xdai,
   ...props
 }: Props) => {
   const [tokenImage, setTokenImage] = useState<string | undefined>();


### PR DESCRIPTION
This PR does a small refactor to `HookedTokenIcon` so that it will fetch token icons on the Xdai network as well.

This is in lieu of adding the Xdai token logo manually, as this is more maintainable.

**Changes** 

- Change `constants` `TOKEN_LOGOS_REPO_URL` to allow for use of `network`
- Refactor `HookedTokenIcon` to determine network and fetch token icon based on that

**Screenshots**

![Screenshot from 2021-03-22 22-39-41](https://user-images.githubusercontent.com/1193222/112056484-bda8a700-8b60-11eb-94c3-ae2e4eb3816d.png)
![Screenshot from 2021-03-22 22-39-52](https://user-images.githubusercontent.com/1193222/112056488-be413d80-8b60-11eb-9862-15777c16dc75.png)

Resolves DEV-258