### PR TITLE
Use moveDecimal to display stake rewards

### DIFF
--- a/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
@@ -24,7 +24,6 @@ import { ActionTypes } from '~redux/index';
 import { ColonyMotions } from '~types/index';
 import { mapPayload } from '~utils/actions';
 import { getMainClasses } from '~utils/css';
-import { getTokenDecimalsWithFallback } from '~utils/tokens';
 import { MotionVote, MotionState } from '~utils/colonyMotions';
 
 import VoteResults from './VoteResults';
@@ -178,15 +177,8 @@ const FinalizeMotionAndClaimWidget = ({
 
   const { userStake, userWinnings, userTotals } = useMemo(() => {
     let stake = bigNumberify(0);
-    let winnings;
+    let winnings = bigNumberify(0);
     let totals = bigNumberify(0);
-    const safeLowReward = bigNumberify(1)
-      .mul(
-        bigNumberify(10).pow(
-          getTokenDecimalsWithFallback(nativeToken?.decimals),
-        ),
-      )
-      .div(100);
     if (stakerRewards?.motionStakerReward) {
       const {
         stakesYay,
@@ -195,19 +187,10 @@ const FinalizeMotionAndClaimWidget = ({
         stakingRewardYay,
       } = stakerRewards.motionStakerReward;
       stake = stake.add(bigNumberify(stakesYay)).add(bigNumberify(stakesNay));
-      if (stake.lt(safeLowReward)) {
-        stake = bigNumberify(0);
-      }
       totals = totals
         .add(bigNumberify(stakingRewardYay))
         .add(bigNumberify(stakingRewardNay));
-      if (totals.lt(safeLowReward)) {
-        totals = bigNumberify(0);
-      }
       winnings = totals.sub(stake);
-      if (winnings.lt(safeLowReward)) {
-        winnings = bigNumberify(0);
-      }
     }
     return {
       userStake: moveDecimal(stake, -(nativeToken?.decimals || 0)),

--- a/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
@@ -3,6 +3,7 @@ import { FormikProps } from 'formik';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { ROOT_DOMAIN_ID } from '@colony/colony-js';
 import { bigNumberify } from 'ethers/utils';
+import moveDecimal from 'move-decimal-point';
 
 import Button from '~core/Button';
 import { ActionForm } from '~core/Fields';
@@ -209,9 +210,9 @@ const FinalizeMotionAndClaimWidget = ({
       }
     }
     return {
-      userStake: stake,
-      userWinnings: winnings,
-      userTotals: totals,
+      userStake: moveDecimal(stake, -(nativeToken?.decimals || 0)),
+      userWinnings: moveDecimal(winnings, -(nativeToken?.decimals || 0)),
+      userTotals: moveDecimal(totals, -(nativeToken?.decimals || 0)),
     };
   }, [stakerRewards, nativeToken]);
 
@@ -349,12 +350,8 @@ const FinalizeMotionAndClaimWidget = ({
                     </div>
                     <div className={styles.value}>
                       <Numeral
-                        unit={getTokenDecimalsWithFallback(
-                          nativeToken?.decimals,
-                        )}
                         value={userStake}
                         suffix={` ${nativeToken?.symbol}`}
-                        truncate={2}
                       />
                     </div>
                   </div>
@@ -366,12 +363,8 @@ const FinalizeMotionAndClaimWidget = ({
                     </div>
                     <div className={styles.value}>
                       <Numeral
-                        unit={getTokenDecimalsWithFallback(
-                          nativeToken?.decimals,
-                        )}
                         value={userWinnings}
                         suffix={` ${nativeToken?.symbol}`}
-                        truncate={2}
                       />
                     </div>
                   </div>
@@ -383,12 +376,8 @@ const FinalizeMotionAndClaimWidget = ({
                     </div>
                     <div className={styles.value}>
                       <Numeral
-                        unit={getTokenDecimalsWithFallback(
-                          nativeToken?.decimals,
-                        )}
                         value={userTotals}
                         suffix={` ${nativeToken?.symbol}`}
-                        truncate={2}
                       />
                     </div>
                   </div>

--- a/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
@@ -335,6 +335,7 @@ const FinalizeMotionAndClaimWidget = ({
                       <Numeral
                         value={userStake}
                         suffix={` ${nativeToken?.symbol}`}
+                        truncate={5}
                       />
                     </div>
                   </div>
@@ -348,6 +349,7 @@ const FinalizeMotionAndClaimWidget = ({
                       <Numeral
                         value={userWinnings}
                         suffix={` ${nativeToken?.symbol}`}
+                        truncate={5}
                       />
                     </div>
                   </div>
@@ -361,6 +363,7 @@ const FinalizeMotionAndClaimWidget = ({
                       <Numeral
                         value={userTotals}
                         suffix={` ${nativeToken?.symbol}`}
+                        truncate={5}
                       />
                     </div>
                   </div>


### PR DESCRIPTION
- Use moveDecimal to convert stake rewards to ETH instead of directly using Numeral
- Removed truncate from Numeral of the rewards

Resolves DEV-314
