### PR TITLE
Add MotionStaked NAY side event variant

### DIFF
--- a/src/i18n/en-events.ts
+++ b/src/i18n/en-events.ts
@@ -14,7 +14,7 @@ const eventsMessageDescriptors = {
       ${ColonyAndExtensionsEvents.RecoveryModeExitApproved} {{initiator} approved exiting}
       ${ColonyAndExtensionsEvents.RecoveryModeExited} {{initiator} exited Recovery Mode}
       ${ColonyAndExtensionsEvents.MotionCreated} {{initiator} created a {motionTag}}
-      ${ColonyAndExtensionsEvents.MotionStaked} {{initiator} backed the {motionTag} by staking {amountTag}}
+      ${ColonyAndExtensionsEvents.MotionStaked} {{initiator} backed the {backedSideTag} by staking {amountTag}}
       other {{eventNameDecorated} emmited by {clientOrExtensionType}}
     }`,
   /*

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
@@ -67,6 +67,7 @@ const MintTokenMotion = ({
   const motionTag = MOTION_TAG_MAP[MotionState.Motion];
   const passedTag = MOTION_TAG_MAP[MotionState.Passed];
   const revealTag = MOTION_TAG_MAP[MotionState.Reveal];
+  const objectionTag = MOTION_TAG_MAP[MotionState.Objection];
   const motionCreatedEvent = colonyAction.events.find(
     ({ name }) => name === ColonyAndExtensionsEvents.MotionCreated,
   );
@@ -120,6 +121,9 @@ const MintTokenMotion = ({
       </span>
     ),
     revealTag: <Tag text={revealTag.name} appearance={{ theme: 'blue' }} />,
+    objectionTag: (
+      <Tag text={objectionTag.name} appearance={{ theme: 'danger' }} />
+    ),
   };
   const motionStyles = MOTION_TAG_MAP[motionState || MotionState.Invalid];
 

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageEvent/ActionsPageEvent.tsx
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageEvent/ActionsPageEvent.tsx
@@ -30,6 +30,7 @@ import {
 } from '~utils/colonyActions';
 import { useDataFetcher } from '~utils/hooks';
 import { getTokenDecimalsWithFallback } from '~utils/tokens';
+import { MotionVote } from '~utils/colonyMotions';
 
 import { ipfsDataFetcher } from '../../../../core/fetchers';
 
@@ -360,6 +361,7 @@ const ActionsPageEvent = ({
                           colonyNativeToken?.decimals,
                         )}
                         suffix={` ${colonyNativeToken?.symbol}`}
+                        truncate={2}
                       />
                     </Tag>
                   </div>
@@ -377,6 +379,9 @@ const ActionsPageEvent = ({
                     </div>
                   </>
                 ),
+                backedSideTag: values?.vote?.eq(MotionVote.Yay)
+                  ? values.motionTag
+                  : values?.objectionTag,
               }}
             />
           </div>

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeed.tsx
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeed.tsx
@@ -55,6 +55,9 @@ export interface EventValues {
   initiator?: string | ReactElement;
   staker?: string;
   stakeAmount?: BigNumber;
+  vote?: BigNumber;
+  motionTag: ReactElement;
+  objectionTag: ReactElement;
 }
 
 export type FeedItemWithId<T> = T & { uniqueId: string };

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeed.tsx
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeed.tsx
@@ -56,8 +56,8 @@ export interface EventValues {
   staker?: string;
   stakeAmount?: BigNumber;
   vote?: BigNumber;
-  motionTag: ReactElement;
-  objectionTag: ReactElement;
+  motionTag?: ReactElement;
+  objectionTag?: ReactElement;
 }
 
 export type FeedItemWithId<T> = T & { uniqueId: string };


### PR DESCRIPTION
- Updated ActionsPageFeedd to make MotionStaked event dynamic and change backed side tag according to vote
- Truncated stakeAmount to 2 decimals only

![FireShot Capture 223 - Colony - localhost](https://user-images.githubusercontent.com/18473896/115578846-035daa00-a29c-11eb-9984-d13b40eaee27.png)

