### PR TITLE
Filter out events from contract

### DIFF
--- a/src/modules/dashboard/transformers.ts
+++ b/src/modules/dashboard/transformers.ts
@@ -89,28 +89,16 @@ export const getActionsListData = (
         if (isTransactionRepeated) return acc;
 
         /*
-         * Filter out events that have the recipient an extension's address
+         * Filter out events that have the recipient or initiator an extension's address
          *
          * This is used to filter out setting root roles to extensions after
-         * they have been installed
+         * they have been installed. This also filter out duplicated events
+         * which occurs when motion is finalized.
          */
         if (
           extensionAddresses?.find(
             (extensionAddress) =>
-              extensionAddress === event?.processedValues?.user,
-          )
-        ) {
-          return acc;
-        }
-        /*
-         * Filter out events that have the initiator an extension's address
-         *
-         * This is used to filter out duplicated events which occrus when
-         * motion is finalized. (one motion event + one event from contract)
-         */
-        if (
-          extensionAddresses?.find(
-            (extensionAddress) =>
+              extensionAddress === event?.processedValues?.user ||
               extensionAddress === event?.processedValues?.agent,
           )
         ) {

--- a/src/modules/dashboard/transformers.ts
+++ b/src/modules/dashboard/transformers.ts
@@ -62,6 +62,7 @@ export const getActionsListData = (
    * We only consider an action that we manually trigger ourselves, so if the transaction
    * hashes match, throw them out.
    */
+
   const filteredUnformattedActions = {
     oneTxPayments: unformattedActions?.oneTxPayments || [],
     events:
@@ -97,6 +98,20 @@ export const getActionsListData = (
           extensionAddresses?.find(
             (extensionAddress) =>
               extensionAddress === event?.processedValues?.user,
+          )
+        ) {
+          return acc;
+        }
+        /*
+         * Filter out events that have the initiator an extension's address
+         *
+         * This is used to filter out duplicated events which occrus when
+         * motion is finalized. (one motion event + one event from contract)
+         */
+        if (
+          extensionAddresses?.find(
+            (extensionAddress) =>
+              extensionAddress === event?.processedValues?.agent,
           )
         ) {
           return acc;


### PR DESCRIPTION
## Description

This PR fixes duplicated events in Action List. When motion is finalised, contract emit event for this action (for example "Mint tokens") Because of that, we're ending with to Mint tokens event in action list (for one of them, initiator is contract) Because of this issue, people was thinking that "someone which is not a member of colony, minted tokens with force" (reported on QA)


**Changes** 🏗

* Filtering out events where initiator is contract

## TODO

- Make sure if we're not "filtering too much"
- If so, narrow down filtering to = agent !== votingContractAddress

Resolves DEV-321