### PR TITLE
Fix ActionPage showing StakeRequired on Failed motion

### DIFF
--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -290,6 +290,7 @@ export type Query = {
   motionObjectionAnnotation: MotionObjectionAnnotation;
   motionStakerReward: MotionStakerRewards;
   motionStakes: MotionStakes;
+  motionStatus: Scalars['String'];
   motionUserVoteRevealed: MotionVoteReveal;
   motionVoteResults: MotionVoteResults;
   motionVoterReward: Scalars['String'];
@@ -440,6 +441,12 @@ export type QueryMotionStakesArgs = {
   colonyAddress: Scalars['String'];
   userAddress: Scalars['String'];
   motionId: Scalars['Int'];
+};
+
+
+export type QueryMotionStatusArgs = {
+  motionId: Scalars['Int'];
+  colonyAddress: Scalars['String'];
 };
 
 
@@ -1702,6 +1709,14 @@ export type MotionObjectionAnnotationQueryVariables = Exact<{
 
 
 export type MotionObjectionAnnotationQuery = { motionObjectionAnnotation: Pick<MotionObjectionAnnotation, 'address' | 'metadata'> };
+
+export type MotionStatusQueryVariables = Exact<{
+  motionId: Scalars['Int'];
+  colonyAddress: Scalars['String'];
+}>;
+
+
+export type MotionStatusQuery = Pick<Query, 'motionStatus'>;
 
 export type SubgraphDomainsQueryVariables = Exact<{
   colonyAddress: Scalars['String'];
@@ -4193,6 +4208,38 @@ export function useMotionObjectionAnnotationLazyQuery(baseOptions?: Apollo.LazyQ
 export type MotionObjectionAnnotationQueryHookResult = ReturnType<typeof useMotionObjectionAnnotationQuery>;
 export type MotionObjectionAnnotationLazyQueryHookResult = ReturnType<typeof useMotionObjectionAnnotationLazyQuery>;
 export type MotionObjectionAnnotationQueryResult = Apollo.QueryResult<MotionObjectionAnnotationQuery, MotionObjectionAnnotationQueryVariables>;
+export const MotionStatusDocument = gql`
+    query MotionStatus($motionId: Int!, $colonyAddress: String!) {
+  motionStatus(motionId: $motionId, colonyAddress: $colonyAddress) @client
+}
+    `;
+
+/**
+ * __useMotionStatusQuery__
+ *
+ * To run a query within a React component, call `useMotionStatusQuery` and pass it any options that fit your needs.
+ * When your component renders, `useMotionStatusQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useMotionStatusQuery({
+ *   variables: {
+ *      motionId: // value for 'motionId'
+ *      colonyAddress: // value for 'colonyAddress'
+ *   },
+ * });
+ */
+export function useMotionStatusQuery(baseOptions?: Apollo.QueryHookOptions<MotionStatusQuery, MotionStatusQueryVariables>) {
+        return Apollo.useQuery<MotionStatusQuery, MotionStatusQueryVariables>(MotionStatusDocument, baseOptions);
+      }
+export function useMotionStatusLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<MotionStatusQuery, MotionStatusQueryVariables>) {
+          return Apollo.useLazyQuery<MotionStatusQuery, MotionStatusQueryVariables>(MotionStatusDocument, baseOptions);
+        }
+export type MotionStatusQueryHookResult = ReturnType<typeof useMotionStatusQuery>;
+export type MotionStatusLazyQueryHookResult = ReturnType<typeof useMotionStatusLazyQuery>;
+export type MotionStatusQueryResult = Apollo.QueryResult<MotionStatusQuery, MotionStatusQueryVariables>;
 export const SubgraphDomainsDocument = gql`
     query SubgraphDomains($colonyAddress: String!) {
   domains(where: {colonyAddress: $colonyAddress}) {

--- a/src/data/graphql/queries.graphql
+++ b/src/data/graphql/queries.graphql
@@ -468,6 +468,10 @@ query MotionObjectionAnnotation($motionId: Int!, $colonyAddress: String!) {
   }
 }
 
+query MotionStatus($motionId: Int!, $colonyAddress: String!) {
+  motionStatus(motionId: $motionId, colonyAddress: $colonyAddress) @client
+}
+
 # The Graph
 #
 # @NOTE All queries meant for the subgraph should be prepended with `Subgraph`

--- a/src/data/graphql/typeDefs.ts
+++ b/src/data/graphql/typeDefs.ts
@@ -364,6 +364,7 @@ export default gql`
       colonyAddress: String!
     ): MotionObjectionAnnotation!
     votingState(colonyAddress: String!, motionId: Int!): VotingState!
+    motionStatus(motionId: Int!, colonyAddress: String!): String!
   }
 
   extend type Mutation {

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -602,6 +602,28 @@ export const motionsResolvers = ({
         return null;
       }
     },
+    async motionStatus(_, { motionId, colonyAddress }) {
+      try {
+        const votingReputationClient = await colonyManager.getClient(
+          ClientType.VotingReputationClient,
+          colonyAddress,
+        );
+        const motion = await votingReputationClient.getMotion(motionId);
+        const motionState = await votingReputationClient.getMotionState(
+          motionId,
+        );
+
+        return getMotionState(
+          motionState,
+          votingReputationClient as ExtensionClient,
+          motion,
+        );
+      } catch (error) {
+        console.error('Could not fetch motion state');
+        console.error(error);
+        return null;
+      }
+    },
     async motionFinalized(_, { motionId, colonyAddress }) {
       try {
         const votingReputationClient = await colonyManager.getClient(

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/MintTokenMotion.tsx
@@ -31,6 +31,7 @@ import ProgressBar from '~core/ProgressBar';
 import { getTokenDecimalsWithFallback } from '~utils/tokens';
 import {
   MotionState,
+  MotionValue,
   MOTION_TAG_MAP,
   PERIOD_TYPE_MAP,
   MOTION_STATE_TO_TIMER_TEXT_MAP,
@@ -66,10 +67,6 @@ interface Props {
   transactionHash: string;
   recipient: AnyUser;
   initiator: AnyUser;
-}
-
-interface MotionValue {
-  motionId: number;
 }
 
 const MintTokenMotion = ({

--- a/src/modules/dashboard/components/ActionsPage/ActionsPage.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsPage.tsx
@@ -98,7 +98,7 @@ const ActionsPage = () => {
       loading: colonyActionLoading,
       error: colonyActionError,
     },
-  ] = useColonyActionLazyQuery();
+  ] = useColonyActionLazyQuery({ fetchPolicy: 'network-only' });
 
   const [
     fetchRecipientProfile,

--- a/src/modules/dashboard/components/ActionsPage/ActionsPage.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsPage.tsx
@@ -128,6 +128,8 @@ const ActionsPage = () => {
   ] = useMotionStatusLazyQuery({ fetchPolicy: 'network-only' });
 
   const motionStatus = motionStatusData?.motionStatus;
+  const motionStatusChanged =
+    colonyActionData?.colonyAction.motionState !== motionStatus;
 
   const motionCreatedEvent = colonyActionData?.colonyAction.events.find(
     ({ name }) => name === ColonyAndExtensionsEvents.MotionCreated,
@@ -167,11 +169,13 @@ const ActionsPage = () => {
   }, [colonyActionData, colonyData, fetchMotionStatus, motionCreatedEvent]);
 
   useEffect(() => {
-    if (colonyActionData?.colonyAction && refetchColonyAction && motionStatus) {
-      const motionStatusChanged =
-        colonyActionData.colonyAction.motionState !== motionStatus;
-
-      if (motionStatusChanged) refetchColonyAction();
+    if (
+      colonyActionData?.colonyAction &&
+      refetchColonyAction &&
+      motionStatus &&
+      motionStatusChanged
+    ) {
+      refetchColonyAction();
     }
   }, [colonyActionData, refetchColonyAction, motionStatus]);
 
@@ -246,7 +250,7 @@ const ActionsPage = () => {
     !colonyActionData ||
     !colonyData ||
     !tokenData ||
-    (motionCreatedEvent && !motionStatusData)
+    (motionCreatedEvent && (!motionStatusData || motionStatusChanged))
   ) {
     return <LoadingTemplate loadingText={MSG.loading} />;
   }

--- a/src/utils/colonyMotions.ts
+++ b/src/utils/colonyMotions.ts
@@ -181,3 +181,7 @@ export const shouldDisplayMotion = (
     .times(100)
     .gte(10);
 };
+
+export interface MotionValue {
+  motionId: number;
+}


### PR DESCRIPTION
Fixed ActionPage showing the StakeRequired motion state when the motion actually failed **without** reloading the dapp. 

The ActionsPage wouldn't refetch the action data when you **re-enter** the ActionsPage, therefore if the motion failed it would still show that a stake is required, even if the system message in the feed already shows that the motion failed.

### How to test:
1. Create colony
2. Get reputation
3. Create motion
4. Stake for YAY and/or NAY, but not fully
5. Wait for the motion to fail, or use the time machine to travel to the future (AKA. Reputation monitor, make payments with the monitor ON)
6. Go back to the ActionPage and you should see that it failed, shouldn't be able to stake.

Resolves DEV-320
