### PR TITLE
Add incompatible extension warning

### DIFF
--- a/src/modules/core/components/Warning/Warning.css
+++ b/src/modules/core/components/Warning/Warning.css
@@ -1,0 +1,14 @@
+.warning {
+  display: flex;
+  flex-direction: column;
+  padding: 25px 34px;
+  border-radius: var(--radius-large);
+  background-color: var(--pink);
+  font-weight: var(--weight-bold);
+  color: rgba(255, 255, 255);
+}
+
+.warning button {
+  align-self: flex-end;
+  margin-top: 30px;
+}

--- a/src/modules/core/components/Warning/Warning.css
+++ b/src/modules/core/components/Warning/Warning.css
@@ -1,14 +1,18 @@
 .warning {
   display: flex;
   flex-direction: column;
-  padding: 25px 34px;
+  padding: 12px;
   border-radius: var(--radius-large);
   background-color: var(--pink);
   font-weight: var(--weight-bold);
   color: rgba(255, 255, 255);
 }
 
+.content {
+  padding: 13px 22px;
+}
+
 .warning button {
   align-self: flex-end;
-  margin-top: 30px;
+  margin-top: 10px;
 }

--- a/src/modules/core/components/Warning/Warning.css.d.ts
+++ b/src/modules/core/components/Warning/Warning.css.d.ts
@@ -1,0 +1,1 @@
+export const warning: string;

--- a/src/modules/core/components/Warning/Warning.css.d.ts
+++ b/src/modules/core/components/Warning/Warning.css.d.ts
@@ -1,1 +1,2 @@
 export const warning: string;
+export const content: string;

--- a/src/modules/core/components/Warning/Warning.tsx
+++ b/src/modules/core/components/Warning/Warning.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { MessageDescriptor, useIntl } from 'react-intl';
+
+import { SimpleMessageValues } from '~types/index';
+import Button from '~core/Button';
+
+import styles from './Warning.css';
+
+interface Props {
+  /** A string or a `messageDescriptor` for content text */
+  text?: MessageDescriptor | string;
+
+  /** Values for text */
+  textValues?: SimpleMessageValues;
+
+  /** A string or a `messageDescriptor` for button content */
+  buttonText?: MessageDescriptor | string;
+
+  handleClick?: () => void;
+
+  /** Is button disabled */
+  disabled?: boolean;
+}
+
+const displayName = 'Warning';
+
+const Warning = ({
+  text,
+  textValues,
+  buttonText,
+  handleClick,
+  disabled = false,
+}: Props) => {
+  const { formatMessage } = useIntl();
+
+  const warningText =
+    typeof text === 'string' ? text : text && formatMessage(text, textValues);
+
+  return (
+    <div className={styles.warning}>
+      {warningText}
+      {buttonText && handleClick && (
+        <Button
+          appearance={{ theme: 'primary', size: 'medium' }}
+          onClick={handleClick}
+          text={buttonText}
+          disabled={disabled}
+        />
+      )}
+    </div>
+  );
+};
+
+Warning.displayName = displayName;
+
+export default Warning;

