### PR TITLE
Slider staking limit visual, logic & explanation messages

### DIFF
--- a/src/modules/core/components/Slider/Slider.css
+++ b/src/modules/core/components/Slider/Slider.css
@@ -22,6 +22,6 @@
   Removes `left` property from the dot for the correct visual position.
   I tried many options but that's the only one I found working
 */
-.primary > div > div > span {
+.primary :global(.rc-slider-dot) {
   left: 0 !important;
 }

--- a/src/modules/core/components/Slider/Slider.css
+++ b/src/modules/core/components/Slider/Slider.css
@@ -18,7 +18,10 @@
   box-shadow: 0 0 5px var(--danger);
 }
 
-/* This is to remove `left` from the dot for it have correct visual position */
+/*
+  Removes `left` property from the dot for the correct visual position.
+  I tried many options but that's the only one I found working
+*/
 .primary > div > div > span {
   left: 0 !important;
 }

--- a/src/modules/core/components/Slider/Slider.css
+++ b/src/modules/core/components/Slider/Slider.css
@@ -17,3 +17,8 @@
 .danger :global(.rc-slider-handle:active) {
   box-shadow: 0 0 5px var(--danger);
 }
+
+/* This is to remove `left` from the dot for it have correct visual position */
+.primary > div > div > span {
+  left: 0 !important;
+}

--- a/src/modules/core/components/Slider/Slider.tsx
+++ b/src/modules/core/components/Slider/Slider.tsx
@@ -54,10 +54,15 @@ const Slider = ({
     return limit ? limit * 100 : 0;
   }, [limit]);
 
