### PR TITLE
Fix ChangeTokenStateForm input warning

### DIFF
--- a/src/modules/core/components/Fields/Input/Input.tsx
+++ b/src/modules/core/components/Fields/Input/Input.tsx
@@ -120,6 +120,7 @@ const Input = ({
       : placeholderProp;
 
   const inputProps: InputComponentProps = {
+    ...inputFieldProps,
     appearance,
     'aria-invalid': !!error || !!forcedFieldError,
     formattingOptions,
@@ -130,7 +131,6 @@ const Input = ({
     disabled,
     maxLength,
     maxButtonParams,
-    ...inputFieldProps,
   };
 
   const extensionStringText: string | undefined =

--- a/src/modules/core/components/Fields/Input/InputComponent.tsx
+++ b/src/modules/core/components/Fields/Input/InputComponent.tsx
@@ -95,7 +95,7 @@ const InputComponent = ({
           value: evt.currentTarget?.rawValue as string,
         };
       }
-      if (onChange) onChange(evt);
+      if (onChange && evt.target.name) onChange(evt);
     },
     [onChange],
   );


### PR DESCRIPTION
- Fixed handleCleaveChange calling formik's `onChange` when the Cleave input hasn't even been created/initialized on the ChangeTokenStateForm
- Fixed inputFieldProps possibly overriding name prop of Input

Resolves DEV-283
