### PR TITLE
Fix issue with wrongly displayed total staked value

### DIFF
--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
@@ -204,9 +204,9 @@ const StakingWidget = ({
    * Motion can be still staked (ie: amount left to stake)
    */
   const canUserStakeYay =
-    canUserStake && new Decimal(remainingToFullyYayStaked).gt(0);
+    canUserStake && new Decimal(remainingToFullyYayStaked).gt(1);
   const canUserStakeNay =
-    canUserStake && new Decimal(remainingToFullyNayStaked).gt(0);
+    canUserStake && new Decimal(remainingToFullyNayStaked).gt(1);
 
   const canBeStaked = isObjection ? canUserStakeNay : canUserStakeYay;
 

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidgetFlow.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidgetFlow.tsx
@@ -81,15 +81,19 @@ const StakingWidgetFlow = ({ colony, motionId, scrollToRef }: Props) => {
   }
 
   const { totalStaked, userStake, requiredStake } = data.stakeAmountsForMotion;
+
   const divisibleRequiredStake = !bigNumberify(requiredStake).isZero()
     ? requiredStake
     : 1;
 
   const yayPercentage = bigNumberify(totalStaked.YAY || 0)
+    .add(1)
     .mul(100)
     .div(divisibleRequiredStake)
     .toNumber();
+
   const nayPercentage = bigNumberify(totalStaked.NAY || 0)
+    .add(1)
     .mul(100)
     .div(divisibleRequiredStake)
     .toNumber();

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/SingleTotalStake.tsx
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/SingleTotalStake.tsx
@@ -50,6 +50,7 @@ const SingleTotalStake = ({
   tokenSymbol,
 }: Props) => {
   const userStakePercentage = bigNumberify(userStake || 0)
+    .add(1)
     .mul(100)
     .div(requiredStake)
     .toNumber();


### PR DESCRIPTION
## Description

This PR fixes wrongly displayed value while staking. It was showing 99% when it was actually 100%. The reason behind this was adding one to required stake. To compensate we need to add 1 to staked value as well

**Changes** 🏗

* Added 1 to totalStaked.YAY and totalStaked.NAY

Resolves DEV-373
