### PR TITLE
Failed motion system message

### DIFF
--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -198,6 +198,25 @@ export const motionsResolvers = ({
         }
       }
 
+      if (
+        motionNetworkState === NetworkMotionState.Finalizable ||
+        motionNetworkState === NetworkMotionState.Finalized
+      ) {
+        const newestVoteRevealed = sortedEvents.find(
+          (event) =>
+            event.name === ColonyAndExtensionsEvents.MotionVoteRevealed,
+        );
+        if (newestVoteRevealed) {
+          if (motion.votes[0].gte(motion.votes[1])) {
+            systemMessages.push({
+              type: ActionsPageFeedType.SystemMessage,
+              name: SystemMessagesName.MotionHasFailedFinalizable,
+              createdAt: newestVoteRevealed.createdAt,
+            });
+          }
+        }
+      }
+
       if (motionNetworkState === NetworkMotionState.Failed) {
         systemMessages.push({
           type: ActionsPageFeedType.SystemMessage,

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -198,6 +198,14 @@ export const motionsResolvers = ({
         }
       }
 
+      if (motionNetworkState === NetworkMotionState.Failed) {
+        systemMessages.push({
+          type: ActionsPageFeedType.SystemMessage,
+          name: SystemMessagesName.MotionHasFailedNotFinalizable,
+          createdAt: motion.events[1].toNumber() * 1000,
+        });
+      }
+
       return Promise.all(systemMessages);
     },
     async motionVoterReward(_, { motionId, colonyAddress, userAddress }) {

--- a/src/i18n/en-system-messages.ts
+++ b/src/i18n/en-system-messages.ts
@@ -7,6 +7,8 @@ const systemMessagesMessageDescriptors = {
       ${SystemMessagesName.EnoughExitRecoveryApprovals} {Enough permission holders have now signed to exit recovery mode. As long as no further storage slots are updated, a recovery permission holder may now sign a transaction to reactivate the colony.}
       ${SystemMessagesName.MotionHasPassed} {{motionTag} has {passedTag} and may be finalized.}
       ${SystemMessagesName.MotionRevealPhase} {It's time to {revealTag} votes to the world!}
+      ${SystemMessagesName.MotionHasFailedNotFinalizable} {{motionTag} has failed.}
+      ${SystemMessagesName.MotionHasFailedFinalizable} {{motionTag} has {failedTag} and may be finalized.}
       other {Generic system message}
     }`,
 };

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
@@ -129,9 +129,11 @@ const MintTokenMotion = ({
     passedTag: (
       <span className={motionSpecificStyles.tagWrapper}>{passedTag}</span>
     ),
+    failedTag: (
+      <span className={motionSpecificStyles.tagWrapper}>{failedTag}</span>
+    ),
     objectionTag,
     revealTag,
-    failedTag,
   };
   const motionStyles = MOTION_TAG_MAP[motionState || MotionState.Invalid];
 

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useMemo } from 'react';
+
 import { FormattedMessage } from 'react-intl';
 
 import Numeral from '~core/Numeral';
@@ -47,14 +48,6 @@ interface MotionValue {
   motionId: number;
 }
 
-const getTags = () => {
-  return Object.values(MOTION_TAG_MAP).reduce((map, object) => {
-    const { theme, colorSchema } = object;
-    map[object.tagName] = <Tag text={object.name} appearance={{ theme, colorSchema }} />
-    return map
-  }, {});
-}
-
 const MintTokenMotion = ({
   colony,
   colonyAction: {
@@ -73,7 +66,21 @@ const MintTokenMotion = ({
   transactionHash,
   initiator,
 }: Props) => {
-  const {motionTag, passedTag, revealTag, failedTag, objectionTag} = getTags();
+  const {
+    motionTag,
+    passedTag,
+    revealTag,
+    failedTag,
+    objectionTag,
+  } = useMemo(() => {
+    return Object.values(MOTION_TAG_MAP).reduce((acc, object) => {
+      const { theme, colorSchema } = object as TagAppearance;
+      acc[object.tagName] = (
+        <Tag text={object.name} appearance={{ theme, colorSchema }} />
+      );
+      return acc;
+    }, {} as any);
+  }, []);
 
   const motionCreatedEvent = colonyAction.events.find(
     ({ name }) => name === ColonyAndExtensionsEvents.MotionCreated,
@@ -120,9 +127,7 @@ const MintTokenMotion = ({
     ),
     motionTag,
     passedTag: (
-      <span className={motionSpecificStyles.tagWrapper}>
-        {passedTag}
-      </span>
+      <span className={motionSpecificStyles.tagWrapper}>{passedTag}</span>
     ),
     objectionTag,
     revealTag,

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
@@ -47,6 +47,14 @@ interface MotionValue {
   motionId: number;
 }
 
+const getTags = () => {
+  return Object.values(MOTION_TAG_MAP).reduce((map, object) => {
+    const { theme, colorSchema } = object;
+    map[object.tagName] = <Tag text={object.name} appearance={{ theme, colorSchema }} />
+    return map
+  }, {});
+}
+
 const MintTokenMotion = ({
   colony,
   colonyAction: {
@@ -65,10 +73,8 @@ const MintTokenMotion = ({
   transactionHash,
   initiator,
 }: Props) => {
-  const motionTag = MOTION_TAG_MAP[MotionState.Motion];
-  const passedTag = MOTION_TAG_MAP[MotionState.Passed];
-  const revealTag = MOTION_TAG_MAP[MotionState.Reveal];
-  const objectionTag = MOTION_TAG_MAP[MotionState.Objection];
+  const {motionTag, passedTag, revealTag, failedTag, objectionTag} = getTags();
+
   const motionCreatedEvent = colonyAction.events.find(
     ({ name }) => name === ColonyAndExtensionsEvents.MotionCreated,
   );
@@ -112,19 +118,15 @@ const MintTokenMotion = ({
         autoShrinkAddress
       />
     ),
-    motionTag: <Tag text={motionTag.name} appearance={{ theme: 'primary' }} />,
+    motionTag,
     passedTag: (
       <span className={motionSpecificStyles.tagWrapper}>
-        <Tag
-          text={passedTag.name}
-          appearance={{ theme: 'primary', colorSchema: 'plain' }}
-        />
+        {passedTag}
       </span>
     ),
-    revealTag: <Tag text={revealTag.name} appearance={{ theme: 'blue' }} />,
-    objectionTag: (
-      <Tag text={objectionTag.name} appearance={{ theme: 'danger' }} />
-    ),
+    objectionTag,
+    revealTag,
+    failedTag,
   };
   const motionStyles = MOTION_TAG_MAP[motionState || MotionState.Invalid];
 

--- a/src/modules/dashboard/components/ActionsPageFeed/types.ts
+++ b/src/modules/dashboard/components/ActionsPageFeed/types.ts
@@ -43,6 +43,8 @@ export interface SystemInfo {
 export enum SystemMessagesName {
   EnoughExitRecoveryApprovals = 'EnoughExitRecoveryApprovals',
   MotionHasPassed = 'MotionHasPassed',
+  MotionHasFailedNotFinalizable = 'MotionHasFailedNotFinalizable',
+  MotionHasFailedFinalizable = 'MotionHasFailedFinalizable',
   MotionRevealPhase = 'MotionRevealPhase',
 }
 

--- a/src/utils/colonyMotions.ts
+++ b/src/utils/colonyMotions.ts
@@ -56,40 +56,48 @@ export const MOTION_TAG_MAP = {
     theme: 'primary',
     colorSchema: 'fullColor',
     name: MSG.motionTag,
+    tagName: 'motionTag',
   },
   [MotionState.StakeRequired]: {
     theme: 'pink',
     colorSchema: 'fullColor',
     name: MSG.stakeRequiredTag,
+    tagName: 'stakeRequiredTag',
   },
   [MotionState.Voting]: {
     theme: 'golden',
     colorSchema: 'fullColor',
     name: MSG.votingTag,
+    tagName: 'votingTag',
   },
   [MotionState.Reveal]: {
     theme: 'blue',
     colorSchema: 'fullColor',
     name: MSG.revealTag,
+    tagName: 'revealTag',
   },
   [MotionState.Objection]: {
     theme: 'pink',
     colorSchema: 'fullColor',
     name: MSG.objectionTag,
+    tagName: 'objectionTag',
   },
   [MotionState.Failed]: {
     theme: 'pink',
     colorSchema: 'plain',
     name: MSG.failedTag,
+    tagName: 'failedTag',
   },
   [MotionState.Passed]: {
     theme: 'primary',
     colorSchema: 'plain',
     name: MSG.passedTag,
+    tagName: 'passedTag',
   },
   [MotionState.Invalid]: {
     theme: 'pink',
     colorSchema: 'plain',
     name: MSG.invalidTag,
+    tagName: 'invalidTag',
   },
 };


### PR DESCRIPTION
## Description

This PR adds in displaying failed system message in motion feed

**New stuff** ✨

* Added message descriptors and system messages types for failed motion
* Displayed MotionHasFailedNotFinalizable system message (failed because not enough stakes or more stakes for no)
* Displayed MotionHasFailedFinalizable system message (failed because more or equal votes for no)

**Changes** 🏗

* Refactored tags in MintTokenMotion component

MotionHasFailedNotFinalizable
<img width="975" alt="failed not finalizable" src="https://user-images.githubusercontent.com/13069555/115707601-4b99cc80-a36f-11eb-893c-f599994b3a70.png">
MotionHasFailedFinalizable
<img width="1021" alt="failed finalizable" src="https://user-images.githubusercontent.com/13069555/115707624-52284400-a36f-11eb-893c-4da9bebbe4e2.png">


Resolves DEV-293
