### PR TITLE
Fix motion page banner and objection modal covering gas station

### DIFF
--- a/src/modules/pages/components/RouteLayouts/NavBar/NavBar.css
+++ b/src/modules/pages/components/RouteLayouts/NavBar/NavBar.css
@@ -17,7 +17,6 @@
   display: flex;
   align-content: stretch;
   padding: 0 20px;
-  z-index: var(--z-index-positioning);
   border: 1px solid transparent;
   border-color: var(--grey-blue-0);
   background-color: var(--grey-blue-3);


### PR DESCRIPTION
Self-explanatory title. 

Now the gas station should show up when you make a stake through the objection modal. Also the motion page banner shouldn't be on top of the navbar menus/gas station

Resolves DEV-343
