### PR TITLE
Motions and Disputes Reveal Vote Widget

### DIFF
--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -285,6 +285,7 @@ export type Query = {
   getRecoveryStorageSlot: Scalars['String'];
   legacyNumberOfRecoveryRoles: Scalars['Int'];
   loggedInUser: LoggedInUser;
+  motionUserVoteRevealed: MotionVoteReveal;
   motionVoterReward: Scalars['String'];
   motionsSystemMessages: Array<SystemMessage>;
   networkContracts: NetworkContracts;
@@ -398,6 +399,13 @@ export type QueryGetRecoveryStorageSlotArgs = {
 
 export type QueryLegacyNumberOfRecoveryRolesArgs = {
   colonyAddress: Scalars['String'];
+};
+
+
+export type QueryMotionUserVoteRevealedArgs = {
+  motionId: Scalars['Int'];
+  colonyAddress: Scalars['String'];
+  userAddress: Scalars['String'];
 };
 
 
@@ -807,6 +815,11 @@ export type UsersAndRecoveryApprovals = {
 export type ActionThatNeedsAttention = {
   transactionHash: Scalars['String'];
   needsAction: Scalars['Boolean'];
+};
+
+export type MotionVoteReveal = {
+  revealed: Scalars['Boolean'];
+  vote: Scalars['Int'];
 };
 
 export type ByColonyFilter = {
@@ -1495,6 +1508,15 @@ export type MotionsVoterRewardQueryVariables = Exact<{
 
 
 export type MotionsVoterRewardQuery = Pick<Query, 'motionVoterReward'>;
+
+export type MotionUserVoteRevealedQueryVariables = Exact<{
+  motionId: Scalars['Int'];
+  colonyAddress: Scalars['String'];
+  userAddress: Scalars['String'];
+}>;
+
+
+export type MotionUserVoteRevealedQuery = { motionUserVoteRevealed: Pick<MotionVoteReveal, 'revealed' | 'vote'> };
 
 export type SubgraphDomainsQueryVariables = Exact<{
   colonyAddress: Scalars['String'];
@@ -3643,6 +3665,42 @@ export function useMotionsVoterRewardLazyQuery(baseOptions?: Apollo.LazyQueryHoo
 export type MotionsVoterRewardQueryHookResult = ReturnType<typeof useMotionsVoterRewardQuery>;
 export type MotionsVoterRewardLazyQueryHookResult = ReturnType<typeof useMotionsVoterRewardLazyQuery>;
 export type MotionsVoterRewardQueryResult = Apollo.QueryResult<MotionsVoterRewardQuery, MotionsVoterRewardQueryVariables>;
+export const MotionUserVoteRevealedDocument = gql`
+    query MotionUserVoteRevealed($motionId: Int!, $colonyAddress: String!, $userAddress: String!) {
+  motionUserVoteRevealed(motionId: $motionId, colonyAddress: $colonyAddress, userAddress: $userAddress) @client {
+    revealed
+    vote
+  }
+}
+    `;
+
+/**
+ * __useMotionUserVoteRevealedQuery__
+ *
+ * To run a query within a React component, call `useMotionUserVoteRevealedQuery` and pass it any options that fit your needs.
+ * When your component renders, `useMotionUserVoteRevealedQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useMotionUserVoteRevealedQuery({
+ *   variables: {
+ *      motionId: // value for 'motionId'
+ *      colonyAddress: // value for 'colonyAddress'
+ *      userAddress: // value for 'userAddress'
+ *   },
+ * });
+ */
+export function useMotionUserVoteRevealedQuery(baseOptions?: Apollo.QueryHookOptions<MotionUserVoteRevealedQuery, MotionUserVoteRevealedQueryVariables>) {
+        return Apollo.useQuery<MotionUserVoteRevealedQuery, MotionUserVoteRevealedQueryVariables>(MotionUserVoteRevealedDocument, baseOptions);
+      }
+export function useMotionUserVoteRevealedLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<MotionUserVoteRevealedQuery, MotionUserVoteRevealedQueryVariables>) {
+          return Apollo.useLazyQuery<MotionUserVoteRevealedQuery, MotionUserVoteRevealedQueryVariables>(MotionUserVoteRevealedDocument, baseOptions);
+        }
+export type MotionUserVoteRevealedQueryHookResult = ReturnType<typeof useMotionUserVoteRevealedQuery>;
+export type MotionUserVoteRevealedLazyQueryHookResult = ReturnType<typeof useMotionUserVoteRevealedLazyQuery>;
+export type MotionUserVoteRevealedQueryResult = Apollo.QueryResult<MotionUserVoteRevealedQuery, MotionUserVoteRevealedQueryVariables>;
 export const SubgraphDomainsDocument = gql`
     query SubgraphDomains($colonyAddress: String!) {
   domains(where: {colonyAddress: $colonyAddress}) {

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -285,6 +285,7 @@ export type Query = {
   getRecoveryStorageSlot: Scalars['String'];
   legacyNumberOfRecoveryRoles: Scalars['Int'];
   loggedInUser: LoggedInUser;
+  motionCurrentUserVoted: Scalars['Boolean'];
   motionUserVoteRevealed: MotionVoteReveal;
   motionVoterReward: Scalars['String'];
   motionsSystemMessages: Array<SystemMessage>;
@@ -399,6 +400,13 @@ export type QueryGetRecoveryStorageSlotArgs = {
 
 export type QueryLegacyNumberOfRecoveryRolesArgs = {
   colonyAddress: Scalars['String'];
+};
+
+
+export type QueryMotionCurrentUserVotedArgs = {
+  motionId: Scalars['Int'];
+  colonyAddress: Scalars['String'];
+  userAddress: Scalars['String'];
 };
 
 
@@ -1517,6 +1525,15 @@ export type MotionUserVoteRevealedQueryVariables = Exact<{
 
 
 export type MotionUserVoteRevealedQuery = { motionUserVoteRevealed: Pick<MotionVoteReveal, 'revealed' | 'vote'> };
+
+export type MotionCurrentUserVotedQueryVariables = Exact<{
+  motionId: Scalars['Int'];
+  colonyAddress: Scalars['String'];
+  userAddress: Scalars['String'];
+}>;
+
+
+export type MotionCurrentUserVotedQuery = Pick<Query, 'motionCurrentUserVoted'>;
 
 export type SubgraphDomainsQueryVariables = Exact<{
   colonyAddress: Scalars['String'];
@@ -3701,6 +3718,39 @@ export function useMotionUserVoteRevealedLazyQuery(baseOptions?: Apollo.LazyQuer
 export type MotionUserVoteRevealedQueryHookResult = ReturnType<typeof useMotionUserVoteRevealedQuery>;
 export type MotionUserVoteRevealedLazyQueryHookResult = ReturnType<typeof useMotionUserVoteRevealedLazyQuery>;
 export type MotionUserVoteRevealedQueryResult = Apollo.QueryResult<MotionUserVoteRevealedQuery, MotionUserVoteRevealedQueryVariables>;
+export const MotionCurrentUserVotedDocument = gql`
+    query MotionCurrentUserVoted($motionId: Int!, $colonyAddress: String!, $userAddress: String!) {
+  motionCurrentUserVoted(motionId: $motionId, colonyAddress: $colonyAddress, userAddress: $userAddress) @client
+}
+    `;
+
+/**
+ * __useMotionCurrentUserVotedQuery__
+ *
+ * To run a query within a React component, call `useMotionCurrentUserVotedQuery` and pass it any options that fit your needs.
+ * When your component renders, `useMotionCurrentUserVotedQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useMotionCurrentUserVotedQuery({
+ *   variables: {
+ *      motionId: // value for 'motionId'
+ *      colonyAddress: // value for 'colonyAddress'
+ *      userAddress: // value for 'userAddress'
+ *   },
+ * });
+ */
+export function useMotionCurrentUserVotedQuery(baseOptions?: Apollo.QueryHookOptions<MotionCurrentUserVotedQuery, MotionCurrentUserVotedQueryVariables>) {
+        return Apollo.useQuery<MotionCurrentUserVotedQuery, MotionCurrentUserVotedQueryVariables>(MotionCurrentUserVotedDocument, baseOptions);
+      }
+export function useMotionCurrentUserVotedLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<MotionCurrentUserVotedQuery, MotionCurrentUserVotedQueryVariables>) {
+          return Apollo.useLazyQuery<MotionCurrentUserVotedQuery, MotionCurrentUserVotedQueryVariables>(MotionCurrentUserVotedDocument, baseOptions);
+        }
+export type MotionCurrentUserVotedQueryHookResult = ReturnType<typeof useMotionCurrentUserVotedQuery>;
+export type MotionCurrentUserVotedLazyQueryHookResult = ReturnType<typeof useMotionCurrentUserVotedLazyQuery>;
+export type MotionCurrentUserVotedQueryResult = Apollo.QueryResult<MotionCurrentUserVotedQuery, MotionCurrentUserVotedQueryVariables>;
 export const SubgraphDomainsDocument = gql`
     query SubgraphDomains($colonyAddress: String!) {
   domains(where: {colonyAddress: $colonyAddress}) {

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -698,6 +698,7 @@ export type ColonyAction = {
   domainColor: Scalars['String'];
   blockNumber: Scalars['Int'];
   motionState?: Maybe<Scalars['String']>;
+  motionDomain: Scalars['Int'];
 };
 
 export type NetworkContractsInput = {
@@ -1390,7 +1391,7 @@ export type ColonyActionQueryVariables = Exact<{
 
 
 export type ColonyActionQuery = { colonyAction: (
-    Pick<ColonyAction, 'hash' | 'actionInitiator' | 'fromDomain' | 'toDomain' | 'recipient' | 'status' | 'createdAt' | 'actionType' | 'amount' | 'tokenAddress' | 'annotationHash' | 'newVersion' | 'oldVersion' | 'colonyDisplayName' | 'colonyAvatarHash' | 'colonyTokens' | 'domainName' | 'domainPurpose' | 'domainColor' | 'motionState' | 'blockNumber'>
+    Pick<ColonyAction, 'hash' | 'actionInitiator' | 'fromDomain' | 'toDomain' | 'recipient' | 'status' | 'createdAt' | 'actionType' | 'amount' | 'tokenAddress' | 'annotationHash' | 'newVersion' | 'oldVersion' | 'colonyDisplayName' | 'colonyAvatarHash' | 'colonyTokens' | 'domainName' | 'domainPurpose' | 'domainColor' | 'motionState' | 'motionDomain' | 'blockNumber'>
     & { events: Array<Pick<ParsedEvent, 'type' | 'name' | 'values' | 'createdAt' | 'emmitedBy' | 'transactionHash'>>, roles: Array<Pick<ColonyActionRoles, 'id' | 'setTo'>> }
   ) };
 
@@ -3103,6 +3104,7 @@ export const ColonyActionDocument = gql`
     domainPurpose
     domainColor
     motionState
+    motionDomain
     roles {
       id
       setTo

--- a/src/data/graphql/queries.graphql
+++ b/src/data/graphql/queries.graphql
@@ -390,6 +390,13 @@ query MotionsVoterReward($motionId: Int!, $colonyAddress: String!, $userAddress:
   motionVoterReward(motionId: $motionId, colonyAddress: $colonyAddress, userAddress: $userAddress) @client
 }
 
+query MotionUserVoteRevealed($motionId: Int!, $colonyAddress: String!, $userAddress: String!) {
+  motionUserVoteRevealed(motionId: $motionId, colonyAddress: $colonyAddress, userAddress: $userAddress) @client {
+    revealed
+    vote
+  }
+}
+
 # The Graph
 #
 # @NOTE All queries meant for the subgraph should be prepended with `Subgraph`

--- a/src/data/graphql/queries.graphql
+++ b/src/data/graphql/queries.graphql
@@ -397,6 +397,10 @@ query MotionUserVoteRevealed($motionId: Int!, $colonyAddress: String!, $userAddr
   }
 }
 
+query MotionCurrentUserVoted($motionId: Int!, $colonyAddress: String!, $userAddress: String!) {
+  motionCurrentUserVoted(motionId: $motionId, colonyAddress: $colonyAddress, userAddress: $userAddress) @client
+}
+
 # The Graph
 #
 # @NOTE All queries meant for the subgraph should be prepended with `Subgraph`

--- a/src/data/graphql/queries.graphql
+++ b/src/data/graphql/queries.graphql
@@ -249,6 +249,7 @@ query ColonyAction($transactionHash: String!, $colonyAddress: String!) {
     domainPurpose
     domainColor
     motionState
+    motionDomain
     roles {
       id
       setTo

--- a/src/data/graphql/typeDefs.ts
+++ b/src/data/graphql/typeDefs.ts
@@ -63,6 +63,7 @@ export default gql`
     domainColor: String!
     blockNumber: Int!
     motionState: String
+    motionDomain: Int!
   }
 
   input NetworkContractsInput {

--- a/src/data/graphql/typeDefs.ts
+++ b/src/data/graphql/typeDefs.ts
@@ -203,6 +203,11 @@ export default gql`
     needsAction: Boolean!
   }
 
+  type MotionVoteReveal {
+    revealed: Boolean!
+    vote: Int!
+  }
+
   extend type Query {
     loggedInUser: LoggedInUser!
     colonyAddress(name: String!): String!
@@ -272,6 +277,11 @@ export default gql`
       colonyAddress: String!
       userAddress: String!
     ): String!
+    motionUserVoteRevealed(
+      motionId: Int!
+      colonyAddress: String!
+      userAddress: String!
+    ): MotionVoteReveal!
   }
 
   extend type Mutation {

--- a/src/data/graphql/typeDefs.ts
+++ b/src/data/graphql/typeDefs.ts
@@ -282,6 +282,11 @@ export default gql`
       colonyAddress: String!
       userAddress: String!
     ): MotionVoteReveal!
+    motionCurrentUserVoted(
+      motionId: Int!
+      colonyAddress: String!
+      userAddress: String!
+    ): Boolean!
   }
 
   extend type Mutation {

--- a/src/data/resolvers/colonyActions.ts
+++ b/src/data/resolvers/colonyActions.ts
@@ -170,7 +170,7 @@ export const colonyActionsResolvers = ({
           actionType = await getMotionActionType(
             votingClient as ExtensionClient,
             colonyClient as ColonyClient,
-            motionCreatedEvent.values.domainId,
+            motionCreatedEvent.values.motionId,
           );
         } else {
           actionType = getActionType(reverseSortedEvents);

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -244,6 +244,29 @@ export const motionsResolvers = ({
         return [];
       }
     },
+    async motionCurrentUserVoted(_, { motionId, colonyAddress, userAddress }) {
+      try {
+        const votingReputationClient = await colonyManager.getClient(
+          ClientType.VotingReputationClient,
+          colonyAddress,
+        );
+        // @ts-ignore
+        // eslint-disable-next-line max-len
+        const motionVoteFilter = votingReputationClient.filters.MotionVoteSubmitted(
+          bigNumberify(motionId),
+          userAddress,
+        );
+        const voteSubmittedEvents = await getEvents(
+          votingReputationClient,
+          motionVoteFilter,
+        );
+        return !!voteSubmittedEvents.length;
+      } catch (error) {
+        console.error('Could not fetch current user vote status');
+        console.error(error);
+        return null;
+      }
+    },
     async motionUserVoteRevealed(_, { motionId, colonyAddress, userAddress }) {
       try {
         let userVote = {

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -244,6 +244,40 @@ export const motionsResolvers = ({
         return [];
       }
     },
+    async motionUserVoteRevealed(_, { motionId, colonyAddress, userAddress }) {
+      try {
+        let userVote = {
+          revealed: false,
+          vote: null,
+        };
+        const votingReputationClient = await colonyManager.getClient(
+          ClientType.VotingReputationClient,
+          colonyAddress,
+        );
+        // @ts-ignore
+        // eslint-disable-next-line max-len
+        const motionVoteRevealedFilter = votingReputationClient.filters.MotionVoteRevealed(
+          bigNumberify(motionId),
+          userAddress,
+          null,
+        );
+        const [userReveal] = await getEvents(
+          votingReputationClient,
+          motionVoteRevealedFilter,
+        );
+        if (userReveal) {
+          userVote = {
+            revealed: true,
+            vote: userReveal.values.vote.toNumber(),
+          };
+        }
+        return userVote;
+      } catch (error) {
+        console.error('Could not fetch user vote revealed state');
+        console.error(error);
+        return null;
+      }
+    },
   },
   Motion: {
     async state({ fundamentalChainId, associatedColony: { colonyAddress } }) {

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -4,6 +4,7 @@ import {
   getLogs,
   getBlockTime,
   MotionState as NetworkMotionState,
+  getEvents,
 } from '@colony/colony-js';
 import { bigNumberify } from 'ethers/utils';
 import { Resolvers } from '@apollo/client';

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
@@ -56,6 +56,7 @@ const MintTokenMotion = ({
     colonyDisplayName,
     amount,
     motionState,
+    motionDomain,
     actionInitiator,
   },
   colonyAction,
@@ -188,6 +189,7 @@ const MintTokenMotion = ({
               colony={colony}
               actionType={actionType}
               motionId={motionId}
+              motionDomain={motionDomain}
             />
           )}
           {motionState === MotionState.Reveal && (

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
@@ -24,6 +24,7 @@ import { MotionState, MOTION_TAG_MAP } from '~utils/colonyMotions';
 
 import DetailsWidget from '../DetailsWidget';
 import VoteWidget from '../VoteWidget';
+import RevealWidget from '../RevealWidget';
 
 import { motionCountdownTimerMsg as MSG } from './motionCountdownTimerMsg';
 
@@ -188,6 +189,9 @@ const MintTokenMotion = ({
               actionType={actionType}
               motionId={motionId}
             />
+          )}
+          {motionState === MotionState.Reveal && (
+            <RevealWidget colony={colony} motionId={motionId} />
           )}
           <DetailsWidget
             actionType={actionType as ColonyMotions}

--- a/src/modules/dashboard/components/ActionsPage/RevealWidget/RevealWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/RevealWidget/RevealWidget.css
@@ -1,0 +1,8 @@
+.main {
+  display: block;
+  margin: 0px 0 100px 0;
+}
+
+.main h4 {
+  padding: 20px 0;
+}

--- a/src/modules/dashboard/components/ActionsPage/RevealWidget/RevealWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/RevealWidget/RevealWidget.css
@@ -7,6 +7,10 @@
   padding: 20px 0 10px;
 }
 
+.main label {
+  cursor: default;
+}
+
 .voteHiddenInfo {
   padding: 12px 0;
   background-color: color-mod(var(--text-disabled) alpha(12%));

--- a/src/modules/dashboard/components/ActionsPage/RevealWidget/RevealWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/RevealWidget/RevealWidget.css
@@ -4,5 +4,14 @@
 }
 
 .main h4 {
-  padding: 20px 0;
+  padding: 20px 0 10px;
+}
+
+.voteHiddenInfo {
+  padding: 12px 0;
+  background-color: color-mod(var(--text-disabled) alpha(12%));
+  font-size: var(--size-smallish);
+  font-weight: var(--weight-bold);
+  text-align: center;
+  color: color-mod(var(--temp-grey-blue-7) alpha(50%));
 }

--- a/src/modules/dashboard/components/ActionsPage/RevealWidget/RevealWidget.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/RevealWidget/RevealWidget.css.d.ts
@@ -1,0 +1,1 @@
+export const main: string;

--- a/src/modules/dashboard/components/ActionsPage/RevealWidget/RevealWidget.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/RevealWidget/RevealWidget.css.d.ts
@@ -1,1 +1,2 @@
 export const main: string;
+export const voteHiddenInfo: string;

--- a/src/modules/dashboard/components/ActionsPage/RevealWidget/RevealWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/RevealWidget/RevealWidget.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback } from 'react';
 import { FormikProps } from 'formik';
-import * as yup from 'yup';
-import { defineMessages } from 'react-intl';
+import { defineMessages, FormattedMessage } from 'react-intl';
 
 import Button from '~core/Button';
 import { ActionForm } from '~core/Fields';
@@ -29,14 +28,14 @@ const MSG = defineMessages({
     id: 'dashboard.ActionsPage.RevealWidget.title',
     defaultMessage: `Reveal your vote to others to claim your reward.`,
   },
+  voteHiddnInfo: {
+    id: 'dashboard.ActionsPage.RevealWidget.voteHiddnInfo',
+    defaultMessage: `Your vote is hidden from others.`,
+  },
   buttonReveal: {
     id: 'dashboard.ActionsPage.RevealWidget.buttonReveal',
     defaultMessage: `Reveal`,
   },
-});
-
-const validationSchema = yup.object().shape({
-  vote: yup.number().required(),
 });
 
 const RevealWidget = ({
@@ -59,26 +58,21 @@ const RevealWidget = ({
 
   return (
     <ActionForm
-      initialValues={{
-        vote: undefined,
-      }}
-      validationSchema={validationSchema}
+      initialValues={{}}
       submit={ActionTypes.COLONY_ACTION_GENERIC}
       error={ActionTypes.COLONY_ACTION_GENERIC_ERROR}
       success={ActionTypes.COLONY_ACTION_GENERIC_SUCCESS}
       transform={transform}
     >
-      {({
-        handleSubmit,
-        isSubmitting,
-        isValid,
-        values,
-      }: FormikProps<FormValues>) => (
+      {({ handleSubmit, isSubmitting }: FormikProps<FormValues>) => (
         <div className={styles.main}>
           <Heading
             text={MSG.title}
             appearance={{ size: 'normal', theme: 'dark', margin: 'none' }}
           />
+          <div className={styles.voteHiddenInfo}>
+            <FormattedMessage {...MSG.voteHiddnInfo} />
+          </div>
           <VoteDetails
             colony={colony}
             motionId={motionId}
@@ -86,7 +80,7 @@ const RevealWidget = ({
               <Button
                 appearance={{ theme: 'primary', size: 'medium' }}
                 text={MSG.buttonReveal}
-                disabled={!isValid || !hasRegisteredProfile || !values.vote}
+                disabled={!hasRegisteredProfile}
                 onClick={() => handleSubmit()}
                 loading={isSubmitting}
               />

--- a/src/modules/dashboard/components/ActionsPage/RevealWidget/RevealWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/RevealWidget/RevealWidget.tsx
@@ -1,0 +1,103 @@
+import React, { useCallback } from 'react';
+import { FormikProps } from 'formik';
+import * as yup from 'yup';
+import { defineMessages } from 'react-intl';
+
+import Button from '~core/Button';
+import { ActionForm } from '~core/Fields';
+import Heading from '~core/Heading';
+
+import { Colony, useLoggedInUser } from '~data/index';
+import { ActionTypes } from '~redux/index';
+import { mapPayload } from '~utils/actions';
+
+import VoteDetails from '../VoteWidget/VoteDetails';
+
+import styles from './RevealWidget.css';
+
+export interface FormValues {
+  vote: string;
+}
+
+interface Props {
+  colony: Colony;
+  motionId: number;
+}
+
+const MSG = defineMessages({
+  title: {
+    id: 'dashboard.ActionsPage.RevealWidget.title',
+    defaultMessage: `Reveal your vote to others to claim your reward.`,
+  },
+  buttonReveal: {
+    id: 'dashboard.ActionsPage.RevealWidget.buttonReveal',
+    defaultMessage: `Reveal`,
+  },
+});
+
+const validationSchema = yup.object().shape({
+  vote: yup.number().required(),
+});
+
+const RevealWidget = ({
+  colony: { colonyAddress },
+  colony,
+  motionId,
+}: Props) => {
+  const { walletAddress, username, ethereal } = useLoggedInUser();
+
+  const transform = useCallback(
+    mapPayload(({ vote }) => ({
+      colonyAddress,
+      walletAddress,
+      vote: parseInt(vote, 10),
+    })),
+    [],
+  );
+
+  const hasRegisteredProfile = !!username && !ethereal;
+
+  return (
+    <ActionForm
+      initialValues={{
+        vote: undefined,
+      }}
+      validationSchema={validationSchema}
+      submit={ActionTypes.COLONY_ACTION_GENERIC}
+      error={ActionTypes.COLONY_ACTION_GENERIC_ERROR}
+      success={ActionTypes.COLONY_ACTION_GENERIC_SUCCESS}
+      transform={transform}
+    >
+      {({
+        handleSubmit,
+        isSubmitting,
+        isValid,
+        values,
+      }: FormikProps<FormValues>) => (
+        <div className={styles.main}>
+          <Heading
+            text={MSG.title}
+            appearance={{ size: 'normal', theme: 'dark', margin: 'none' }}
+          />
+          <VoteDetails
+            colony={colony}
+            motionId={motionId}
+            buttonComponent={
+              <Button
+                appearance={{ theme: 'primary', size: 'medium' }}
+                text={MSG.buttonReveal}
+                disabled={!isValid || !hasRegisteredProfile || !values.vote}
+                onClick={() => handleSubmit()}
+                loading={isSubmitting}
+              />
+            }
+          />
+        </div>
+      )}
+    </ActionForm>
+  );
+};
+
+RevealWidget.displayName = 'dashboard.ActionsPage.RevealWidget';
+
+export default RevealWidget;

--- a/src/modules/dashboard/components/ActionsPage/RevealWidget/index.ts
+++ b/src/modules/dashboard/components/ActionsPage/RevealWidget/index.ts
@@ -1,0 +1,1 @@
+export { default } from './RevealWidget';

--- a/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteDetails.tsx
+++ b/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteDetails.tsx
@@ -129,10 +129,12 @@ const VoteDetails = ({
               </div>
             </div>
             <div className={styles.value}>
-              <MemberReputation
-                walletAddress={walletAddress}
-                colonyAddress={colonyAddress}
-              />
+              <div className={styles.reputation}>
+                <MemberReputation
+                  walletAddress={walletAddress}
+                  colonyAddress={colonyAddress}
+                />
+              </div>
             </div>
           </div>
           <div className={styles.item}>

--- a/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteDetails.tsx
+++ b/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteDetails.tsx
@@ -1,0 +1,186 @@
+import React, { ReactElement } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import QuestionMarkTooltip from '~core/QuestionMarkTooltip';
+import MemberReputation from '~core/MemberReputation';
+import Numeral from '~core/Numeral';
+
+import {
+  Colony,
+  useLoggedInUser,
+  useMotionsVoterRewardQuery,
+} from '~data/index';
+import { getTokenDecimalsWithFallback } from '~utils/tokens';
+
+import styles from './VoteWidget.css';
+
+export interface FormValues {
+  vote: string;
+}
+
+interface Props {
+  colony: Colony;
+  motionId: number;
+  buttonComponent?: ReactElement;
+}
+
+const MSG = defineMessages({
+  votingMethodLabel: {
+    id: 'dashboard.ActionsPage.VoteWidget.votingMethodLabel',
+    defaultMessage: `Voting method`,
+  },
+  votingMethodValue: {
+    id: 'dashboard.ActionsPage.VoteWidget.votingMethodValue',
+    defaultMessage: `Reputation-weighted`,
+  },
+  votingMethodTooltip: {
+    id: 'dashboard.ActionsPage.VoteWidget.votingMethodTooltip',
+    defaultMessage: `Colony makes it possible to utilize different voting methods. Selected vothing method depends on installed extensions. You can change voting method in Governance Policy.`,
+  },
+  reputationTeamLabel: {
+    id: 'dashboard.ActionsPage.VoteWidget.reputationTeamLabel',
+    defaultMessage: `Reputation in team`,
+  },
+  reputationTeamTooltip: {
+    id: 'dashboard.ActionsPage.VoteWidget.reputationTeamTooltip',
+    defaultMessage: `Displays users own reputation in a domain. For example, for reputation 3.5%, user vote is going to be counted as 3.5. Users without reputation, couldn’t vote.`,
+  },
+  rewardLabel: {
+    id: 'dashboard.ActionsPage.VoteWidget.rewardLabel',
+    defaultMessage: `Reward`,
+  },
+  rewardTooltip: {
+    id: 'dashboard.ActionsPage.VoteWidget.rewardTooltip',
+    defaultMessage: `Displays possible reward range for an individual user. If prediction aligns with the winning outcome, than user receives reward. Final value depends on [TO BE ADDED]`,
+  },
+  rulesLabel: {
+    id: 'dashboard.ActionsPage.VoteWidget.rulesLabel',
+    defaultMessage: `Rules`,
+  },
+  rulesTooltip: {
+    id: 'dashboard.ActionsPage.VoteWidget.rulesTooltip',
+    defaultMessage: `Voting process goes in stages. User selects option to vote upon. Than reveals the own vote before the ‘Reveal’ stage passes. Later on, user has to claim tokens and finalize transaction.`,
+  },
+});
+
+const VoteDetails = ({
+  colony: { colonyAddress, tokens, nativeTokenAddress },
+  buttonComponent,
+  motionId,
+}: Props) => {
+  const { walletAddress, username, ethereal } = useLoggedInUser();
+
+  const { data: voterReward } = useMotionsVoterRewardQuery({
+    variables: {
+      colonyAddress,
+      userAddress: walletAddress,
+      motionId,
+    },
+  });
+
+  const nativeToken = tokens.find(
+    ({ address }) => address === nativeTokenAddress,
+  );
+
+  const hasRegisteredProfile = !!username && !ethereal;
+
+  return (
+    <div>
+      <div className={styles.item}>
+        <div className={styles.label}>
+          <div>
+            <FormattedMessage {...MSG.votingMethodLabel} />
+            <QuestionMarkTooltip
+              tooltipText={MSG.votingMethodTooltip}
+              className={styles.help}
+              tooltipClassName={styles.tooltip}
+              tooltipPopperProps={{
+                placement: 'right',
+              }}
+            />
+          </div>
+        </div>
+        <div className={styles.value}>
+          {/*
+           * @TODO This needs to be dynamic, once we'll have more voting methods:
+           * - reputation based
+           * - token based
+           * - hybrid
+           */}
+          <FormattedMessage {...MSG.votingMethodValue} />
+        </div>
+      </div>
+      {hasRegisteredProfile && (
+        <>
+          <div className={styles.item}>
+            <div className={styles.label}>
+              <div>
+                <FormattedMessage {...MSG.reputationTeamLabel} />
+                <QuestionMarkTooltip
+                  tooltipText={MSG.reputationTeamTooltip}
+                  className={styles.help}
+                  tooltipClassName={styles.tooltip}
+                  tooltipPopperProps={{
+                    placement: 'right',
+                  }}
+                />
+              </div>
+            </div>
+            <div className={styles.value}>
+              <MemberReputation
+                walletAddress={walletAddress}
+                colonyAddress={colonyAddress}
+              />
+            </div>
+          </div>
+          <div className={styles.item}>
+            <div className={styles.label}>
+              <div>
+                <FormattedMessage {...MSG.rewardLabel} />
+                <QuestionMarkTooltip
+                  tooltipText={MSG.rewardTooltip}
+                  className={styles.help}
+                  tooltipClassName={styles.tooltip}
+                  tooltipPopperProps={{
+                    placement: 'right',
+                  }}
+                />
+              </div>
+            </div>
+            <div className={styles.value}>
+              {voterReward?.motionVoterReward && (
+                <Numeral
+                  unit={getTokenDecimalsWithFallback(nativeToken?.decimals)}
+                  value={voterReward.motionVoterReward}
+                  suffix={` ${nativeToken?.symbol}`}
+                />
+              )}
+            </div>
+          </div>
+        </>
+      )}
+      {buttonComponent && (
+        <div className={styles.item}>
+          <div className={styles.label}>
+            <div>
+              <FormattedMessage {...MSG.rulesLabel} />
+              <QuestionMarkTooltip
+                tooltipText={MSG.rulesTooltip}
+                className={styles.help}
+                tooltipClassName={styles.tooltip}
+                tooltipPopperProps={{
+                  placement: 'right',
+                }}
+              />
+            </div>
+          </div>
+          <div className={styles.value}>{buttonComponent}</div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+VoteDetails.displayName = 'dashboard.ActionsPage.VoteDetails';
+
+export default VoteDetails;

--- a/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteDetails.tsx
+++ b/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteDetails.tsx
@@ -22,6 +22,7 @@ interface Props {
   colony: Colony;
   motionId: number;
   buttonComponent?: ReactElement;
+  showReward?: boolean;
 }
 
 const MSG = defineMessages({
@@ -67,6 +68,7 @@ const VoteDetails = ({
   colony: { colonyAddress, tokens, nativeTokenAddress },
   buttonComponent,
   motionId,
+  showReward = true,
 }: Props) => {
   const { walletAddress, username, ethereal } = useLoggedInUser();
 
@@ -110,7 +112,7 @@ const VoteDetails = ({
           <FormattedMessage {...MSG.votingMethodValue} />
         </div>
       </div>
-      {hasRegisteredProfile && (
+      {hasRegisteredProfile && showReward && (
         <>
           <div className={styles.item}>
             <div className={styles.label}>

--- a/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteWidget.css
@@ -28,6 +28,10 @@
   font-size: var(--size-smal);
 }
 
+.reputation i {
+  vertical-align: initial;
+}
+
 .help {
   display: inline-block;
   margin-left: 7px;

--- a/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteWidget.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteWidget.css.d.ts
@@ -2,5 +2,6 @@ export const main: string;
 export const item: string;
 export const label: string;
 export const value: string;
+export const reputation: string;
 export const help: string;
 export const tooltip: string;

--- a/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteWidget.tsx
@@ -1,24 +1,18 @@
 import React, { useCallback } from 'react';
 import { FormikProps } from 'formik';
 import * as yup from 'yup';
-import { defineMessages, FormattedMessage } from 'react-intl';
+import { defineMessages } from 'react-intl';
 
 import Button from '~core/Button';
 import { ActionForm, CustomRadioGroup, CustomRadioProps } from '~core/Fields';
 import Heading from '~core/Heading';
-import QuestionMarkTooltip from '~core/QuestionMarkTooltip';
-import MemberReputation from '~core/MemberReputation';
-import Numeral from '~core/Numeral';
 
-import {
-  Colony,
-  useLoggedInUser,
-  useMotionsVoterRewardQuery,
-} from '~data/index';
+import { Colony, useLoggedInUser } from '~data/index';
 import { ActionTypes } from '~redux/index';
 import { ColonyMotions } from '~types/index';
 import { mapPayload } from '~utils/actions';
-import { getTokenDecimalsWithFallback } from '~utils/tokens';
+
+import VoteDetails from './VoteDetails';
 
 import styles from './VoteWidget.css';
 
@@ -47,42 +41,6 @@ const MSG = defineMessages({
       other {Generic Action}
     }" be approved?`,
   },
-  votingMethodLabel: {
-    id: 'dashboard.ActionsPage.VoteWidget.votingMethodLabel',
-    defaultMessage: `Voting method`,
-  },
-  votingMethodValue: {
-    id: 'dashboard.ActionsPage.VoteWidget.votingMethodValue',
-    defaultMessage: `Reputation-weighted`,
-  },
-  votingMethodTooltip: {
-    id: 'dashboard.ActionsPage.VoteWidget.votingMethodTooltip',
-    defaultMessage: `Colony makes it possible to utilize different voting methods. Selected vothing method depends on installed extensions. You can change voting method in Governance Policy.`,
-  },
-  reputationTeamLabel: {
-    id: 'dashboard.ActionsPage.VoteWidget.reputationTeamLabel',
-    defaultMessage: `Reputation in team`,
-  },
-  reputationTeamTooltip: {
-    id: 'dashboard.ActionsPage.VoteWidget.reputationTeamTooltip',
-    defaultMessage: `Displays users own reputation in a domain. For example, for reputation 3.5%, user vote is going to be counted as 3.5. Users without reputation, couldn’t vote.`,
-  },
-  rewardLabel: {
-    id: 'dashboard.ActionsPage.VoteWidget.rewardLabel',
-    defaultMessage: `Reward`,
-  },
-  rewardTooltip: {
-    id: 'dashboard.ActionsPage.VoteWidget.rewardTooltip',
-    defaultMessage: `Displays possible reward range for an individual user. If prediction aligns with the winning outcome, than user receives reward. Final value depends on [TO BE ADDED]`,
-  },
-  rulesLabel: {
-    id: 'dashboard.ActionsPage.VoteWidget.rulesLabel',
-    defaultMessage: `Rules`,
-  },
-  rulesTooltip: {
-    id: 'dashboard.ActionsPage.VoteWidget.rulesTooltip',
-    defaultMessage: `Voting process goes in stages. User selects option to vote upon. Than reveals the own vote before the ‘Reveal’ stage passes. Later on, user has to claim tokens and finalize transaction.`,
-  },
   buttonVote: {
     id: 'dashboard.ActionsPage.VoteWidget.buttonVote',
     defaultMessage: `Vote`,
@@ -94,23 +52,12 @@ const validationSchema = yup.object().shape({
 });
 
 const VoteWidget = ({
-  colony: { colonyAddress, tokens, nativeTokenAddress },
+  colony: { colonyAddress },
+  colony,
   actionType,
   motionId,
 }: Props) => {
   const { walletAddress, username, ethereal } = useLoggedInUser();
-
-  const { data: voterReward } = useMotionsVoterRewardQuery({
-    variables: {
-      colonyAddress,
-      userAddress: walletAddress,
-      motionId,
-    },
-  });
-
-  const nativeToken = tokens.find(
-    ({ address }) => address === nativeTokenAddress,
-  );
 
   const transform = useCallback(
     mapPayload(({ vote }) => ({
@@ -175,107 +122,19 @@ const VoteWidget = ({
             name="vote"
             disabled={!hasRegisteredProfile}
           />
-          <div>
-            <div className={styles.item}>
-              <div className={styles.label}>
-                <div>
-                  <FormattedMessage {...MSG.votingMethodLabel} />
-                  <QuestionMarkTooltip
-                    tooltipText={MSG.votingMethodTooltip}
-                    className={styles.help}
-                    tooltipClassName={styles.tooltip}
-                    tooltipPopperProps={{
-                      placement: 'right',
-                    }}
-                  />
-                </div>
-              </div>
-              <div className={styles.value}>
-                {/*
-                 * @TODO This needs to be dynamic, once we'll have more voting methods:
-                 * - reputation based
-                 * - token based
-                 * - hybrid
-                 */}
-                <FormattedMessage {...MSG.votingMethodValue} />
-              </div>
-            </div>
-            {hasRegisteredProfile && (
-              <>
-                <div className={styles.item}>
-                  <div className={styles.label}>
-                    <div>
-                      <FormattedMessage {...MSG.reputationTeamLabel} />
-                      <QuestionMarkTooltip
-                        tooltipText={MSG.reputationTeamTooltip}
-                        className={styles.help}
-                        tooltipClassName={styles.tooltip}
-                        tooltipPopperProps={{
-                          placement: 'right',
-                        }}
-                      />
-                    </div>
-                  </div>
-                  <div className={styles.value}>
-                    <MemberReputation
-                      walletAddress={walletAddress}
-                      colonyAddress={colonyAddress}
-                    />
-                  </div>
-                </div>
-                <div className={styles.item}>
-                  <div className={styles.label}>
-                    <div>
-                      <FormattedMessage {...MSG.rewardLabel} />
-                      <QuestionMarkTooltip
-                        tooltipText={MSG.rewardTooltip}
-                        className={styles.help}
-                        tooltipClassName={styles.tooltip}
-                        tooltipPopperProps={{
-                          placement: 'right',
-                        }}
-                      />
-                    </div>
-                  </div>
-                  <div className={styles.value}>
-                    {voterReward?.motionVoterReward && (
-                      <Numeral
-                        unit={getTokenDecimalsWithFallback(
-                          nativeToken?.decimals,
-                        )}
-                        value={voterReward.motionVoterReward}
-                        suffix={` ${nativeToken?.symbol}`}
-                      />
-                    )}
-                  </div>
-                </div>
-              </>
-            )}
-            <div className={styles.item}>
-              <div className={styles.label}>
-                <div>
-                  <FormattedMessage {...MSG.rulesLabel} />
-                  <QuestionMarkTooltip
-                    tooltipText={MSG.rulesTooltip}
-                    className={styles.help}
-                    tooltipClassName={styles.tooltip}
-                    tooltipPopperProps={{
-                      placement: 'right',
-                    }}
-                  />
-                </div>
-              </div>
-              <div className={styles.value}>
-                <Button
-                  appearance={{ theme: 'primary', size: 'medium' }}
-                  text={MSG.buttonVote}
-                  disabled={!isValid || !hasRegisteredProfile || !values.vote}
-                  onClick={() => handleSubmit()}
-                  loading={isSubmitting}
-                />
-              </div>
-            </div>
-          </div>
+          <VoteDetails
+            colony={colony}
+            motionId={motionId}
+            buttonComponent={
+              <Button
+                appearance={{ theme: 'primary', size: 'medium' }}
+                text={MSG.buttonVote}
+                disabled={!isValid || !hasRegisteredProfile || !values.vote}
+                onClick={() => handleSubmit()}
+                loading={isSubmitting}
+              />
+            }
+          />
         </div>
       )}
     </ActionForm>

--- a/src/utils/colonyMotions.ts
+++ b/src/utils/colonyMotions.ts
@@ -13,7 +13,7 @@ export enum MotionState {
 
 export enum MotionVote {
   Yay = 1,
-  Nay = 2,
+  Nay = 0,
 }
 
 const MSG = defineMessage({

--- a/src/utils/colonyMotions.ts
+++ b/src/utils/colonyMotions.ts
@@ -11,6 +11,11 @@ export enum MotionState {
   Invalid = 'Invalid',
 }
 
+export enum MotionVote {
+  Yay = 1,
+  Nay = 2,
+}
+
 const MSG = defineMessage({
   motionTag: {
     id: 'dashboard.ActionsPage.motionTag',

--- a/src/utils/events/index.ts
+++ b/src/utils/events/index.ts
@@ -589,6 +589,7 @@ const getMintTokensMotionValues = async (
     actionInitiator: string;
     recipient: Address;
     tokenAddress: Address;
+    motionDomain: number;
   } = {
     motionState,
     address: motionCreatedEvent.address,
@@ -596,6 +597,7 @@ const getMintTokensMotionValues = async (
     actionInitiator: motionCreatedEvent.values.creator,
     amount: bigNumberify(values.args[0] || '0').toString(),
     tokenAddress,
+    motionDomain: motion.domainId.toNumber(),
   };
 
   return mintTokensMotionValues;

--- a/src/utils/events/index.ts
+++ b/src/utils/events/index.ts
@@ -512,7 +512,8 @@ export const getMotionState = async (
     .div(bigNumberify(10).pow(18));
   switch (motionNetworkState) {
     case NetworkMotionState.Staking:
-      return motion.stakes[1].eq(requiredStakes) && motion.stakes[0].isZero()
+      return bigNumberify(motion.stakes[0]).gt(bigNumberify(0)) ||
+        bigNumberify(motion.stakes[1]).gt(bigNumberify(0))
         ? MotionState.Motion
         : MotionState.StakeRequired;
     case NetworkMotionState.Submit:


### PR DESCRIPTION
## Description

This PR adds in the voting reveal widget to the motion page, but does not wire in the saga

This widget has two states:
1. vote was not revealed yet, just show a info message
2. vote was revealed, show the user's vote

**Notes on testing**
To test this properly you'll need to 
- get two users in the colony
- make sure both have 50% reputation (eg: make a payment of 1000 to each user)
- create the motion
- stake both sides (you can do this with just one user)
- vote (one user for yes, another one for no)
- _at this point you can see the initial state of the reveal widget_
- reveal one user's vote
- _now you can see the vote, of the user who revealed_
- _log in with the user who didn't reveal to make sure that it doesn't show a revealed vote_

**Changes** 
- [x] Extract `VoteDetails` into separate component
- [x] Added `RevealWidget` Component
- [x] Added `motionUserVoteRevealed` client resolver
- [x] Added `MotionVote` enum type
- [x] Fixed `getMotionState` util

**Demo**

Both states, voting not revealed yet (first motion), vote revealed (second motion)

![demo-md-reveal-widget-1](https://user-images.githubusercontent.com/1193222/115291719-c2f81200-a15d-11eb-974a-6cd533a1cbba.gif)

Vote not revealed user logged out / logged in

![demo-md-reveal-widget-2](https://user-images.githubusercontent.com/1193222/115291724-c390a880-a15d-11eb-88f8-5772690bc771.gif)

Vote revealed user logged out / logged in

![demo-md-reveal-widget-3](https://user-images.githubusercontent.com/1193222/115291725-c4293f00-a15d-11eb-9fec-c69eded0e48a.gif)

User not logged in:
![Screenshot from 2021-04-21 13-24-12](https://user-images.githubusercontent.com/1193222/115538914-0ad58100-a2a5-11eb-8bcc-416cb979e84d.png)

User logged in, who VOTED
![Screenshot from 2021-04-21 13-24-17](https://user-images.githubusercontent.com/1193222/115538946-13c65280-a2a5-11eb-99ae-9e30a6b61195.png)

User logged in, didn't VOTE
![Screenshot from 2021-04-21 13-24-24](https://user-images.githubusercontent.com/1193222/115538969-1aed6080-a2a5-11eb-9b9e-6358e02dc0ca.png)

Resolves DEV-288