### PR TITLE
Balance activation issue

### DIFF
--- a/src/modules/dashboard/sagas/actions/payment.ts
+++ b/src/modules/dashboard/sagas/actions/payment.ts
@@ -11,6 +11,7 @@ import {
   UserBalanceWithLockQuery,
   UserBalanceWithLockQueryVariables,
   UserBalanceWithLockDocument,
+  getLoggedInUser,
 } from '~data/index';
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
@@ -82,6 +83,7 @@ function* createPaymentAction({
     }
 
     const { amount, tokenAddress, decimals = 18 } = singlePayment;
+    const { walletAddress } = yield getLoggedInUser();
 
     txChannel = yield call(getTxChannel, metaId);
 
@@ -204,7 +206,7 @@ function* createPaymentAction({
     >({
       query: UserBalanceWithLockDocument,
       variables: {
-        address: recipientAddress,
+        address: walletAddress,
         tokenAddress,
         colonyAddress,
       },


### PR DESCRIPTION
## Description

This PR fixes refetching query after payment. Till now we was refetching balance with recipientAddress. The change is to use currently logged in address. 

**Changes** 🏗

* Replacing recipientAddress with loggedIn user address in payment saga for refetching user balance

**How to test** ⚰️
1. Create colony
2. Mint tokens
3. Create payment to currently logged in user A
4. You should see inactive balance in your wallet at that point
5. Join with user B to this colony
6. Log in on user A
7. Create payment to user B
8. You should NOT see inactive tokens in your wallet
9. Login to user B
10. You should see inactive tokens in your wallet


Resolves DEV-318
