### PR TITLE
Uninstall extension warning modal

### DIFF
--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.css
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.css
@@ -68,39 +68,10 @@
   text-align: right;
 }
 
-.inputContainer {
-  margin-top: 27px;
-}
-
-.input {
-  padding: 0 16px;
-  height: 32px;
-  width: 100%;
-  border: 1px solid var(--temp-grey-5);
-  border-radius: var(--radius-tiny);
-  background-color: var(--colony-white);
-  font-size: var(--size-normal);
-  line-height: 32px;
-  color: var(--text);
-  outline: none;
-  letter-spacing: var(--spacing-normal);
-  transition: border-color 0.1s ease-in;
-
-  &:focus {
-    border-color: var(--primary);
-  }
-
-  &::placeholder {
-    font-size: var(--size-normal);
-    letter-spacing: var(--spacing-normal);
-    color: var(--text-disabled);
-  }
-}
-
 .warning {
-  background-color: var(--pink);
-  color: rgba(255, 255, 255);
-  font-weight: var(--weight-bold);
   padding: 25px 34px;
   border-radius: var(--radius-large);
+  background-color: var(--pink);
+  font-weight: var(--weight-bold);
+  color: rgba(255, 255, 255);
 }

--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.css
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.css
@@ -67,3 +67,40 @@
   margin-top: 10px;
   text-align: right;
 }
+
+.inputContainer {
+  margin-top: 27px;
+}
+
+.input {
+  padding: 0 16px;
+  height: 32px;
+  width: 100%;
+  border: 1px solid var(--temp-grey-5);
+  border-radius: var(--radius-tiny);
+  background-color: var(--colony-white);
+  font-size: var(--size-normal);
+  line-height: 32px;
+  color: var(--text);
+  outline: none;
+  letter-spacing: var(--spacing-normal);
+  transition: border-color 0.1s ease-in;
+
+  &:focus {
+    border-color: var(--primary);
+  }
+
+  &::placeholder {
+    font-size: var(--size-normal);
+    letter-spacing: var(--spacing-normal);
+    color: var(--text-disabled);
+  }
+}
+
+.warning {
+  background-color: var(--pink);
+  color: rgba(255, 255, 255);
+  font-weight: var(--weight-bold);
+  padding: 25px 34px;
+  border-radius: var(--radius-large);
+}

--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.css.d.ts
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.css.d.ts
@@ -9,3 +9,6 @@ export const installedBy: string;
 export const installedByAddress: string;
 export const permissions: string;
 export const buttonUninstall: string;
+export const inputContainer: string;
+export const input: string;
+export const warning: string;

--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.css.d.ts
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.css.d.ts
@@ -9,6 +9,4 @@ export const installedBy: string;
 export const installedByAddress: string;
 export const permissions: string;
 export const buttonUninstall: string;
-export const inputContainer: string;
-export const input: string;
 export const warning: string;

