### PR TITLE
Add MotionFullyStaked system message

### DIFF
--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -235,11 +235,11 @@ export const motionsResolvers = ({
         (event) => event.name === ColonyAndExtensionsEvents.MotionVoteSubmitted,
       );
 
-      const newestMotionStakedEvent = sortedEvents.find(
+      const latestMotionStakedEvent = sortedEvents.find(
         (event) => event.name === ColonyAndExtensionsEvents.MotionStaked,
       );
 
-      if (newestMotionStakedEvent) {
+      if (latestMotionStakedEvent) {
         // eslint-disable-next-line max-len
         const totalStakeFraction = await votingReputationClient.getTotalStakeFraction();
         const requiredStake = getMotionRequiredStake(
@@ -252,7 +252,7 @@ export const motionsResolvers = ({
           systemMessages.push({
             type: ActionsPageFeedType.SystemMessage,
             name: SystemMessagesName.MotionFullyStaked,
-            createdAt: newestMotionStakedEvent.createdAt,
+            createdAt: latestMotionStakedEvent.createdAt,
           });
         }
       }

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -248,7 +248,7 @@ export const motionsResolvers = ({
           18,
         );
 
-        if (motion.stakes[MotionVote.Yay].eq(requiredStake)) {
+        if (motion.stakes[MotionVote.Yay].gte(requiredStake)) {
           systemMessages.push({
             type: ActionsPageFeedType.SystemMessage,
             name: SystemMessagesName.MotionFullyStaked,

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -14,7 +14,7 @@ import { Resolvers } from '@apollo/client';
 import { Context } from '~context/index';
 import { createAddress } from '~utils/web3';
 import { getMotionActionType, getMotionState } from '~utils/events';
-import { MotionVote } from '~utils/colonyMotions';
+import { MotionVote, getMotionRequiredStake } from '~utils/colonyMotions';
 import { ColonyAndExtensionsEvents } from '~types/index';
 import {
   UserReputationQuery,
@@ -234,6 +234,28 @@ export const motionsResolvers = ({
       const newestVoteSubmittedEvent = sortedEvents.find(
         (event) => event.name === ColonyAndExtensionsEvents.MotionVoteSubmitted,
       );
+
+      const newestMotionStakedEvent = sortedEvents.find(
+        (event) => event.name === ColonyAndExtensionsEvents.MotionStaked,
+      );
+
+      if (newestMotionStakedEvent) {
+        // eslint-disable-next-line max-len
+        const totalStakeFraction = await votingReputationClient.getTotalStakeFraction();
+        const requiredStake = getMotionRequiredStake(
+          motion.skillRep,
+          totalStakeFraction,
+          18,
+        );
+
+        if (motion.stakes[MotionVote.Yay].eq(requiredStake)) {
+          systemMessages.push({
+            type: ActionsPageFeedType.SystemMessage,
+            name: SystemMessagesName.MotionFullyStaked,
+            createdAt: newestMotionStakedEvent.createdAt,
+          });
+        }
+      }
 
       if (
         motionNetworkState === NetworkMotionState.Reveal ||

--- a/src/i18n/en-system-messages.ts
+++ b/src/i18n/en-system-messages.ts
@@ -10,7 +10,7 @@ const systemMessagesMessageDescriptors = {
       ${SystemMessagesName.MotionHasFailedNotFinalizable} {{motionTag} has failed.}
       ${SystemMessagesName.MotionHasFailedFinalizable} {{motionTag} has {failedTag} and may be finalized.}
       ${SystemMessagesName.MotionVotingPhase} {{votingTag} has started! Voting is secret 😀, and weighted by Reputation.}
-      ${SystemMessagesName.MotionFullyStaked} {{motionTag} is fully staked; Staking period has reset. As long as there is no {objectionTag}, the motion will pass.}
+      ${SystemMessagesName.MotionFullyStaked} {{motionTag} is fully staked; Staking period has reset. As long as there is no {objectionTag} , the motion will pass.}
       other {Generic system message}
     }`,
 };

--- a/src/i18n/en-system-messages.ts
+++ b/src/i18n/en-system-messages.ts
@@ -10,6 +10,7 @@ const systemMessagesMessageDescriptors = {
       ${SystemMessagesName.MotionHasFailedNotFinalizable} {{motionTag} has failed.}
       ${SystemMessagesName.MotionHasFailedFinalizable} {{motionTag} has {failedTag} and may be finalized.}
       ${SystemMessagesName.MotionVotingPhase} {{votingTag} has started! Voting is secret 😀, and weighted by Reputation.}
+      ${SystemMessagesName.MotionFullyStaked} {{motionTag} is fully staked; Staking period has reset. As long as there is no {objectionTag}, the motion will pass.}
       other {Generic system message}
     }`,
 };

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
@@ -144,6 +144,12 @@ const MintTokenMotion = ({
     failedTag: (
       <span className={motionSpecificStyles.tagWrapper}>{failedTag}</span>
     ),
+    revealTag: <Tag text={revealTag.name} appearance={{ theme: 'blue' }} />,
+    objectionTag: (
+      <span className={motionSpecificStyles.tagWrapper}>
+        <Tag text={objectionTag.name} appearance={{ theme: 'danger' }} />
+      </span>
+    ),
     ...tags,
   };
   const motionStyles = MOTION_TAG_MAP[motionState || MotionState.Invalid];

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
@@ -73,13 +73,7 @@ const MintTokenMotion = ({
 }: Props) => {
   const bottomElementRef = useRef<HTMLInputElement>(null);
 
-  const {
-    passedTag,
-    failedTag,
-    objectionTag,
-    revealTag,
-    ...tags
-  } = useMemo(() => {
+  const { passedTag, failedTag, objectionTag, ...tags } = useMemo(() => {
     return Object.values(MOTION_TAG_MAP).reduce((acc, object) => {
       const { theme, colorSchema } = object as TagAppearance;
       acc[object.tagName] = (
@@ -150,7 +144,6 @@ const MintTokenMotion = ({
     failedTag: (
       <span className={motionSpecificStyles.tagWrapper}>{failedTag}</span>
     ),
-    revealTag,
     objectionTag: (
       <span className={motionSpecificStyles.tagWrapper}>{objectionTag}</span>
     ),

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
@@ -73,7 +73,13 @@ const MintTokenMotion = ({
 }: Props) => {
   const bottomElementRef = useRef<HTMLInputElement>(null);
 
-  const { passedTag, failedTag, ...tags } = useMemo(() => {
+  const {
+    passedTag,
+    failedTag,
+    objectionTag,
+    revealTag,
+    ...tags
+  } = useMemo(() => {
     return Object.values(MOTION_TAG_MAP).reduce((acc, object) => {
       const { theme, colorSchema } = object as TagAppearance;
       acc[object.tagName] = (
@@ -144,11 +150,9 @@ const MintTokenMotion = ({
     failedTag: (
       <span className={motionSpecificStyles.tagWrapper}>{failedTag}</span>
     ),
-    revealTag: <Tag text={revealTag.name} appearance={{ theme: 'blue' }} />,
+    revealTag,
     objectionTag: (
-      <span className={motionSpecificStyles.tagWrapper}>
-        <Tag text={objectionTag.name} appearance={{ theme: 'danger' }} />
-      </span>
+      <span className={motionSpecificStyles.tagWrapper}>{objectionTag}</span>
     ),
     ...tags,
   };

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageSystemMessage/ActionsPageSystemMessage.css
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageSystemMessage/ActionsPageSystemMessage.css
@@ -14,7 +14,7 @@
 
 .details {
   display: flex;
-  margin: 8px 0 0 -5px;
+  margin-top: 8px;
 }
 
 .content {

--- a/src/modules/dashboard/components/ActionsPageFeed/types.ts
+++ b/src/modules/dashboard/components/ActionsPageFeed/types.ts
@@ -47,6 +47,7 @@ export enum SystemMessagesName {
   MotionHasFailedFinalizable = 'MotionHasFailedFinalizable',
   MotionRevealPhase = 'MotionRevealPhase',
   MotionVotingPhase = 'MotionVotingPhase',
+  MotionFullyStaked = 'MotionFullyStaked',
 }
 
 export interface SystemMessage {


### PR DESCRIPTION
* Added system message for when a motion is fully staked
* Fixed system message timestamp not being properly aligned with the message
* Added `getMotionRequiredStake` util function (This was also added in another PR of mine, will resolve the conflict/remove duplicates when the time comes).
* Fixed `motionDomain` missing a default value in `colonyAction`
* Removed left margin of ObjectionTag when it's on a message

![FireShot Capture 233 - Colony - localhost](https://user-images.githubusercontent.com/18473896/115615974-fc4b9180-a2c5-11eb-88b1-4ce657697269.png)


Resolves DEV-274
