### PR TITLE
Display Motions in Actions List

### DIFF
--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -1014,6 +1014,12 @@ export type SubscriptionMotion = {
   state: Scalars['Int'];
   action: Scalars['String'];
   type: Scalars['String'];
+  args: SubscriptionMotionArguments;
+};
+
+export type SubscriptionMotionArguments = {
+  amount: Scalars['String'];
+  tokenAddress: Scalars['String'];
 };
 
 export type Subscription = {
@@ -1742,7 +1748,7 @@ export type SubscriptionsMotionsSubscription = { motions: Array<(
     ), domain: (
       Pick<SubgraphDomain, 'name'>
       & { ethDomainId: SubgraphDomain['domainChainId'] }
-    ) }
+    ), args: Pick<SubscriptionMotionArguments, 'amount' | 'tokenAddress'> }
   )> };
 
 export const ColonyProfileFragmentDoc = gql`
@@ -4504,6 +4510,10 @@ export const SubscriptionsMotionsDocument = gql`
     action
     state @client
     type @client
+    args @client {
+      amount
+      tokenAddress
+    }
   }
 }
     `;

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -1012,6 +1012,7 @@ export type SubscriptionMotion = {
   requiredStake: Scalars['String'];
   escalated: Scalars['Boolean'];
   state: Scalars['Int'];
+  action: Scalars['String'];
 };
 
 export type Subscription = {
@@ -1727,7 +1728,7 @@ export type SubscriptionsMotionsSubscriptionVariables = Exact<{
 
 
 export type SubscriptionsMotionsSubscription = { motions: Array<(
-    Pick<SubscriptionMotion, 'id' | 'fundamentalChainId' | 'extensionAddress' | 'agent' | 'currentStake' | 'requiredStake' | 'escalated' | 'state'>
+    Pick<SubscriptionMotion, 'id' | 'fundamentalChainId' | 'extensionAddress' | 'agent' | 'currentStake' | 'requiredStake' | 'escalated' | 'action' | 'state'>
     & { associatedColony: (
       { colonyAddress: SubgraphColony['id'], id: SubgraphColony['colonyChainId'] }
       & { token: (
@@ -4499,6 +4500,7 @@ export const SubscriptionsMotionsDocument = gql`
     currentStake
     requiredStake
     escalated
