### PR TITLE
Add mini side loading states

### DIFF
--- a/src/modules/core/components/Heading/Heading.tsx
+++ b/src/modules/core/components/Heading/Heading.tsx
@@ -8,7 +8,7 @@ import styles from './Heading.css';
 
 const displayName = 'Heading';
 
-type Appearance = {
+export type Appearance = {
   theme?: 'primary' | 'dark' | 'invert' | 'uppercase' | 'grey';
   margin?: 'none' | 'small' | 'double';
   size: 'tiny' | 'small' | 'normal' | 'medium' | 'large' | 'huge';

--- a/src/modules/core/components/Heading/index.ts
+++ b/src/modules/core/components/Heading/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Heading';
+export { default, Appearance } from './Heading';

--- a/src/modules/core/components/Preloaders/MiniSpinnerLoader.css
+++ b/src/modules/core/components/Preloaders/MiniSpinnerLoader.css
@@ -1,0 +1,7 @@
+.loadingText {
+  display: inline-block;
+  margin: -8px 0 0 5px;
+  vertical-align: middle;
+  font-size: var(--size-small);
+  letter-spacing: initial;
+}

--- a/src/modules/core/components/Preloaders/MiniSpinnerLoader.css.d.ts
+++ b/src/modules/core/components/Preloaders/MiniSpinnerLoader.css.d.ts
@@ -1,0 +1,1 @@
+export const loadingText: string;

--- a/src/modules/core/components/Preloaders/MiniSpinnerLoader.tsx
+++ b/src/modules/core/components/Preloaders/MiniSpinnerLoader.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { FormattedMessage, MessageDescriptor } from 'react-intl';
+
+import Heading, { Appearance as HeadingAppearance } from '~core/Heading';
+import { SimpleMessageValues } from '~types/index';
+
+import SpinnerLoader, { Appearance } from './SpinnerLoader';
+
+interface Props {
+  appearance?: Appearance;
+  titleAppearance?: HeadingAppearance;
+  title?: string | MessageDescriptor;
+  /** Values for text (react-intl interpolation) */
+  titleTextValues?: SimpleMessageValues;
+  loadingText?: string | MessageDescriptor;
+  className?: string;
+  loadingTextClassName?: string;
+}
+
+const MiniSpinnerLoader = ({
+  appearance,
+  titleAppearance = { size: 'normal', weight: 'bold' },
+  title,
+  titleTextValues,
+  loadingText,
+  className,
+  loadingTextClassName,
+}: Props) => {
+  return (
+    <div className={className}>
+      {title && (
+        <Heading
+          text={title}
+          textValues={titleTextValues}
+          appearance={titleAppearance}
+        />
+      )}
+      <SpinnerLoader appearance={appearance} />
+      {loadingText && (
+        <span className={loadingTextClassName}>
+          <FormattedMessage {...loadingText} />
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default MiniSpinnerLoader;

--- a/src/modules/core/components/Preloaders/MiniSpinnerLoader.tsx
+++ b/src/modules/core/components/Preloaders/MiniSpinnerLoader.tsx
@@ -5,6 +5,7 @@ import Heading, { Appearance as HeadingAppearance } from '~core/Heading';
 import { SimpleMessageValues } from '~types/index';
 
 import SpinnerLoader, { Appearance } from './SpinnerLoader';
+import styles from './MiniSpinnerLoader.css';
 
 interface Props {
   appearance?: Appearance;
@@ -37,7 +38,7 @@ const MiniSpinnerLoader = ({
       )}
       <SpinnerLoader appearance={appearance} />
       {loadingText && (
-        <span className={loadingTextClassName}>
+        <span className={loadingTextClassName || styles.loadingText}>
           <FormattedMessage {...loadingText} />
         </span>
       )}

--- a/src/modules/core/components/Preloaders/SpinnerLoader.css
+++ b/src/modules/core/components/Preloaders/SpinnerLoader.css
@@ -69,6 +69,10 @@
   user-select: none;
 }
 
+.themeGrey {
+  composes: main;
+}
+
 .themePrimary .loader {
   border-left-color: var(--primary);
   border-bottom-color: var(--primary);

--- a/src/modules/core/components/Preloaders/SpinnerLoader.css.d.ts
+++ b/src/modules/core/components/Preloaders/SpinnerLoader.css.d.ts
@@ -7,4 +7,5 @@ export const sizeLarge: string;
 export const sizeHuge: string;
 export const sizeMassive: string;
 export const loadingTextContainer: string;
+export const themeGrey: string;
 export const themePrimary: string;

--- a/src/modules/core/components/Preloaders/SpinnerLoader.tsx
+++ b/src/modules/core/components/Preloaders/SpinnerLoader.tsx
@@ -6,9 +6,9 @@ import { getMainClasses } from '~utils/css';
 
 import styles from './SpinnerLoader.css';
 
-interface Appearance {
+export interface Appearance {
   size: 'small' | 'medium' | 'large' | 'huge' | 'massive';
-  theme?: 'primary';
+  theme?: 'grey' | 'primary';
 }
 
 interface Props {
@@ -23,7 +23,7 @@ interface Props {
 }
 
 const SpinnerLoader = ({
-  appearance = { size: 'small' },
+  appearance = { size: 'small', theme: 'grey' },
   loadingText,
   textValues,
 }: Props) => {

--- a/src/modules/core/components/Preloaders/index.ts
+++ b/src/modules/core/components/Preloaders/index.ts
@@ -1,2 +1,3 @@
 export { default as SpinnerLoader } from './SpinnerLoader';
 export { default as DotsLoader } from './DotsLoader';
+export { default as MiniSpinnerLoader } from './MiniSpinnerLoader';

--- a/src/modules/dashboard/components/ActionsPage/InputStorageWidget/InputStorageWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/InputStorageWidget/InputStorageWidget.tsx
@@ -6,7 +6,7 @@ import { ColonyRole } from '@colony/colony-js';
 
 import Button from '~core/Button';
 import { ActionForm, TextareaAutoresize, InputStatus } from '~core/Fields';
-import { SpinnerLoader } from '~core/Preloaders';
+import { MiniSpinnerLoader } from '~core/Preloaders';
 
 import {
   Colony,
@@ -251,10 +251,10 @@ const InputStorageWidget = ({
             )}
             <div className={styles.currentValueText}>
               {loadinStorageSlotValue && (
-                <div className={styles.loadingSlotValue}>
-                  <SpinnerLoader />
-                  <FormattedMessage tagName="span" {...MSG.loadingSlotValue} />
-                </div>
+                <MiniSpinnerLoader
+                  className={styles.loadingSlotValue}
+                  loadingText={MSG.loadingSlotValue}
+                />
               )}
               {data?.getRecoveryStorageSlot && storageSlot && (
                 <FormattedMessage

--- a/src/modules/dashboard/components/ActionsPage/MultisigWidget/MultisigWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/MultisigWidget/MultisigWidget.css
@@ -90,11 +90,3 @@
   padding: 16px 0;
   border-bottom: 1px solid color-mod(var(--temp-grey-blue-7) alpha(15%));
 }
-
-.loadingText {
-  display: inline-block;
-  margin: -8px 0 0 5px;
-  vertical-align: middle;
-  font-size: var(--size-small);
-  letter-spacing: initial;
-}

--- a/src/modules/dashboard/components/ActionsPage/MultisigWidget/MultisigWidget.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/MultisigWidget/MultisigWidget.css.d.ts
@@ -11,4 +11,3 @@ export const buttonWrapper: string;
 export const totalRequired: string;
 export const tooltip: string;
 export const loading: string;
-export const loadingText: string;

--- a/src/modules/dashboard/components/ActionsPage/MultisigWidget/MultisigWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/MultisigWidget/MultisigWidget.tsx
@@ -7,7 +7,7 @@ import PermissionsLabel from '~core/PermissionsLabel';
 import ProgressBar from '~core/ProgressBar';
 import { ActionButton } from '~core/Button';
 import { Tooltip } from '~core/Popover';
-import { SpinnerLoader } from '~core/Preloaders';
+import { MiniSpinnerLoader } from '~core/Preloaders';
 
 import {
   Colony,
@@ -124,41 +124,34 @@ const MultisigWidget = ({
       userAddress === walletAddress,
   )?.approvedRecoveryExit;
 
+  const MembersWithPermissions = () => (
+    <div className={styles.title}>
+      <FormattedMessage
+        {...MSG.title}
+        values={{
+          permissionLabel: (
+            <PermissionsLabel permission={ColonyRole.Recovery} />
+          ),
+        }}
+      />
+    </div>
+  );
+
   if (loading) {
     return (
       <div className={styles.wrapper}>
-        <div className={styles.title}>
-          <FormattedMessage
-            {...MSG.title}
-            values={{
-              permissionLabel: (
-                <PermissionsLabel permission={ColonyRole.Recovery} />
-              ),
-            }}
-          />
-        </div>
-        <div className={styles.loading}>
-          <SpinnerLoader appearance={{ size: 'small' }} />
-          <span className={styles.loadingText}>
-            <FormattedMessage {...MSG.loadingData} />
-          </span>
-        </div>
+        <MembersWithPermissions />
+        <MiniSpinnerLoader
+          className={styles.loading}
+          loadingText={MSG.loadingData}
+        />
       </div>
     );
   }
 
   return (
     <div className={styles.wrapper}>
-      <div className={styles.title}>
-        <FormattedMessage
-          {...MSG.title}
-          values={{
-            permissionLabel: (
-              <PermissionsLabel permission={ColonyRole.Recovery} />
-            ),
-          }}
-        />
-      </div>
+      <MembersWithPermissions />
       <div className={styles.avatars}>
         {data?.recoveryRolesAndApprovalsForSession?.map((user) => (
           <div key={user.id}>

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeed.tsx
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeed.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useMemo, ReactElement, ReactNode } from 'react';
 import { nanoid } from 'nanoid';
-import { FormattedMessage, defineMessages } from 'react-intl';
+import { defineMessages } from 'react-intl';
 
-import { SpinnerLoader } from '~core/Preloaders';
+import { MiniSpinnerLoader } from '~core/Preloaders';
 
 import { getEventsForActions } from '~utils/events';
 
@@ -264,12 +264,11 @@ const ActionsPageFeed = ({
     <>
       <ul className={styles.main}>{customRenderWithFallback()}</ul>
       {(loadingServerComments || extenalLoadingState) && (
-        <div className={styles.loading}>
-          <SpinnerLoader />
-          <span className={styles.loaderMessage}>
-            <FormattedMessage {...MSG.loading} />
-          </span>
-        </div>
+        <MiniSpinnerLoader
+          className={styles.loading}
+          loadingTextClassName={styles.loaderMessage}
+          loadingText={MSG.loading}
+        />
       )}
     </>
   );

--- a/src/modules/dashboard/components/ColonyHome/ColonyExtensions/ColonyExtensions.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyExtensions/ColonyExtensions.css
@@ -24,11 +24,3 @@
 .invisibleLink:hover {
   color: color-mod(var(--dark) alpha(50%));
 }
-
-.loadingText {
-  display: inline-block;
-  margin: -8px 0 0 5px;
-  vertical-align: middle;
-  font-size: var(--size-small);
-  letter-spacing: initial;
-}

--- a/src/modules/dashboard/components/ColonyHome/ColonyExtensions/ColonyExtensions.css.d.ts
+++ b/src/modules/dashboard/components/ColonyHome/ColonyExtensions/ColonyExtensions.css.d.ts
@@ -1,4 +1,3 @@
 export const main: string;
 export const extension: string;
 export const invisibleLink: string;
-export const loadingText: string;

--- a/src/modules/dashboard/components/ColonyHome/ColonyExtensions/ColonyExtensions.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyExtensions/ColonyExtensions.tsx
@@ -3,7 +3,7 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 
 import Heading from '~core/Heading';
 import { Colony, useColonyExtensionsQuery } from '~data/index';
-import { SpinnerLoader } from '~core/Preloaders';
+import { MiniSpinnerLoader } from '~core/Preloaders';
 import extensionData from '~data/staticData/extensionData';
 
 import styles from './ColonyExtensions.css';
@@ -34,15 +34,11 @@ const ColonyExtensions = ({ colony: { colonyName, colonyAddress } }: Props) => {
 
   if (loading) {
     return (
-      <div className={styles.main}>
-        <Heading appearance={{ size: 'normal', weight: 'bold' }}>
-          <FormattedMessage {...MSG.title} />
-        </Heading>
-        <SpinnerLoader />
-        <span className={styles.loadingText}>
-          <FormattedMessage {...MSG.loadingData} />
-        </span>
-      </div>
+      <MiniSpinnerLoader
+        className={styles.main}
+        title={MSG.title}
+        loadingText={MSG.loadingData}
+      />
     );
   }
 

--- a/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.tsx
@@ -4,7 +4,7 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 import NavLink from '~core/NavLink';
 import Heading from '~core/Heading';
 import HookedUserAvatar from '~users/HookedUserAvatar';
-import { SpinnerLoader } from '~core/Preloaders';
+import { MiniSpinnerLoader } from '~core/Preloaders';
 import useAvatarDisplayCounter from '~utils/hooks/useAvatarDisplayCounter';
 import { Colony, useColonyMembersWithReputationQuery } from '~data/index';
 import { Address } from '~types/index';
@@ -68,17 +68,12 @@ const ColonyMembers = ({
 
   if (loadingColonyMembersWithReputation) {
     return (
-      <div className={styles.main}>
-        <Heading
-          appearance={{ size: 'normal', weight: 'bold' }}
-          text={MSG.title}
-          textValues={{ hasCounter: false }}
-        />
-        <SpinnerLoader appearance={{ size: 'small' }} />
-        <span className={styles.loadingText}>
-          <FormattedMessage {...MSG.loadingData} />
-        </span>
-      </div>
+      <MiniSpinnerLoader
+        className={styles.main}
+        title={MSG.title}
+        loadingText={MSG.loadingData}
+        titleTextValues={{ hasCounter: false }}
+      />
     );
   }
 

--- a/src/modules/dashboard/components/ColonyTotalFunds/ColonyTotalFunds.css
+++ b/src/modules/dashboard/components/ColonyTotalFunds/ColonyTotalFunds.css
@@ -10,14 +10,6 @@
   letter-spacing: 0.5px;
 }
 
-.loadingText {
-  display: inline-block;
-  margin: -8px 0 0 5px;
-  vertical-align: middle;
-  font-size: var(--size-small);
-  letter-spacing: initial;
-}
-
 .selectedToken {
   display: block;
   color: var(--dark);

--- a/src/modules/dashboard/components/ColonyTotalFunds/ColonyTotalFunds.css.d.ts
+++ b/src/modules/dashboard/components/ColonyTotalFunds/ColonyTotalFunds.css.d.ts
@@ -1,7 +1,6 @@
 export const tokenDisplaySymbolFontSize: string;
 export const tokenDisplayFontWeight: string;
 export const main: string;
-export const loadingText: string;
 export const selectedToken: string;
 export const selectedTokenAmount: string;
 export const selectedTokenSymbol: string;

--- a/src/modules/dashboard/components/ColonyTotalFunds/ColonyTotalFunds.tsx
+++ b/src/modules/dashboard/components/ColonyTotalFunds/ColonyTotalFunds.tsx
@@ -5,7 +5,7 @@ import { ColonyVersion } from '@colony/colony-js';
 import Icon from '~core/Icon';
 import Link from '~core/Link';
 import Numeral from '~core/Numeral';
-import { SpinnerLoader } from '~core/Preloaders';
+import { MiniSpinnerLoader } from '~core/Preloaders';
 import {
   Colony,
   useTokenBalancesForDomainsQuery,
@@ -89,12 +89,11 @@ const ColonyTotalFunds = ({
 
   if (!data || !currentToken || isLoadingTokenBalances) {
     return (
-      <div className={styles.main}>
-        <SpinnerLoader appearance={{ size: 'small' }} />
-        <span className={styles.loadingText}>
-          <FormattedMessage {...MSG.loadingData} />
-        </span>
-      </div>
+      <MiniSpinnerLoader
+        className={styles.main}
+        loadingText={MSG.loadingData}
+        titleTextValues={{ hasCounter: false }}
+      />
     );
   }
 

--- a/src/modules/dashboard/components/NetworkContractUpgradeDialog/NetworkContractUpgradeDialogForm.css
+++ b/src/modules/dashboard/components/NetworkContractUpgradeDialog/NetworkContractUpgradeDialogForm.css
@@ -69,11 +69,3 @@
   composes: permissionsWarning;
   background-color: color-mod(var(--primary) alpha(6%));
 }
-
-.loadingText {
-  display: inline-block;
-  margin: -8px 0 0 5px;
-  vertical-align: middle;
-  font-size: var(--size-small);
-  letter-spacing: initial;
-}

--- a/src/modules/dashboard/components/NetworkContractUpgradeDialog/NetworkContractUpgradeDialogForm.css.d.ts
+++ b/src/modules/dashboard/components/NetworkContractUpgradeDialog/NetworkContractUpgradeDialogForm.css.d.ts
@@ -8,4 +8,3 @@ export const warningTitle: string;
 export const warningDescription: string;
 export const highlightInstruction: string;
 export const loadingInfo: string;
-export const loadingText: string;

--- a/src/modules/dashboard/components/NetworkContractUpgradeDialog/NetworkContractUpgradeDialogForm.tsx
+++ b/src/modules/dashboard/components/NetworkContractUpgradeDialog/NetworkContractUpgradeDialogForm.tsx
@@ -9,7 +9,7 @@ import { Annotations } from '~core/Fields';
 import Heading from '~core/Heading';
 import PermissionsLabel from '~core/PermissionsLabel';
 import PermissionRequiredInfo from '~core/PermissionRequiredInfo';
-import { SpinnerLoader } from '~core/Preloaders';
+import { MiniSpinnerLoader } from '~core/Preloaders';
 
 import {
   Colony,
@@ -144,12 +144,10 @@ const NetworkContractUpgradeDialogForm = ({
       </DialogSection>
       {loadingLegacyRecoveyRole && (
         <DialogSection>
-          <div className={styles.loadingInfo}>
-            <SpinnerLoader appearance={{ size: 'small' }} />
-            <span className={styles.loadingText}>
-              <FormattedMessage {...MSG.loadingData} />
-            </span>
-          </div>
+          <MiniSpinnerLoader
+            className={styles.loadingInfo}
+            loadingText={MSG.loadingData}
+          />
         </DialogSection>
       )}
       {PREVENT_UPGRADE_IF_LEGACY_RECOVERY_ROLES && (

--- a/src/modules/dashboard/components/UnclaimedTransfers/UnclaimedTransfers.css
+++ b/src/modules/dashboard/components/UnclaimedTransfers/UnclaimedTransfers.css
@@ -8,11 +8,3 @@
   font-weight: var(--weight-bold);
   color: var(--dark);
 }
-
-.loadingText {
-  display: inline-block;
-  margin: -8px 0 0 5px;
-  vertical-align: middle;
-  font-size: var(--size-small);
-  letter-spacing: initial;
-}

--- a/src/modules/dashboard/components/UnclaimedTransfers/UnclaimedTransfers.css.d.ts
+++ b/src/modules/dashboard/components/UnclaimedTransfers/UnclaimedTransfers.css.d.ts
@@ -1,3 +1,2 @@
 export const main: string;
 export const title: string;
-export const loadingText: string;

--- a/src/modules/dashboard/components/UnclaimedTransfers/UnclaimedTransfers.tsx
+++ b/src/modules/dashboard/components/UnclaimedTransfers/UnclaimedTransfers.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { useColonyTransfersQuery, Colony } from '~data/index';
 
-import { SpinnerLoader } from '~core/Preloaders';
+import { MiniSpinnerLoader } from '~core/Preloaders';
 import UnclaimedTransfersItem from './UnclaimedTransfersItem';
 
 import styles from './UnclaimedTransfers.css';
@@ -32,12 +32,10 @@ const UnclaimedTransfers = ({ colony: { colonyAddress }, colony }: Props) => {
 
   if (loading) {
     return (
-      <div className={styles.main}>
-        <SpinnerLoader appearance={{ size: 'small' }} />
-        <span className={styles.loadingText}>
-          <FormattedMessage {...MSG.loadingData} />
-        </span>
-      </div>
+      <MiniSpinnerLoader
+        className={styles.main}
+        loadingText={MSG.loadingData}
+      />
     );
   }
 

--- a/src/modules/users/components/GasStation/MessageCard/MessageCardStatus.tsx
+++ b/src/modules/users/components/GasStation/MessageCard/MessageCardStatus.tsx
@@ -55,12 +55,7 @@ const MessageCardStatus = ({ status }: Props) => (
         )}
         {status === TRANSACTION_STATUSES.PENDING && (
           <div className={styles.spinner}>
-            <SpinnerLoader
-              appearance={{
-                size: 'small',
-                theme: 'primary',
-              }}
-            />
+            <SpinnerLoader appearance={{ size: 'small', theme: 'primary' }} />
           </div>
         )}
         {status === TRANSACTION_STATUSES.SUCCEEDED && (

--- a/src/modules/users/components/GasStation/TransactionCard/TransactionStatus.tsx
+++ b/src/modules/users/components/GasStation/TransactionCard/TransactionStatus.tsx
@@ -106,12 +106,7 @@ const TransactionStatus = ({
             className={styles.spinner}
             data-test="gasStationTransactionPending"
           >
-            <SpinnerLoader
-              appearance={{
-                size: 'small',
-                theme: 'primary',
-              }}
-            />
+            <SpinnerLoader appearance={{ size: 'small', theme: 'primary' }} />
           </div>
         )}
         {status === TRANSACTION_STATUSES.MULTISIG && (


### PR DESCRIPTION
## Description

This PR adds `MiniSpinnerLoader` core component to replace repetitive code in places where small spinners are used.

**New stuff** ✨

- add `MiniSpinnerLoader`

**Changes** 🏗

- replace `SpinnerLoader` with `MiniSpinnerLoader`
- replace repetitive css with standard css in `MiniSpinnerLoader`

**Deletions** ⚰️

none

## TODO

none

Resolves DEV-227
