### PR TITLE
Add `TokenSymbolSelector` & replace in `TransferFunds` & `CreatePayment`

### DIFF
--- a/src/modules/core/components/Fields/Select/Select.tsx
+++ b/src/modules/core/components/Fields/Select/Select.tsx
@@ -29,7 +29,7 @@ const MSG = defineMessages({
   },
 });
 
-interface Props {
+export interface Props {
   /** Appearance object */
   appearance?: Appearance;
 
@@ -255,6 +255,8 @@ const Select = ({
           activeOption.label,
           activeOption.labelValues,
         );
+      } else if (activeOption.labelElement) {
+        activeOptionLabel = activeOption.labelElement;
       } else {
         activeOptionLabel = activeOption.label;
       }

--- a/src/modules/core/components/Fields/Select/types.ts
+++ b/src/modules/core/components/Fields/Select/types.ts
@@ -3,6 +3,8 @@ import { MessageDescriptor } from 'react-intl';
 
 import { SimpleMessageValues } from '~types/index';
 
+export { Props } from './Select';
+
 export interface Appearance {
   alignOptions?: 'left' | 'center' | 'right';
   borderedOptions?: 'true' | 'false';
@@ -18,4 +20,5 @@ export interface SelectOption {
   label: MessageDescriptor | string;
   value: string;
   labelValues?: SimpleMessageValues;
+  labelElement?: ReactNode;
 }

--- a/src/modules/core/components/Fields/TokenSymbolSelector/TokenSymbolSelector.css
+++ b/src/modules/core/components/Fields/TokenSymbolSelector/TokenSymbolSelector.css
@@ -1,0 +1,18 @@
+.labelElement {
+  display: flex;
+  align-items: center;
+}
+
+.labelElement > figure {
+  margin-right: 11px;
+}
+
+.symbol {
+  width: 55px;
+  text-align: left;
+}
+
+.optionElement {
+  composes: labelElement;
+  height: 42px;
+}

--- a/src/modules/core/components/Fields/TokenSymbolSelector/TokenSymbolSelector.css.d.ts
+++ b/src/modules/core/components/Fields/TokenSymbolSelector/TokenSymbolSelector.css.d.ts
@@ -1,0 +1,3 @@
+export const labelElement: string;
+export const symbol: string;
+export const optionElement: string;

--- a/src/modules/core/components/Fields/TokenSymbolSelector/TokenSymbolSelector.tsx
+++ b/src/modules/core/components/Fields/TokenSymbolSelector/TokenSymbolSelector.tsx
@@ -18,7 +18,7 @@ const displayName = 'TokenSymbolSelector';
 const TokenSymbolSelector = ({ tokens, ...props }: Props) => {
   const tokenOptions = useMemo(
     () =>
-      tokens?.map((token) => {
+      tokens.map((token) => {
         const labelElement = (
           elementType: 'labelElement' | 'optionElement',
         ) => (

--- a/src/modules/core/components/Fields/TokenSymbolSelector/TokenSymbolSelector.tsx
+++ b/src/modules/core/components/Fields/TokenSymbolSelector/TokenSymbolSelector.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 
-import { ColonyTokens, UserTokens } from '~data/index';
+import { AnyToken } from '~data/index';
 
 import Select from '~core/Fields/Select';
 import TokenIcon from '~dashboard/HookedTokenIcon';
@@ -10,7 +10,7 @@ import { Props as SelectProps } from '../Select/types';
 import styles from './TokenSymbolSelector.css';
 
 interface Props extends Omit<SelectProps, 'options'> {
-  tokens: ColonyTokens | UserTokens;
+  tokens: AnyToken[];
 }
 
 const displayName = 'TokenSymbolSelector';

--- a/src/modules/core/components/Fields/TokenSymbolSelector/TokenSymbolSelector.tsx
+++ b/src/modules/core/components/Fields/TokenSymbolSelector/TokenSymbolSelector.tsx
@@ -1,0 +1,54 @@
+import React, { useMemo } from 'react';
+
+import { ColonyTokens, UserTokens } from '~data/index';
+
+import Select from '~core/Fields/Select';
+import TokenIcon from '~dashboard/HookedTokenIcon';
+
+import { Props as SelectProps } from '../Select/types';
+
+import styles from './TokenSymbolSelector.css';
+
+interface Props extends Omit<SelectProps, 'options'> {
+  tokens: ColonyTokens | UserTokens;
+}
+
+const displayName = 'TokenSymbolSelector';
+
+const TokenSymbolSelector = ({ tokens, ...props }: Props) => {
+  const tokenOptions = useMemo(
+    () =>
+      tokens?.map((token) => {
+        const labelElement = (
+          elementType: 'labelElement' | 'optionElement',
+        ) => (
+          <div className={styles[elementType]}>
+            <TokenIcon
+              token={token}
+              name={token.name || undefined}
+              size="xxs"
+            />
+            <span
+              className={elementType === 'labelElement' ? styles.symbol : ''}
+            >
+              {token.symbol || '???'}
+            </span>
+          </div>
+        );
+
+        return {
+          value: token.address,
+          label: token.symbol,
+          labelElement: labelElement('labelElement'),
+          children: labelElement('optionElement'),
+        };
+      }),
+    [tokens],
+  );
+
+  return <Select options={tokenOptions} {...props} />;
+};
+
+TokenSymbolSelector.displayName = displayName;
+
+export default TokenSymbolSelector;

--- a/src/modules/core/components/Fields/TokenSymbolSelector/index.ts
+++ b/src/modules/core/components/Fields/TokenSymbolSelector/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TokenSymbolSelector';

--- a/src/modules/core/components/Fields/index.ts
+++ b/src/modules/core/components/Fields/index.ts
@@ -7,6 +7,7 @@ export { default as Input } from './Input';
 export { default as InputLabel } from './InputLabel';
 export { default as InputStatus } from './InputStatus';
 export { default as Select, Appearance, SelectOption } from './Select';
+export { default as TokenSymbolSelector } from './TokenSymbolSelector';
 export { default as Textarea, TextareaAutoresize } from './Textarea';
 export { default as Radio } from './Radio';
 export { default as RadioGroup } from './RadioGroup';

--- a/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialogForm.tsx
+++ b/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialogForm.tsx
@@ -17,7 +17,7 @@ import PermissionsLabel from '~core/PermissionsLabel';
 import Button from '~core/Button';
 import { ItemDataType } from '~core/OmniPicker';
 import DialogSection from '~core/Dialog/DialogSection';
-import { Select, Input, Annotations } from '~core/Fields';
+import { Select, Input, Annotations, TokenSymbolSelector } from '~core/Fields';
 import Heading from '~core/Heading';
 import SingleUserPicker, { filterUserSelection } from '~core/SingleUserPicker';
 import PermissionRequiredInfo from '~core/PermissionRequiredInfo';
@@ -136,15 +136,6 @@ const CreatePaymentDialogForm = ({
   const selectedToken = useMemo(
     () => tokens.find((token) => token.address === values.tokenAddress),
     [tokens, values.tokenAddress],
-  );
-
-  const tokenOptions = useMemo(
-    () =>
-      tokens.map(({ address, symbol }) => ({
-        value: address,
-        label: symbol || '???',
-      })),
-    [tokens],
   );
 
   const { walletAddress } = useLoggedInUser();
@@ -351,9 +342,9 @@ const CreatePaymentDialogForm = ({
             />
           </div>
           <div className={styles.tokenAmountSelect}>
-            <Select
+            <TokenSymbolSelector
               label={MSG.token}
-              options={tokenOptions}
+              tokens={tokens}
               name="tokenAddress"
               elementOnly
               appearance={{ alignOptions: 'right', theme: 'grey' }}

--- a/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialogForm.css
+++ b/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialogForm.css
@@ -1,9 +1,12 @@
 @value wideButton: 160px;
 
 .tokenAmount {
-  display: grid;
+  display: flex;
   width: 100%;
-  grid-template-columns: auto 120px;
+}
+
+.amountContainer {
+  width: 100%;
 }
 
 .tokenAmountSelect {

--- a/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialogForm.css.d.ts
+++ b/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialogForm.css.d.ts
@@ -1,5 +1,6 @@
 export const wideButton: string;
 export const tokenAmount: string;
+export const amountContainer: string;
 export const tokenAmountSelect: string;
 export const tokenAmountUsd: string;
 export const domainPotBalance: string;

--- a/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialogForm.tsx
+++ b/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialogForm.tsx
@@ -10,7 +10,13 @@ import { AddressZero } from 'ethers/constants';
 import { useTransformer } from '~utils/hooks';
 import Button from '~core/Button';
 import DialogSection from '~core/Dialog/DialogSection';
-import { Select, Input, FormStatus, Annotations } from '~core/Fields';
+import {
+  Select,
+  Input,
+  FormStatus,
+  Annotations,
+  TokenSymbolSelector,
+} from '~core/Fields';
 import Heading from '~core/Heading';
 import PermissionRequiredInfo from '~core/PermissionRequiredInfo';
 import PermissionsLabel from '~core/PermissionsLabel';
@@ -122,15 +128,6 @@ const TransferFundsDialogForm = ({
   const selectedToken = useMemo(
     () => tokens.find((token) => token.address === values.tokenAddress),
     [tokens, values.tokenAddress],
-  );
-
-  const tokenOptions = useMemo(
-    () =>
-      tokens.map(({ address, symbol }) => ({
-        value: address,
-        label: symbol || '???',
-      })),
-    [tokens],
   );
 
   const { walletAddress } = useLoggedInUser();
@@ -339,7 +336,7 @@ const TransferFundsDialogForm = ({
       </DialogSection>
       <DialogSection>
         <div className={styles.tokenAmount}>
-          <div>
+          <div className={styles.amountContainer}>
             <Input
               label={MSG.amount}
               name="amount"
@@ -359,9 +356,9 @@ const TransferFundsDialogForm = ({
             />
           </div>
           <div className={styles.tokenAmountSelect}>
-            <Select
+            <TokenSymbolSelector
               label={MSG.token}
-              options={tokenOptions}
+              tokens={tokens}
               name="tokenAddress"
               elementOnly
               appearance={{ alignOptions: 'right', theme: 'grey' }}


### PR DESCRIPTION
## Description

This PR adds  new core component TokenSymbolSelector that will work similarly to the Select, just that it will also need to display the token's avatar.

**New stuff** ✨

- add `TokenSymbolSelector`

**Changes** 🏗

- replace `Select` with `TokenSymbolSelector` in `TransferFundsDialogForm` & `CreatePaymentDialogForm`
- update css in `TransferFundsDialogForm` so that the avatar is not squashed

**Deletions** ⚰️

none

## TODO

none

Resolves DEV-265

<img width="536" alt="Screenshot 2021-03-24 at 18 57 54" src="https://user-images.githubusercontent.com/34057551/112368923-81e21e80-8cd3-11eb-932f-5205367898ad.png">
<img width="518" alt="Screenshot 2021-03-24 at 18 58 20" src="https://user-images.githubusercontent.com/34057551/112368932-83abe200-8cd3-11eb-867c-a50b6e6ddce9.png">
<img width="548" alt="Screenshot 2021-03-24 at 18 58 47" src="https://user-images.githubusercontent.com/34057551/112368934-84447880-8cd3-11eb-9161-2579ffa32336.png">

