### PR TITLE
Wire Extensions Compatibility Mapping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4348,9 +4348,9 @@
       }
     },
     "@colony/colony-js": {
-      "version": "4.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-4.0.0-rc.4.tgz",
-      "integrity": "sha512-4pOSPTazxogESZBxmv1aDMmWDM5zoXmb+Mg3aTd4HFd6HUKXjvP7fKTzzIj2EqwZ3KvTS8c7xCkoQ/aEeEEvpA==",
+      "version": "4.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-4.0.0-rc.5.tgz",
+      "integrity": "sha512-rilBZ6PxkomSgauA/64RD9D5z60PLcXUXkmwvOtqvcfSOiAsCjkDyyn9vBfTsDVKJ/ngUAsVnedvOMRHQvvCTw==",
       "requires": {
         "isomorphic-fetch": "^2.2.1",
         "lodash.isequal": "^4.5.0"

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.0.2",
-    "@colony/colony-js": "^4.0.0-rc.4",
+    "@colony/colony-js": "^4.0.0-rc.5",
     "@colony/redux-promise-listener": "^1.2.0",
     "@feedback-fish/react": "^1.2.1",
     "@formatjs/intl-pluralrules": "^1.5.7",

--- a/src/modules/dashboard/components/Extensions/ExtensionActionButton.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionActionButton.tsx
@@ -25,6 +25,7 @@ interface Props {
   extension: ExtensionData;
   installedExtension?: ColonyExtensionQuery['colonyExtension'] | null;
   colonyVersion: string;
+  extensionCompatible?: boolean;
 }
 
 const ExtensionActionButton = ({
@@ -32,6 +33,7 @@ const ExtensionActionButton = ({
   colonyVersion,
   extension,
   installedExtension,
+  extensionCompatible = true,
 }: Props) => {
   const history = useHistory();
   const { colonyName, extensionId } = useParams<{
@@ -59,7 +61,7 @@ const ExtensionActionButton = ({
           extensionId: extension.extensionId,
         }}
         text={MSG.install}
-        disabled={!isSupportedColonyVersion}
+        disabled={!isSupportedColonyVersion || !extensionCompatible}
       />
     );
   }

--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
@@ -208,7 +208,7 @@ const ExtensionDetails = ({
     latestNetworkExtensionVersion > extension.currentVersion;
 
   // TEMP flag
-  const shouldShowWarning = false;
+  const extensionCompatible = false;
 
   let tableData;
 
@@ -264,7 +264,7 @@ const ExtensionDetails = ({
       {
         label: MSG.latestVersion,
         value: `v${extension.currentVersion}`,
-        icon: shouldShowWarning && (
+        icon: !extensionCompatible && (
           <Icon name="triangle-warning" title={MSG.warning} />
         ),
       },
@@ -310,7 +310,7 @@ const ExtensionDetails = ({
         <BreadCrumb elements={breadCrumbs} />
         <hr className={styles.headerLine} />
         <div>
-          {shouldShowWarning && (
+          {!extensionCompatible && (
             <Warning
               text={MSG.warning}
               buttonText={{ id: 'button.upgrade' }}
@@ -379,6 +379,7 @@ const ExtensionDetails = ({
                 colonyVersion={colonyVersion}
                 installedExtension={installedExtension}
                 extension={extension}
+                extensionCompatible={extensionCompatible}
               />
             )}
             {extensionCanBeUpgraded && (

--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
@@ -391,7 +391,11 @@ const ExtensionDetails = ({
               />
             )}
             {extensionCanBeUpgraded && (
-              <ExtensionUpgrade colony={colony} extension={extension} />
+              <ExtensionUpgrade
+                colony={colony}
+                extension={extension}
+                canUpgrade={canInstall}
+              />
             )}
           </div>
           <Table appearance={{ theme: 'lined' }}>

--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
@@ -7,7 +7,12 @@ import {
   useRouteMatch,
   Redirect,
 } from 'react-router';
-import { ColonyRole, ColonyVersion, Extension } from '@colony/colony-js';
+import {
+  ColonyRole,
+  ColonyVersion,
+  Extension,
+  extensionsIncompatibilityMap,
+} from '@colony/colony-js';
 
 import BreadCrumb, { Crumb } from '~core/BreadCrumb';
 import Heading from '~core/Heading';
@@ -207,8 +212,11 @@ const ExtensionDetails = ({
     !(extesionCanBeInstalled || extesionCanBeEnabled) &&
     latestNetworkExtensionVersion > extension.currentVersion;
 
-  // TEMP flag
-  const extensionCompatible = false;
+  const extensionCompatible = extension?.currentVersion
+    ? !extensionsIncompatibilityMap[extensionId][extension.currentVersion].find(
+        (version: number) => version === parseInt(colonyVersion, 10),
+      )
+    : false;
 
   let tableData;
 

--- a/src/modules/dashboard/components/Extensions/ExtensionUpgrade/ExtensionUpgrade.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionUpgrade/ExtensionUpgrade.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback } from 'react';
-import { ColonyVersion } from '@colony/colony-js';
+import { ColonyVersion, extensionsIncompatibilityMap } from '@colony/colony-js';
 
 import { ActionButton } from '~core/Button';
-import { Colony } from '~data/index';
+import { Colony, useLoggedInUser } from '~data/index';
 import { ExtensionData } from '~data/staticData/extensionData';
 import { ActionTypes } from '~redux/index';
 import { mapPayload } from '~utils/actions';
@@ -13,9 +13,11 @@ interface Props {
 }
 
 const ExtensionActionButton = ({
-  colony: { colonyAddress, version },
+  colony: { colonyAddress, version: colonyVersion },
   extension,
 }: Props) => {
+  const { username, ethereal } = useLoggedInUser();
+  const hasRegisteredProfile = !!username && !ethereal;
   const transform = useCallback(
     mapPayload(() => ({
       colonyAddress,
@@ -26,7 +28,23 @@ const ExtensionActionButton = ({
   );
 
   const isSupportedColonyVersion =
-    parseInt(version || '1', 10) >= ColonyVersion.LightweightSpaceship;
+    parseInt(colonyVersion || '1', 10) >= ColonyVersion.LightweightSpaceship;
+
+  const nextVersionIncompatibilityMappingExists =
+    extensionsIncompatibilityMap[extension.extensionId] &&
+    extensionsIncompatibilityMap[extension.extensionId][
+      extension.currentVersion + 1
+    ];
+  const extensionCompatible =
+    extension?.currentVersion && nextVersionIncompatibilityMappingExists
+      ? !extensionsIncompatibilityMap[extension.extensionId][
+          extension.currentVersion + 1
+        ].find((version: number) => version === parseInt(colonyVersion, 10))
+      : false;
+
+  if (!hasRegisteredProfile) {
+    return null;
+  }
 
   return (
     <ActionButton
@@ -36,7 +54,7 @@ const ExtensionActionButton = ({
       success={ActionTypes.COLONY_EXTENSION_UPGRADE_SUCCESS}
       transform={transform}
       text={{ id: 'button.upgrade' }}
-      disabled={!isSupportedColonyVersion}
+      disabled={!isSupportedColonyVersion || !extensionCompatible}
     />
   );
 };

--- a/src/modules/dashboard/components/Extensions/ExtensionUpgrade/ExtensionUpgrade.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionUpgrade/ExtensionUpgrade.tsx
@@ -10,11 +10,13 @@ import { mapPayload } from '~utils/actions';
 interface Props {
   colony: Colony;
   extension: ExtensionData;
+  canUpgrade?: boolean;
 }
 
 const ExtensionActionButton = ({
   colony: { colonyAddress, version: colonyVersion },
   extension,
+  canUpgrade = false,
 }: Props) => {
   const { username, ethereal } = useLoggedInUser();
   const hasRegisteredProfile = !!username && !ethereal;
@@ -54,7 +56,9 @@ const ExtensionActionButton = ({
       success={ActionTypes.COLONY_EXTENSION_UPGRADE_SUCCESS}
       transform={transform}
       text={{ id: 'button.upgrade' }}
-      disabled={!isSupportedColonyVersion || !extensionCompatible}
+      disabled={
+        !isSupportedColonyVersion || !extensionCompatible || !canUpgrade
+      }
     />
   );
 };


### PR DESCRIPTION
## Description

This PR wires in the extension version mapping to prevent certain versions of extensions to be installed with certain versions of colonies

**Changes** 

- [x] Updated `colonyJS` version
- [x] Refactored `Extensions` compatibility check 
- [x] Add `ExtensionDetails` check if version is compatible before installing
- [x] Add `ExtensionUpgrade` check if version is compatible before upgrading

Resolves DEV-365
Resolves DEV-367