+    action
     state @client
   }
 }

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -4420,6 +4420,11 @@ export const SubscriptionSubgraphEventsThatAreActionsDocument = gql`
     associatedColony {
       colonyAddress: id
       id: colonyChainId
+      token {
+        address: id
+        decimals
+        symbol
+      }
     }
     transaction {
       hash: id
@@ -4481,11 +4486,6 @@ export const SubscriptionsMotionsDocument = gql`
     associatedColony {
       colonyAddress: id
       id: colonyChainId
-      token {
-        address: id
-        decimals
-        symbol
-      }
     }
     transaction {
       hash: id

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -1019,7 +1019,7 @@ export type SubscriptionMotion = {
 
 export type SubscriptionMotionArguments = {
   amount: Scalars['String'];
-  tokenAddress: Scalars['String'];
+  token: SubgraphToken;
 };
 
 export type Subscription = {
@@ -1736,19 +1736,19 @@ export type SubscriptionsMotionsSubscriptionVariables = Exact<{
 
 export type SubscriptionsMotionsSubscription = { motions: Array<(
     Pick<SubscriptionMotion, 'id' | 'fundamentalChainId' | 'extensionAddress' | 'agent' | 'currentStake' | 'requiredStake' | 'escalated' | 'action' | 'state' | 'type'>
-    & { associatedColony: (
-      { colonyAddress: SubgraphColony['id'], id: SubgraphColony['colonyChainId'] }
-      & { token: (
-        Pick<SubgraphToken, 'decimals' | 'symbol'>
-        & { address: SubgraphToken['id'] }
-      ) }
-    ), transaction: (
+    & { associatedColony: { colonyAddress: SubgraphColony['id'], id: SubgraphColony['colonyChainId'] }, transaction: (
       { hash: SubgraphTransaction['id'] }
       & { block: Pick<SubgraphBlock, 'timestamp'> }
     ), domain: (
       Pick<SubgraphDomain, 'name'>
       & { ethDomainId: SubgraphDomain['domainChainId'] }
-    ), args: Pick<SubscriptionMotionArguments, 'amount' | 'tokenAddress'> }
+    ), args: (
+      Pick<SubscriptionMotionArguments, 'amount'>
+      & { token: (
+        Pick<SubgraphToken, 'symbol' | 'decimals'>
+        & { address: SubgraphToken['id'] }
+      ) }
+    ) }
   )> };
 
 export const ColonyProfileFragmentDoc = gql`
@@ -4420,11 +4420,6 @@ export const SubscriptionSubgraphEventsThatAreActionsDocument = gql`
     associatedColony {
       colonyAddress: id
       id: colonyChainId
-      token {
-        address: id
-        decimals
-        symbol
-      }
     }
     transaction {
       hash: id
@@ -4512,7 +4507,11 @@ export const SubscriptionsMotionsDocument = gql`
     type @client
     args @client {
       amount
-      tokenAddress
+      token {
+        address: id
+        symbol
+        decimals
+      }
     }
   }
 }

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -958,6 +958,11 @@ export type EventsFilter = {
   name_in?: Maybe<Array<Scalars['String']>>;
 };
 
+export type MotionsFilter = {
+  associatedColony?: Maybe<Scalars['String']>;
+  extensionAddress?: Maybe<Scalars['String']>;
+};
+
 export type OneTxPayment = {
   id: Scalars['String'];
   agent: Scalars['String'];
@@ -995,9 +1000,23 @@ export type SubscriptionEvent = {
   processedValues: EventProcessedValues;
 };
 
+export type SubscriptionMotion = {
+  id: Scalars['String'];
+  transaction: SubgraphTransaction;
+  associatedColony: SubgraphColony;
+  domain: SubgraphDomain;
+  extensionAddress: Scalars['String'];
+  agent: Scalars['String'];
+  currentStake: Scalars['String'];
+  requiredStake: Scalars['String'];
+  escalated: Scalars['Boolean'];
+  state: Scalars['Int'];
+};
+
 export type Subscription = {
   oneTxPayments: Array<OneTxPayment>;
   events: Array<SubscriptionEvent>;
+  motions: Array<SubscriptionMotion>;
 };
 
 
@@ -1012,6 +1031,13 @@ export type SubscriptionEventsArgs = {
   skip: Scalars['Int'];
   first: Scalars['Int'];
   where: EventsFilter;
+};
+
+
+export type SubscriptionMotionsArgs = {
+  skip: Scalars['Int'];
+  first: Scalars['Int'];
+  where: MotionsFilter;
 };
 
 export type TokensFragment = (
@@ -1689,6 +1715,31 @@ export type SubscriptionSubgraphEventsThatAreActionsSubscription = { events: Arr
       { hash: SubgraphTransaction['id'] }
       & { block: Pick<SubgraphBlock, 'timestamp'> }
     ), processedValues: Pick<EventProcessedValues, 'agent' | 'who' | 'fromPot' | 'fromDomain' | 'toPot' | 'toDomain' | 'domainId' | 'amount' | 'token' | 'metadata' | 'user' | 'oldVersion' | 'newVersion' | 'storageSlot' | 'storageSlotValue'> }
+  )> };
+
+export type SubscriptionsMotionsSubscriptionVariables = Exact<{
+  skip: Scalars['Int'];
+  first: Scalars['Int'];
+  colonyAddress: Scalars['String'];
+  extensionAddress: Scalars['String'];
+}>;
+
+
+export type SubscriptionsMotionsSubscription = { motions: Array<(
+    Pick<SubscriptionMotion, 'id' | 'extensionAddress' | 'agent' | 'currentStake' | 'requiredStake' | 'escalated' | 'state'>
+    & { associatedColony: (
+      { colonyAddress: SubgraphColony['id'], id: SubgraphColony['colonyChainId'] }
+      & { token: (
+        Pick<SubgraphToken, 'decimals' | 'symbol'>
+        & { address: SubgraphToken['id'] }
+      ) }
+    ), transaction: (
+      { hash: SubgraphTransaction['id'] }
+      & { block: Pick<SubgraphBlock, 'timestamp'> }
+    ), domain: (
+      Pick<SubgraphDomain, 'name'>
+      & { ethDomainId: SubgraphDomain['domainChainId'] }
+    ) }
   )> };
 
 export const ColonyProfileFragmentDoc = gql`
@@ -4418,3 +4469,60 @@ export function useSubscriptionSubgraphEventsThatAreActionsSubscription(baseOpti
       }
 export type SubscriptionSubgraphEventsThatAreActionsSubscriptionHookResult = ReturnType<typeof useSubscriptionSubgraphEventsThatAreActionsSubscription>;
 export type SubscriptionSubgraphEventsThatAreActionsSubscriptionResult = Apollo.SubscriptionResult<SubscriptionSubgraphEventsThatAreActionsSubscription>;
+export const SubscriptionsMotionsDocument = gql`
+    subscription SubscriptionsMotions($skip: Int!, $first: Int!, $colonyAddress: String!, $extensionAddress: String!) {
+  motions(skip: $skip, first: $first, where: {associatedColony: $colonyAddress, extensionAddress: $extensionAddress}) {
+    id
+    associatedColony {
+      colonyAddress: id
+      id: colonyChainId
+      token {
+        address: id
+        decimals
+        symbol
+      }
+    }
+    transaction {
+      hash: id
+      block {
+        timestamp
+      }
+    }
+    extensionAddress
+    agent
+    domain {
+      ethDomainId: domainChainId
+      name
+    }
+    currentStake
+    requiredStake
+    escalated
+    state @client
+  }
+}
+    `;
+
+/**
+ * __useSubscriptionsMotionsSubscription__
+ *
+ * To run a query within a React component, call `useSubscriptionsMotionsSubscription` and pass it any options that fit your needs.
+ * When your component renders, `useSubscriptionsMotionsSubscription` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the subscription, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useSubscriptionsMotionsSubscription({
+ *   variables: {
+ *      skip: // value for 'skip'
+ *      first: // value for 'first'
+ *      colonyAddress: // value for 'colonyAddress'
+ *      extensionAddress: // value for 'extensionAddress'
+ *   },
+ * });
+ */
+export function useSubscriptionsMotionsSubscription(baseOptions?: Apollo.SubscriptionHookOptions<SubscriptionsMotionsSubscription, SubscriptionsMotionsSubscriptionVariables>) {
+        return Apollo.useSubscription<SubscriptionsMotionsSubscription, SubscriptionsMotionsSubscriptionVariables>(SubscriptionsMotionsDocument, baseOptions);
+      }
+export type SubscriptionsMotionsSubscriptionHookResult = ReturnType<typeof useSubscriptionsMotionsSubscription>;
+export type SubscriptionsMotionsSubscriptionResult = Apollo.SubscriptionResult<SubscriptionsMotionsSubscription>;

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -1002,6 +1002,7 @@ export type SubscriptionEvent = {
 
 export type SubscriptionMotion = {
   id: Scalars['String'];
+  fundamentalChainId: Scalars['String'];
   transaction: SubgraphTransaction;
   associatedColony: SubgraphColony;
   domain: SubgraphDomain;
@@ -1726,7 +1727,7 @@ export type SubscriptionsMotionsSubscriptionVariables = Exact<{
 
 
 export type SubscriptionsMotionsSubscription = { motions: Array<(
-    Pick<SubscriptionMotion, 'id' | 'extensionAddress' | 'agent' | 'currentStake' | 'requiredStake' | 'escalated' | 'state'>
+    Pick<SubscriptionMotion, 'id' | 'fundamentalChainId' | 'extensionAddress' | 'agent' | 'currentStake' | 'requiredStake' | 'escalated' | 'state'>
     & { associatedColony: (
       { colonyAddress: SubgraphColony['id'], id: SubgraphColony['colonyChainId'] }
       & { token: (
@@ -4473,6 +4474,7 @@ export const SubscriptionsMotionsDocument = gql`
     subscription SubscriptionsMotions($skip: Int!, $first: Int!, $colonyAddress: String!, $extensionAddress: String!) {
   motions(skip: $skip, first: $first, where: {associatedColony: $colonyAddress, extensionAddress: $extensionAddress}) {
     id
+    fundamentalChainId
     associatedColony {
       colonyAddress: id
       id: colonyChainId

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -1013,6 +1013,7 @@ export type SubscriptionMotion = {
   escalated: Scalars['Boolean'];
   state: Scalars['Int'];
   action: Scalars['String'];
+  type: Scalars['String'];
 };
 
 export type Subscription = {
@@ -1728,7 +1729,7 @@ export type SubscriptionsMotionsSubscriptionVariables = Exact<{
 
 
 export type SubscriptionsMotionsSubscription = { motions: Array<(
-    Pick<SubscriptionMotion, 'id' | 'fundamentalChainId' | 'extensionAddress' | 'agent' | 'currentStake' | 'requiredStake' | 'escalated' | 'action' | 'state'>
+    Pick<SubscriptionMotion, 'id' | 'fundamentalChainId' | 'extensionAddress' | 'agent' | 'currentStake' | 'requiredStake' | 'escalated' | 'action' | 'state' | 'type'>
     & { associatedColony: (
       { colonyAddress: SubgraphColony['id'], id: SubgraphColony['colonyChainId'] }
       & { token: (
@@ -4502,6 +4503,7 @@ export const SubscriptionsMotionsDocument = gql`
     escalated
     action
     state @client
+    type @client
   }
 }
     `;

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -1011,7 +1011,7 @@ export type SubscriptionMotion = {
   currentStake: Scalars['String'];
   requiredStake: Scalars['String'];
   escalated: Scalars['Boolean'];
-  state: Scalars['Int'];
+  state: Scalars['String'];
   action: Scalars['String'];
   type: Scalars['String'];
   args: SubscriptionMotionArguments;

--- a/src/data/graphql/subscriptions.graphql
+++ b/src/data/graphql/subscriptions.graphql
@@ -148,5 +148,9 @@ subscription SubscriptionsMotions($skip: Int!, $first: Int!, $colonyAddress: Str
     action
     state @client
     type @client
+    args @client {
+      amount
+      tokenAddress
+    }
   }
 }

--- a/src/data/graphql/subscriptions.graphql
+++ b/src/data/graphql/subscriptions.graphql
@@ -120,6 +120,7 @@ subscription SubscriptionsMotions($skip: Int!, $first: Int!, $colonyAddress: Str
       extensionAddress: $extensionAddress,
     }) {
     id
+    fundamentalChainId
     associatedColony {
       colonyAddress: id
       id: colonyChainId

--- a/src/data/graphql/subscriptions.graphql
+++ b/src/data/graphql/subscriptions.graphql
@@ -145,6 +145,7 @@ subscription SubscriptionsMotions($skip: Int!, $first: Int!, $colonyAddress: Str
     currentStake
     requiredStake
     escalated
+    action
     state @client
   }
 }

--- a/src/data/graphql/subscriptions.graphql
+++ b/src/data/graphql/subscriptions.graphql
@@ -124,11 +124,6 @@ subscription SubscriptionsMotions($skip: Int!, $first: Int!, $colonyAddress: Str
     associatedColony {
       colonyAddress: id
       id: colonyChainId
-      token {
-        address: id
-        decimals
-        symbol
-      }
     }
     transaction {
       hash: id
@@ -150,7 +145,11 @@ subscription SubscriptionsMotions($skip: Int!, $first: Int!, $colonyAddress: Str
     type @client
     args @client {
       amount
-      tokenAddress
+      token {
+        address: id
+        symbol
+        decimals
+      }
     }
   }
 }

--- a/src/data/graphql/subscriptions.graphql
+++ b/src/data/graphql/subscriptions.graphql
@@ -147,5 +147,6 @@ subscription SubscriptionsMotions($skip: Int!, $first: Int!, $colonyAddress: Str
     escalated
     action
     state @client
+    type @client
   }
 }

--- a/src/data/graphql/subscriptions.graphql
+++ b/src/data/graphql/subscriptions.graphql
@@ -110,3 +110,40 @@ subscription SubscriptionSubgraphEventsThatAreActions($skip: Int!, $first: Int!,
     }
   }
 }
+
+subscription SubscriptionsMotions($skip: Int!, $first: Int!, $colonyAddress: String!, $extensionAddress: String!) {
+  motions(
+    skip: $skip,
+    first: $first,
+    where: {
+      associatedColony: $colonyAddress,
+      extensionAddress: $extensionAddress,
+    }) {
+    id
+    associatedColony {
+      colonyAddress: id
+      id: colonyChainId
+      token {
+        address: id
+        decimals
+        symbol
+      }
+    }
+    transaction {
+      hash: id
+      block {
+        timestamp
+      }
+    }
+    extensionAddress
+    agent
+    domain {
+      ethDomainId: domainChainId
+      name
+    }
+    currentStake
+    requiredStake
+    escalated
+    state @client
+  }
+}

--- a/src/data/graphql/typeDefsSubscriptions.ts
+++ b/src/data/graphql/typeDefsSubscriptions.ts
@@ -11,6 +11,11 @@ export default gql`
     name_in: [String!]
   }
 
+  input MotionsFilter {
+    associatedColony: String
+    extensionAddress: String
+  }
+
   type OneTxPayment {
     id: String!
     agent: String!
@@ -48,6 +53,19 @@ export default gql`
     processedValues: EventProcessedValues!
   }
 
+  type SubscriptionMotion {
+    id: String!
+    transaction: SubgraphTransaction!
+    associatedColony: SubgraphColony!
+    domain: SubgraphDomain!
+    extensionAddress: String!
+    agent: String!
+    currentStake: String!
+    requiredStake: String!
+    escalated: Boolean!
+    state: Int!
+  }
+
   #
   # Subgraph Subscriptions
   #
@@ -58,5 +76,10 @@ export default gql`
       where: ActionsFilter!
     ): [OneTxPayment!]!
     events(skip: Int!, first: Int!, where: EventsFilter!): [SubscriptionEvent!]!
+    motions(
+      skip: Int!
+      first: Int!
+      where: MotionsFilter!
+    ): [SubscriptionMotion!]!
   }
 `;

--- a/src/data/graphql/typeDefsSubscriptions.ts
+++ b/src/data/graphql/typeDefsSubscriptions.ts
@@ -67,6 +67,14 @@ export default gql`
     state: Int!
     action: String!
     type: String!
+    args: SubscriptionMotionArguments!
+  }
+
+  # @TODO Add types for the rest of the arguments
+  #
+  type SubscriptionMotionArguments {
+    amount: String!
+    tokenAddress: String!
   }
 
   #

--- a/src/data/graphql/typeDefsSubscriptions.ts
+++ b/src/data/graphql/typeDefsSubscriptions.ts
@@ -74,7 +74,7 @@ export default gql`
   #
   type SubscriptionMotionArguments {
     amount: String!
-    tokenAddress: String!
+    token: SubgraphToken!
   }
 
   #

--- a/src/data/graphql/typeDefsSubscriptions.ts
+++ b/src/data/graphql/typeDefsSubscriptions.ts
@@ -65,6 +65,7 @@ export default gql`
     requiredStake: String!
     escalated: Boolean!
     state: Int!
+    action: String!
   }
 
   #

--- a/src/data/graphql/typeDefsSubscriptions.ts
+++ b/src/data/graphql/typeDefsSubscriptions.ts
@@ -64,7 +64,7 @@ export default gql`
     currentStake: String!
     requiredStake: String!
     escalated: Boolean!
-    state: Int!
+    state: String!
     action: String!
     type: String!
     args: SubscriptionMotionArguments!

--- a/src/data/graphql/typeDefsSubscriptions.ts
+++ b/src/data/graphql/typeDefsSubscriptions.ts
@@ -55,6 +55,7 @@ export default gql`
 
   type SubscriptionMotion {
     id: String!
+    fundamentalChainId: String!
     transaction: SubgraphTransaction!
     associatedColony: SubgraphColony!
     domain: SubgraphDomain!

--- a/src/data/graphql/typeDefsSubscriptions.ts
+++ b/src/data/graphql/typeDefsSubscriptions.ts
@@ -66,6 +66,7 @@ export default gql`
     escalated: Boolean!
     state: Int!
     action: String!
+    type: String!
   }
 
   #

--- a/src/data/resolvers/colonyActions.ts
+++ b/src/data/resolvers/colonyActions.ts
@@ -170,7 +170,7 @@ export const colonyActionsResolvers = ({
           actionType = await getMotionActionType(
             votingClient as ExtensionClient,
             colonyClient as ColonyClient,
-            motionCreatedEvent,
+            motionCreatedEvent.values.domainId,
           );
         } else {
           actionType = getActionType(reverseSortedEvents);

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -1,13 +1,12 @@
-import { ClientType, ExtensionClient } from '@colony/colony-js';
-import { bigNumberify } from 'ethers/utils';
-import { Resolvers } from '@apollo/client';
 import {
   ClientType,
+  ExtensionClient,
   getLogs,
   getBlockTime,
-  ExtensionClient,
   MotionState as NetworkMotionState,
 } from '@colony/colony-js';
+import { bigNumberify } from 'ethers/utils';
+import { Resolvers } from '@apollo/client';
 
 import { Context } from '~context/index';
 import { createAddress } from '~utils/web3';

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -141,5 +141,23 @@ export const motionsResolvers = ({
         bigNumberify(fundamentalChainId),
       );
     },
+    async args({ action, associatedColony: { colonyAddress } }) {
+      const colonyClient = await colonyManager.getClient(
+        ClientType.ColonyClient,
+        colonyAddress,
+      );
+      const actionValues = colonyClient.interface.parseTransaction({
+        data: action,
+      });
+      const tokenAddress = await colonyClient.getToken();
+      /*
+       * @TODO Return argumnents for the other motions as well, as soon
+       * as they get wired into the dapp
+       */
+      return {
+        amount: bigNumberify(actionValues?.args[0] || '0').toString(),
+        tokenAddress,
+      };
+    },
   },
 });

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -153,14 +153,22 @@ export const motionsResolvers = ({
       const actionValues = colonyClient.interface.parseTransaction({
         data: action,
       });
-      const tokenAddress = await colonyClient.getToken();
+      const tokenAddress = colonyClient.tokenClient.address;
+      const {
+        symbol,
+        decimals,
+      } = await colonyClient.tokenClient.getTokenInfo();
       /*
        * @TODO Return argumnents for the other motions as well, as soon
        * as they get wired into the dapp
        */
       return {
         amount: bigNumberify(actionValues?.args[0] || '0').toString(),
-        tokenAddress,
+        token: {
+          id: tokenAddress,
+          symbol,
+          decimals,
+        },
       };
     },
   },

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -12,6 +12,7 @@ import {
 
 import { Context } from '~context/index';
 import { createAddress } from '~utils/web3';
+import { getMotionActionType } from '~utils/events';
 import { ColonyAndExtensionsEvents } from '~types/index';
 import {
   ActionsPageFeedType,
@@ -121,5 +122,24 @@ export const motionsResolvers = ({
         bigNumberify(fundamentalChainId),
       );
     },
- },
+    async type({
+      fundamentalChainId,
+      associatedColony: { colonyAddress: address },
+    }) {
+      const colonyAddress = createAddress(address);
+      const votingReputationClient = await colonyManager.getClient(
+        ClientType.VotingReputationClient,
+        colonyAddress,
+      );
+      const colonyClient = await colonyManager.getClient(
+        ClientType.ColonyClient,
+        colonyAddress,
+      );
+      return getMotionActionType(
+        votingReputationClient as ExtensionClient,
+        colonyClient,
+        bigNumberify(fundamentalChainId),
+      );
+    },
+  },
 });

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -1,3 +1,5 @@
+import { ClientType } from '@colony/colony-js';
+import { bigNumberify } from 'ethers/utils';
 import { Resolvers } from '@apollo/client';
 
 import {
@@ -9,6 +11,7 @@ import {
 } from '@colony/colony-js';
 
 import { Context } from '~context/index';
+import { createAddress } from '~utils/web3';
 import { ColonyAndExtensionsEvents } from '~types/index';
 import {
   ActionsPageFeedType,
@@ -108,4 +111,15 @@ export const motionsResolvers = ({
       return Promise.all(systemMessages);
     },
   },
+  Motion: {
+    async state({ fundamentalChainId, associatedColony: { colonyAddress } }) {
+      const votingReputationClient = await colonyManager.getClient(
+        ClientType.VotingReputationClient,
+        createAddress(colonyAddress),
+      );
+      return votingReputationClient.getMotionState(
+        bigNumberify(fundamentalChainId),
+      );
+    },
+ },
 });

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -1,7 +1,6 @@
-import { ClientType } from '@colony/colony-js';
+import { ClientType, ExtensionClient } from '@colony/colony-js';
 import { bigNumberify } from 'ethers/utils';
 import { Resolvers } from '@apollo/client';
-
 import {
   ClientType,
   getLogs,
@@ -12,7 +11,7 @@ import {
 
 import { Context } from '~context/index';
 import { createAddress } from '~utils/web3';
-import { getMotionActionType } from '~utils/events';
+import { getMotionActionType, getMotionState } from '~utils/events';
 import { ColonyAndExtensionsEvents } from '~types/index';
 import {
   ActionsPageFeedType,
@@ -114,12 +113,17 @@ export const motionsResolvers = ({
   },
   Motion: {
     async state({ fundamentalChainId, associatedColony: { colonyAddress } }) {
+      const motionId = bigNumberify(fundamentalChainId);
       const votingReputationClient = await colonyManager.getClient(
         ClientType.VotingReputationClient,
         createAddress(colonyAddress),
       );
-      return votingReputationClient.getMotionState(
-        bigNumberify(fundamentalChainId),
+      const motion = await votingReputationClient.getMotion(motionId);
+      const state = await votingReputationClient.getMotionState(motionId);
+      return getMotionState(
+        state,
+        votingReputationClient as ExtensionClient,
+        motion,
       );
     },
     async type({

--- a/src/i18n/en-actions.ts
+++ b/src/i18n/en-actions.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 
-import { ColonyActions } from '~types/index';
+import { ColonyActions, ColonyMotions } from '~types/index';
 
 const actionsMessageDescriptors = {
   'action.title': `{actionType, select,
@@ -8,6 +8,7 @@ const actionsMessageDescriptors = {
       ${ColonyActions.Payment} {Pay {recipient} {amount} {tokenSymbol}}
       ${ColonyActions.MoveFunds} {Move {amount} {tokenSymbol} from {fromDomain} to {toDomain}}
       ${ColonyActions.MintTokens} {Mint {amount} {tokenSymbol}}
+      ${ColonyMotions.MintTokensMotion} {Mint {amount} {tokenSymbol}}
       ${ColonyActions.CreateDomain} {New team: {fromDomain}}
       ${ColonyActions.VersionUpgrade} {Upgrade Colony to Version {newVersion}!}
       ${ColonyActions.ColonyEdit} {Colony details changed}

--- a/src/i18n/en-events.ts
+++ b/src/i18n/en-events.ts
@@ -60,6 +60,9 @@ const eventsMessageDescriptors = {
       ${ColonyAndExtensionsEvents.RecoveryStorageSlotSet} {{agent} set storage slot {storageSlot} to {storageSlotValue}}
       ${ColonyAndExtensionsEvents.RecoveryModeExitApproved} {{agent} approved exiting the Recovery Mode}
       ${ColonyAndExtensionsEvents.RecoveryModeExited} {{agent} exited the colony from Recovery Mode}
+      ${ColonyAndExtensionsEvents.MotionCreated} {{agent} created motion {motionId} in {domain}}
+      ${ColonyAndExtensionsEvents.MotionStaked} {{agent} {voteSide} motion {motionId} for {amount} {tokenSymbol}}
+      ${ColonyAndExtensionsEvents.MotionEscalated} {{agent} escalated motion {motionId} from {domain} to {newDomain}}
       other {{eventName} emmited with values: {displayValues}}
     }`,
   [`eventList.${ColonyAndExtensionsEvents.ColonyRoleSet}.assign`]: `{agent} assigned the {role} permission in the {domain} team to {recipient}`,

--- a/src/modules/core/components/ActionsList/ActionsListItem.css
+++ b/src/modules/core/components/ActionsList/ActionsListItem.css
@@ -147,3 +147,10 @@
 .titleDecoration {
   color: var(--pink);
 }
+
+.motionTagWrapper {
+  display: inline-block;
+  margin: -5px 0 0 12px;
+  padding: 0;
+  vertical-align: middle;
+}

--- a/src/modules/core/components/ActionsList/ActionsListItem.css.d.ts
+++ b/src/modules/core/components/ActionsList/ActionsListItem.css.d.ts
@@ -18,3 +18,4 @@ export const commentCountIcon: string;
 export const userMention: string;
 export const stateNoPointer: string;
 export const titleDecoration: string;
+export const motionTagWrapper: string;

--- a/src/modules/core/components/ActionsList/ActionsListItem.tsx
+++ b/src/modules/core/components/ActionsList/ActionsListItem.tsx
@@ -11,6 +11,7 @@ import HookedUserAvatar from '~users/HookedUserAvatar';
 import Numeral, { AbbreviatedNumeral } from '~core/Numeral';
 import Icon from '~core/Icon';
 import FriendlyName from '~core/FriendlyName';
+import Tag, { Appearance as TagAppearance } from '~core/Tag';
 
 import { getMainClasses, removeValueUnits } from '~utils/css';
 import { getTokenDecimalsWithFallback } from '~utils/tokens';
@@ -20,6 +21,7 @@ import { FormattedAction, ColonyActions } from '~types/index';
 import { useDataFetcher } from '~utils/hooks';
 import { parseDomainMetadata } from '~utils/colonyActions';
 import { useFormatRolesTitle } from '~utils/hooks/useFormatRolesTitle';
+import { MotionState, MOTION_TAG_MAP } from '~utils/colonyMotions';
 import { ipfsDataFetcher } from '../../../core/fetchers';
 
 import { ClickHandlerProps } from './ActionsList';
@@ -77,6 +79,7 @@ const ActionsListItem = ({
     roles,
     newVersion,
     status = ItemStatus.Defused,
+    motionState,
   },
   colony,
   handleOnClick,
@@ -126,6 +129,7 @@ const ActionsListItem = ({
     const domainObject = parseDomainMetadata(metadataJSON);
     domainName = domainObject.domainName;
   }
+  const motionStyles = MOTION_TAG_MAP[motionState || MotionState.Invalid];
 
   return (
     <li>
@@ -215,6 +219,21 @@ const ActionsListItem = ({
                 newVersion: newVersion || '0',
               }}
             />
+            {motionState && (
+              <div className={styles.motionTagWrapper}>
+                <Tag
+                  text={motionStyles.name}
+                  appearance={{
+                    theme: motionStyles.theme as TagAppearance['theme'],
+                    /*
+                     * @NOTE Prettier is being stupid
+                     */
+                    // eslint-disable-next-line max-len
+                    colorSchema: motionStyles.colorSchema as TagAppearance['colorSchema'],
+                  }}
+                />
+              </div>
+            )}
           </div>
           <div className={styles.meta}>
             <FormattedDateParts value={createdAt} month="short" day="numeric">

--- a/src/modules/core/components/Tag/Tag.tsx
+++ b/src/modules/core/components/Tag/Tag.tsx
@@ -5,7 +5,7 @@ import { useMainClasses } from '~utils/hooks';
 
 import styles from './Tag.css';
 
-interface Appearance {
+export interface Appearance {
   /* "light" is default */
   theme: 'primary' | 'light' | 'golden' | 'danger' | 'pink' | 'blue';
   fontSize?: 'tiny' | 'small';

--- a/src/modules/core/components/Tag/index.ts
+++ b/src/modules/core/components/Tag/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Tag';
+export { default, Appearance } from './Tag';

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
@@ -15,7 +15,7 @@ import {
   AnyUser,
   useMotionsSystemMessagesQuery,
 } from '~data/index';
-import Tag from '~core/Tag';
+import Tag, { Appearance as TagAppearance } from '~core/Tag';
 import FriendlyName from '~core/FriendlyName';
 import MemberReputation from '~core/MemberReputation';
 import CountDownTimer from '~core/CountDownTimer';
@@ -121,8 +121,12 @@ const MintTokenMotion = ({
           <Tag
             text={motionStyles.name}
             appearance={{
-              theme: motionStyles.theme,
-              colorSchema: motionStyles.colorSchema,
+              theme: motionStyles.theme as TagAppearance['theme'],
+              /*
+               * @NOTE Prettier is being stupid
+               */
+              // eslint-disable-next-line max-len
+              colorSchema: motionStyles.colorSchema as TagAppearance['colorSchema'],
             }}
           />
         </p>

--- a/src/modules/dashboard/components/ColonyEvents/ColonyEventsListItem.tsx
+++ b/src/modules/dashboard/components/ColonyEvents/ColonyEventsListItem.tsx
@@ -35,6 +35,14 @@ const MSG = defineMessages({
     id: 'dashboard.ColonyEvents.ColonyEventsListItem.domain',
     defaultMessage: 'Domain {domainId}',
   },
+  voteSide: {
+    id: 'dashboard.ColonyEvents.ColonyEventsListItem.voteSide',
+    defaultMessage: `{vote, select,
+      0 {objected}
+      1 {staked}
+      other {supported}
+    }`,
+  },
 });
 
 interface Props {
@@ -52,6 +60,7 @@ const ColonyEventsListItem = ({
     decimals,
     transactionHash,
     domainId,
+    newDomainId,
     createdAt,
     displayValues,
     fundingPot,
@@ -66,6 +75,8 @@ const ColonyEventsListItem = ({
     newVersion,
     storageSlot,
     storageSlotValue,
+    motionId,
+    vote,
   },
   colony: { tokens, nativeTokenAddress },
   colony,
@@ -80,6 +91,9 @@ const ColonyEventsListItem = ({
 
   const domain = colony.domains.find(
     ({ ethDomainId }) => ethDomainId === parseInt(domainId, 10),
+  );
+  const newDomain = colony.domains.find(
+    ({ ethDomainId }) => ethDomainId === parseInt(newDomainId, 10),
   );
 
   const token = tokens.find(({ address }) => address === tokenAddress);
@@ -117,10 +131,14 @@ const ColonyEventsListItem = ({
       </span>
     ),
     amount: (
-      <Numeral value={amount} unit={getTokenDecimalsWithFallback(decimals)} />
+      <Numeral
+        value={amount}
+        unit={getTokenDecimalsWithFallback(decimals || token?.decimals)}
+      />
     ),
     tokenSymbol: token?.symbol || colonyNativeToken?.symbol,
     domain: domain?.name || '',
+    newDomain: newDomain?.name || '',
     transactionHash,
     fundingPot,
     metadata,
@@ -134,6 +152,8 @@ const ColonyEventsListItem = ({
     newVersion,
     storageSlot,
     storageSlotValue,
+    motionId,
+    voteSide: <FormattedMessage {...MSG.voteSide} values={{ vote }} />,
   };
 
   return (

--- a/src/modules/dashboard/transformers.ts
+++ b/src/modules/dashboard/transformers.ts
@@ -371,7 +371,11 @@ export const getEventsListData = (
       } = event;
       const {
         agent,
+        creator,
+        staker,
+        escalator,
         domainId,
+        newDomainId,
         recipient,
         fundingPotId,
         metadata,
@@ -389,6 +393,8 @@ export const getEventsListData = (
         newVersion,
         slot,
         toValue,
+        motionId,
+        vote,
       } = JSON.parse(args || '{}');
       const checksummedColonyAddress = createAddress(colonyAddress);
       const getRecipient = () => {
@@ -400,20 +406,25 @@ export const getEventsListData = (
         }
         return checksummedColonyAddress;
       };
+      const getAgent = () => {
+        const userAddress = agent || user || creator || staker || escalator;
+        if (userAddress) {
+          return createAddress(userAddress);
+        }
+        return checksummedColonyAddress;
+      };
       return [
         ...processedEvents,
         {
           id,
-          agent:
-            agent || user
-              ? createAddress(agent || user)
-              : checksummedColonyAddress,
+          agent: getAgent(),
           eventName: formatEventName(name),
           transactionHash: hash,
           colonyAddress: checksummedColonyAddress,
           createdAt: new Date(parseInt(`${timestamp}000`, 10)),
           displayValues: args,
           domainId: domainId || null,
+          newDomainId: newDomainId || null,
           recipient: getRecipient(),
           fundingPot: fundingPotId,
           metadata,
@@ -429,6 +440,8 @@ export const getEventsListData = (
           newVersion: newVersion || '0',
           storageSlot: slot ? toHex(parseInt(slot, 10)) : '0',
           storageSlotValue: toValue || AddressZero,
+          motionId,
+          vote,
         },
       ];
     } catch (error) {

--- a/src/modules/dashboard/transformers.ts
+++ b/src/modules/dashboard/transformers.ts
@@ -1,4 +1,5 @@
 import { AddressZero, HashZero } from 'ethers/constants';
+import { bigNumberify } from 'ethers/utils';
 
 import {
   TransactionsMessagesCount,
@@ -102,7 +103,21 @@ export const getActionsListData = (
 
         return [...acc, event];
       }, []) || [],
-    motions: unformattedActions?.motions || [],
+    /*
+     * Only display motions in the list if their stake reached 10% or
+     * if they have been escalated
+     */
+    motions:
+      unformattedActions?.motions?.reduce((acc, motion) => {
+        const { requiredStake, currentStake, escalated } = motion;
+        const stakePercentage = bigNumberify(currentStake)
+          .div(bigNumberify(requiredStake))
+          .mul(100);
+        if (escalated || stakePercentage.gte(10)) {
+          return [...acc, motion];
+        }
+        return acc;
+      }, []) || [],
   };
 
   Object.keys(filteredUnformattedActions || {}).map((subgraphActionType) => {

--- a/src/types/colonyActions.ts
+++ b/src/types/colonyActions.ts
@@ -147,6 +147,7 @@ export interface FormattedEvent {
   createdAt: Date;
   displayValues: string;
   domainId: string;
+  newDomainId: string;
   fundingPot?: string;
   metadata?: string;
   tokenAddress?: string | null;
@@ -161,4 +162,6 @@ export interface FormattedEvent {
   newVersion?: string;
   storageSlot?: string;
   storageSlotValue?: string;
+  motionId?: string;
+  vote?: string;
 }

--- a/src/types/colonyActions.ts
+++ b/src/types/colonyActions.ts
@@ -2,6 +2,7 @@ import { ColonyRole } from '@colony/colony-js';
 
 import { ItemStatus } from '~core/ActionsList';
 import { Address, ActionUserRoles } from './index';
+import { MotionState } from '~utils/colonyMotions';
 
 export enum ColonyActions {
   Generic = 'Generic',
@@ -132,6 +133,7 @@ export interface FormattedAction {
   roles: ActionUserRoles[];
   oldVersion?: string;
   newVersion?: string;
+  motionState?: MotionState;
 }
 
 export interface FormattedEvent {

--- a/src/utils/colonyMotions.ts
+++ b/src/utils/colonyMotions.ts
@@ -1,16 +1,5 @@
 import { defineMessage } from 'react-intl';
 
-export enum NetworkMotionState {
-  Null = 0,
-  Staking = 1,
-  Submit = 2,
-  Reveal = 3,
-  Closed = 4,
-  Finalizable = 5,
-  Finalized = 6,
-  Failed = 7,
-}
-
 export enum MotionState {
   Motion = 'Motion',
   StakeRequired = 'StakeRequired',

--- a/src/utils/events/index.ts
+++ b/src/utils/events/index.ts
@@ -5,7 +5,7 @@ import {
   getLogs,
   ExtensionClient,
 } from '@colony/colony-js';
-import { bigNumberify } from 'ethers/utils';
+import { bigNumberify, BigNumberish } from 'ethers/utils';
 import { AddressZero } from 'ethers/constants';
 
 import ColonyManagerClass from '~lib/ColonyManager';
@@ -803,10 +803,9 @@ export const groupSetUserRolesActions = (actions): FormattedAction[] => {
 export const getMotionActionType = async (
   votingClient: ExtensionClient,
   colonyClient: ColonyClient,
-  motionCreatedEvent: any,
+  motionId: BigNumberish,
 ) => {
-  const motionid = motionCreatedEvent.values.motionId.toString();
-  const motion = await votingClient.getMotion(motionid);
+  const motion = await votingClient.getMotion(motionId);
   const values = colonyClient.interface.parseTransaction({
     data: motion.action,
   });

--- a/src/utils/events/index.ts
+++ b/src/utils/events/index.ts
@@ -501,7 +501,7 @@ const getRecoveryActionValues = async (
 };
 
 // Motions
-const getMotionState = async (
+export const getMotionState = async (
   motionNetworkState: NetworkMotionState,
   votingClient: ExtensionClient,
   motion,

--- a/src/utils/events/index.ts
+++ b/src/utils/events/index.ts
@@ -4,6 +4,7 @@ import {
   ClientType,
   getLogs,
   ExtensionClient,
+  MotionState as NetworkMotionState,
 } from '@colony/colony-js';
 import { bigNumberify, BigNumberish } from 'ethers/utils';
 import { AddressZero } from 'ethers/constants';
@@ -29,7 +30,7 @@ import ipfs from '~context/ipfsWithFallbackContext';
 import { log } from '~utils/debug';
 
 import { getSetUserRolesMessageDescriptorsIds } from '../colonyActions';
-import { NetworkMotionState, MotionState } from '../colonyMotions';
+import { MotionState } from '../colonyMotions';
 
 interface ActionValues {
   recipient: Address;


### PR DESCRIPTION
## Description

This PR adds in the required queries, resolvers and transformers in order to display motions that are created inside the Colony Home actions list

**Note:** that this requires the changes brought in by [subgraph#21](https://github.com/JoinColony/subgraph/pull/21) so make sure to run `provision` prior to testing

**Changes** 
- [x] Updated `subgraph` repo
- [x] Updated `colonyJS` to the latest release candidate
- [x] Added `motions` local resolver
- [x] Added `motions` subscription query 
- [x] Refactored `getMotionState`
- [x] Refactored `getMotionActionType`
- [x] Updated `getActionsListData` to display motions
- [x] Updated `ActionsListItem` to display a motion tag

**Screenshots**
![Screenshot from 2021-04-15 17-04-50](https://user-images.githubusercontent.com/1193222/114895209-fbbf8080-9e17-11eb-9b6b-620d761c7a0f.png)
![Screenshot from 2021-04-15 17-09-44](https://user-images.githubusercontent.com/1193222/114895221-fd894400-9e17-11eb-9ed3-e62737c16d2e.png)
![Screenshot from 2021-04-15 17-26-16](https://user-images.githubusercontent.com/1193222/114895224-fe21da80-9e17-11eb-803f-b203186f13a5.png)
![Screenshot from 2021-04-15 17-35-23](https://user-images.githubusercontent.com/1193222/114895322-17c32200-9e18-11eb-9bec-1b0a3e25c439.png)

Resolves DEV-278