### PR TITLE
Add 1 to required stake

### DIFF
--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -174,7 +174,8 @@ export const motionsResolvers = ({
         const [totalNAYStakes, totalYAYStaked] = stakes;
         const requiredStake = skillRep
           .mul(totalStakeFraction)
-          .div(bigNumberify(10).pow(tokenDecimals));
+          .div(bigNumberify(10).pow(tokenDecimals))
+          .add(1);
         const remainingToFullyYayStaked = requiredStake.sub(totalYAYStaked);
         const remainingToFullyNayStaked = requiredStake.sub(totalNAYStakes);
         const userMinStakeAmount = skillRep

--- a/src/utils/colonyMotions.ts
+++ b/src/utils/colonyMotions.ts
@@ -119,7 +119,8 @@ export const getMotionRequiredStake = (
 ): BigNumber => {
   const requiredStake = skillRep
     .mul(totalStakeFraction)
-    .div(bigNumberify(10).pow(decimals));
+    .div(bigNumberify(10).pow(decimals))
+    .add(1);
 
   return requiredStake;
 };


### PR DESCRIPTION
## Description

This PR fixes not being able to fully staked on motion. From time to time, our staking buttons was showing "fully staked" even if motion was still in stake required state. It was because super small amount of stake was missing. 

**Changes** 🏗

* Added 1 to required stake

Resolves DEV-366
