### PR TITLE
Default 1 Gwei Gas Price on Xdai

### DIFF
--- a/src/immutable/Transaction.ts
+++ b/src/immutable/Transaction.ts
@@ -1,7 +1,7 @@
 import { Record } from 'immutable';
-import { BigNumber } from 'ethers/utils';
+import { BigNumber, bigNumberify } from 'ethers/utils';
 import { TransactionReceipt } from 'ethers/providers';
-import { ClientType, TransactionOverrides } from '@colony/colony-js';
+import { ClientType, TransactionOverrides, Network } from '@colony/colony-js';
 
 import {
   Address,
@@ -10,6 +10,7 @@ import {
   MethodParams,
   RecordToJS,
 } from '~types/index';
+import { DEFAULT_NETWORK } from '~constants';
 
 export enum TRANSACTION_ERRORS {
   ESTIMATE = 'ESTIMATE',
@@ -85,7 +86,10 @@ const defaultValues: DefaultValues<TransactionRecordProps> = {
   eventData: undefined,
   from: undefined,
   gasLimit: undefined,
-  gasPrice: undefined,
+  gasPrice:
+    DEFAULT_NETWORK === Network.Local || DEFAULT_NETWORK === Network.Xdai
+      ? bigNumberify('1000000000')
+      : undefined,
   group: undefined,
   hash: undefined,
   id: undefined,

--- a/src/modules/core/reducers/transactions.ts
+++ b/src/modules/core/reducers/transactions.ts
@@ -44,6 +44,8 @@ const coreTransactionsReducer: ReducerType<CoreTransactionsRecord> = (
           options,
           params,
           status,
+          gasPrice,
+          gasLimit,
         },
       } = action;
 
@@ -60,6 +62,8 @@ const coreTransactionsReducer: ReducerType<CoreTransactionsRecord> = (
         options,
         params,
         status,
+        gasLimit,
+        gasPrice,
       } as TransactionRecordProps);
 
       return state.setIn(

--- a/src/redux/types/actions/multisig.ts
+++ b/src/redux/types/actions/multisig.ts
@@ -22,6 +22,8 @@ export type MultisigActionTypes =
         | 'multisig'
         | 'options'
         | 'params'
+        | 'gasPrice'
+        | 'gasLimit'
         | 'status'
       >,
       WithId

--- a/src/redux/types/actions/transaction.ts
+++ b/src/redux/types/actions/transaction.ts
@@ -37,6 +37,8 @@ export type TransactionActionTypes =
         | 'multisig'
         | 'options'
         | 'params'
+        | 'gasPrice'
+        | 'gasLimit'
         | 'status'
       >,
       WithId


### PR DESCRIPTION
## Description

This PR sets the default gas price value on Xdai and Local networks to 1 Gwei as that is a safe value for the transaction to go trough, while consuming the minimal amount of Xdai

**Changes**

- [x] Added immutable `Transaction` default `gasPrice` value
- [x] Updated `TRANSACTION_CREATED` reducer to include gas price and limit
