### PR TITLE
Remove staking error messages when user is not logged in

### DIFF
--- a/src/modules/dashboard/components/ActionsPage/StakingValidationError/StakingValidationError.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingValidationError/StakingValidationError.tsx
@@ -4,7 +4,11 @@ import { defineMessage, FormattedMessage } from 'react-intl';
 import styles from './StakingValidationError.css';
 
 interface Props {
-  stakeType: 'tokens' | 'reputation' | 'stakeMore';
+  stakeType:
+    | 'tokens'
+    | 'reputation'
+    | 'stakeMoreTokens'
+    | 'stakeMoreReputation';
 }
 
 const stakeValidationMSG = defineMessage({
@@ -16,9 +20,13 @@ const stakeValidationMSG = defineMessage({
     id: 'dashboard.ActionsPage.StakingValidationError.reputation',
     defaultMessage: 'You do not have enough reputation to be able to stake.',
   },
-  stakeMore: {
+  stakeMoreTokens: {
     id: 'dashboard.ActionsPage.StakingValidationError.stakeMore',
     defaultMessage: 'You do not have enough active tokens to stake more.',
+  },
+  stakeMoreReputation: {
+    id: 'dashboard.ActionsPage.StakingValidationError.stakeMore',
+    defaultMessage: 'You do not have enough reputation to stake more.',
   },
 });
 

--- a/src/modules/dashboard/components/ActionsPage/StakingValidationError/StakingValidationError.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingValidationError/StakingValidationError.tsx
@@ -4,11 +4,7 @@ import { defineMessage, FormattedMessage } from 'react-intl';
 import styles from './StakingValidationError.css';
 
 interface Props {
-  stakeType:
-    | 'tokens'
-    | 'reputation'
-    | 'stakeMoreTokens'
-    | 'stakeMoreReputation';
+  stakeType: 'tokens' | 'reputation' | 'stakeMoreTokens' | 'cantStakeMore';
 }
 
 const stakeValidationMSG = defineMessage({
@@ -24,9 +20,9 @@ const stakeValidationMSG = defineMessage({
     id: 'dashboard.ActionsPage.StakingValidationError.stakeMore',
     defaultMessage: 'You do not have enough active tokens to stake more.',
   },
-  stakeMoreReputation: {
+  cantStakeMore: {
     id: 'dashboard.ActionsPage.StakingValidationError.stakeMore',
-    defaultMessage: 'You do not have enough reputation to stake more.',
+    defaultMessage: `The motion can't be staked more than the minimum stake.`,
   },
 });
 

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
@@ -143,7 +143,15 @@ const StakingSlider = ({
           exceedLimit={exceedLimit}
         />
       </div>
-      {showError && <StakingValidationError stakeType="stakeMore" />}
+      {showError && (
+        <StakingValidationError
+          stakeType={
+            remainingToStake.lte(minUserStake)
+              ? 'cantStakeMore'
+              : 'stakeMoreTokens'
+          }
+        />
+      )}
     </>
   );
 };

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
@@ -274,10 +274,10 @@ const StakingWidget = ({
                 )}
               </span>
             </div>
-            {hasRegisteredProfile && !enoughReputation && (
+            {!ethereal && !enoughReputation && (
               <StakingValidationError stakeType="reputation" />
             )}
-            {hasRegisteredProfile && !enoughTokens && (
+            {!ethereal && !enoughTokens && (
               <StakingValidationError stakeType="tokens" />
             )}
           </div>

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
@@ -274,10 +274,12 @@ const StakingWidget = ({
                 )}
               </span>
             </div>
-            {!enoughReputation && (
+            {hasRegisteredProfile && !enoughReputation && (
               <StakingValidationError stakeType="reputation" />
             )}
-            {!enoughTokens && <StakingValidationError stakeType="tokens" />}
+            {hasRegisteredProfile && !enoughTokens && (
+              <StakingValidationError stakeType="tokens" />
+            )}
           </div>
         )}
       </ActionForm>


### PR DESCRIPTION
## Description

This PR adds another check to staking error messages in order to show them only when the user is logged in.

**New stuff** ✨

none

**Changes** 🏗

- added `hasRegisteredProfile` check to staking error messages

**Deletions** ⚰️

none

## TODO

none

Resolves DEV-369
<img width="573" alt="Screenshot 2021-05-26 at 10 58 14" src="https://user-images.githubusercontent.com/34057551/119623898-883e6500-be00-11eb-8559-2dd2f3b5050a.png">
