### PR TITLE
Fix displaying staked tokens

### DIFF
--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -845,6 +845,7 @@ export type UserLock = {
   nativeToken?: Maybe<UserToken>;
   totalObligation: Scalars['String'];
   pendingBalance: Scalars['String'];
+  activeTokens: Scalars['String'];
 };
 
 export type ProcessedMetaColony = {
@@ -1340,7 +1341,7 @@ export type UserBalanceWithLockQueryVariables = Exact<{
 export type UserBalanceWithLockQuery = { user: (
     Pick<User, 'id'>
     & { userLock: (
-      Pick<UserLock, 'balance' | 'totalObligation' | 'pendingBalance'>
+      Pick<UserLock, 'balance' | 'totalObligation' | 'pendingBalance' | 'activeTokens'>
       & { nativeToken?: Maybe<Pick<UserToken, 'decimals' | 'name' | 'symbol' | 'balance' | 'address' | 'verified'>> }
     ) }
   ) };
@@ -2681,6 +2682,7 @@ export const UserBalanceWithLockDocument = gql`
       }
       totalObligation
       pendingBalance
+      activeTokens
     }
   }
 }

--- a/src/data/graphql/queries.graphql
+++ b/src/data/graphql/queries.graphql
@@ -78,6 +78,7 @@ query UserBalanceWithLock($address: String!, $tokenAddress: String!, $colonyAddr
       }
       totalObligation
       pendingBalance
+      activeTokens
     }
   }
 }

--- a/src/data/graphql/typeDefs.ts
+++ b/src/data/graphql/typeDefs.ts
@@ -159,6 +159,7 @@ export default gql`
     nativeToken: UserToken
     totalObligation: String!
     pendingBalance: String!
+    activeTokens: String!
   }
 
   extend type User {

--- a/src/data/resolvers/user.ts
+++ b/src/data/resolvers/user.ts
@@ -5,8 +5,9 @@ import {
   ROOT_DOMAIN_ID,
   getBlockTime,
   getLogs,
+  getEvents,
 } from '@colony/colony-js';
-import { BigNumber } from 'ethers/utils';
+import { BigNumber, bigNumberify } from 'ethers/utils';
 import { AddressZero, HashZero } from 'ethers/constants';
 
 import { Context } from '~context/index';
@@ -50,6 +51,73 @@ const getUserReputation = async (
   return reputationAmount;
 };
 
+const getUserStakedBalance = async (
+  colonyManager: ColonyManager,
+  colonyAddress: Address,
+  walletAddress: Address,
+): Promise<BigNumber> => {
+  const votingReputationClient = await colonyManager.getClient(
+    ClientType.VotingReputationClient,
+    colonyAddress,
+  );
+  // @ts-ignore
+  // eslint-disable-next-line max-len
+  const motionStakeFilter = votingReputationClient.filters.MotionStaked(
+    null,
+    walletAddress,
+    null,
+    null,
+  );
+  const motionStakeEvents = await getEvents(
+    votingReputationClient,
+    motionStakeFilter,
+  );
+  const groupedMotionStakeEvents = motionStakeEvents.reduce((acc, event) => {
+    const { vote, motionId } = event.values;
+    const key = `${motionId.toString()}-${vote.toString()}`;
+    if (!acc[key]) {
+      acc[key] = [event];
+    } else {
+      acc[key].push(event);
+    }
+    return acc;
+  }, {});
+
+  // @ts-ignore
+  // eslint-disable-next-line max-len
+  const motionRewardClaimedFilter = votingReputationClient.filters.MotionRewardClaimed(
+    null,
+    walletAddress,
+    null,
+    null,
+  );
+  const motionRewardClaimedEvents = await getEvents(
+    votingReputationClient,
+    motionRewardClaimedFilter,
+  );
+
+  const filteredKeys = Object.keys(groupedMotionStakeEvents).filter((key) => {
+    const { motionId, vote } = groupedMotionStakeEvents[key][0].values;
+    const mappedMotionRewardClaimedEvent = motionRewardClaimedEvents.find(
+      (claimedEvent) =>
+        claimedEvent.values.motionId.toString() === motionId.toString() &&
+        claimedEvent.values.vote.toString() === vote.toString(),
+    );
+
+    return !mappedMotionRewardClaimedEvent;
+  });
+
+  const notClaimedEvents = filteredKeys.reduce((acc, key) => {
+    return [...acc, ...groupedMotionStakeEvents[key]];
+  }, []);
+
+  const totalStaked = notClaimedEvents.reduce((acc, event) => {
+    return acc.add(event.values.amount);
+  }, bigNumberify(0));
+
+  return totalStaked;
+};
+
 const getUserLock = async (
   apolloClient: ApolloClient<object>,
   colonyManager: ColonyManager,
@@ -69,6 +137,12 @@ const getUserLock = async (
     walletAddress,
     tokenAddress,
   );
+
+  const stakedTokens = await getUserStakedBalance(
+    colonyManager,
+    colonyAddress,
+    walletAddress,
+  );
   const nativeToken = (await getToken(
     { colonyManager, client: apolloClient },
     tokenAddress,
@@ -77,7 +151,7 @@ const getUserLock = async (
   return {
     balance: userLock.balance.toString(),
     nativeToken: nativeToken || null,
-    totalObligation: totalObligation.toString(),
+    totalObligation: totalObligation.add(stakedTokens).toString(),
     pendingBalance: userLock.pendingBalance.toString(),
   };
 };

--- a/src/data/resolvers/user.ts
+++ b/src/data/resolvers/user.ts
@@ -157,6 +157,7 @@ const getUserLock = async (
     balance: userLock.balance.toString(),
     nativeToken: nativeToken || null,
     totalObligation: totalObligation.add(stakedTokens).toString(),
+    activeTokens: userLock.balance.sub(totalObligation).toString(),
     pendingBalance: userLock.pendingBalance.toString(),
   };
 };

--- a/src/data/resolvers/user.ts
+++ b/src/data/resolvers/user.ts
@@ -56,10 +56,16 @@ const getUserStakedBalance = async (
   colonyAddress: Address,
   walletAddress: Address,
 ): Promise<BigNumber> => {
-  const votingReputationClient = await colonyManager.getClient(
-    ClientType.VotingReputationClient,
-    colonyAddress,
-  );
+  let votingReputationClient;
+
+  try {
+    votingReputationClient = await colonyManager.getClient(
+      ClientType.VotingReputationClient,
+      colonyAddress,
+    );
+  } catch (error) {
+    return bigNumberify(0);
+  }
   /**
    * @NOTE If there will be more staking events
    * on reputation voting extension we need to remember to filter them out
@@ -148,6 +154,7 @@ const getUserLock = async (
     colonyAddress,
     walletAddress,
   );
+
   const nativeToken = (await getToken(
     { colonyManager, client: apolloClient },
     tokenAddress,

--- a/src/data/resolvers/user.ts
+++ b/src/data/resolvers/user.ts
@@ -60,6 +60,11 @@ const getUserStakedBalance = async (
     ClientType.VotingReputationClient,
     colonyAddress,
   );
+  /**
+   * @NOTE If there will be more staking events
+   * on reputation voting extension we need to remember to filter them out
+   * in here for correct value of staked tokens.
+   */
   // @ts-ignore
   // eslint-disable-next-line max-len
   const motionStakeFilter = votingReputationClient.filters.MotionStaked(

--- a/src/modules/dashboard/sagas/utils/updateMotionValues.ts
+++ b/src/modules/dashboard/sagas/utils/updateMotionValues.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from 'ethers/utils';
+import { ClientType } from '@colony/colony-js';
 
 import { TEMP_getContext, ContextModule } from '~context/index';
 import { Address } from '~types/index';
@@ -30,6 +31,9 @@ import {
   MotionStakerRewardQuery,
   MotionStakerRewardQueryVariables,
   MotionStakerRewardDocument,
+  UserBalanceWithLockQuery,
+  UserBalanceWithLockQueryVariables,
+  UserBalanceWithLockDocument,
 } from '~data/index';
 
 export function* updateMotionValues(
@@ -40,7 +44,12 @@ export function* updateMotionValues(
   stakeSide?: string,
 ) {
   const apolloClient = TEMP_getContext(ContextModule.ApolloClient);
-
+  const context = TEMP_getContext(ContextModule.ColonyManager);
+  const colonyClient = yield context.getClient(
+    ClientType.ColonyClient,
+    colonyAddress,
+  );
+  const tokenAddress = colonyClient.tokenClient.address;
   /*
    * Staking values
    */
@@ -176,6 +185,22 @@ export function* updateMotionValues(
     variables: {
       colonyAddress,
       transactionHash,
+    },
+    fetchPolicy: 'network-only',
+  });
+
+  /*
+   * Refresh wallet balance
+   */
+  yield apolloClient.query<
+    UserBalanceWithLockQuery,
+    UserBalanceWithLockQueryVariables
+  >({
+    query: UserBalanceWithLockDocument,
+    variables: {
+      address: userAddress,
+      tokenAddress,
+      colonyAddress,
     },
     fetchPolicy: 'network-only',
   });

--- a/src/modules/pages/components/RouteLayouts/UserNavigation.css
+++ b/src/modules/pages/components/RouteLayouts/UserNavigation.css
@@ -132,16 +132,20 @@
 }
 
 .buttonsWrapper {
+  margin-right: 12px;
   padding: 1px;
+  position: relative;
   border-radius: var(--radius-normal);
   background-color: color-mod(var(--temp-grey-blue-7) alpha(10%));
 }
 
 .readyTransactionsCount {
-  margin: -27px 0 0 -22px;
   padding-top: 2px;
   height: 20px;
   min-width: 20px;
+  position: absolute;
+  top: -10px;
+  right: -10px;
   border-radius: 50px;
   background-color: var(--pink);
   font-size: var(--size-tiny);

--- a/src/modules/users/components/UserTokenActivationButton/UserTokenActivationButton.tsx
+++ b/src/modules/users/components/UserTokenActivationButton/UserTokenActivationButton.tsx
@@ -27,8 +27,7 @@ const UserTokenActivationButton = ({
   const inactiveBalance = bigNumberify(nativeToken?.balance || 0);
 
   const lockedBalance = bigNumberify(userLock?.totalObligation || 0);
-  const lockContractBalance = bigNumberify(userLock?.balance || 0);
-  const activeBalance = lockContractBalance.sub(lockedBalance);
+  const activeBalance = bigNumberify(userLock?.activeTokens || 0);
   const totalBalance = inactiveBalance.add(activeBalance);
   const isPendingBalanceZero = bigNumberify(
     userLock?.pendingBalance || 0,


### PR DESCRIPTION
## Description

This PR fixes displaying staked tokens in TokenActivationWallet

**Changes** 🏗

* Different way of calculating staked tokens, as getTotalObligation doesn't include tokens staked on voting reputation extension
* Fetched MotionStaked events, grouped them by motion id and vote
* Filtered them out by MotionRewardClaimed events (mapped by vote and motionId)
* stakedTokens = sum(filtered motionStaked events) + totalObligation
* Fixed wrong calculation of active tokens and total user balance

<img width="1116" alt="Screenshot 2021-04-26 at 17 14 24" src="https://user-images.githubusercontent.com/13069555/116107221-211f7a80-a6b3-11eb-85c8-f08a2439b6fc.png">

<img width="485" alt="Screenshot 2021-04-28 at 10 49 19" src="https://user-images.githubusercontent.com/13069555/116375845-f4cd4080-a80f-11eb-9b7c-f6013e3c2229.png">


Resolves DEV-308
