### PR TITLE
Improve Token Activation popover styles

### DIFF
--- a/src/modules/core/components/Fields/Input/InputComponent.css
+++ b/src/modules/core/components/Fields/Input/InputComponent.css
@@ -184,6 +184,7 @@
   border: none;
   background: none;
   font-size: var(--size-tiny);
+  font-weight: var(--weight-bold);
   color: var(--action-secondary);
   cursor: pointer;
 }

--- a/src/modules/pages/components/RouteLayouts/UserNavigation.css
+++ b/src/modules/pages/components/RouteLayouts/UserNavigation.css
@@ -96,6 +96,8 @@
 }
 
 .walletAddress {
+  padding: 2px 9px 3px;
+
   /*
    * @NOTE We need to do border sizing shenanigans due to how the border color
    * is required by spec to have opacity.
@@ -106,7 +108,7 @@
    * active class (the one that has a different colored border), we remove the extra padding
    * and set the border
    */
-  padding: 2px 9px 3px;
+  height: 100%;
   border: none;
   border-radius: var(--radius-normal);
   background-color: color-mod(var(--temp-grey-blue-7) alpha(10%));
@@ -134,6 +136,7 @@
 .buttonsWrapper {
   margin-right: 12px;
   padding: 1px;
+  height: 26px;
   position: relative;
   border-radius: var(--radius-normal);
   background-color: color-mod(var(--temp-grey-blue-7) alpha(10%));

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/TokenActivationContent.css
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/TokenActivationContent.css
@@ -88,7 +88,7 @@
 
 .tokensDetailsContainer {
   composes: mainDivider;
-  padding: 13px 16px 15px 16px;
+  padding: 18px 16px 19px 16px;
   min-height: 189px;
   width: 100%;
 }
@@ -101,7 +101,7 @@
 
   &::before {
     display: inline-block;
-    margin-right: 10px;
+    margin-right: 15px;
     height: 10px;
     width: 10px;
     border-radius: 50%;
@@ -112,9 +112,10 @@
 
 .lockedTokens {
   composes: listItemActive;
-  margin-left: 20px;
+  margin-left: 25px;
 
   &::before {
+    margin-right: 10px;
     background-color: var(--golden);
   }
 }
@@ -129,7 +130,7 @@
 
 .tokenNumbers {
   margin-bottom: 19px;
-  margin-left: 20px;
+  margin-left: 25px;
   color: var(--dark);
   font: var(--size-normal);
   overflow-wrap: anywhere;
@@ -137,7 +138,7 @@
 
 .tokenNumbersLocked {
   composes: tokenNumbers;
-  margin-left: 40px;
+  margin-left: 45px;
 }
 
 .tokenNumbersInactive {

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/TokenActivationContent.css
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/TokenActivationContent.css
@@ -70,6 +70,7 @@
 .totalTokens {
   margin-left: 16px;
   font-size: var(--size-medium-l);
+  line-height: 18px;
   white-space: nowrap;
   color: var(--dark);
 }

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/TokenActivationContent.css
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/TokenActivationContent.css
@@ -257,7 +257,11 @@
 }
 
 .form > button {
+  padding: 4px 0 7px 0;
+  height: 29px;
   width: 100px;
+  border: none;
+  line-height: 18px;
 }
 
 .claimsContainer {

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/TokenActivationContent.css
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/TokenActivationContent.css
@@ -57,11 +57,13 @@
 }
 
 .tokenSymbol {
+  height: 26px;
   width: 26px;
 }
 
 .tokenSymbolSmall {
   margin-left: 5px;
+  height: 16px;
   width: 16px;
 }
 

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/TokenActivationContent.css
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/TokenActivationContent.css
@@ -179,7 +179,10 @@
 
 .changeStateButtonsContainer > div > button {
   margin-left: 0;
+  padding: 4px 0 7px 0;
+  height: 29px;
   width: 95px;
+  line-height: 18px;
   outline: none;
 }
 


### PR DESCRIPTION
Improved some of the styles of the Token Activation popover

* Aligned token avatar to the center
* Updated padding and margin so that it looks more like the specs
* Updated max button font weight
* Improved alignment of Confirm button and wallet address button

![FireShot Capture 305 - Colony - localhost](https://user-images.githubusercontent.com/18473896/118504102-9ce47400-b701-11eb-8383-25ae80ec1bce.png)


Resolves DEV-327
