### PR TITLE
Extract IPFS logic from ActionsPageFeedItem

### DIFF
--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultAction.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultAction.tsx
@@ -7,7 +7,7 @@ import { EventValue } from '~data/resolvers/colonyActions';
 import { parseDomainMetadata } from '~utils/colonyActions';
 
 import ActionsPageFeed, {
-  ActionsPageFeedItem,
+  ActionsPageFeedItemWithIPFS,
 } from '~dashboard/ActionsPageFeed';
 import ActionsPageComment from '~dashboard/ActionsPageComment';
 
@@ -183,11 +183,11 @@ const DefaultAction = ({
             />
           </h1>
           {actionType !== ColonyActions.Generic && annotationHash && (
-            <ActionsPageFeedItem
+            <ActionsPageFeedItemWithIPFS
               createdAt={createdAt}
               user={initiator}
               annotation
-              comment={annotationHash}
+              hash={annotationHash}
             />
           )}
           <ActionsPageFeed

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/RecoveryAction.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/RecoveryAction.tsx
@@ -9,6 +9,7 @@ import ActionsPageFeed, {
   SystemMessage,
   ActionsPageFeedType,
   ActionsPageFeedItem,
+  ActionsPageFeedItemWithIPFS,
   ActionsPageEvent,
   EventValues,
   FeedItemWithId,
@@ -213,11 +214,11 @@ const RecoveryAction = ({
             />
           </h1>
           {annotationHash && (
-            <ActionsPageFeedItem
+            <ActionsPageFeedItemWithIPFS
               createdAt={actionCreatedAt}
               user={initiator}
               annotation
-              comment={annotationHash}
+              hash={annotationHash}
             />
           )}
           <ActionsPageFeed

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeedItem/ActionsPageFeedItem.tsx
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeedItem/ActionsPageFeedItem.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 
 import { TransactionMeta } from '~dashboard/ActionsPage';
 import UserMention from '~core/UserMention';
@@ -8,14 +8,12 @@ import { getMainClasses } from '~utils/css';
 import TextDecorator from '~lib/TextDecorator';
 import { AnyUser } from '~data/index';
 import FriendlyName from '~core/FriendlyName';
-import { useDataFetcher } from '~utils/hooks';
-import { ipfsDataFetcher } from '../../../../core/fetchers';
 
 import styles from './ActionsPageFeedItem.css';
 
 const displayName = 'dashboard.ActionsPageFeed.ActionsPageFeedItem';
 
-interface Props {
+export interface Props {
   comment?: string;
   user?: AnyUser | null;
   annotation?: boolean;
@@ -36,32 +34,6 @@ const ActionsPageFeedItem = ({
     ),
   });
 
-  const { data: annotationJSON } = useDataFetcher(
-    ipfsDataFetcher,
-    [annotation ? (comment as string) : ''], // Technically a bug, shouldn't need type override
-    [annotation ? comment : ''],
-  );
-
-  const getAnnotationMessage = useCallback(() => {
-    if (!annotationJSON) {
-      return undefined;
-    }
-    const annotationObject = JSON.parse(annotationJSON);
-    if (annotationObject && annotationObject.annotationMessage) {
-      return annotationObject.annotationMessage;
-    }
-    return undefined;
-  }, [annotationJSON]);
-
-  const annotationMessage = getAnnotationMessage();
-
-  /*
-   * This means that the annotation object is in a format we don't recognize
-   */
-  if (annotation && !annotationMessage) {
-    return null;
-  }
-
   return (
     <div className={getMainClasses({}, styles, { annotation })}>
       <div className={styles.avatar}>
@@ -81,7 +53,7 @@ const ActionsPageFeedItem = ({
           {createdAt && <TransactionMeta createdAt={createdAt} />}
         </div>
         <div className={styles.text}>
-          <Decorate>{annotation ? annotationMessage : comment}</Decorate>
+          <Decorate>{comment}</Decorate>
         </div>
       </div>
     </div>

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeedItem/index.ts
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeedItem/index.ts
@@ -1,1 +1,4 @@
-export { default } from './ActionsPageFeedItem';
+export {
+  default,
+  Props as ActionsPageFeedItemProps,
+} from './ActionsPageFeedItem';

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeedItemWithIPFS/ActionsPageFeedItemWithIPFS.tsx
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeedItemWithIPFS/ActionsPageFeedItemWithIPFS.tsx
@@ -1,0 +1,59 @@
+import React, { useCallback } from 'react';
+
+import { useDataFetcher } from '~utils/hooks';
+import { ipfsDataFetcher } from '../../../../core/fetchers';
+
+import ActionsPageFeedItem, {
+  ActionsPageFeedItemProps,
+} from '../ActionsPageFeedItem';
+
+const displayName = 'dashboard.ActionsPageFeed.ActionsPageFeedItemWithIPFS';
+
+interface Props extends ActionsPageFeedItemProps {
+  hash: string;
+}
+
+const ActionsPageFeedItemWithIPFS = ({
+  hash,
+  annotation = false,
+  comment,
+  ...rest
+}: Props) => {
+  const { data: ipfsDataJSON } = useDataFetcher(
+    ipfsDataFetcher,
+    [hash],
+    [hash],
+  );
+
+  const getAnnotationMessage = useCallback(() => {
+    if (!annotation || !ipfsDataJSON) {
+      return undefined;
+    }
+    const annotationObject = JSON.parse(ipfsDataJSON);
+    if (annotationObject && annotationObject.annotationMessage) {
+      return annotationObject.annotationMessage;
+    }
+    return undefined;
+  }, [annotation, ipfsDataJSON]);
+
+  const annotationMessage = getAnnotationMessage();
+
+  /*
+   * This means that the annotation object is in a format we don't recognize
+   */
+  if (annotation && !annotationMessage) {
+    return null;
+  }
+
+  return (
+    <ActionsPageFeedItem
+      {...rest}
+      comment={annotation ? annotationMessage : comment}
+      annotation={annotation}
+    />
+  );
+};
+
+ActionsPageFeedItemWithIPFS.displayName = displayName;
+
+export default ActionsPageFeedItemWithIPFS;

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeedItemWithIPFS/index.ts
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeedItemWithIPFS/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ActionsPageFeedItemWithIPFS';

--- a/src/modules/dashboard/components/ActionsPageFeed/index.ts
+++ b/src/modules/dashboard/components/ActionsPageFeed/index.ts
@@ -1,6 +1,7 @@
 export { default } from './ActionsPageFeed';
 export { default as ActionsPageEvent } from './ActionsPageEvent';
 export { default as ActionsPageFeedItem } from './ActionsPageFeedItem';
+export { default as ActionsPageFeedItemWithIPFS } from './ActionsPageFeedItemWithIPFS';
 export { default as ActionsPageSystemInfo } from './ActionsPageSystemInfo';
 export { default as ActionsPageSystemMessage } from './ActionsPageSystemMessage';
 


### PR DESCRIPTION
Extracted IPFS and annotation related logic from ActionsPageFeedItem into ActionsPageFeedItemWithIPFS

**New stuff** ✨

* New ActionsPageFeedItemWithIPFS component which receives all the props of the normal version of the component plus an `hash` props which is used to retrieve IPFS data (Right now it's only used to retrieve annotations)

**Deletions** ⚰️

* IPFS and annotation logic in ActionsPageFeedItem

Resolves DEV-228
