### PR TITLE
Add missing motion titles to the action list

### DIFF
--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -973,6 +973,12 @@ export const motionsResolvers = ({
         };
       }
 
+      if (actionValues.name === 'addDomain') {
+        return {
+          metadata: actionValues.args[3],
+        };
+      }
+
       const tokenAddress = colonyClient.tokenClient.address;
       const {
         symbol,

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -920,11 +920,39 @@ export const motionsResolvers = ({
       const actionValues = colonyClient.interface.parseTransaction({
         data: action,
       });
+
+      if (!actionValues) {
+        const oneTxPaymentClient = await colonyManager.getClient(
+          ClientType.OneTxPaymentClient,
+          colonyAddress,
+        );
+
+        const paymentValues = oneTxPaymentClient.interface.parseTransaction({
+          data: action,
+        });
+
+        const tokenClient = await colonyManager.getTokenClient(
+          paymentValues.args[5][0],
+        );
+        const { symbol, decimals } = await tokenClient.getTokenInfo();
+
+        return {
+          amount: paymentValues.args[6][0].toString(),
+          recipient: paymentValues.args[4][0],
+          token: {
+            id: paymentValues.args[5][0],
+            symbol,
+            decimals,
+          },
+        };
+      }
+
       const tokenAddress = colonyClient.tokenClient.address;
       const {
         symbol,
         decimals,
       } = await colonyClient.tokenClient.getTokenInfo();
+
       /*
        * @TODO Return argumnents for the other motions as well, as soon
        * as they get wired into the dapp

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -1011,16 +1011,13 @@ export const motionsResolvers = ({
         };
       }
 
+      // MintTokenMotion - default
       const tokenAddress = colonyClient.tokenClient.address;
       const {
         symbol,
         decimals,
       } = await colonyClient.tokenClient.getTokenInfo();
 
-      /*
-       * @TODO Return argumnents for the other motions as well, as soon
-       * as they get wired into the dapp
-       */
       return {
         amount: bigNumberify(actionValues?.args[0] || '0').toString(),
         token: {

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -979,6 +979,12 @@ export const motionsResolvers = ({
         };
       }
 
+      if (actionValues.name === 'editDomain') {
+        return {
+          fromDomain: parseInt(actionValues.args[2].toString(), 10),
+        };
+      }
+
       if (actionValues.name === 'editColony') {
         return {
           metadata: actionValues.args[0],

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -979,6 +979,12 @@ export const motionsResolvers = ({
         };
       }
 
+      if (actionValues.name === 'editColony') {
+        return {
+          metadata: actionValues.args[0],
+        };
+      }
+
       const tokenAddress = colonyClient.tokenClient.address;
       const {
         symbol,

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -921,6 +921,7 @@ export const motionsResolvers = ({
         data: action,
       });
 
+      // PaymentMotion
       if (!actionValues) {
         const oneTxPaymentClient = await colonyManager.getClient(
           ClientType.OneTxPaymentClient,
@@ -941,6 +942,31 @@ export const motionsResolvers = ({
           recipient: paymentValues.args[4][0],
           token: {
             id: paymentValues.args[5][0],
+            symbol,
+            decimals,
+          },
+        };
+      }
+
+      if (actionValues.name === 'moveFundsBetweenPots') {
+        const fromDomain = await colonyClient.getDomainFromFundingPot(
+          actionValues.args[5],
+        );
+        const toDomain = await colonyClient.getDomainFromFundingPot(
+          actionValues.args[6],
+        );
+
+        const tokenClient = await colonyManager.getTokenClient(
+          actionValues.args[8],
+        );
+        const { symbol, decimals } = await tokenClient.getTokenInfo();
+
+        return {
+          amount: actionValues.args[7].toString(),
+          fromDomain: fromDomain.toNumber(),
+          toDomain: toDomain.toNumber(),
+          token: {
+            id: actionValues.args[8],
             symbol,
             decimals,
           },

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -934,9 +934,20 @@ export const motionsResolvers = ({
         });
 
         const tokenClient = await colonyManager.getTokenClient(
-          paymentValues.args[5][0],
+          paymentValues?.args[5][0] || colonyClient.tokenClient.address,
         );
         const { symbol, decimals } = await tokenClient.getTokenInfo();
+
+        if (!paymentValues) {
+          return {
+            amount: 0,
+            token: {
+              id: colonyClient.tokenClient.address,
+              symbol,
+              decimals,
+            },
+          };
+        }
 
         return {
           amount: paymentValues.args[6][0].toString(),

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -8,7 +8,7 @@ import {
   getEvents,
   getMultipleEvents,
 } from '@colony/colony-js';
-import { bigNumberify, LogDescription } from 'ethers/utils';
+import { bigNumberify, LogDescription, hexStripZeros } from 'ethers/utils';
 import { Resolvers } from '@apollo/client';
 
 import { Context } from '~context/index';
@@ -31,6 +31,7 @@ import {
   SystemMessage,
   SystemMessagesName,
 } from '~dashboard/ActionsPageFeed';
+import { availableRoles } from '~dashboard/PermissionManagementDialog';
 
 import { ProcessedEvent } from './colonyActions';
 
@@ -988,6 +989,25 @@ export const motionsResolvers = ({
       if (actionValues.name === 'editColony') {
         return {
           metadata: actionValues.args[0],
+        };
+      }
+
+      if (actionValues.name === 'setUserRoles') {
+        const roleBitMask = parseInt(
+          hexStripZeros(actionValues.args[4]),
+          16,
+        ).toString(2);
+        const roleBitMaskArray = roleBitMask.split('').reverse();
+
+        const roles = availableRoles.map((role) => ({
+          id: role,
+          setTo: roleBitMaskArray[role] === '1',
+        }));
+
+        return {
+          recipient: actionValues.args[2],
+          fromDomain: bigNumberify(actionValues.args[3]).toNumber(),
+          roles,
         };
       }
 

--- a/src/i18n/en-actions.ts
+++ b/src/i18n/en-actions.ts
@@ -6,19 +6,27 @@ const actionsMessageDescriptors = {
   'action.title': `{actionType, select,
       ${ColonyActions.WrongColony} {Unknown Action}
       ${ColonyActions.Payment} {Pay {recipient} {amount} {tokenSymbol}}
+      ${ColonyMotions.PaymentMotion} {Pay {recipient} {amount} {tokenSymbol}}
       ${ColonyActions.MoveFunds} {Move {amount} {tokenSymbol} from {fromDomain} to {toDomain}}
+      ${ColonyMotions.MoveFundsMotion} {Move {amount} {tokenSymbol} from {fromDomain} to {toDomain}}
       ${ColonyActions.MintTokens} {Mint {amount} {tokenSymbol}}
       ${ColonyMotions.MintTokensMotion} {Mint {amount} {tokenSymbol}}
       ${ColonyActions.CreateDomain} {New team: {fromDomain}}
+      ${ColonyMotions.CreateDomainMotion} {New team: {fromDomain}}
       ${ColonyActions.VersionUpgrade} {Upgrade Colony to Version {newVersion}!}
       ${ColonyActions.ColonyEdit} {Colony details changed}
+      ${ColonyMotions.ColonyEditMotion} {Change colony details}
       ${ColonyActions.EditDomain} {{fromDomain} team details edited}
+      ${ColonyMotions.EditDomainMotion} {Edit {fromDomain} team details}
       ${ColonyActions.Recovery} {Recovery mode activated by {initiator}}
       other {Generic action we don't have information about}
     }`,
   [`action.${ColonyActions.SetUserRoles}.assign`]: `Assign the {roles} in {fromDomain} to {recipient}`,
+  [`action.${ColonyMotions.SetUserRolesMotion}.assign`]: `Assign the {roles} in {fromDomain} to {recipient}`,
   [`action.${ColonyActions.SetUserRoles}.remove`]: `Remove the {roles} in {fromDomain} from {recipient}`,
+  [`action.${ColonyMotions.SetUserRolesMotion}.remove`]: `Remove the {roles} in {fromDomain} from {recipient}`,
   [`action.${ColonyActions.SetUserRoles}.assignAndRemove`]: `{roles} in {fromDomain} to/from {recipient}`,
+  [`action.${ColonyMotions.SetUserRolesMotion}.assignAndRemove`]: `{roles} in {fromDomain} to/from {recipient}`,
   'action.type': `{actionType, select,
       ${ColonyActions.WrongColony} {Not part of the Colony}
       ${ColonyActions.Payment} {Payment}

--- a/src/modules/core/components/ActionsList/ActionsListItem.css
+++ b/src/modules/core/components/ActionsList/ActionsListItem.css
@@ -150,7 +150,7 @@
 
 .motionTagWrapper {
   display: inline-block;
-  margin: -5px 0 0 12px;
+  margin: -1px 0 0 12px;
   padding: 0;
   vertical-align: middle;
 }

--- a/src/modules/core/components/ActionsList/ActionsListItem.tsx
+++ b/src/modules/core/components/ActionsList/ActionsListItem.tsx
@@ -17,7 +17,7 @@ import { getMainClasses, removeValueUnits } from '~utils/css';
 import { getTokenDecimalsWithFallback } from '~utils/tokens';
 import { useUser, Colony } from '~data/index';
 import { createAddress } from '~utils/web3';
-import { FormattedAction, ColonyActions } from '~types/index';
+import { FormattedAction, ColonyActions, ColonyMotions } from '~types/index';
 import { useDataFetcher } from '~utils/hooks';
 import { parseDomainMetadata } from '~utils/colonyActions';
 import { useFormatRolesTitle } from '~utils/hooks/useFormatRolesTitle';
@@ -124,7 +124,8 @@ const ActionsListItem = ({
   if (
     metadataJSON &&
     (actionType === ColonyActions.EditDomain ||
-      actionType === ColonyActions.CreateDomain)
+      actionType === ColonyActions.CreateDomain ||
+      actionType === ColonyMotions.CreateDomainMotion)
   ) {
     const domainObject = parseDomainMetadata(metadataJSON);
     domainName = domainObject.domainName;

--- a/src/modules/core/components/ActionsList/ActionsListItem.tsx
+++ b/src/modules/core/components/ActionsList/ActionsListItem.tsx
@@ -21,7 +21,11 @@ import { FormattedAction, ColonyActions, ColonyMotions } from '~types/index';
 import { useDataFetcher } from '~utils/hooks';
 import { parseDomainMetadata } from '~utils/colonyActions';
 import { useFormatRolesTitle } from '~utils/hooks/useFormatRolesTitle';
-import { MotionState, MOTION_TAG_MAP } from '~utils/colonyMotions';
+import {
+  getUpdatedDecodedMotionRoles,
+  MotionState,
+  MOTION_TAG_MAP,
+} from '~utils/colonyMotions';
 import { ipfsDataFetcher } from '../../../core/fetchers';
 
 import { ClickHandlerProps } from './ActionsList';
@@ -105,8 +109,14 @@ const ActionsListItem = ({
     ({ ethDomainId }) => ethDomainId === parseInt(toDomainId, 10),
   );
 
+  const updatedRoles = getUpdatedDecodedMotionRoles(
+    colony,
+    fallbackRecipientProfile,
+    parseInt(fromDomainId, 10),
+    roles || [],
+  );
   const { roleMessageDescriptorId, roleTitle } = useFormatRolesTitle(
-    roles,
+    actionType === ColonyMotions.SetUserRolesMotion ? updatedRoles : roles,
     actionType,
   );
 

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
@@ -1,7 +1,6 @@
 import { bigNumberify } from 'ethers/utils';
 import React, { useMemo, useRef } from 'react';
 import { FormattedMessage, defineMessages } from 'react-intl';
-import { isNil } from 'lodash';
 
 import Heading from '~core/Heading';
 import ActionsPageFeed, {
@@ -31,6 +30,7 @@ import MemberReputation from '~core/MemberReputation';
 import ProgressBar from '~core/ProgressBar';
 import { getFormattedTokenValue } from '~utils/tokens';
 import {
+  getUpdatedDecodedMotionRoles,
   MotionState,
   MotionValue,
   MOTION_TAG_MAP,
@@ -38,7 +38,6 @@ import {
 } from '~utils/colonyMotions';
 import { useFormatRolesTitle } from '~utils/hooks/useFormatRolesTitle';
 
-import { getUserRolesForDomain } from '../../../../transformers';
 import DetailsWidget from '../DetailsWidget';
 import StakingWidgetFlow from '../StakingWidget';
 import VoteWidget from '../VoteWidget';
@@ -107,20 +106,12 @@ const DefaultMotion = ({
     }, {} as any);
   }, []);
 
-  const userCurrentRoles = getUserRolesForDomain(
+  const updatedRoles = getUpdatedDecodedMotionRoles(
     colony,
-    recipient.profile.walletAddress,
+    recipient,
     fromDomain,
+    roles,
   );
-  const updatedRoles = roles.filter((role) => {
-    const foundCurrentRole = userCurrentRoles.find(
-      (currentRole) => currentRole === role.id,
-    );
-    if (!isNil(foundCurrentRole)) {
-      return !role.setTo;
-    }
-    return role.setTo;
-  });
 
   const motionCreatedEvent = colonyAction.events.find(
     ({ name }) => name === ColonyAndExtensionsEvents.MotionCreated,

--- a/src/modules/dashboard/transformers.ts
+++ b/src/modules/dashboard/transformers.ts
@@ -253,18 +253,19 @@ export const getActionsListData = (
             }
           }
           if (subgraphActionType === FilteredUnformattedAction.Motions) {
-            const {
-              args: {
-                token: { address: tokenAddress, symbol, decimals },
-              },
-              args,
-              agent,
-              type,
-              state,
-            } = unformattedAction;
-            formatedAction.tokenAddress = tokenAddress;
-            formatedAction.symbol = symbol;
-            formatedAction.decimals = decimals;
+            const { args, agent, type, state } = unformattedAction;
+
+            if (args.token) {
+              const {
+                args: {
+                  token: { address: tokenAddress, symbol, decimals },
+                },
+              } = unformattedAction;
+
+              formatedAction.tokenAddress = tokenAddress;
+              formatedAction.symbol = symbol;
+              formatedAction.decimals = decimals;
+            }
             formatedAction.initiator = agent;
             formatedAction.actionType = type;
             formatedAction.motionState = state;

--- a/src/types/colonyActions.ts
+++ b/src/types/colonyActions.ts
@@ -3,6 +3,7 @@ import { ColonyRole } from '@colony/colony-js';
 import { ItemStatus } from '~core/ActionsList';
 import { Address, ActionUserRoles } from './index';
 import { MotionState } from '~utils/colonyMotions';
+import { ColonyMotions } from './colonyMotions';
 
 export enum ColonyActions {
   Generic = 'Generic',
@@ -118,7 +119,7 @@ export enum ColonyAndExtensionsEvents {
 export interface FormattedAction {
   id: string;
   status?: ItemStatus;
-  actionType: ColonyActions;
+  actionType: ColonyActions | ColonyMotions;
   initiator: Address;
   recipient: Address;
   amount: string;

--- a/src/utils/colonyMotions.ts
+++ b/src/utils/colonyMotions.ts
@@ -1,6 +1,11 @@
 import { defineMessage } from 'react-intl';
 import { BigNumber, bigNumberify } from 'ethers/utils';
 import { Decimal } from 'decimal.js';
+import { isNil } from 'lodash';
+
+import { getUserRolesForDomain } from '../modules/transformers';
+import { Colony, AnyUser } from '~data/index';
+import { ActionUserRoles } from '~types/index';
 
 export enum MotionState {
   Motion = 'Motion',
@@ -147,3 +152,27 @@ export const shouldDisplayMotion = (
 export interface MotionValue {
   motionId: number;
 }
+
+export const getUpdatedDecodedMotionRoles = (
+  colony: Colony,
+  recipient: AnyUser,
+  fromDomain: number,
+  roles: ActionUserRoles[],
+) => {
+  const userCurrentRoles = getUserRolesForDomain(
+    colony,
+    recipient.profile.walletAddress,
+    fromDomain,
+  );
+  const updatedRoles = roles.filter((role) => {
+    const foundCurrentRole = userCurrentRoles.find(
+      (currentRole) => currentRole === role.id,
+    );
+    if (!isNil(foundCurrentRole)) {
+      return !role.setTo;
+    }
+    return role.setTo;
+  });
+
+  return updatedRoles;
+};

--- a/src/utils/hooks/useFormatRolesTitle.ts
+++ b/src/utils/hooks/useFormatRolesTitle.ts
@@ -14,8 +14,8 @@ export const useFormatRolesTitle = (
 
   if (
     !roles ||
-    actionType !==
-      (isMotion ? ColonyMotions.SetUserRolesMotion : ColonyActions.SetUserRoles)
+    (actionType !== ColonyMotions.SetUserRolesMotion &&
+      actionType !== ColonyActions.SetUserRoles)
   ) {
     return { roleTitle };
   }
@@ -49,15 +49,15 @@ export const useFormatRolesTitle = (
   if (!isEmpty(assignedRoles)) {
     roleTitle += getFormattedRoleList(assignedRoles, unassignedRoles);
     roleMessageDescriptorId = isMotion
-      ? `motion.${ColonyMotions.SetUserRolesMotion}.assign`
-      : `action.${ColonyActions.SetUserRoles}.assign`;
+      ? `motion.${actionType}.assign`
+      : `action.${actionType}.assign`;
   }
 
   if (isEmpty(assignedRoles) && !isEmpty(unassignedRoles)) {
     roleTitle += getFormattedRoleList(unassignedRoles, null);
     roleMessageDescriptorId = isMotion
-      ? `motion.${ColonyMotions.SetUserRolesMotion}.remove`
-      : `action.${ColonyActions.SetUserRoles}.remove`;
+      ? `motion.${actionType}.remove`
+      : `action.${actionType}.remove`;
   } else if (!isEmpty(unassignedRoles)) {
     roleTitle = `Assign the ${roleTitle}`;
     roleTitle += ` and remove the${getFormattedRoleList(


### PR DESCRIPTION
## Description

- Add `action.title` for the just recently wire up motions

**New stuff** ✨

* Added handling for the wire up motions in the `args` resolver
* Added messages for motions in action list

**Changes** 🏗

* Added `getUpdatedDecodedMotionRoles` for reusability puposes
* Updated useFormatRolesTitles to get a more dynamic title id
*Fixed motion tag being clipped on action list

![FireShot Capture 328 - Colony - localhost](https://user-images.githubusercontent.com/18473896/119848068-e2632700-bee1-11eb-8f38-6002c1e5f4e1.png)

Resolves DEV-370
