### PR TITLE
Flesh out DetailsWidget of motion page

### DIFF
--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
@@ -86,6 +86,7 @@ const MintTokenMotion = ({
   colonyAction,
   token: { decimals, symbol },
   transactionHash,
+  recipient,
   initiator,
 }: Props) => {
   const bottomElementRef = useRef<HTMLInputElement>(null);
@@ -359,7 +360,9 @@ const MintTokenMotion = ({
           )}
           <DetailsWidget
             actionType={actionType as ColonyMotions}
+            recipient={recipient}
             transactionHash={transactionHash}
+            values={actionAndEventValues}
             colony={colony}
           />
         </div>

--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.tsx
@@ -78,6 +78,7 @@ const DetailsWidget = ({
 }: Props) => {
   const { formatMessage } = useIntl();
 
+  const messageId = ColonyMotions[actionType] ? 'motion.type' : 'action.type';
   const showFullDetails = actionType !== ColonyActions.Generic;
 
   const splitHash = splitTransactionHash(transactionHash as string);
@@ -104,7 +105,7 @@ const DetailsWidget = ({
         <div className={styles.value}>
           <Icon
             title={formatMessage(
-              { id: 'action.type' },
+              { id: messageId },
               {
                 actionType: values?.actionType,
               },
@@ -113,7 +114,7 @@ const DetailsWidget = ({
             name={ACTION_TYPES_ICONS_MAP[actionType]}
           />
           <FormattedMessage
-            id="action.type"
+            id={messageId}
             /*
              * @NOTE We need to use the action type value that was converted to
              * camelCase since ReactIntl doesn't like keys that are composed

--- a/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
@@ -259,11 +259,7 @@ const FinalizeMotionAndClaimWidget = ({
     : voteResults?.motionVoteResults?.currentUserVoteSide === MotionVote.Nay;
 
   return (
-    <div
-      className={getMainClasses({}, styles, {
-        marginBottom: showFinalizeButton || false,
-      })}
-    >
+    <div className={getMainClasses({}, styles)}>
       {showFinalizeButton && (
         <ActionForm
           initialValues={{}}

--- a/src/modules/dashboard/components/ActionsPage/staticMaps.ts
+++ b/src/modules/dashboard/components/ActionsPage/staticMaps.ts
@@ -32,7 +32,7 @@ type ActionsEventsMap = Partial<
 
 type ActionsDetailsMap = Partial<
   {
-    [key in ColonyActions]: ActionPageDetails[];
+    [key in ColonyActions | ColonyMotions]: ActionPageDetails[];
   }
 >;
 
@@ -64,7 +64,9 @@ export const EVENT_ROLES_MAP: EventRolesMap = {
 /*
  * Which icons correspond to which action types in the details widget
  */
-export const ACTION_TYPES_ICONS_MAP: { [key in ColonyActions]: string } = {
+export const ACTION_TYPES_ICONS_MAP: {
+  [key in ColonyActions | ColonyMotions]: string;
+} = {
   [ColonyActions.WrongColony]: 'forbidden-signal',
   [ColonyActions.Payment]: 'emoji-dollar-stack',
   [ColonyActions.Recovery]: 'emoji-alarm-lamp',
@@ -75,6 +77,7 @@ export const ACTION_TYPES_ICONS_MAP: { [key in ColonyActions]: string } = {
   [ColonyActions.ColonyEdit]: 'emoji-edit-tools',
   [ColonyActions.EditDomain]: 'emoji-pencil-note',
   [ColonyActions.SetUserRoles]: 'emoji-crane',
+  [ColonyMotions.MintTokensMotion]: 'emoji-seed-sprout',
   [ColonyActions.Generic]: 'circle-check-primary',
 };
 
@@ -184,4 +187,5 @@ export const DETAILS_FOR_ACTION: ActionsDetailsMap = {
     ActionPageDetails.Permissions,
   ],
   [ColonyActions.Recovery]: [],
+  [ColonyMotions.MintTokensMotion]: [ActionPageDetails.Amount],
 };


### PR DESCRIPTION
## Description

- Add details to DetailsWidget of motion page

**New stuff** ✨

* Added MintTokenMotions emoji and details

**Changes** 🏗

* Added dynamic message-id to DetailsWidget to cover motion titles

## TODO

- Add the details for the other motions when they are ready


![FireShot Capture 257 - Colony - localhost](https://user-images.githubusercontent.com/18473896/116411405-10364c80-a80c-11eb-9186-43457da28833.png)


Resolves DEV-300
