### PR TITLE
Add Motion has passed event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4348,9 +4348,9 @@
       }
     },
     "@colony/colony-js": {
-      "version": "4.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-4.0.0-beta.0.tgz",
-      "integrity": "sha512-sToWh8/GWpPwQzZaBKhDMsac1iPnxU4k7mVKiS7xlJhcFM/D0QyL/K9rJ72b1zdneuspW2MoPQyDASAnAPQ2Jg==",
+      "version": "4.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-4.0.0-rc.0.tgz",
+      "integrity": "sha512-RMVok3hCuQwCNLF7y0rQK34cjGK6L7NlnFyZ+/+owGwE7Hj20XKFplc+4qw8MJ/VRU+sz9Z5SzYjJV5yQw4ZrQ==",
       "requires": {
         "isomorphic-fetch": "^2.2.1",
         "lodash.isequal": "^4.5.0"

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.0.2",
-    "@colony/colony-js": "^4.0.0-beta.0",
+    "@colony/colony-js": "^4.0.0-rc.0",
     "@colony/redux-promise-listener": "^1.2.0",
     "@feedback-fish/react": "^1.2.1",
     "@formatjs/intl-pluralrules": "^1.5.7",

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -284,6 +284,7 @@ export type Query = {
   getRecoveryStorageSlot: Scalars['String'];
   legacyNumberOfRecoveryRoles: Scalars['Int'];
   loggedInUser: LoggedInUser;
+  motionsSystemMessages: Array<SystemMessage>;
   networkContracts: NetworkContracts;
   processedColony: ProcessedColony;
   processedMetaColony?: Maybe<ProcessedMetaColony>;
@@ -387,6 +388,12 @@ export type QueryGetRecoveryStorageSlotArgs = {
 
 
 export type QueryLegacyNumberOfRecoveryRolesArgs = {
+  colonyAddress: Scalars['String'];
+};
+
+
+export type QueryMotionsSystemMessagesArgs = {
+  motionId: Scalars['Int'];
   colonyAddress: Scalars['String'];
 };
 
@@ -1399,6 +1406,14 @@ export type LegacyNumberOfRecoveryRolesQueryVariables = Exact<{
 
 
 export type LegacyNumberOfRecoveryRolesQuery = Pick<Query, 'legacyNumberOfRecoveryRoles'>;
+
+export type MotionsSystemMessagesQueryVariables = Exact<{
+  motionId: Scalars['Int'];
+  colonyAddress: Scalars['String'];
+}>;
+
+
+export type MotionsSystemMessagesQuery = { motionsSystemMessages: Array<Pick<SystemMessage, 'type' | 'name' | 'createdAt'>> };
 
 export type SubgraphDomainsQueryVariables = Exact<{
   colonyAddress: Scalars['String'];
@@ -3380,6 +3395,42 @@ export function useLegacyNumberOfRecoveryRolesLazyQuery(baseOptions?: Apollo.Laz
 export type LegacyNumberOfRecoveryRolesQueryHookResult = ReturnType<typeof useLegacyNumberOfRecoveryRolesQuery>;
 export type LegacyNumberOfRecoveryRolesLazyQueryHookResult = ReturnType<typeof useLegacyNumberOfRecoveryRolesLazyQuery>;
 export type LegacyNumberOfRecoveryRolesQueryResult = Apollo.QueryResult<LegacyNumberOfRecoveryRolesQuery, LegacyNumberOfRecoveryRolesQueryVariables>;
+export const MotionsSystemMessagesDocument = gql`
+    query MotionsSystemMessages($motionId: Int!, $colonyAddress: String!) {
+  motionsSystemMessages(motionId: $motionId, colonyAddress: $colonyAddress) @client {
+    type
+    name
+    createdAt
+  }
+}
+    `;
+
+/**
+ * __useMotionsSystemMessagesQuery__
+ *
+ * To run a query within a React component, call `useMotionsSystemMessagesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useMotionsSystemMessagesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useMotionsSystemMessagesQuery({
+ *   variables: {
+ *      motionId: // value for 'motionId'
+ *      colonyAddress: // value for 'colonyAddress'
+ *   },
+ * });
+ */
+export function useMotionsSystemMessagesQuery(baseOptions?: Apollo.QueryHookOptions<MotionsSystemMessagesQuery, MotionsSystemMessagesQueryVariables>) {
+        return Apollo.useQuery<MotionsSystemMessagesQuery, MotionsSystemMessagesQueryVariables>(MotionsSystemMessagesDocument, baseOptions);
+      }
+export function useMotionsSystemMessagesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<MotionsSystemMessagesQuery, MotionsSystemMessagesQueryVariables>) {
+          return Apollo.useLazyQuery<MotionsSystemMessagesQuery, MotionsSystemMessagesQueryVariables>(MotionsSystemMessagesDocument, baseOptions);
+        }
+export type MotionsSystemMessagesQueryHookResult = ReturnType<typeof useMotionsSystemMessagesQuery>;
+export type MotionsSystemMessagesLazyQueryHookResult = ReturnType<typeof useMotionsSystemMessagesLazyQuery>;
+export type MotionsSystemMessagesQueryResult = Apollo.QueryResult<MotionsSystemMessagesQuery, MotionsSystemMessagesQueryVariables>;
 export const SubgraphDomainsDocument = gql`
     query SubgraphDomains($colonyAddress: String!) {
   domains(where: {colonyAddress: $colonyAddress}) {

--- a/src/data/graphql/queries.graphql
+++ b/src/data/graphql/queries.graphql
@@ -356,6 +356,13 @@ query LegacyNumberOfRecoveryRoles($colonyAddress: String!) {
   legacyNumberOfRecoveryRoles(colonyAddress: $colonyAddress) @client
 }
 
+query MotionsSystemMessages($motionId: Int!, $colonyAddress: String!) {
+  motionsSystemMessages(motionId: $motionId, colonyAddress: $colonyAddress) @client {
+    type
+    name
+    createdAt
+  }
+}
 
 # The Graph
 #

--- a/src/data/graphql/typeDefs.ts
+++ b/src/data/graphql/typeDefs.ts
@@ -260,6 +260,10 @@ export default gql`
     legacyNumberOfRecoveryRoles(colonyAddress: String!): Int!
     votingExtensionParams(colonyAddress: String!): VotingExtensionParams!
     blockTime(blockHash: String): Int!
+    motionsSystemMessages(
+      motionId: Int!
+      colonyAddress: String!
+    ): [SystemMessage!]!
   }
 
   extend type Mutation {

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -38,6 +38,7 @@ import { metaColonyResolvers } from './resolvers/metacolony';
 import { eventsResolvers } from './resolvers/events';
 import { recoveryModeResolvers } from './resolvers/recovery';
 import { extensionsResolvers } from './resolvers/extensions';
+import { motionsResolvers } from './resolvers/motions';
 
 import { FixedToken } from '../types';
 
@@ -64,6 +65,7 @@ export const resolvers: ResolverFactory[] = [
   eventsResolvers,
   recoveryModeResolvers,
   extensionsResolvers,
+  motionsResolvers,
 ];
 
 // export all the generated types and helpers

--- a/src/data/resolvers/colonyActions.ts
+++ b/src/data/resolvers/colonyActions.ts
@@ -170,7 +170,7 @@ export const colonyActionsResolvers = ({
           actionType = await getMotionActionType(
             votingClient as ExtensionClient,
             colonyClient as ColonyClient,
-            reverseSortedEvents[0],
+            motionCreatedEvent,
           );
         } else {
           actionType = getActionType(reverseSortedEvents);

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -5,6 +5,7 @@ import {
   getLogs,
   getBlockTime,
   ExtensionClient,
+  NetworkMotionState,
 } from '@colony/colony-js';
 
 import { Context } from '~context/index';
@@ -14,7 +15,6 @@ import {
   SystemMessage,
   SystemMessagesName,
 } from '~dashboard/ActionsPageFeed';
-import { NetworkMotionState } from '~utils/colonyMotions';
 
 import { ProcessedEvent } from './colonyActions';
 
@@ -35,6 +35,7 @@ export const motionsResolvers = ({
       );
       const systemMessages: SystemMessage[] = [];
 
+      // @TODO Add missing types to colonyjs
       // @ts-ignore
       const motionStakedFilter = votingReputationClient.filters.MotionStaked(
         motionId,

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -5,7 +5,7 @@ import {
   getLogs,
   getBlockTime,
   ExtensionClient,
-  NetworkMotionState,
+  MotionState as NetworkMotionState,
 } from '@colony/colony-js';
 
 import { Context } from '~context/index';

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -4,13 +4,11 @@ import {
   ClientType,
   getLogs,
   getBlockTime,
-  ExtensionClient
+  ExtensionClient,
 } from '@colony/colony-js';
 
 import { Context } from '~context/index';
-import {
-  ColonyAndExtensionsEvents,
-} from '~types/index';
+import { ColonyAndExtensionsEvents } from '~types/index';
 import {
   ActionsPageFeedType,
   SystemMessage,
@@ -32,46 +30,71 @@ export const motionsResolvers = ({
         colonyAddress,
       )) as ExtensionClient;
       const motion = await votingReputationClient.getMotion(motionId);
-      const motionNetworkState = await votingReputationClient.getMotionState(motionId);
+      const motionNetworkState = await votingReputationClient.getMotionState(
+        motionId,
+      );
       const systemMessages: SystemMessage[] = [];
 
       // @ts-ignore
-      const motionStakedFilter = votingReputationClient.filters.MotionStaked(motionId, null, null, null);
-      const motionStakedLogs = await getLogs(votingReputationClient, motionStakedFilter);
+      const motionStakedFilter = votingReputationClient.filters.MotionStaked(
+        motionId,
+        null,
+        null,
+        null,
+      );
+      const motionStakedLogs = await getLogs(
+        votingReputationClient,
+        motionStakedFilter,
+      );
       // @ts-ignore
-      const motionVoteRevealedFilter = votingReputationClient.filters.MotionVoteRevealed(motionId, null, null);
-      const motionVoteRevealedLogs = await getLogs(votingReputationClient, motionVoteRevealedFilter);
+      // eslint-disable-next-line max-len
+      const motionVoteRevealedFilter = votingReputationClient.filters.MotionVoteRevealed(
+        motionId,
+        null,
+        null,
+      );
+      const motionVoteRevealedLogs = await getLogs(
+        votingReputationClient,
+        motionVoteRevealedFilter,
+      );
 
       const parsedEvents = await Promise.all(
-        [...motionStakedLogs, ...motionVoteRevealedLogs].map(
-          async (log) => {
-            const parsedLog = votingReputationClient.interface.parseLog(log);
-            const { address, blockHash, blockNumber, transactionHash } = log;
-            const { name, values } = parsedLog;
-            return {
-              type: ActionsPageFeedType.NetworkEvent,
-              name,
-              values,
-              createdAt: blockHash
-                ? await getBlockTime(provider, blockHash)
-                : 0,
-              emmitedBy: ClientType.ColonyClient,
-              address,
-              blockNumber,
-              transactionHash,
-            } as ProcessedEvent;
-          },
-        ),
+        [...motionStakedLogs, ...motionVoteRevealedLogs].map(async (log) => {
+          const parsedLog = votingReputationClient.interface.parseLog(log);
+          const { address, blockHash, blockNumber, transactionHash } = log;
+          const { name, values } = parsedLog;
+          return {
+            type: ActionsPageFeedType.NetworkEvent,
+            name,
+            values,
+            createdAt: blockHash ? await getBlockTime(provider, blockHash) : 0,
+            emmitedBy: ClientType.ColonyClient,
+            address,
+            blockNumber,
+            transactionHash,
+          } as ProcessedEvent;
+        }),
       );
 
       const sortedEvents = parsedEvents.sort(
-        (firstEvent, secondEvent) => secondEvent.createdAt - firstEvent.createdAt,
+        (firstEvent, secondEvent) =>
+          secondEvent.createdAt - firstEvent.createdAt,
       );
 
-      if (motionNetworkState === NetworkMotionState.Finalizable || motionNetworkState === NetworkMotionState.Finalized) {
-        const newestStakeOrVoteEvent = sortedEvents.find(event => (event.name === ColonyAndExtensionsEvents.MotionStaked) || event.name === ColonyAndExtensionsEvents.MotionVoteRevealed);
+      if (
+        motionNetworkState === NetworkMotionState.Finalizable ||
+        motionNetworkState === NetworkMotionState.Finalized
+      ) {
+        const newestStakeOrVoteEvent = sortedEvents.find(
+          (event) =>
+            event.name === ColonyAndExtensionsEvents.MotionStaked ||
+            event.name === ColonyAndExtensionsEvents.MotionVoteRevealed,
+        );
         if (newestStakeOrVoteEvent) {
-          if (motion.votes[0].lt(motion.votes[1]) || motion.stakes[0].lt(motion.stakes[1])) {
+          if (
+            motion.votes[0].lt(motion.votes[1]) ||
+            motion.stakes[0].lt(motion.stakes[1])
+          ) {
             systemMessages.push({
               type: ActionsPageFeedType.SystemMessage,
               name: SystemMessagesName.MotionHasPassed,
@@ -83,5 +106,5 @@ export const motionsResolvers = ({
 
       return Promise.all(systemMessages);
     },
-  }
+  },
 });

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -35,8 +35,10 @@ export const motionsResolvers = ({
       const motionNetworkState = await votingReputationClient.getMotionState(motionId);
       const systemMessages: SystemMessage[] = [];
 
+      // @ts-ignore
       const motionStakedFilter = votingReputationClient.filters.MotionStaked(motionId, null, null, null);
       const motionStakedLogs = await getLogs(votingReputationClient, motionStakedFilter);
+      // @ts-ignore
       const motionVoteRevealedFilter = votingReputationClient.filters.MotionVoteRevealed(motionId, null, null);
       const motionVoteRevealedLogs = await getLogs(votingReputationClient, motionVoteRevealedFilter);
 

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -1,0 +1,85 @@
+import { Resolvers } from '@apollo/client';
+
+import {
+  ClientType,
+  getLogs,
+  getBlockTime,
+  ExtensionClient
+} from '@colony/colony-js';
+
+import { Context } from '~context/index';
+import {
+  ColonyAndExtensionsEvents,
+} from '~types/index';
+import {
+  ActionsPageFeedType,
+  SystemMessage,
+  SystemMessagesName,
+} from '~dashboard/ActionsPageFeed';
+import { NetworkMotionState } from '~utils/colonyMotions';
+
+import { ProcessedEvent } from './colonyActions';
+
+export const motionsResolvers = ({
+  colonyManager: { networkClient },
+  colonyManager,
+}: Required<Context>): Resolvers => ({
+  Query: {
+    async motionsSystemMessages(_, { motionId, colonyAddress }) {
+      const { provider } = networkClient;
+      const votingReputationClient = (await colonyManager.getClient(
+        ClientType.VotingReputationClient,
+        colonyAddress,
+      )) as ExtensionClient;
+      const motion = await votingReputationClient.getMotion(motionId);
+      const motionNetworkState = await votingReputationClient.getMotionState(motionId);
+      const systemMessages: SystemMessage[] = [];
+
+      const motionStakedFilter = votingReputationClient.filters.MotionStaked(motionId, null, null, null);
+      const motionStakedLogs = await getLogs(votingReputationClient, motionStakedFilter);
+      const motionVoteRevealedFilter = votingReputationClient.filters.MotionVoteRevealed(motionId, null, null);
+      const motionVoteRevealedLogs = await getLogs(votingReputationClient, motionVoteRevealedFilter);
+
+      const parsedEvents = await Promise.all(
+        [...motionStakedLogs, ...motionVoteRevealedLogs].map(
+          async (log) => {
+            const parsedLog = votingReputationClient.interface.parseLog(log);
+            const { address, blockHash, blockNumber, transactionHash } = log;
+            const { name, values } = parsedLog;
+            return {
+              type: ActionsPageFeedType.NetworkEvent,
+              name,
+              values,
+              createdAt: blockHash
+                ? await getBlockTime(provider, blockHash)
+                : 0,
+              emmitedBy: ClientType.ColonyClient,
+              address,
+              blockNumber,
+              transactionHash,
+            } as ProcessedEvent;
+          },
+        ),
+      );
+
+      const sortedEvents = parsedEvents.sort(
+        (firstEvent, secondEvent) => secondEvent.createdAt - firstEvent.createdAt,
+      );
+
+      if (motionNetworkState === NetworkMotionState.Finalizable || motionNetworkState === NetworkMotionState.Finalized) {
+        const newestStakeOrVoteEvent = sortedEvents.find(event => (event.name === ColonyAndExtensionsEvents.MotionStaked) || event.name === ColonyAndExtensionsEvents.MotionVoteRevealed);
+        if (newestStakeOrVoteEvent) {
+          if (motion.votes[0].lt(motion.votes[1]) || motion.stakes[0].lt(motion.stakes[1])) {
+            systemMessages.push({
+              type: ActionsPageFeedType.SystemMessage,
+              name: SystemMessagesName.MotionHasPassed,
+              createdAt: newestStakeOrVoteEvent.createdAt,
+            });
+          }
+        }
+      }
+
+      return Promise.all(systemMessages);
+    },
+  }
+});

--- a/src/i18n/en-system-messages.ts
+++ b/src/i18n/en-system-messages.ts
@@ -5,6 +5,7 @@ import { SystemMessagesName } from '~dashboard/ActionsPageFeed';
 const systemMessagesMessageDescriptors = {
   'systemMessage.title': `{name, select,
       ${SystemMessagesName.EnoughExitRecoveryApprovals} {Enough permission holders have now signed to exit recovery mode. As long as no further storage slots are updated, a recovery permission holder may now sign a transaction to reactivate the colony.}
+      ${SystemMessagesName.MotionHasPassed} {{motionTag} has {passedTag} and may be finalized.}
       other {Generic system message}
     }`,
 };

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.css
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.css
@@ -2,3 +2,7 @@
   display: inline-block;
   margin-left: 4px;
 }
+
+.tagWrapper > span {
+  margin-left: 0;
+}

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.css.d.ts
@@ -1,1 +1,2 @@
 export const reputation: string;
+export const tagWrapper: string;

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
@@ -5,6 +5,7 @@ import { FormattedMessage } from 'react-intl';
 import Numeral from '~core/Numeral';
 import ActionsPageFeed, {
   ActionsPageFeedItem,
+  SystemMessage,
 } from '~dashboard/ActionsPageFeed';
 import { ColonyMotions, ColonyAndExtensionsEvents } from '~types/index';
 import {
@@ -12,7 +13,7 @@ import {
   ColonyActionQuery,
   TokenInfoQuery,
   AnyUser,
-  useMotionsSystemMessagesQuery
+  useMotionsSystemMessagesQuery,
 } from '~data/index';
 import Tag from '~core/Tag';
 import FriendlyName from '~core/FriendlyName';
@@ -60,12 +61,13 @@ const MintTokenMotion = ({
   initiator,
 }: Props) => {
   const motionTag = MOTION_TAG_MAP[MotionState.Motion];
-  const motionCreatedEvent = colonyAction.events.find(({name}) => name === ColonyAndExtensionsEvents.MotionCreated);
-  const motionId = ((motionCreatedEvent?.values as unknown) as MotionValue).motionId;
+  const passedTag = MOTION_TAG_MAP[MotionState.Passed];
+  const motionCreatedEvent = colonyAction.events.find(
+    ({ name }) => name === ColonyAndExtensionsEvents.MotionCreated,
+  );
+  const { motionId } = (motionCreatedEvent?.values as unknown) as MotionValue;
 
-  const {
-    data: motionsSystemMessages,
-  } = useMotionsSystemMessagesQuery({
+  const { data: motionsSystemMessagesData } = useMotionsSystemMessagesQuery({
     variables: {
       motionId,
       colonyAddress: colony.colonyAddress,
@@ -101,8 +103,17 @@ const MintTokenMotion = ({
       />
     ),
     motionTag: <Tag text={motionTag.name} appearance={{ theme: 'primary' }} />,
+    passedTag: (
+      <span className={motionSpecificStyles.tagWrapper}>
+        <Tag
+          text={passedTag.name}
+          appearance={{ theme: 'primary', colorSchema: 'plain' }}
+        />
+      </span>
+    ),
   };
   const motionStyles = MOTION_TAG_MAP[motionState || MotionState.Invalid];
+
   return (
     <div className={styles.main}>
       <div className={styles.upperContainer}>
@@ -147,6 +158,10 @@ const MintTokenMotion = ({
             actionType={actionType}
             transactionHash={transactionHash as string}
             networkEvents={events}
+            systemMessages={
+              // eslint-disable-next-line max-len
+              motionsSystemMessagesData?.motionsSystemMessages as SystemMessage[]
+            }
             values={actionAndEventValues}
             actionData={colonyAction}
             colony={colony}

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
@@ -6,12 +6,13 @@ import Numeral from '~core/Numeral';
 import ActionsPageFeed, {
   ActionsPageFeedItem,
 } from '~dashboard/ActionsPageFeed';
-import { ColonyMotions } from '~types/index';
+import { ColonyMotions, ColonyAndExtensionsEvents } from '~types/index';
 import {
   Colony,
   ColonyActionQuery,
   TokenInfoQuery,
   AnyUser,
+  useMotionsSystemMessagesQuery
 } from '~data/index';
 import Tag from '~core/Tag';
 import FriendlyName from '~core/FriendlyName';
@@ -37,6 +38,10 @@ interface Props {
   initiator: AnyUser;
 }
 
+interface MotionValue {
+  motionId: number;
+}
+
 const MintTokenMotion = ({
   colony,
   colonyAction: {
@@ -55,6 +60,17 @@ const MintTokenMotion = ({
   initiator,
 }: Props) => {
   const motionTag = MOTION_TAG_MAP[MotionState.Motion];
+  const motionCreatedEvent = colonyAction.events.find(({name}) => name === ColonyAndExtensionsEvents.MotionCreated);
+  const motionId = ((motionCreatedEvent?.values as unknown) as MotionValue).motionId;
+
+  const {
+    data: motionsSystemMessages,
+  } = useMotionsSystemMessagesQuery({
+    variables: {
+      motionId,
+      colonyAddress: colony.colonyAddress,
+    },
+  });
 
   const actionAndEventValues = {
     actionType,

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeed.tsx
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeed.tsx
@@ -252,6 +252,7 @@ const ActionsPageFeed = ({
           <ActionsPageSystemMessage
             key={uniqueId}
             systemMessage={feedItem as SystemMessage}
+            values={values}
           />
         );
       }

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageSystemMessage/ActionsPageSystemMessage.tsx
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageSystemMessage/ActionsPageSystemMessage.tsx
@@ -5,6 +5,7 @@ import { TransactionMeta, TransactionStatus } from '~dashboard/ActionsPage';
 
 import { STATUS } from '../../ActionsPage/types';
 import { SystemMessage } from '../types';
+import { EventValues } from '../ActionsPageFeed';
 
 import styles from './ActionsPageSystemMessage.css';
 
@@ -12,10 +13,12 @@ const displayName = 'dashboard.ActionsPageFeed.ActionsPageSystemMessage';
 
 interface Props {
   systemMessage: SystemMessage;
+  values?: EventValues;
 }
 
 const ActionsPageSystemMessage = ({
   systemMessage: { name, createdAt },
+  values,
 }: Props) => (
   <div className={styles.main}>
     <div className={styles.wrapper}>
@@ -24,7 +27,10 @@ const ActionsPageSystemMessage = ({
       </div>
       <div className={styles.content}>
         <div className={styles.text}>
-          <FormattedMessage id="systemMessage.title" values={{ name }} />
+          <FormattedMessage
+            id="systemMessage.title"
+            values={{ name, ...values }}
+          />
         </div>
         <div className={styles.details}>
           <div className={styles.meta}>

--- a/src/modules/dashboard/components/ActionsPageFeed/types.ts
+++ b/src/modules/dashboard/components/ActionsPageFeed/types.ts
@@ -42,6 +42,7 @@ export interface SystemInfo {
  */
 export enum SystemMessagesName {
   EnoughExitRecoveryApprovals = 'EnoughExitRecoveryApprovals',
+  MotionHasPassed = 'MotionHasPassed',
 }
 
 export interface SystemMessage {

--- a/src/types/colonyActions.ts
+++ b/src/types/colonyActions.ts
@@ -104,6 +104,13 @@ export enum ColonyAndExtensionsEvents {
    * Motion events
    */
   MotionCreated = 'MotionCreated',
+  MotionStaked = 'MotionStaked',
+  MotionVoteSubmitted = 'MotionVoteSubmitted',
+  MotionVoteRevealed = 'MotionVoteRevealed',
+  MotionFinalized = 'MotionFinalized',
+  MotionEscalated = 'MotionEscalated',
+  MotionRewardClaimed = 'MotionRewardClaimed',
+  MotionEventSet = 'MotionEventSet',
 }
 
 export interface FormattedAction {


### PR DESCRIPTION
## Description

This PR adds in motion has passed event

**New stuff** ✨

* Added motionSystemMessages resolver and query
* Added motionSystemMessage query to MintTokenMotion component
* Added System messages to MintTokenMotion component

<img width="954" alt="Screenshot 2021-04-15 at 13 35 22" src="https://user-images.githubusercontent.com/13069555/114870054-01a56980-9df8-11eb-9f05-db423eff40fb.png">

## TODO

- Found small bug connected to motion state, it will be fixed in DEV-285

## How to test [sorry it wont be super easy]
In truffle console you need to create needed events.

```
ethers = require("ethers")

c = await IColony.at(colonyAddress)
cnaddress = await c.getColonyNetwork()
cn = await IColonyNetwork.at(cnaddress)
tladdress = await cn.getTokenLocking()
tl = await ITokenLocking.at(tladdress)

votingAddress = await cn.getExtensionInstallation(web3.utils.soliditySha3("VotingReputation"), c.address);

v = await VotingReputation.at(votingAddress);

tokenAddress = await c.getToken()

t = await Token.at(tokenAddress)

// Amount required to stake depends on how much reputation was
// in the colony when the motion was created, and the total_stake_fraction that the extension was deployed with.

t.approve(tl.address, AMOUNT);
tl.deposit(t.address, AMOUNT, true);
// 1 here is the domain the motion has been made in
c.approveStake(v.address, 1, AMOUNT)

// The 1 before AMOUNT here is to stake that the motion should take place. If you want to stake against it, use 0.

// If the motion is not in the root domain the second and third parameters might be different. They are domain proofs, that the `withProofs` helpers deal with in colonyJS

// key value branchmask siblings come from the reputation oracle.

// Query http://localhost:3001/reputation/local/${motion.roothash}/${c.address}/${skillid corresponding to the domain the hash is taking place in }/${user address}

voting.stakeMotion(motionid, 1, ethers.constants.MaxUint256, 1, AMOUNT, key, value, branchmask, siblings)```

To make it passed:
```curl -X POST --data '{"jsonrpc":"2.0","method":"evm_increaseTime","params":[604800],"id":1}' localhost:8545
curl -X POST --data '{"jsonrpc":"2.0","method":"evm_mine","params":[],"id":1}' localhost:8545```
```

Resolves DEV-275