--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { defineMessages, FormattedDate, FormattedMessage, useIntl } from 'react-intl';
+import React from 'react';
+import { FormattedDate, defineMessages, FormattedMessage } from 'react-intl';
 import {
   useParams,
   Switch,
@@ -11,7 +11,6 @@ import { ColonyRole, ColonyVersion, Extension } from '@colony/colony-js';
 
 import BreadCrumb, { Crumb } from '~core/BreadCrumb';
 import Heading from '~core/Heading';
-import InputLabel from '~core/Fields/InputLabel';
 import {
   Colony,
   useLoggedInUser,
@@ -43,6 +42,7 @@ import ExtensionActionButton from './ExtensionActionButton';
 import ExtensionSetup from './ExtensionSetup';
 import ExtensionStatus from './ExtensionStatus';
 import ExtensionUpgrade from './ExtensionUpgrade';
+import ExtensionUninstallConfirmDialog from './ExtensionUninstallConfirmDialog';
 import { ExtensionsMSG } from './extensionsMSG';
 
 const MSG = defineMessages({
@@ -135,8 +135,6 @@ const ExtensionDetails = ({
   const match = useRouteMatch();
   const onSetupRoute = useRouteMatch(COLONY_EXTENSION_SETUP_ROUTE);
   const { walletAddress, username, ethereal } = useLoggedInUser();
-  const { formatMessage } = useIntl();
-  const [isWarningInputValid, setIsWarningInputValid] = useState<boolean>(false);
 
   const { data, loading } = useColonyExtensionQuery({
     variables: { colonyAddress, extensionId },
@@ -262,40 +260,24 @@ const ExtensionDetails = ({
     return <SpinnerLoader appearance={{ theme: 'primary', size: 'massive' }} />;
   }
 
-  const onWarningInputChange = (e) => {
-    setIsWarningInputValid(e.target.value === "I UNDERSTAND");
-  }
-
-  const modalContent = (content) => (
-    <div>
-      {content}
-      <div className={styles.inputContainer}>
-        <InputLabel
-          label={ExtensionsMSG.typeInBox}
-          appearance={{ colorSchema: 'grey' }}
-        />
-        <input
-          name="warning"
-          className={styles.input}
-          onChange={onWarningInputChange}
-          placeholder={formatMessage(ExtensionsMSG.warningPlaceholder)}
-        />
-      </div>
-    </div>
-  )
-
   const uninstallModalProps = {
     [Extension.VotingReputation]: {
       heading: ExtensionsMSG.headingVotingUninstall,
-      children: modalContent(<div className={styles.warning}><FormattedMessage {...ExtensionsMSG.textVotingUninstall} /></div>),
-      disabled: !isWarningInputValid,
+      children: (
+        <div className={styles.warning}>
+          <FormattedMessage {...ExtensionsMSG.textVotingUninstall} />
+        </div>
+      ),
     },
     [Extension.OneTxPayment]: {
       heading: ExtensionsMSG.headingDefaultUninstall,
-      children: modalContent(<FormattedMessage {...ExtensionsMSG.textDefaultUninstall} />),
-      disabled: !isWarningInputValid,
-    }
-  }
+      children: <FormattedMessage {...ExtensionsMSG.textDefaultUninstall} />,
+    },
+    DEFAULT: {
+      heading: ExtensionsMSG.headingDefaultUninstall,
+      children: <FormattedMessage {...ExtensionsMSG.textDefaultUninstall} />,
+    },
+  };
 
   return (
     <div className={styles.main}>
@@ -392,8 +374,11 @@ const ExtensionDetails = ({
           {extesionCanBeUninstalled ? (
             <div className={styles.buttonUninstall}>
               <DialogActionButton
-                dialog={ConfirmDialog}
-                dialogProps={uninstallModalProps[extensionId]}
+                dialog={ExtensionUninstallConfirmDialog}
+                dialogProps={
+                  uninstallModalProps[extensionId] ||
+                  uninstallModalProps.DEFAULT
+                }
                 appearance={{ theme: 'blue' }}
                 submit={ActionTypes.COLONY_EXTENSION_UNINSTALL}
                 error={ActionTypes.COLONY_EXTENSION_UNINSTALL_ERROR}

--- a/src/modules/dashboard/components/Extensions/ExtensionUninstallConfirmDialog/ExtensionUninstallConfirmDialog.css
+++ b/src/modules/dashboard/components/Extensions/ExtensionUninstallConfirmDialog/ExtensionUninstallConfirmDialog.css
@@ -1,0 +1,41 @@
+@value wideButton: 160px;
+
+.title {
+  font-size: var(--size-medium-l);
+  font-weight: var(--weight-bold);
+  line-height: 24px;
+  color: var(--dark);
+}
+
+.content {
+  padding-bottom: 40px;
+}
+
+.inputContainer {
+  margin-top: 27px;
+}
+
+.input {
+  padding: 0 16px;
+  height: 32px;
+  width: 100%;
+  border: 1px solid var(--temp-grey-5);
+  border-radius: var(--radius-tiny);
+  background-color: var(--colony-white);
+  font-size: var(--size-normal);
+  line-height: 32px;
+  color: var(--text);
+  outline: none;
+  letter-spacing: var(--spacing-normal);
+  transition: border-color 0.1s ease-in;
+
+  &:focus {
+    border-color: var(--primary);
+  }
+
+  &::placeholder {
+    font-size: var(--size-normal);
+    letter-spacing: var(--spacing-normal);
+    color: var(--text-disabled);
+  }
+}

--- a/src/modules/dashboard/components/Extensions/ExtensionUninstallConfirmDialog/ExtensionUninstallConfirmDialog.css
+++ b/src/modules/dashboard/components/Extensions/ExtensionUninstallConfirmDialog/ExtensionUninstallConfirmDialog.css
@@ -35,7 +35,7 @@
 
   &::placeholder {
     font-size: var(--size-normal);
-    letter-spacing: var(--spacing-normal);
     color: var(--text-disabled);
+    letter-spacing: var(--spacing-normal);
   }
 }

--- a/src/modules/dashboard/components/Extensions/ExtensionUninstallConfirmDialog/ExtensionUninstallConfirmDialog.css.d.ts
+++ b/src/modules/dashboard/components/Extensions/ExtensionUninstallConfirmDialog/ExtensionUninstallConfirmDialog.css.d.ts
@@ -1,0 +1,5 @@
+export const wideButton: string;
+export const title: string;
+export const content: string;
+export const inputContainer: string;
+export const input: string;

--- a/src/modules/dashboard/components/Extensions/ExtensionUninstallConfirmDialog/ExtensionUninstallConfirmDialog.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionUninstallConfirmDialog/ExtensionUninstallConfirmDialog.tsx
@@ -1,10 +1,5 @@
 import React, { ReactNode, useState } from 'react';
-import {
-  MessageDescriptor,
-  defineMessages,
-  FormattedMessage,
-  useIntl
-} from 'react-intl';
+import { MessageDescriptor, useIntl } from 'react-intl';
 
 import Button from '~core/Button';
 import Heading from '~core/Heading';
@@ -31,11 +26,13 @@ const ExtensionUninstallConfirmDialog = ({
   onClick = () => close(null),
 }: Props) => {
   const { formatMessage } = useIntl();
-  const [isWarningInputValid, setIsWarningInputValid] = useState<boolean>(false);
+  const [isWarningInputValid, setIsWarningInputValid] = useState<boolean>(
+    false,
+  );
 
   const onWarningInputChange = (e) => {
-    setIsWarningInputValid(e.target.value === "I UNDERSTAND");
-  }
+    setIsWarningInputValid(e.target.value === 'I UNDERSTAND');
+  };
 
   return (
     <Dialog cancel={cancel}>
@@ -82,7 +79,7 @@ const ExtensionUninstallConfirmDialog = ({
         />
       </DialogSection>
     </Dialog>
-  )
+  );
 };
 
 export default ExtensionUninstallConfirmDialog;

--- a/src/modules/dashboard/components/Extensions/ExtensionUninstallConfirmDialog/ExtensionUninstallConfirmDialog.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionUninstallConfirmDialog/ExtensionUninstallConfirmDialog.tsx
@@ -1,0 +1,88 @@
+import React, { ReactNode, useState } from 'react';
+import {
+  MessageDescriptor,
+  defineMessages,
+  FormattedMessage,
+  useIntl
+} from 'react-intl';
+
+import Button from '~core/Button';
+import Heading from '~core/Heading';
+import Dialog from '~core/Dialog';
+import DialogSection from '~core/Dialog/DialogSection';
+import InputLabel from '~core/Fields/InputLabel';
+
+import { ExtensionsMSG } from '../extensionsMSG';
+import styles from './ExtensionUninstallConfirmDialog.css';
+
+interface Props {
+  cancel: () => void;
+  close: (val: any) => void;
+  onClick?: () => void;
+  heading?: string | MessageDescriptor;
+  children?: ReactNode;
+}
+
+const ExtensionUninstallConfirmDialog = ({
+  cancel,
+  close,
+  heading,
+  children,
+  onClick = () => close(null),
+}: Props) => {
+  const { formatMessage } = useIntl();
+  const [isWarningInputValid, setIsWarningInputValid] = useState<boolean>(false);
+
+  const onWarningInputChange = (e) => {
+    setIsWarningInputValid(e.target.value === "I UNDERSTAND");
+  }
+
+  return (
+    <Dialog cancel={cancel}>
+      <DialogSection appearance={{ theme: 'heading' }}>
+        <Heading
+          appearance={{ size: 'medium', margin: 'none' }}
+          text={heading}
+          className={styles.title}
+        />
+      </DialogSection>
+      <DialogSection appearance={{ theme: 'sidePadding' }}>
+        <div className={styles.content}>
+          {children}
+          <div className={styles.inputContainer}>
+            <InputLabel
+              label={ExtensionsMSG.typeInBox}
+              appearance={{ colorSchema: 'grey' }}
+            />
+            <input
+              name="warning"
+              className={styles.input}
+              onChange={onWarningInputChange}
+              placeholder={formatMessage(ExtensionsMSG.warningPlaceholder)}
+            />
+          </div>
+        </div>
+      </DialogSection>
+      <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
+        <Button
+          appearance={{ theme: 'secondary', size: 'large' }}
+          onClick={() => cancel()}
+          text={{ id: 'button.cancel' }}
+        />
+        <Button
+          appearance={{
+            theme: 'primary',
+            size: 'large',
+          }}
+          autoFocus
+          onClick={onClick}
+          text={{ id: 'button.confirm' }}
+          style={{ width: styles.wideButton }}
+          disabled={!isWarningInputValid}
+        />
+      </DialogSection>
+    </Dialog>
+  )
+};
+
+export default ExtensionUninstallConfirmDialog;

--- a/src/modules/dashboard/components/Extensions/ExtensionUninstallConfirmDialog/index.ts
+++ b/src/modules/dashboard/components/Extensions/ExtensionUninstallConfirmDialog/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ExtensionUninstallConfirmDialog';

--- a/src/modules/dashboard/components/Extensions/extensionsMSG.ts
+++ b/src/modules/dashboard/components/Extensions/extensionsMSG.ts
@@ -1,0 +1,28 @@
+import { defineMessages } from 'react-intl';
+
+export const ExtensionsMSG = defineMessages({
+  headingDefaultUninstall: {
+    id: 'dashboard.Extensions.ExtensionDetails.headingDefaultUninstall',
+    defaultMessage: 'Uninstall extension',
+  },
+  textDefaultUninstall: {
+    id: 'dashboard.Extensions.ExtensionDetails.textDefaultUninstall',
+    defaultMessage: `This extension is currently deprecated, and may be uninstalled. Doing so will remove it from the colony and any processes requiring it will no longer work.`,
+  },
+  headingVotingUninstall: {
+    id: 'dashboard.Extensions.ExtensionDetails.headingVotingUninstall',
+    defaultMessage: 'WARNING',
+  },
+  textVotingUninstall: {
+    id: 'dashboard.Extensions.ExtensionDetails.textVotingUninstall',
+    defaultMessage: `Please ensure that all funds in processes associated with this extension are claimed by their owners before uninstalling. Not doing so will result in permanent loss of the unclaimed funds.`,
+  },
+  typeInBox: {
+    id: 'dashboard.Extensions.ExtensionDetails.typeInBox',
+    defaultMessage: `Type "I UNDERSTAND" in the box below to proceed.`,
+  },
+  warningPlaceholder: {
+    id: 'dashboard.Extensions.ExtensionDetails.warningPlaceholder',
+    defaultMessage: `I UNDERSTAND`,
+  }
+});

--- a/src/modules/dashboard/components/Extensions/extensionsMSG.ts
+++ b/src/modules/dashboard/components/Extensions/extensionsMSG.ts
@@ -24,5 +24,5 @@ export const ExtensionsMSG = defineMessages({
   warningPlaceholder: {
     id: 'dashboard.Extensions.ExtensionDetails.warningPlaceholder',
     defaultMessage: `I UNDERSTAND`,
-  }
+  },
 });


### PR DESCRIPTION
## Description

This PR adds in warning modal with confirmation input whenever user want to uninstall extension

**New stuff** ✨

* ExtensionUninstallConfirmDialog
* extension message descriptors
* Created map with content for dialog depend on extension id

**Changes** 🏗

* Displaying ExtensionUninstallConfirmDialog with "I UNDERSTAND" input whenever user want to uninstall extension

Voting reputation warning modal:
<img width="513" alt="WARNING" src="https://user-images.githubusercontent.com/13069555/118638105-c8855e00-b7d6-11eb-9114-5b2d137880f4.png">

Default & Payment extension modal
<img width="498" alt="Screenshot 2021-05-18 at 12 41 42" src="https://user-images.githubusercontent.com/13069555/118638234-e652c300-b7d6-11eb-9c70-ffc7d47246a9.png">

Resolves DEV-347
