### PR TITLE
Fix invalid tag

### DIFF
--- a/src/utils/colonyMotions.ts
+++ b/src/utils/colonyMotions.ts
@@ -32,6 +32,7 @@ export enum MotionState {
   Objection = 'Objection',
   Failed = 'Failed',
   Passed = 'Passed',
+  FailedNoFinalizable = 'FailedNoFinalizable',
   Invalid = 'Invalid',
   Escalation = 'Escalation',
 }
@@ -108,6 +109,12 @@ export const MOTION_TAG_MAP = {
     tagName: 'objectionTag',
   },
   [MotionState.Failed]: {
+    theme: 'pink',
+    colorSchema: 'plain',
+    name: MSG.failedTag,
+    tagName: 'failedTag',
+  },
+  [MotionState.FailedNoFinalizable]: {
     theme: 'pink',
     colorSchema: 'plain',
     name: MSG.failedTag,

--- a/src/utils/events/index.ts
+++ b/src/utils/events/index.ts
@@ -556,7 +556,7 @@ export const getMotionState = async (
       return MotionState.Failed;
     }
     case NetworkMotionState.Failed:
-      return MotionState.Invalid;
+      return MotionState.FailedNoFinalizable;
     default:
       return MotionState.Invalid;
   }


### PR DESCRIPTION
## Description

This PR fixes incorrectly displayed invalid tag when motion is. failing

**New stuff** ✨

* Added FailedNoFinalizable motion state

**Changes** 🏗

* Updated getMotionState helper to return FailedNoFinalizable when motionNetworkState is failed (when there was not enough votes for yes) 

## How to test

1. Create motion
2. Stake small amount for yes / or stake for no
3. run:
curl -X POST --data '{"jsonrpc":"2.0","method":"evm_increaseTime","params":[604800],"id":1}' localhost:8545
curl -X POST --data '{"jsonrpc":"2.0","method":"evm_mine","params":[],"id":1}' localhost:8545

The motion will fail due to not enough stakes. It wont be finalizable, so you should see "failed" tag, but you shouldn't see "finalize" widget

Resolves DEV-319