--- a/src/modules/core/components/Warning/Warning.tsx
+++ b/src/modules/core/components/Warning/Warning.tsx
@@ -38,7 +38,7 @@ const Warning = ({
 
   return (
     <div className={styles.warning}>
-      {warningText}
+      <div className={styles.content}>{warningText}</div>
       {buttonText && handleClick && (
         <Button
           appearance={{ theme: 'primary', size: 'medium' }}

--- a/src/modules/core/components/Warning/index.tsx
+++ b/src/modules/core/components/Warning/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './Warning';

--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.css
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.css
@@ -68,3 +68,15 @@
   margin-top: 10px;
   text-align: right;
 }
+
+.iconWrapper {
+  display: inline-block;
+  margin-left: 7px;
+  vertical-align: middle;
+}
+
+.iconWrapper svg {
+  fill: var(--golden);
+  stroke: none;
+  cursor: pointer;
+}

--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.css
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.css
@@ -68,11 +68,3 @@
   margin-top: 10px;
   text-align: right;
 }
-
-.warning {
-  padding: 25px 34px;
-  border-radius: var(--radius-large);
-  background-color: var(--pink);
-  font-weight: var(--weight-bold);
-  color: rgba(255, 255, 255);
-}

--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.css.d.ts
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.css.d.ts
@@ -9,3 +9,4 @@ export const installedBy: string;
 export const installedByAddress: string;
 export const permissions: string;
 export const buttonUninstall: string;
+export const iconWrapper: string;

--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.css.d.ts
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.css.d.ts
@@ -9,4 +9,3 @@ export const installedBy: string;
 export const installedByAddress: string;
 export const permissions: string;
 export const buttonUninstall: string;
-export const warning: string;

--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
@@ -12,6 +12,7 @@ import { ColonyRole, ColonyVersion, Extension } from '@colony/colony-js';
 import BreadCrumb, { Crumb } from '~core/BreadCrumb';
 import Heading from '~core/Heading';
 import Warning from '~core/Warning';
+import Icon from '~core/Icon';
 import NetworkContractUpgradeDialog from '~dashboard/NetworkContractUpgradeDialog';
 import { useDialog, ConfirmDialog } from '~core/Dialog';
 import {
@@ -206,6 +207,9 @@ const ExtensionDetails = ({
     !(extesionCanBeInstalled || extesionCanBeEnabled) &&
     latestNetworkExtensionVersion > extension.currentVersion;
 
+  // TEMP flag
+  const shouldShowWarning = false;
+
   let tableData;
 
   if (installedExtension) {
@@ -260,6 +264,9 @@ const ExtensionDetails = ({
       {
         label: MSG.latestVersion,
         value: `v${extension.currentVersion}`,
+        icon: shouldShowWarning && (
+          <Icon name="triangle-warning" title={MSG.warning} />
+        ),
       },
       {
         label: MSG.developer,
@@ -296,9 +303,6 @@ const ExtensionDetails = ({
       children: <FormattedMessage {...ExtensionsMSG.textDefaultUninstall} />,
     },
   };
-
-  // TEMP flag
-  const shouldShowWarning = true;
 
   return (
     <div className={styles.main}>
@@ -383,10 +387,11 @@ const ExtensionDetails = ({
           </div>
           <Table appearance={{ theme: 'lined' }}>
             <TableBody>
-              {tableData.map(({ label, value }) => (
+              {tableData.map(({ label, value, icon }) => (
                 <TableRow key={label.id}>
                   <TableCell className={styles.cellLabel}>
                     <FormattedMessage {...label} />
+                    {icon && <span className={styles.iconWrapper}>{icon}</span>}
                   </TableCell>
                   <TableCell className={styles.cellData}>{value}</TableCell>
                 </TableRow>

--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
@@ -11,6 +11,7 @@ import { ColonyRole, ColonyVersion, Extension } from '@colony/colony-js';
 
 import BreadCrumb, { Crumb } from '~core/BreadCrumb';
 import Heading from '~core/Heading';
+import Warning from '~core/Warning';
 import {
   Colony,
   useLoggedInUser,
@@ -117,6 +118,10 @@ const MSG = defineMessages({
   setup: {
     id: 'dashboard.Extensions.ExtensionDetails.setup',
     defaultMessage: 'Setup',
+  },
+  warning: {
+    id: 'dashboard.Extensions.ExtensionDetails.warning',
+    defaultMessage: `This extension is incompatible with your current colony version. You must upgrade your colony before installing it.`,
   },
 });
 
@@ -264,9 +269,7 @@ const ExtensionDetails = ({
     [Extension.VotingReputation]: {
       heading: ExtensionsMSG.headingVotingUninstall,
       children: (
-        <div className={styles.warning}>
-          <FormattedMessage {...ExtensionsMSG.textVotingUninstall} />
-        </div>
+        <Warning text={ExtensionsMSG.textVotingUninstall} />
       ),
     },
     [Extension.OneTxPayment]: {


### PR DESCRIPTION
## Description

This PR adds in incompatible extension warning to extension page

**New stuff** ✨

* Warning core component

**Changes** 🏗

* Refactored ExtensionDetails to show extension warning (currently with temp flag is true)
* Refactored ExtensionDetails to use new Warning component also for modal content warning
* Displayed warning icon next to installed extension label

<img width="546" alt="Screenshot 2021-05-25 at 12 01 54" src="https://user-images.githubusercontent.com/13069555/119479524-04796f80-bd51-11eb-97b2-53bac7ee1b96.png">

<img width="400" alt="Screenshot 2021-05-25 at 12 34 58" src="https://user-images.githubusercontent.com/13069555/119484044-eb26f200-bd55-11eb-928c-773b88779dcc.png">


Resolves DEV-364
