### PR TITLE
Update Voting / Revealing Entropy Message

### DIFF
--- a/src/modules/dashboard/sagas/motions/revealVoteMotion.ts
+++ b/src/modules/dashboard/sagas/motions/revealVoteMotion.ts
@@ -50,10 +50,17 @@ function* revealVoteMotion({
       rootHash,
     );
 
-    const signature = yield signMessage(
-      'motionRevealVote',
-      'Sign this message to generate "salt" entrophy',
-    );
+    /*
+     * @NOTE We this to be all in one line (no new lines, or line breaks) since
+     * Metamask doesn't play nice with them and will replace them, in the message
+     * presented to the user with \n
+     */
+    // eslint-disable-next-line max-len
+    const message = `Sign this message to generate 'salt' entropy. Extension Address: ${
+      votingReputationClient.address
+    } Motion ID: ${motionId.toNumber()}`;
+
+    const signature = yield signMessage('motionRevealVote', message);
     const salt = soliditySha3Raw(signature);
 
     /*

--- a/src/modules/dashboard/sagas/motions/voteMotion.ts
+++ b/src/modules/dashboard/sagas/motions/voteMotion.ts
@@ -50,10 +50,17 @@ function* voteMotion({
       rootHash,
     );
 
-    const signature = yield signMessage(
-      'motionVote',
-      'Sign this message to generate "salt" entrophy',
-    );
+    /*
+     * @NOTE We this to be all in one line (no new lines, or line breaks) since
+     * Metamask doesn't play nice with them and will replace them, in the message
+     * presented to the user with \n
+     */
+    // eslint-disable-next-line max-len
+    const message = `Sign this message to generate 'salt' entropy. Extension Address: ${
+      votingReputationClient.address
+    } Motion ID: ${motionId.toNumber()}`;
+
+    const signature = yield signMessage('motionRevealVote', message);
     const hash = soliditySha3(soliditySha3Raw(signature), vote);
 
     const { voteMotionTransaction } = yield createTransactionChannels(meta.id, [


### PR DESCRIPTION
## Description

This PR updates the message string that we use to generate salt entropy when voting or revealing a vote. Besides a spell check, it now also includes the extension's address as well as the motion id, otherwise it would be possible for a party to work out the vote of another party by looking up a vote signature on a previous motion and comparing that against the current one. _(since the message would be the same always)_

**Testing:** Just go through the staking / voting / revealing flow using a metamask address

**Changes**

- [x] Update entropy message in `revealVoteMotion` saga
- [x] Update entropy message in `voteMotion` saga

**Demo**
![Screenshot from 2021-05-22 23-52-07](https://user-images.githubusercontent.com/1193222/119240827-0ed21880-bb5b-11eb-87ec-e37232faedb3.png)
![Screenshot from 2021-05-22 23-55-09](https://user-images.githubusercontent.com/1193222/119240829-0f6aaf00-bb5b-11eb-8003-46fe970edcbe.png)


Resolves DEV-360
