### PR TITLE
Add reveal result system message

### DIFF
--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -370,7 +370,18 @@ export const motionsResolvers = ({
           if (motion.votes[0].gte(motion.votes[1])) {
             systemMessages.push({
               type: ActionsPageFeedType.SystemMessage,
+              name: SystemMessagesName.MotionRevealResultObjectionWon,
+              createdAt: newestVoteRevealed.createdAt,
+            });
+            systemMessages.push({
+              type: ActionsPageFeedType.SystemMessage,
               name: SystemMessagesName.MotionHasFailedFinalizable,
+              createdAt: newestVoteRevealed.createdAt,
+            });
+          } else {
+            systemMessages.push({
+              type: ActionsPageFeedType.SystemMessage,
+              name: SystemMessagesName.MotionRevealResultMotionWon,
               createdAt: newestVoteRevealed.createdAt,
             });
           }

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -352,7 +352,10 @@ export const motionsResolvers = ({
             systemMessages.push({
               type: ActionsPageFeedType.SystemMessage,
               name: SystemMessagesName.MotionHasPassed,
-              createdAt: newestStakeOrVoteEvent.createdAt,
+              createdAt: getEarlierEventTimestamp(
+                newestStakeOrVoteEvent.createdAt,
+                -5,
+              ),
             });
           }
         }
@@ -371,18 +374,27 @@ export const motionsResolvers = ({
             systemMessages.push({
               type: ActionsPageFeedType.SystemMessage,
               name: SystemMessagesName.MotionRevealResultObjectionWon,
-              createdAt: newestVoteRevealed.createdAt,
+              createdAt: getEarlierEventTimestamp(
+                newestVoteRevealed.createdAt,
+                -1,
+              ),
             });
             systemMessages.push({
               type: ActionsPageFeedType.SystemMessage,
               name: SystemMessagesName.MotionHasFailedFinalizable,
-              createdAt: newestVoteRevealed.createdAt,
+              createdAt: getEarlierEventTimestamp(
+                newestVoteRevealed.createdAt,
+                -5,
+              ),
             });
           } else {
             systemMessages.push({
               type: ActionsPageFeedType.SystemMessage,
               name: SystemMessagesName.MotionRevealResultMotionWon,
-              createdAt: newestVoteRevealed.createdAt,
+              createdAt: getEarlierEventTimestamp(
+                newestVoteRevealed.createdAt,
+                -1,
+              ),
             });
           }
         }

--- a/src/i18n/en-system-messages.ts
+++ b/src/i18n/en-system-messages.ts
@@ -11,6 +11,8 @@ const systemMessagesMessageDescriptors = {
       ${SystemMessagesName.MotionHasFailedFinalizable} {{motionTag} has {failedTag} and may be finalized.}
       ${SystemMessagesName.MotionVotingPhase} {{votingTag} has started! Voting is secret 😀, and weighted by Reputation.}
       ${SystemMessagesName.MotionFullyStaked} {{motionTag} is fully staked; Staking period has reset. As long as there is no {objectionTag} , the motion will pass.}
+      ${SystemMessagesName.MotionRevealResultObjectionWon} {{objectionTag} sustained! {voteResultsWidget} The motion will fail at the end of the escalation period unless the dispute is escalated to a higher domain.}
+      ${SystemMessagesName.MotionRevealResultMotionWon} {{motionTag} sustained! {voteResultsWidget} The motion will pass at the end of the escalation period unless the dispute is escalated to a higher domain.}
       other {Generic system message}
     }`,
 };

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.css
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.css
@@ -22,3 +22,10 @@
   margin-left: 4px;
   width: 116px;
 }
+
+.voteResultsWrapper {
+  padding: 17px 23px;
+  margin: 14px 0;
+  border: 1px solid var(--text-disabled);
+  border-radius: var(--radius-large);
+}

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.css
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.css
@@ -24,8 +24,8 @@
 }
 
 .voteResultsWrapper {
-  padding: 17px 23px;
   margin: 14px 0;
+  padding: 17px 23px;
   border: 1px solid var(--text-disabled);
   border-radius: var(--radius-large);
 }

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.css.d.ts
@@ -3,3 +3,4 @@ export const tagWrapper: string;
 export const annotation: string;
 export const text: string;
 export const progressBarContainer: string;
+export const voteResultsWrapper: string;

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
@@ -3,6 +3,7 @@ import React, { useMemo, useRef } from 'react';
 import { FormattedMessage, defineMessages } from 'react-intl';
 
 import Numeral from '~core/Numeral';
+import Heading from '~core/Heading';
 import ActionsPageFeed, {
   ActionsPageFeedItemWithIPFS,
   SystemMessage,
@@ -38,7 +39,8 @@ import DetailsWidget from '../DetailsWidget';
 import StakingWidgetFlow from '../StakingWidget';
 import VoteWidget from '../VoteWidget';
 import RevealWidget from '../RevealWidget';
-import FinalizeMotionAndClaimWidget from '../FinalizeMotionAndClaimWidget';
+import FinalizeMotionAndClaimWidget, { MSG as voteResultsMSG } from '../FinalizeMotionAndClaimWidget';
+import VoteResults from '../FinalizeMotionAndClaimWidget/VoteResults';
 
 import styles from './DefaultAction.css';
 import motionSpecificStyles from './MintTokenMotion.css';
@@ -190,6 +192,19 @@ const MintTokenMotion = ({
       <span className={motionSpecificStyles.tagWrapper}>{objectionTag}</span>
     ),
     ...tags,
+    voteResultsWidget: (
+      <div className={motionSpecificStyles.voteResultsWrapper}>
+        <Heading
+          text={voteResultsMSG.title}
+          textValues={{ actionType }}
+          appearance={{ size: 'normal', theme: 'dark', margin: 'none' }}
+        />
+        <VoteResults
+          colony={colony}
+          motionId={motionId}
+        />
+      </div>
+    ),
   };
   const motionStyles = MOTION_TAG_MAP[motionState || MotionState.Invalid];
 

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
@@ -39,7 +39,9 @@ import DetailsWidget from '../DetailsWidget';
 import StakingWidgetFlow from '../StakingWidget';
 import VoteWidget from '../VoteWidget';
 import RevealWidget from '../RevealWidget';
-import FinalizeMotionAndClaimWidget, { MSG as voteResultsMSG } from '../FinalizeMotionAndClaimWidget';
+import FinalizeMotionAndClaimWidget, {
+  MSG as voteResultsMSG,
+} from '../FinalizeMotionAndClaimWidget';
 import VoteResults from '../FinalizeMotionAndClaimWidget/VoteResults';
 
 import styles from './DefaultAction.css';
@@ -199,10 +201,7 @@ const MintTokenMotion = ({
           textValues={{ actionType }}
           appearance={{ size: 'normal', theme: 'dark', margin: 'none' }}
         />
-        <VoteResults
-          colony={colony}
-          motionId={motionId}
-        />
+        <VoteResults colony={colony} motionId={motionId} />
       </div>
     ),
   };

--- a/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
@@ -39,7 +39,7 @@ interface Props {
   transactionHash: string;
 }
 
-const MSG = defineMessages({
+export const MSG = defineMessages({
   /*
    * @NOTE I didn't want to create a mapping for this, since they will only
    * be used in this instance

--- a/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/index.ts
+++ b/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/index.ts
@@ -1,1 +1,2 @@
 export { default } from './FinalizeMotionAndClaimWidget';
+export { MSG } from './FinalizeMotionAndClaimWidget';

--- a/src/modules/dashboard/components/ActionsPageFeed/types.ts
+++ b/src/modules/dashboard/components/ActionsPageFeed/types.ts
@@ -48,6 +48,8 @@ export enum SystemMessagesName {
   MotionRevealPhase = 'MotionRevealPhase',
   MotionVotingPhase = 'MotionVotingPhase',
   MotionFullyStaked = 'MotionFullyStaked',
+  MotionRevealResultObjectionWon = 'MotionRevealResultObjectionWon',
+  MotionRevealResultMotionWon = 'MotionRevealResultMotionWon',
 }
 
 export interface SystemMessage {

--- a/src/utils/colonyMotions.ts
+++ b/src/utils/colonyMotions.ts
@@ -155,7 +155,7 @@ export const getMotionRequiredStake = (
   return requiredStake;
 };
 
-export const getEarlierEventTimestamp = (currentTimestamp: number) => {
-  const oneSecond = 1000;
-  return currentTimestamp - oneSecond;
+const ONE_SECOND = 1000;
+export const getEarlierEventTimestamp = (currentTimestamp: number, subTime = ONE_SECOND) => {
+  return currentTimestamp - subTime;
 };

--- a/src/utils/colonyMotions.ts
+++ b/src/utils/colonyMotions.ts
@@ -156,6 +156,9 @@ export const getMotionRequiredStake = (
 };
 
 const ONE_SECOND = 1000;
-export const getEarlierEventTimestamp = (currentTimestamp: number, subTime = ONE_SECOND) => {
+export const getEarlierEventTimestamp = (
+  currentTimestamp: number,
+  subTime = ONE_SECOND,
+) => {
   return currentTimestamp - subTime;
 };


### PR DESCRIPTION
## Description
This PR adds in voting results system message (including voting results widget)

**New stuff** ✨

* Message descriptors and types for voting results system message

**Changes** 🏗

* Updated systemMessages resolver to return new type of system messages
* Updated getEarlierEventTimestamp util
* Updated MintTokenMotion component action and values with voteResultsWidget

<img width="546" alt="Screenshot 2021-05-05 at 11 32 45" src="https://user-images.githubusercontent.com/13069555/117135027-b3580a80-ada6-11eb-8874-5048a9acf6e0.png">
<img width="502" alt="Screenshot 2021-05-05 at 13 28 37" src="https://user-images.githubusercontent.com/13069555/117135039-b652fb00-ada6-11eb-899d-7f42d9676f35.png">


Resolves DEV-292
