### PR TITLE
Fix motion states

### DIFF
--- a/src/utils/events/index.ts
+++ b/src/utils/events/index.ts
@@ -524,7 +524,8 @@ const getMotionState = async (
         : MotionState.Motion;
     case NetworkMotionState.Finalizable:
     case NetworkMotionState.Finalized:
-      return motion.votes[0].gte(motion.votes[1])
+      return motion.votes[0].gt(motion.votes[1]) ||
+        motion.stakes[0].gt(motion.stakes[1])
         ? MotionState.Failed
         : MotionState.Passed;
     case NetworkMotionState.Failed:


### PR DESCRIPTION
## Description

IN cases when motion is in Finalizable or Finalized state, and there was no voting, check stakes array to find out if motion passed or failed

**Changes** 🏗

* Updated getMotionState logic


Resolves DEV-285