+  const gradientPercentage = useMemo(
+    () => (limitValue >= 100 ? 100 : limitValue),
+    [limitValue],
+  );
+
   const onSliderChange = useCallback(
     (val): void => {
       if (
-        (limitValue && sliderValue < limitValue) ||
+        (limit !== undefined && sliderValue < limitValue) ||
         val < sliderValue ||
         !limitValue
       ) {
@@ -67,7 +72,10 @@ const Slider = ({
           onChange(val);
         }
       }
-      if (limitValue && (sliderValue > limitValue || val > limitValue)) {
+      if (
+        limit !== undefined &&
+        (sliderValue > limitValue || val > limitValue)
+      ) {
         setSliderValue(limitValue);
         setValue(limitValue);
 
@@ -138,18 +146,19 @@ const Slider = ({
           backgroundColor: '#FFFFFF',
         }}
         dotStyle={{
+          display: gradientPercentage === 100 ? 'none' : '',
           height: sizes.markHeight,
           width: sizes.markWidth,
           backgroundColor: '#76748B',
           border: 0,
           borderRadius: 0,
           top: sizes.markPositionTop,
-          marginLeft: `${limitValue}%`,
+          marginLeft: `${gradientPercentage}%`,
         }}
         railStyle={{
           backgroundColor: '#C2CCCC',
           height: sizes.height,
-          backgroundImage: `linear-gradient(90deg, #76748B 0% ${limitValue}%, transparent ${limitValue}%)`,
+          backgroundImage: `linear-gradient(90deg, #76748B 0% ${gradientPercentage}%, transparent ${gradientPercentage}%)`,
         }}
       />
     </div>

--- a/src/modules/core/components/Slider/Slider.tsx
+++ b/src/modules/core/components/Slider/Slider.tsx
@@ -22,6 +22,7 @@ interface Props {
   disabled?: boolean;
   step?: number;
   onReset?: (val: any) => void;
+  exceedLimit?: (val: boolean) => void;
 }
 
 const displayName = 'Slider';
@@ -36,6 +37,7 @@ const Slider = ({
   name,
   step = 1,
   disabled = false,
+  exceedLimit,
 }: Props) => {
   const [sliderValue, setSliderValue] = useState<number>(value);
   const [, , { setValue }] = useField(name);
@@ -71,6 +73,9 @@ const Slider = ({
         if (onChange) {
           onChange(val);
         }
+        if (exceedLimit) {
+          exceedLimit(false);
+        }
       }
       if (
         limit !== undefined &&
@@ -81,6 +86,9 @@ const Slider = ({
 
         if (onChange) {
           onChange(limitValue);
+        }
+        if (exceedLimit) {
+          exceedLimit(true);
         }
       }
     },

--- a/src/modules/core/components/Slider/Slider.tsx
+++ b/src/modules/core/components/Slider/Slider.tsx
@@ -50,30 +50,34 @@ const Slider = ({
     }
   }, [sliderValue, value, setSliderValue]);
 
-  const gradientStopPercentage = useMemo(() => {
-    return limit ? Math.round((limit / max) * 100) : 0;
-  }, [limit, max]);
+  const limitValue = useMemo(() => {
+    return limit ? limit * 100 : 0;
+  }, [limit]);
 
   const onSliderChange = useCallback(
     (val): void => {
-      if ((limit && sliderValue < limit) || val < sliderValue || !limit) {
+      if (
+        (limitValue && sliderValue < limitValue) ||
+        val < sliderValue ||
+        !limitValue
+      ) {
         setSliderValue(val);
         setValue(val);
         if (onChange) {
           onChange(val);
         }
       }
-      if (limit && (sliderValue > limit || val > limit)) {
-        setSliderValue(limit);
-        setValue(limit);
+      if (limitValue && (sliderValue > limitValue || val > limitValue)) {
+        setSliderValue(limitValue);
+        setValue(limitValue);
 
         if (onChange) {
-          onChange(limit);
+          onChange(limitValue);
         }
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [setSliderValue, onChange, limit, sliderValue],
+    [setSliderValue, onChange, limitValue, sliderValue],
   );
 
   const marks = {};
@@ -140,12 +144,12 @@ const Slider = ({
           border: 0,
           borderRadius: 0,
           top: sizes.markPositionTop,
-          marginLeft: 0,
+          marginLeft: `${limitValue}%`,
         }}
         railStyle={{
           backgroundColor: '#C2CCCC',
           height: sizes.height,
-          backgroundImage: `linear-gradient(90deg, #76748B 0% ${gradientStopPercentage}%, transparent ${gradientStopPercentage}%)`,
+          backgroundImage: `linear-gradient(90deg, #76748B 0% ${limitValue}%, transparent ${limitValue}%)`,
         }}
       />
     </div>

--- a/src/modules/core/components/Slider/Slider.tsx
+++ b/src/modules/core/components/Slider/Slider.tsx
@@ -154,7 +154,8 @@ const Slider = ({
           backgroundColor: '#FFFFFF',
         }}
         dotStyle={{
-          display: gradientPercentage === 100 ? 'none' : '',
+          display:
+            gradientPercentage === 100 || gradientPercentage <= 0 ? 'none' : '',
           height: sizes.markHeight,
           width: sizes.markWidth,
           backgroundColor: '#76748B',

--- a/src/modules/dashboard/components/ActionsPage/StakingValidationError/StakingValidationError.css
+++ b/src/modules/dashboard/components/ActionsPage/StakingValidationError/StakingValidationError.css
@@ -1,6 +1,6 @@
 .validationError {
   margin-top: 10px;
-  font-size: var(--size-small);
+  font-size: var(--size-tiny);
   font-weight: var(--weight-bold);
-  color: color-mod(var(--temp-grey-blue-7) alpha(85%));
+  color: var(--pink);
 }

--- a/src/modules/dashboard/components/ActionsPage/StakingValidationError/StakingValidationError.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingValidationError/StakingValidationError.tsx
@@ -1,50 +1,30 @@
 import React from 'react';
 import { defineMessage, FormattedMessage } from 'react-intl';
-import { Decimal } from 'decimal.js';
-import { BigNumber } from 'ethers/utils';
 
 import styles from './StakingValidationError.css';
 
 interface Props {
-  userInactivatedTokens: BigNumber;
-  userActivatedTokens: Decimal;
-  decimalAmount: Decimal;
+  stakeType: 'tokens' | 'reputation';
 }
 
 const stakeValidationMSG = defineMessage({
-  hasInactiveTokens: {
-    id: 'dashboard.ActionsPage.StakingValidationError.hasInactiveTokens',
-    defaultMessage: `You have inactive tokens which cannot be staked, please activate them.`,
-  },
-  notEnoughTokens: {
+  tokens: {
     id: 'dashboard.ActionsPage.StakingValidationError.notEnoughTokens',
-    defaultMessage: 'You do not have enough activated tokens to stake.',
+    defaultMessage: 'You do not have enough active tokens to stake.',
+  },
+  reputation: {
+    id: 'dashboard.ActionsPage.StakingValidationError.notEnoughTokens',
+    defaultMessage: 'You do not have enough reputation to stake.',
   },
 });
 
 const displayName = 'StakingValidationError';
 
-const StakingValidationError = ({
-  userInactivatedTokens,
-  userActivatedTokens,
-  decimalAmount,
-}: Props) => {
-  const notEnoughActiveTokens = userActivatedTokens.lt(decimalAmount);
-  return (
-    <>
-      {notEnoughActiveTokens && !userInactivatedTokens.isZero() && (
-        <div className={styles.validationError}>
-          <FormattedMessage {...stakeValidationMSG.hasInactiveTokens} />
-        </div>
-      )}
-      {notEnoughActiveTokens && userInactivatedTokens.isZero() && (
-        <div className={styles.validationError}>
-          <FormattedMessage {...stakeValidationMSG.notEnoughTokens} />
-        </div>
-      )}
-    </>
-  );
-};
+const StakingValidationError = ({ stakeType }: Props) => (
+  <div className={styles.validationError}>
+    <FormattedMessage {...stakeValidationMSG[stakeType]} />
+  </div>
+);
 
 StakingValidationError.displayName = displayName;
 

--- a/src/modules/dashboard/components/ActionsPage/StakingValidationError/StakingValidationError.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingValidationError/StakingValidationError.tsx
@@ -4,17 +4,21 @@ import { defineMessage, FormattedMessage } from 'react-intl';
 import styles from './StakingValidationError.css';
 
 interface Props {
-  stakeType: 'tokens' | 'reputation';
+  stakeType: 'tokens' | 'reputation' | 'stakeMore';
 }
 
 const stakeValidationMSG = defineMessage({
   tokens: {
-    id: 'dashboard.ActionsPage.StakingValidationError.notEnoughTokens',
+    id: 'dashboard.ActionsPage.StakingValidationError.tokens',
     defaultMessage: 'You do not have enough active tokens to stake.',
   },
   reputation: {
-    id: 'dashboard.ActionsPage.StakingValidationError.notEnoughTokens',
-    defaultMessage: 'You do not have enough reputation to stake.',
+    id: 'dashboard.ActionsPage.StakingValidationError.reputation',
+    defaultMessage: 'You do not have enough reputation to be able to stake.',
+  },
+  stakeMore: {
+    id: 'dashboard.ActionsPage.StakingValidationError.stakeMore',
+    defaultMessage: 'You do not have enough active tokens to stake more.',
   },
 });
 

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { Decimal } from 'decimal.js';
 
 import Heading from '~core/Heading';
 import Slider, { Appearance } from '~core/Slider';
 import QuestionMarkTooltip from '~core/QuestionMarkTooltip';
+import StakingValidationError from '~dashboard/ActionsPage/StakingValidationError';
 
 import { Colony } from '~data/index';
 import { getTokenDecimalsWithFallback } from '~utils/tokens';
@@ -69,7 +70,13 @@ const StakingSlider = ({
   appearance,
   userActivatedTokens,
   isObjection,
-}: Props) => {
+}: // userInactivatedTokens,
+Props) => {
+  const [showError, setShowError] = useState(false);
+
+  const exceedLimit = (isLimitExceeded: boolean) =>
+    setShowError(isLimitExceeded);
+
   const nativeToken = tokens.find(
     ({ address }) => address === nativeTokenAddress,
   );
@@ -134,8 +141,12 @@ const StakingSlider = ({
           max={100}
           disabled={!canUserStake}
           appearance={appearance}
+          exceedLimit={exceedLimit}
         />
       </div>
+      {(userActivatedTokens.lessThan(minUserStake) || showError) && (
+        <StakingValidationError stakeType="tokens" />
+      )}
     </>
   );
 };

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
@@ -80,12 +80,16 @@ const StakingSlider = ({
 
   const maxStake = new Decimal(maxUserStake);
 
-  const userStakeLimitPercentage = (maxStake.gte(userActivatedTokens)
-    ? userActivatedTokens
-    : maxStake
-  ).div(remainingToStake);
+  const userStakeLimitPercentage = remainingToStake.lte(minUserStake)
+    ? 0
+    : (maxStake.gte(userActivatedTokens) ? userActivatedTokens : maxStake)
+        .minus(minUserStake)
+        .div(remainingToStake.minus(minUserStake));
 
-  const stake = new Decimal(values.amount).times(remainingToStake).div(100);
+  const stake = new Decimal(values.amount)
+    .div(100)
+    .times(remainingToStake.minus(minUserStake))
+    .plus(minUserStake);
   const stakeWithMin = new Decimal(minUserStake).gte(stake)
     ? new Decimal(minUserStake)
     : stake;
@@ -124,7 +128,7 @@ const StakingSlider = ({
         <Slider
           name="amount"
           value={values.amount}
-          limit={parseFloat(userStakeLimitPercentage.toFixed(4))}
+          limit={parseFloat(userStakeLimitPercentage.toFixed(5))}
           step={0.01}
           min={0}
           max={100}

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
@@ -70,8 +70,7 @@ const StakingSlider = ({
   appearance,
   userActivatedTokens,
   isObjection,
-}: // userInactivatedTokens,
-Props) => {
+}: Props) => {
   const [showError, setShowError] = useState(false);
 
   const exceedLimit = (isLimitExceeded: boolean) =>
@@ -144,9 +143,7 @@ Props) => {
           exceedLimit={exceedLimit}
         />
       </div>
-      {(userActivatedTokens.lessThan(minUserStake) || showError) && (
-        <StakingValidationError stakeType="tokens" />
-      )}
+      {showError && <StakingValidationError stakeType="stakeMore" />}
     </>
   );
 };

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
@@ -16,6 +16,7 @@ export interface StakingAmounts {
   remainingToFullyNayStaked: string;
   maxUserStake: string;
   minUserStake: string;
+  userActivatedTokens: Decimal;
 }
 
 interface Props extends StakingAmounts {
@@ -66,6 +67,7 @@ const StakingSlider = ({
   minUserStake,
   canUserStake,
   appearance,
+  userActivatedTokens,
   isObjection,
 }: Props) => {
   const nativeToken = tokens.find(
@@ -76,9 +78,12 @@ const StakingSlider = ({
     isObjection ? remainingToFullyNayStaked : remainingToFullyYayStaked,
   );
 
-  const userStakeLimitPercentage = new Decimal(maxUserStake)
-    .div(remainingToStake)
-    .times(100);
+  const maxStake = new Decimal(maxUserStake);
+
+  const userStakeLimitPercentage = (maxStake.gte(userActivatedTokens)
+    ? userActivatedTokens
+    : maxStake
+  ).div(remainingToStake);
 
   const stake = new Decimal(values.amount).times(remainingToStake).div(100);
   const stakeWithMin = new Decimal(minUserStake).gte(stake)
@@ -119,7 +124,7 @@ const StakingSlider = ({
         <Slider
           name="amount"
           value={values.amount}
-          limit={parseFloat(userStakeLimitPercentage.toFixed(2))}
+          limit={parseFloat(userStakeLimitPercentage.toFixed(4))}
           step={0.01}
           min={0}
           max={100}

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
@@ -180,6 +180,8 @@ const StakingWidget = ({
     bigNumberify(maxUserStake).gt(0) &&
     bigNumberify(maxUserStake).gte(bigNumberify(minUserStake));
 
+  const enoughTokens = userActivatedTokens.gte(userStakeBottomLimit);
+
   const canUserStake =
     /*
      * Has a profile registered
@@ -192,7 +194,7 @@ const StakingWidget = ({
     /*
      * Activated tokens are more than the minimum required stake amount
      */
-    userActivatedTokens.gte(userStakeBottomLimit) &&
+    enoughTokens &&
     /*
      * Has activated tokens
      */
@@ -275,6 +277,7 @@ const StakingWidget = ({
             {!enoughReputation && (
               <StakingValidationError stakeType="reputation" />
             )}
+            {!enoughTokens && <StakingValidationError stakeType="tokens" />}
           </div>
         )}
       </ActionForm>

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
@@ -82,10 +82,6 @@ const StakingWidget = ({
       colonyAddress,
     },
   });
-
-  const userInactivatedTokens = bigNumberify(
-    userData?.user?.userLock?.nativeToken?.balance || 0,
-  );
   const userActivatedTokens = new Decimal(
     userData?.user?.userLock?.balance || 0,
   );
@@ -99,16 +95,9 @@ const StakingWidget = ({
         colony,
         canUserStake: userHasPermission,
         scrollToRef,
-        userInactivatedTokens,
         ...stakingAmounts,
       }),
-    [
-      colony,
-      openRaiseObjectionDialog,
-      scrollToRef,
-      motionId,
-      userInactivatedTokens,
-    ],
+    [colony, openRaiseObjectionDialog, scrollToRef, motionId],
   );
 
   const getDecimalStake = useCallback(
@@ -187,6 +176,10 @@ const StakingWidget = ({
 
   const userStakeBottomLimit = new Decimal(minUserStake);
 
+  const enoughReputation =
+    bigNumberify(maxUserStake).gt(0) &&
+    bigNumberify(maxUserStake).gte(bigNumberify(minUserStake));
+
   const canUserStake =
     /*
      * Has a profile registered
@@ -195,8 +188,7 @@ const StakingWidget = ({
     /*
      * User has enough reputation to stake
      */
-    bigNumberify(maxUserStake).gt(0) &&
-    bigNumberify(maxUserStake).gte(bigNumberify(minUserStake)) &&
+    enoughReputation &&
     /*
      * Activated tokens are more than the minimum required stake amount
      */
@@ -280,11 +272,9 @@ const StakingWidget = ({
                 )}
               </span>
             </div>
-            <StakingValidationError
-              userActivatedTokens={userActivatedTokens}
-              userInactivatedTokens={userInactivatedTokens}
-              decimalAmount={getDecimalStake(values.amount)}
-            />
+            {!enoughReputation && (
+              <StakingValidationError stakeType="reputation" />
+            )}
           </div>
         )}
       </ActionForm>

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
@@ -100,7 +100,6 @@ const StakingWidget = ({
         canUserStake: userHasPermission,
         scrollToRef,
         userInactivatedTokens,
-        userActivatedTokens,
         ...stakingAmounts,
       }),
     [
@@ -109,10 +108,9 @@ const StakingWidget = ({
       scrollToRef,
       motionId,
       userInactivatedTokens,
-      userActivatedTokens,
     ],
   );
-
+  // !!!!!!!
   const getDecimalStake = useCallback(
     (stake: number) => {
       if (data?.motionStakes) {
@@ -239,6 +237,7 @@ const StakingWidget = ({
               remainingToFullyNayStaked={remainingToFullyNayStaked}
               maxUserStake={maxUserStake}
               minUserStake={minUserStake}
+              userActivatedTokens={userActivatedTokens}
             />
             <div className={styles.buttonGroup}>
               <Button
@@ -267,7 +266,10 @@ const StakingWidget = ({
                     disabled={!canUserStakeNay}
                     onClick={() =>
                       bigNumberify(totalNAYStakes).isZero()
-                        ? handleRaiseObjection(canUserStake, data.motionStakes)
+                        ? handleRaiseObjection(canUserStake, {
+                            ...data.motionStakes,
+                            userActivatedTokens,
+                          })
                         : handleWidgetState(true)
                     }
                   />

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
@@ -110,19 +110,23 @@ const StakingWidget = ({
       userInactivatedTokens,
     ],
   );
-  // !!!!!!!
+
   const getDecimalStake = useCallback(
     (stake: number) => {
       if (data?.motionStakes) {
         const {
           remainingToFullyNayStaked,
           remainingToFullyYayStaked,
+          minUserStake,
         } = data.motionStakes;
         const remainingToStake = new Decimal(
           isObjection ? remainingToFullyNayStaked : remainingToFullyYayStaked,
         );
 
-        return new Decimal(stake).times(remainingToStake).div(100);
+        return new Decimal(stake)
+          .div(100)
+          .times(remainingToStake.minus(minUserStake))
+          .plus(minUserStake);
       }
       return new Decimal(0);
     },

--- a/src/modules/dashboard/components/RaiseObjectionDialog/RaiseObjectionDialogForm.tsx
+++ b/src/modules/dashboard/components/RaiseObjectionDialog/RaiseObjectionDialogForm.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { FormattedMessage, defineMessages } from 'react-intl';
 import { FormikProps } from 'formik';
 import Decimal from 'decimal.js';
-import { BigNumber } from 'ethers/utils';
 
 import Button from '~core/Button';
 import DialogSection from '~core/Dialog/DialogSection';
@@ -13,7 +12,6 @@ import {
   StakingSlider,
   StakingAmounts,
 } from '~dashboard/ActionsPage/StakingWidget';
-import StakingValidationError from '~dashboard/ActionsPage/StakingValidationError';
 
 import { Colony } from '~data/index';
 
@@ -47,7 +45,6 @@ const OBJECTION_HELP_LINK = `https://colony.io/dev/docs/colonynetwork/whitepaper
 export interface Props extends StakingAmounts {
   colony: Colony;
   canUserStake: boolean;
-  userInactivatedTokens: BigNumber;
   userActivatedTokens: Decimal;
   cancel: () => void;
 }
@@ -59,7 +56,6 @@ const RaiseObjectionDialogForm = ({
   canUserStake,
   values,
   cancel,
-  userInactivatedTokens,
   userActivatedTokens,
   remainingToFullyNayStaked,
   ...props
@@ -108,13 +104,6 @@ const RaiseObjectionDialogForm = ({
           name="annotation"
           maxLength={90}
           disabled={!canUserStake}
-        />
-      </DialogSection>
-      <DialogSection>
-        <StakingValidationError
-          userActivatedTokens={userActivatedTokens}
-          userInactivatedTokens={userInactivatedTokens}
-          decimalAmount={decimalAmount}
         />
       </DialogSection>
       <DialogSection appearance={{ align: 'right', theme: 'footer' }}>

--- a/src/modules/dashboard/components/RaiseObjectionDialog/RaiseObjectionDialogForm.tsx
+++ b/src/modules/dashboard/components/RaiseObjectionDialog/RaiseObjectionDialogForm.tsx
@@ -97,6 +97,7 @@ const RaiseObjectionDialogForm = ({
             appearance={{ theme: 'danger' }}
             isObjection
             remainingToFullyNayStaked={remainingToFullyNayStaked}
+            userActivatedTokens={userActivatedTokens}
             {...props}
           />
         </div>

--- a/src/modules/dashboard/sagas/motions/paymentMotion.ts
+++ b/src/modules/dashboard/sagas/motions/paymentMotion.ts
@@ -1,7 +1,12 @@
 import { call, fork, put, takeEvery } from 'redux-saga/effects';
-import { ClientType, ColonyRole, getPermissionProofs } from '@colony/colony-js';
+import {
+  ClientType,
+  ColonyRole,
+  getPermissionProofs,
+  getExtensionPermissionProofs,
+} from '@colony/colony-js';
 import { AddressZero } from 'ethers/constants';
-import { bigNumberify, BigNumberish } from 'ethers/utils';
+import { bigNumberify } from 'ethers/utils';
 import moveDecimal from 'move-decimal-point';
 
 import { ContextModule, TEMP_getContext } from '~context/index';
@@ -18,37 +23,6 @@ import {
   transactionPending,
   transactionAddParams,
 } from '../../../core/actionCreators';
-
-const getExtensionPermissionProofs = async (
-  colonyClient: any,
-  domainId: BigNumberish,
-  address?: string,
-): Promise<[BigNumberish, BigNumberish]> => {
-  const [fundingPDID, fundingCSI] = await getPermissionProofs(
-    colonyClient,
-    domainId,
-    ColonyRole.Funding,
-    address,
-  );
-  const [adminPDID, adminCSI] = await getPermissionProofs(
-    colonyClient,
-    domainId,
-    ColonyRole.Administration,
-    address,
-  );
-
-  if (!fundingPDID.eq(adminPDID) || !fundingCSI.eq(adminCSI)) {
-    // @TODO: this can surely be improved
-    throw new Error(
-      // eslint-disable-next-line max-len
-      `${
-        address || 'User'
-      } has to have the funding and administration role in the same domain`,
-    );
-  }
-
-  return [adminPDID, adminCSI];
-};
 
 function* createPaymentMotion({
   payload: {


### PR DESCRIPTION
## Description

This refactors the logic for slider limit visuals, logic & not enough reputation/tokens messages.

**New stuff** ✨

nothing new

**Changes** 🏗

- refactor `Slider` limit logic & visuals
- simplify `StakingValidationError`
- add `StakingValidationError` for tokens to `StakingSlider`
- changed staking slider logic to calculate % so that the visual corresponds to the numbers shown
- simplified `StakingWidget`

**Deletions** ⚰️

none

## TODO

Potentially extract logic for % calculation to a separate function

Resolves DEV-317

Not sure whether to show no reputation/ no tokens messages when user is logged off (for now showing them):

<img width="374" alt="Screenshot 2021-05-21 at 12 28 04" src="https://user-images.githubusercontent.com/34057551/119118449-1b068a80-ba22-11eb-9a1a-0597d855c919.png">

Demo
![stake-limit](https://user-images.githubusercontent.com/34057551/119118497-28237980-ba22-11eb-82a0-7ac292a6b284.gif)

When a person is logged in, has active tokens but doesn't have reputation to stake
<img width="398" alt="Screenshot 2021-05-21 at 12 30 28" src="https://user-images.githubusercontent.com/34057551/119118611-4b4e2900-ba22-11eb-8ace-6ab0bef37584.png">

