### PR TITLE
Decode motion values of wire up motions

### DIFF
--- a/src/data/resolvers/colonyActions.ts
+++ b/src/data/resolvers/colonyActions.ts
@@ -90,6 +90,10 @@ export const colonyActionsResolvers = ({
         (client) => client?.clientType === ClientType.VotingReputationClient,
       );
 
+      const oneTxPaymentClient = clientsInstancesArray.find(
+        (client) => client?.clientType === ClientType.OneTxPaymentClient,
+      );
+
       /*
        * Try to get the transaction receipt. If the transaction is mined, you'll
        * get a return from this call, otherwise, it's null.
@@ -171,6 +175,7 @@ export const colonyActionsResolvers = ({
         if (motionCreatedEvent) {
           actionType = await getMotionActionType(
             votingClient as ExtensionClient,
+            oneTxPaymentClient as ExtensionClient,
             colonyClient as ColonyClient,
             motionCreatedEvent.values.motionId,
           );
@@ -181,6 +186,7 @@ export const colonyActionsResolvers = ({
           reverseSortedEvents,
           colonyClient as ColonyClient,
           votingClient as ExtensionClient,
+          oneTxPaymentClient as ExtensionClient,
           actionType,
         );
 
@@ -269,6 +275,7 @@ export const colonyActionsResolvers = ({
         [],
         colonyClient as ColonyClient,
         votingClient as ExtensionClient,
+        oneTxPaymentClient as ExtensionClient,
         ColonyActions.Generic,
       );
 

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -896,12 +896,17 @@ export const motionsResolvers = ({
         ClientType.VotingReputationClient,
         colonyAddress,
       );
+      const oneTxPaymentClient = await colonyManager.getClient(
+        ClientType.OneTxPaymentClient,
+        colonyAddress,
+      );
       const colonyClient = await colonyManager.getClient(
         ClientType.ColonyClient,
         colonyAddress,
       );
       return getMotionActionType(
         votingReputationClient as ExtensionClient,
+        oneTxPaymentClient as ExtensionClient,
         colonyClient,
         bigNumberify(fundamentalChainId),
       );

--- a/src/i18n/en-motions.ts
+++ b/src/i18n/en-motions.ts
@@ -6,6 +6,7 @@ const motionsMessageDescriptors = {
       ${ColonyMotions.CreateDomainMotion} {New team: {domainName}}
       ${ColonyMotions.EditDomainMotion} {{domainName} team details edited}
       ${ColonyMotions.ColonyEditMotion} {Colony details changed}
+      ${ColonyMotions.PaymentMotion} {Pay {recipient} {amount} {tokenSymbol}}
       other {Generic motion we don't have information about}
     }`,
   [`motion.${ColonyMotions.SetUserRolesMotion}.assign`]: `Assign the {roles} in {domainName} to {recipient}`,

--- a/src/i18n/en-motions.ts
+++ b/src/i18n/en-motions.ts
@@ -3,15 +3,17 @@ import { ColonyMotions } from '~types/index';
 const motionsMessageDescriptors = {
   'motion.title': `{actionType, select,
       ${ColonyMotions.MintTokensMotion} {Mint {amount} {tokenSymbol}}
-      ${ColonyMotions.CreateDomainMotion} {New team: {domainName}}
-      ${ColonyMotions.EditDomainMotion} {{domainName} team details edited}
+      ${ColonyMotions.CreateDomainMotion} {New team: {fromDomainName}}
+      ${ColonyMotions.EditDomainMotion} {{fromDomainName} team details edited}
       ${ColonyMotions.ColonyEditMotion} {Colony details changed}
       ${ColonyMotions.PaymentMotion} {Pay {recipient} {amount} {tokenSymbol}}
+      ${ColonyMotions.MoveFundsMotion}
+        {Move {amount} {tokenSymbol} from {fromDomainName} to {toDomainName}}
       other {Generic motion we don't have information about}
     }`,
-  [`motion.${ColonyMotions.SetUserRolesMotion}.assign`]: `Assign the {roles} in {domainName} to {recipient}`,
-  [`motion.${ColonyMotions.SetUserRolesMotion}.remove`]: `Remove the {roles} in {domainName} from {recipient}`,
-  [`motion.${ColonyMotions.SetUserRolesMotion}.assignAndRemove`]: `{roles} in {domainName} to/from {recipient}`,
+  [`motion.${ColonyMotions.SetUserRolesMotion}.assign`]: `Assign the {roles} in {fromDomainName} to {recipient}`,
+  [`motion.${ColonyMotions.SetUserRolesMotion}.remove`]: `Remove the {roles} in {fromDomainName} from {recipient}`,
+  [`motion.${ColonyMotions.SetUserRolesMotion}.assignAndRemove`]: `{roles} in {fromDomainName} to/from {recipient}`,
   'motion.type': `{actionType, select,
       ${ColonyMotions.MintTokensMotion} {Mint Tokens}
       ${ColonyMotions.PaymentMotion} {Payment}

--- a/src/i18n/en-motions.ts
+++ b/src/i18n/en-motions.ts
@@ -4,7 +4,7 @@ const motionsMessageDescriptors = {
   'motion.title': `{actionType, select,
       ${ColonyMotions.MintTokensMotion} {Mint {amount} {tokenSymbol}}
       ${ColonyMotions.CreateDomainMotion} {New team: {fromDomainName}}
-      ${ColonyMotions.EditDomainMotion} {{Edit {fromDomainName} team details}
+      ${ColonyMotions.EditDomainMotion} {Edit {fromDomainName} team details}
       ${ColonyMotions.ColonyEditMotion} {Change colony details}
       ${ColonyMotions.PaymentMotion} {Pay {recipient} {amount} {tokenSymbol}}
       ${ColonyMotions.MoveFundsMotion}

--- a/src/i18n/en-motions.ts
+++ b/src/i18n/en-motions.ts
@@ -4,6 +4,7 @@ const motionsMessageDescriptors = {
   'motion.title': `{actionType, select,
       ${ColonyMotions.MintTokensMotion} {Mint {amount} {tokenSymbol}}
       ${ColonyMotions.CreateDomainMotion} {New team: {domainName}}
+      ${ColonyMotions.EditDomainMotion} {{domainName} team details edited}
       other {Generic motion we don't have information about}
     }`,
   [`motion.${ColonyMotions.SetUserRolesMotion}.assign`]: `Assign the {roles} in {domainName} to {recipient}`,

--- a/src/i18n/en-motions.ts
+++ b/src/i18n/en-motions.ts
@@ -6,6 +6,9 @@ const motionsMessageDescriptors = {
       ${ColonyMotions.CreateDomainMotion} {New team: {domainName}}
       other {Generic motion we don't have information about}
     }`,
+  [`motion.${ColonyMotions.SetUserRolesMotion}.assign`]: `Assign the {roles} in {domainName} to {recipient}`,
+  [`motion.${ColonyMotions.SetUserRolesMotion}.remove`]: `Remove the {roles} in {domainName} from {recipient}`,
+  [`motion.${ColonyMotions.SetUserRolesMotion}.assignAndRemove`]: `{roles} in {domainName} to/from {recipient}`,
   'motion.type': `{actionType, select,
       ${ColonyMotions.MintTokensMotion} {Mint Tokens}
       ${ColonyMotions.PaymentMotion} {Payment}

--- a/src/i18n/en-motions.ts
+++ b/src/i18n/en-motions.ts
@@ -3,6 +3,7 @@ import { ColonyMotions } from '~types/index';
 const motionsMessageDescriptors = {
   'motion.title': `{actionType, select,
       ${ColonyMotions.MintTokensMotion} {Mint {amount} {tokenSymbol}}
+      ${ColonyMotions.CreateDomainMotion} {New team: {domainName}}
       other {Generic motion we don't have information about}
     }`,
   'motion.type': `{actionType, select,

--- a/src/i18n/en-motions.ts
+++ b/src/i18n/en-motions.ts
@@ -5,6 +5,7 @@ const motionsMessageDescriptors = {
       ${ColonyMotions.MintTokensMotion} {Mint {amount} {tokenSymbol}}
       ${ColonyMotions.CreateDomainMotion} {New team: {domainName}}
       ${ColonyMotions.EditDomainMotion} {{domainName} team details edited}
+      ${ColonyMotions.ColonyEditMotion} {Colony details changed}
       other {Generic motion we don't have information about}
     }`,
   [`motion.${ColonyMotions.SetUserRolesMotion}.assign`]: `Assign the {roles} in {domainName} to {recipient}`,

--- a/src/i18n/en-motions.ts
+++ b/src/i18n/en-motions.ts
@@ -4,8 +4,8 @@ const motionsMessageDescriptors = {
   'motion.title': `{actionType, select,
       ${ColonyMotions.MintTokensMotion} {Mint {amount} {tokenSymbol}}
       ${ColonyMotions.CreateDomainMotion} {New team: {fromDomainName}}
-      ${ColonyMotions.EditDomainMotion} {{fromDomainName} team details edited}
-      ${ColonyMotions.ColonyEditMotion} {Colony details changed}
+      ${ColonyMotions.EditDomainMotion} {{Edit {fromDomainName} team details}
+      ${ColonyMotions.ColonyEditMotion} {Change colony details}
       ${ColonyMotions.PaymentMotion} {Pay {recipient} {amount} {tokenSymbol}}
       ${ColonyMotions.MoveFundsMotion}
         {Move {amount} {tokenSymbol} from {fromDomainName} to {toDomainName}}

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
@@ -1,6 +1,7 @@
 import { bigNumberify } from 'ethers/utils';
 import React, { useMemo, useRef } from 'react';
 import { FormattedMessage, defineMessages } from 'react-intl';
+import { isNil } from 'lodash';
 
 import Numeral from '~core/Numeral';
 import Heading from '~core/Heading';
@@ -23,6 +24,7 @@ import {
   useUser,
   useVotingStateQuery,
   useMotionStatusQuery,
+  OneDomain,
 } from '~data/index';
 import Tag, { Appearance as TagAppearance } from '~core/Tag';
 import FriendlyName from '~core/FriendlyName';
@@ -35,7 +37,9 @@ import {
   MOTION_TAG_MAP,
   shouldDisplayMotion,
 } from '~utils/colonyMotions';
+import { useFormatRolesTitle } from '~utils/hooks/useFormatRolesTitle';
 
+import { getUserRolesForDomain } from '../../../../transformers';
 import DetailsWidget from '../DetailsWidget';
 import StakingWidgetFlow from '../StakingWidget';
 import VoteWidget from '../VoteWidget';
@@ -69,6 +73,7 @@ interface Props {
 }
 
 const DefaultMotion = ({
+  colony: { domains },
   colony,
   colonyAction: {
     events = [],
@@ -81,6 +86,8 @@ const DefaultMotion = ({
     rootHash,
     domainName,
     domainColor,
+    roles,
+    fromDomain,
   },
   colonyAction,
   token: { decimals, symbol },
@@ -99,10 +106,31 @@ const DefaultMotion = ({
     }, {} as any);
   }, []);
 
+  const userCurrentRoles = getUserRolesForDomain(
+    colony,
+    recipient.profile.walletAddress,
+    fromDomain,
+  );
+  const updatedRoles = roles.filter((role) => {
+    const foundCurrentRole = userCurrentRoles.find(
+      (currentRole) => currentRole === role.id,
+    );
+    if (!isNil(foundCurrentRole)) {
+      return !role.setTo;
+    }
+    return true;
+  });
+
   const motionCreatedEvent = colonyAction.events.find(
     ({ name }) => name === ColonyAndExtensionsEvents.MotionCreated,
   );
   const { motionId } = (motionCreatedEvent?.values as unknown) as MotionValue;
+
+  const { roleMessageDescriptorId, roleTitle } = useFormatRolesTitle(
+    updatedRoles,
+    actionType,
+    true,
+  );
 
   const {
     username: currentUserName,
@@ -187,10 +215,18 @@ const DefaultMotion = ({
 
   const actionAndEventValues = {
     actionType,
-    fromDomain: {
+    fromDomain: (domains.find(
+      ({ ethDomainId }) => ethDomainId === fromDomain,
+    ) as OneDomain) || {
       name: domainName,
       color: domainColor,
     },
+    roles: updatedRoles,
+    recipient: (
+      <span className={styles.titleDecoration}>
+        <FriendlyName user={recipient} autoShrinkAddress colony={colony} />
+      </span>
+    ),
     amount: (
       <Numeral value={amount} unit={getTokenDecimalsWithFallback(decimals)} />
     ),
@@ -300,10 +336,11 @@ const DefaultMotion = ({
         <div className={styles.content}>
           <h1 className={styles.heading}>
             <FormattedMessage
-              id="motion.title"
+              id={roleMessageDescriptorId || 'motion.title'}
               values={{
                 ...actionAndEventValues,
                 domainName: actionAndEventValues.fromDomain.name,
+                roles: roleTitle,
               }}
             />
           </h1>

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
@@ -79,6 +79,8 @@ const DefaultMotion = ({
     motionDomain,
     actionInitiator,
     rootHash,
+    domainName,
+    domainColor,
   },
   colonyAction,
   token: { decimals, symbol },
@@ -185,6 +187,10 @@ const DefaultMotion = ({
 
   const actionAndEventValues = {
     actionType,
+    fromDomain: {
+      name: domainName,
+      color: domainColor,
+    },
     amount: (
       <Numeral value={amount} unit={getTokenDecimalsWithFallback(decimals)} />
     ),
@@ -297,6 +303,7 @@ const DefaultMotion = ({
               id="motion.title"
               values={{
                 ...actionAndEventValues,
+                domainName: actionAndEventValues.fromDomain.name,
               }}
             />
           </h1>

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
@@ -86,6 +86,7 @@ const DefaultMotion = ({
     rootHash,
     domainName,
     domainColor,
+    domainPurpose,
     roles,
     fromDomain,
     toDomain,
@@ -213,15 +214,18 @@ const DefaultMotion = ({
       Math.round((totalVotedReputationValue / skillRepValue) * 100)) ||
     0;
   const threasholdPercent = Math.round((threashold / skillRepValue) * 100);
-
+  const domainMetadata = {
+    name: domainName,
+    color: domainColor,
+    description: domainPurpose,
+  };
   const actionAndEventValues = {
     actionType,
-    fromDomain: (domains.find(
-      ({ ethDomainId }) => ethDomainId === fromDomain,
-    ) as OneDomain) || {
-      name: domainName,
-      color: domainColor,
-    },
+    fromDomain:
+      (actionType === ColonyMotions.CreateDomainMotion && domainMetadata) ||
+      (domains.find(
+        ({ ethDomainId }) => ethDomainId === fromDomain,
+      ) as OneDomain),
     toDomain: domains.find(
       ({ ethDomainId }) => ethDomainId === toDomain,
     ) as OneDomain,

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
@@ -438,7 +438,13 @@ const DefaultMotion = ({
             actionType={actionType as ColonyMotions}
             recipient={recipient}
             transactionHash={transactionHash}
-            values={actionAndEventValues}
+            values={{
+              ...actionAndEventValues,
+              fromDomain:
+                actionType === ColonyMotions.EditDomainMotion
+                  ? domainMetadata
+                  : actionAndEventValues.fromDomain,
+            }}
             colony={colony}
           />
         </div>

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
@@ -120,7 +120,7 @@ const DefaultMotion = ({
     if (!isNil(foundCurrentRole)) {
       return !role.setTo;
     }
-    return true;
+    return role.setTo;
   });
 
   const motionCreatedEvent = colonyAction.events.find(

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
@@ -88,6 +88,7 @@ const DefaultMotion = ({
     domainColor,
     roles,
     fromDomain,
+    toDomain,
   },
   colonyAction,
   token: { decimals, symbol },
@@ -221,6 +222,9 @@ const DefaultMotion = ({
       name: domainName,
       color: domainColor,
     },
+    toDomain: domains.find(
+      ({ ethDomainId }) => ethDomainId === toDomain,
+    ) as OneDomain,
     roles: updatedRoles,
     recipient: (
       <span className={styles.titleDecoration}>
@@ -339,7 +343,8 @@ const DefaultMotion = ({
               id={roleMessageDescriptorId || 'motion.title'}
               values={{
                 ...actionAndEventValues,
-                domainName: actionAndEventValues.fromDomain.name,
+                fromDomainName: actionAndEventValues.fromDomain?.name,
+                toDomainName: actionAndEventValues.toDomain?.name,
                 roles: roleTitle,
               }}
             />

--- a/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
@@ -51,6 +51,12 @@ export const MSG = defineMessages({
     id: 'dashboard.ActionsPage.FinalizeMotionAndClaimWidget.title',
     defaultMessage: `Should "{actionType, select,
       ${ColonyMotions.MintTokensMotion} {Mint tokens}
+      ${ColonyMotions.PaymentMotion} {Payment}
+      ${ColonyMotions.CreateDomainMotion} {Create Team}
+      ${ColonyMotions.EditDomainMotion} {Edit Team}
+      ${ColonyMotions.ColonyEditMotion} {Colony Edit}
+      ${ColonyMotions.SetUserRolesMotion} {Permission Management}
+      ${ColonyMotions.MoveFundsMotion} {Move Funds}
       other {Generic Action}
     }" be approved?`,
   },

--- a/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteWidget.tsx
@@ -44,6 +44,12 @@ const MSG = defineMessages({
     id: 'dashboard.ActionsPage.VoteWidget.title',
     defaultMessage: `Should "{actionType, select,
       ${ColonyMotions.MintTokensMotion} {Mint tokens}
+      ${ColonyMotions.PaymentMotion} {Payment}
+      ${ColonyMotions.CreateDomainMotion} {Create Team}
+      ${ColonyMotions.EditDomainMotion} {Edit Team}
+      ${ColonyMotions.ColonyEditMotion} {Colony Edit}
+      ${ColonyMotions.SetUserRolesMotion} {Permission Management}
+      ${ColonyMotions.MoveFundsMotion} {Move Funds}
       other {Generic Action}
     }" be approved?`,
   },

--- a/src/modules/dashboard/components/ActionsPage/staticMaps.ts
+++ b/src/modules/dashboard/components/ActionsPage/staticMaps.ts
@@ -100,6 +100,16 @@ export const STATUS_MAP: { [key in number]: STATUS } = {
 /*
  * Which events to display on which action's page
  */
+
+const MOTION_EVENTS = [
+  ColonyAndExtensionsEvents.MotionCreated,
+  ColonyAndExtensionsEvents.MotionStaked,
+  ColonyAndExtensionsEvents.MotionVoteRevealed,
+  ColonyAndExtensionsEvents.ObjectionRaised,
+  ColonyAndExtensionsEvents.MotionFinalized,
+  ColonyAndExtensionsEvents.MotionRewardClaimed,
+];
+
 export const ACTIONS_EVENTS: ActionsEventsMap = {
   [ColonyActions.Payment]: [ColonyAndExtensionsEvents.OneTxPaymentMade],
   [ColonyActions.MoveFunds]: [
@@ -117,62 +127,13 @@ export const ACTIONS_EVENTS: ActionsEventsMap = {
     ColonyAndExtensionsEvents.RecoveryModeExitApproved,
     ColonyAndExtensionsEvents.RecoveryModeExited,
   ],
-  [ColonyMotions.MintTokensMotion]: [
-    ColonyAndExtensionsEvents.MotionCreated,
-    ColonyAndExtensionsEvents.MotionStaked,
-    ColonyAndExtensionsEvents.MotionVoteRevealed,
-    ColonyAndExtensionsEvents.ObjectionRaised,
-    ColonyAndExtensionsEvents.MotionFinalized,
-    ColonyAndExtensionsEvents.MotionRewardClaimed,
-  ],
-  [ColonyMotions.CreateDomainMotion]: [
-    ColonyAndExtensionsEvents.MotionCreated,
-    ColonyAndExtensionsEvents.MotionStaked,
-    ColonyAndExtensionsEvents.MotionVoteRevealed,
-    ColonyAndExtensionsEvents.ObjectionRaised,
-    ColonyAndExtensionsEvents.MotionFinalized,
-    ColonyAndExtensionsEvents.MotionRewardClaimed,
-  ],
-  [ColonyMotions.EditDomainMotion]: [
-    ColonyAndExtensionsEvents.MotionCreated,
-    ColonyAndExtensionsEvents.MotionStaked,
-    ColonyAndExtensionsEvents.MotionVoteRevealed,
-    ColonyAndExtensionsEvents.ObjectionRaised,
-    ColonyAndExtensionsEvents.MotionFinalized,
-    ColonyAndExtensionsEvents.MotionRewardClaimed,
-  ],
-  [ColonyMotions.ColonyEditMotion]: [
-    ColonyAndExtensionsEvents.MotionCreated,
-    ColonyAndExtensionsEvents.MotionStaked,
-    ColonyAndExtensionsEvents.MotionVoteRevealed,
-    ColonyAndExtensionsEvents.ObjectionRaised,
-    ColonyAndExtensionsEvents.MotionFinalized,
-    ColonyAndExtensionsEvents.MotionRewardClaimed,
-  ],
-  [ColonyMotions.SetUserRolesMotion]: [
-    ColonyAndExtensionsEvents.MotionCreated,
-    ColonyAndExtensionsEvents.MotionStaked,
-    ColonyAndExtensionsEvents.MotionVoteRevealed,
-    ColonyAndExtensionsEvents.ObjectionRaised,
-    ColonyAndExtensionsEvents.MotionFinalized,
-    ColonyAndExtensionsEvents.MotionRewardClaimed,
-  ],
-  [ColonyMotions.PaymentMotion]: [
-    ColonyAndExtensionsEvents.MotionCreated,
-    ColonyAndExtensionsEvents.MotionStaked,
-    ColonyAndExtensionsEvents.MotionVoteRevealed,
-    ColonyAndExtensionsEvents.ObjectionRaised,
-    ColonyAndExtensionsEvents.MotionFinalized,
-    ColonyAndExtensionsEvents.MotionRewardClaimed,
-  ],
-  [ColonyMotions.MoveFundsMotion]: [
-    ColonyAndExtensionsEvents.MotionCreated,
-    ColonyAndExtensionsEvents.MotionStaked,
-    ColonyAndExtensionsEvents.MotionVoteRevealed,
-    ColonyAndExtensionsEvents.ObjectionRaised,
-    ColonyAndExtensionsEvents.MotionFinalized,
-    ColonyAndExtensionsEvents.MotionRewardClaimed,
-  ],
+  [ColonyMotions.MintTokensMotion]: MOTION_EVENTS,
+  [ColonyMotions.CreateDomainMotion]: MOTION_EVENTS,
+  [ColonyMotions.EditDomainMotion]: MOTION_EVENTS,
+  [ColonyMotions.ColonyEditMotion]: MOTION_EVENTS,
+  [ColonyMotions.SetUserRolesMotion]: MOTION_EVENTS,
+  [ColonyMotions.PaymentMotion]: MOTION_EVENTS,
+  [ColonyMotions.MoveFundsMotion]: MOTION_EVENTS,
 };
 
 /*

--- a/src/modules/dashboard/components/ActionsPage/staticMaps.ts
+++ b/src/modules/dashboard/components/ActionsPage/staticMaps.ts
@@ -133,6 +133,22 @@ export const ACTIONS_EVENTS: ActionsEventsMap = {
     ColonyAndExtensionsEvents.MotionFinalized,
     ColonyAndExtensionsEvents.MotionRewardClaimed,
   ],
+  [ColonyMotions.EditDomainMotion]: [
+    ColonyAndExtensionsEvents.MotionCreated,
+    ColonyAndExtensionsEvents.MotionStaked,
+    ColonyAndExtensionsEvents.MotionVoteRevealed,
+    ColonyAndExtensionsEvents.ObjectionRaised,
+    ColonyAndExtensionsEvents.MotionFinalized,
+    ColonyAndExtensionsEvents.MotionRewardClaimed,
+  ],
+  [ColonyMotions.ColonyEditMotion]: [
+    ColonyAndExtensionsEvents.MotionCreated,
+    ColonyAndExtensionsEvents.MotionStaked,
+    ColonyAndExtensionsEvents.MotionVoteRevealed,
+    ColonyAndExtensionsEvents.ObjectionRaised,
+    ColonyAndExtensionsEvents.MotionFinalized,
+    ColonyAndExtensionsEvents.MotionRewardClaimed,
+  ],
   [ColonyMotions.SetUserRolesMotion]: [
     ColonyAndExtensionsEvents.MotionCreated,
     ColonyAndExtensionsEvents.MotionStaked,

--- a/src/modules/dashboard/components/ActionsPage/staticMaps.ts
+++ b/src/modules/dashboard/components/ActionsPage/staticMaps.ts
@@ -125,6 +125,14 @@ export const ACTIONS_EVENTS: ActionsEventsMap = {
     ColonyAndExtensionsEvents.MotionFinalized,
     ColonyAndExtensionsEvents.MotionRewardClaimed,
   ],
+  [ColonyMotions.CreateDomainMotion]: [
+    ColonyAndExtensionsEvents.MotionCreated,
+    ColonyAndExtensionsEvents.MotionStaked,
+    ColonyAndExtensionsEvents.MotionVoteRevealed,
+    ColonyAndExtensionsEvents.ObjectionRaised,
+    ColonyAndExtensionsEvents.MotionFinalized,
+    ColonyAndExtensionsEvents.MotionRewardClaimed,
+  ],
 };
 
 /*

--- a/src/modules/dashboard/components/ActionsPage/staticMaps.ts
+++ b/src/modules/dashboard/components/ActionsPage/staticMaps.ts
@@ -141,6 +141,14 @@ export const ACTIONS_EVENTS: ActionsEventsMap = {
     ColonyAndExtensionsEvents.MotionFinalized,
     ColonyAndExtensionsEvents.MotionRewardClaimed,
   ],
+  [ColonyMotions.PaymentMotion]: [
+    ColonyAndExtensionsEvents.MotionCreated,
+    ColonyAndExtensionsEvents.MotionStaked,
+    ColonyAndExtensionsEvents.MotionVoteRevealed,
+    ColonyAndExtensionsEvents.ObjectionRaised,
+    ColonyAndExtensionsEvents.MotionFinalized,
+    ColonyAndExtensionsEvents.MotionRewardClaimed,
+  ],
 };
 
 /*

--- a/src/modules/dashboard/components/ActionsPage/staticMaps.ts
+++ b/src/modules/dashboard/components/ActionsPage/staticMaps.ts
@@ -133,6 +133,14 @@ export const ACTIONS_EVENTS: ActionsEventsMap = {
     ColonyAndExtensionsEvents.MotionFinalized,
     ColonyAndExtensionsEvents.MotionRewardClaimed,
   ],
+  [ColonyMotions.SetUserRolesMotion]: [
+    ColonyAndExtensionsEvents.MotionCreated,
+    ColonyAndExtensionsEvents.MotionStaked,
+    ColonyAndExtensionsEvents.MotionVoteRevealed,
+    ColonyAndExtensionsEvents.ObjectionRaised,
+    ColonyAndExtensionsEvents.MotionFinalized,
+    ColonyAndExtensionsEvents.MotionRewardClaimed,
+  ],
 };
 
 /*

--- a/src/modules/dashboard/components/ActionsPage/staticMaps.ts
+++ b/src/modules/dashboard/components/ActionsPage/staticMaps.ts
@@ -149,6 +149,14 @@ export const ACTIONS_EVENTS: ActionsEventsMap = {
     ColonyAndExtensionsEvents.MotionFinalized,
     ColonyAndExtensionsEvents.MotionRewardClaimed,
   ],
+  [ColonyMotions.MoveFundsMotion]: [
+    ColonyAndExtensionsEvents.MotionCreated,
+    ColonyAndExtensionsEvents.MotionStaked,
+    ColonyAndExtensionsEvents.MotionVoteRevealed,
+    ColonyAndExtensionsEvents.ObjectionRaised,
+    ColonyAndExtensionsEvents.MotionFinalized,
+    ColonyAndExtensionsEvents.MotionRewardClaimed,
+  ],
 };
 
 /*

--- a/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialog.tsx
+++ b/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialog.tsx
@@ -48,7 +48,13 @@ type Props = DialogProps &
 const displayName = 'dashboard.TransferFundsDialog';
 
 const TransferFundsDialog = ({
-  colony: { tokens = [], colonyAddress, nativeTokenAddress, colonyName },
+  colony: {
+    tokens = [],
+    colonyAddress,
+    nativeTokenAddress,
+    colonyName,
+    version,
+  },
   colony,
   fromDomain,
   callStep,
@@ -105,6 +111,7 @@ const TransferFundsDialog = ({
           return {
             colonyAddress,
             colonyName,
+            version,
             fromDomainId: parseInt(sourceDomain, 10),
             toDomainId: parseInt(toDomain, 10),
             amount,

--- a/src/modules/dashboard/sagas/motions/moveFundsMotion.ts
+++ b/src/modules/dashboard/sagas/motions/moveFundsMotion.ts
@@ -1,5 +1,9 @@
 import { all, call, fork, put, takeEvery } from 'redux-saga/effects';
-import { ClientType, getMoveFundsPermissionProofs } from '@colony/colony-js';
+import {
+  ClientType,
+  ColonyVersion,
+  getMoveFundsPermissionProofs,
+} from '@colony/colony-js';
 import { AddressZero, MaxUint256 } from 'ethers/constants';
 
 import { ContextModule, TEMP_getContext } from '~context/index';
@@ -98,7 +102,8 @@ function* moveFundsMotion({
       'annotateMoveFundsMotion',
     ]);
 
-    const isOldVersion = parseInt(version, 10) <= 6;
+    const isOldVersion =
+      parseInt(version, 10) <= ColonyVersion.CeruleanLightweightSpaceship;
     const encodedAction = colonyClient.interface.functions[
       isOldVersion
         ? // eslint-disable-next-line max-len

--- a/src/modules/dashboard/sagas/motions/moveFundsMotion.ts
+++ b/src/modules/dashboard/sagas/motions/moveFundsMotion.ts
@@ -21,6 +21,7 @@ function* moveFundsMotion({
   payload: {
     colonyAddress,
     colonyName,
+    version,
     fromDomainId,
     toDomainId,
     amount,
@@ -97,18 +98,22 @@ function* moveFundsMotion({
       'annotateMoveFundsMotion',
     ]);
 
-    // eslint-disable-next-line max-len
-    const encodedAction = colonyClient.interface.functions.moveFundsBetweenPots.encode(
-      [
-        permissionDomainId,
-        fromChildSkillIndex,
-        toChildSkillIndex,
-        fromPot,
-        toPot,
-        amount,
-        tokenAddress,
-      ],
-    );
+    const isOldVersion = parseInt(version, 10) <= 6;
+    const encodedAction = colonyClient.interface.functions[
+      isOldVersion
+        ? // eslint-disable-next-line max-len
+          'moveFundsBetweenPots(uint256,uint256,uint256,uint256,uint256,uint256,address)'
+        : 'moveFundsBetweenPots'
+    ].encode([
+      ...(isOldVersion ? [] : [permissionDomainId, MaxUint256]),
+      permissionDomainId,
+      fromChildSkillIndex,
+      toChildSkillIndex,
+      fromPot,
+      toPot,
+      amount,
+      tokenAddress,
+    ]);
 
     // create transactions
     yield fork(createTransaction, createMotion.id, {

--- a/src/redux/types/actions/motion.ts
+++ b/src/redux/types/actions/motion.ts
@@ -161,6 +161,7 @@ export type MotionActionTypes =
       {
         colonyAddress: Address;
         colonyName?: string;
+        version: string;
         tokenAddress: Address;
         fromDomainId: number;
         toDomainId: number;

--- a/src/utils/events/index.ts
+++ b/src/utils/events/index.ts
@@ -914,8 +914,8 @@ const getMoveFundsMotionValues = async (
     colonyClient,
   );
 
-  const fromDomain = await colonyClient.getDomainFromFundingPot(values.args[3]);
-  const toDomain = await colonyClient.getDomainFromFundingPot(values.args[4]);
+  const fromDomain = await colonyClient.getDomainFromFundingPot(values.args[5]);
+  const toDomain = await colonyClient.getDomainFromFundingPot(values.args[6]);
 
   const moveFundsMotionValues: {
     amount: string;
@@ -924,8 +924,8 @@ const getMoveFundsMotionValues = async (
     toDomain: number;
   } = {
     ...motionDefaultValues,
-    amount: values.args[5].toString(),
-    tokenAddress: values.args[6],
+    amount: values.args[7].toString(),
+    tokenAddress: values.args[8],
     fromDomain: fromDomain.toNumber(),
     toDomain: toDomain.toNumber(),
   };

--- a/src/utils/events/index.ts
+++ b/src/utils/events/index.ts
@@ -700,6 +700,38 @@ const getSetUserRolesMotionValues = async (
   return setUserRolesMotionValues;
 };
 
+const getEditDomainMotionValues = async (
+  processedEvents: ProcessedEvent[],
+  votingClient: ExtensionClient,
+  colonyClient: ColonyClient,
+): Promise<Partial<MotionValues>> => {
+  const motionCreatedEvent = processedEvents[0];
+  const motionId = motionCreatedEvent.values.motionId.toString();
+  const motion = await votingClient.getMotion(motionId);
+  const values = colonyClient.interface.parseTransaction({
+    data: motion.action,
+  });
+  const motionDefaultValues = await getMotionValues(
+    processedEvents,
+    votingClient,
+    colonyClient,
+  );
+  const ipfsData = await ipfs.getString(values.args[3]);
+  const domainMetadata = JSON.parse(ipfsData);
+  const editDomainMotionValues: {
+    domainName: string;
+    domainColor: number;
+    domainPurpose: string;
+    fromDomain: number;
+  } = {
+    ...motionDefaultValues,
+    ...domainMetadata,
+    fromDomain: parseInt(values.args[2].toString(), 10),
+  };
+
+  return editDomainMotionValues;
+};
+
 export const getActionValues = async (
   processedEvents: ProcessedEvent[],
   colonyClient: ColonyClient,
@@ -815,8 +847,7 @@ export const getActionValues = async (
     }
     case ColonyMotions.PaymentMotion:
     case ColonyMotions.ColonyEditMotion:
-    case ColonyMotions.MoveFundsMotion:
-    case ColonyMotions.EditDomainMotion: {
+    case ColonyMotions.MoveFundsMotion: {
       const motionValues = await getMotionValues(
         processedEvents,
         votingClient,
@@ -836,6 +867,17 @@ export const getActionValues = async (
       return {
         ...fallbackValues,
         ...createDomainMotionValues,
+      };
+    }
+    case ColonyMotions.EditDomainMotion: {
+      const editDomainMotionValues = await getEditDomainMotionValues(
+        processedEvents,
+        votingClient,
+        colonyClient,
+      );
+      return {
+        ...fallbackValues,
+        ...editDomainMotionValues,
       };
     }
     case ColonyMotions.SetUserRolesMotion: {

--- a/src/utils/hooks/useFormatRolesTitle.ts
+++ b/src/utils/hooks/useFormatRolesTitle.ts
@@ -1,24 +1,35 @@
 import { isEmpty } from 'lodash';
 import { useIntl } from 'react-intl';
 
-import { ColonyActions } from '~types/index';
+import { ActionUserRoles, ColonyActions, ColonyMotions } from '~types/index';
 
-export const useFormatRolesTitle = (roles, actionType) => {
+export const useFormatRolesTitle = (
+  roles: ActionUserRoles[],
+  actionType: string,
+  isMotion?: boolean,
+) => {
   let roleTitle = '';
   let roleMessageDescriptorId = '';
   const { formatMessage } = useIntl();
 
-  if (!roles || actionType !== ColonyActions.SetUserRoles) {
+  if (
+    !roles ||
+    actionType !==
+      (isMotion ? ColonyMotions.SetUserRolesMotion : ColonyActions.SetUserRoles)
+  ) {
     return { roleTitle };
   }
 
   const assignedRoles = roles.filter((role) => role.setTo);
   const unassignedRoles = roles.filter((role) => !role.setTo);
 
-  const getFormattedRoleList = (roleGroupA, roleGroupB) => {
+  const getFormattedRoleList = (
+    roleGroupA: ActionUserRoles[],
+    roleGroupB: ActionUserRoles[] | null,
+  ) => {
     let roleList = '';
 
-    roleGroupA.forEach((role, i) => {
+    roleGroupA.forEach((role: ActionUserRoles, i: number) => {
       const roleNameMessage = { id: `role.${role.id}` };
       const formattedRole = formatMessage(roleNameMessage);
 
@@ -37,12 +48,16 @@ export const useFormatRolesTitle = (roles, actionType) => {
 
   if (!isEmpty(assignedRoles)) {
     roleTitle += getFormattedRoleList(assignedRoles, unassignedRoles);
-    roleMessageDescriptorId = `action.${ColonyActions.SetUserRoles}.assign`;
+    roleMessageDescriptorId = isMotion
+      ? `motion.${ColonyMotions.SetUserRolesMotion}.assign`
+      : `action.${ColonyActions.SetUserRoles}.assign`;
   }
 
   if (isEmpty(assignedRoles) && !isEmpty(unassignedRoles)) {
     roleTitle += getFormattedRoleList(unassignedRoles, null);
-    roleMessageDescriptorId = `action.${ColonyActions.SetUserRoles}.remove`;
+    roleMessageDescriptorId = isMotion
+      ? `motion.${ColonyMotions.SetUserRolesMotion}.remove`
+      : `action.${ColonyActions.SetUserRoles}.remove`;
   } else if (!isEmpty(unassignedRoles)) {
     roleTitle = `Assign the ${roleTitle}`;
     roleTitle += ` and remove the${getFormattedRoleList(


### PR DESCRIPTION
## Description

Decode the motion values of the motion type we have wired up

## New things

* Decoded motion values for payment, permission management, add team, edit team, edit colony, and move funds motion
* Added motion type titles to Claim and Vote widget
* Added motion titles for motion page
* Added motion events reusable variable for event mapping

**NOTE:** Currently the motion saga for `MoveFundsBetweenPot` isn't working. Ideally, this PR should be merged after that it's fixed in order to properly test the decoding of that motion. I've tested the decoding for that motion before the saga stopped working and it was good, however, just to be safe

Resolves DEV-353
