### PR TITLE
Set domain color to null if undefined

### DIFF
--- a/src/utils/events/index.ts
+++ b/src/utils/events/index.ts
@@ -667,7 +667,7 @@ const getCreateDomainMotionValues = async (
       const domainMetadata = JSON.parse(ipfsMetadata);
 
       domainName = domainMetadata.domainName;
-      domainColor = domainMetadata.domainColor;
+      domainColor = domainMetadata.domainColor || null;
       domainPurpose = domainMetadata.domainPurpose || null;
     }
   } catch (error) {
@@ -768,7 +768,7 @@ const getEditDomainMotionValues = async (
       const domainMetadata = JSON.parse(ipfsMetadata);
 
       domainName = domainMetadata.domainName;
-      domainColor = domainMetadata.domainColor;
+      domainColor = domainMetadata.domainColor || null;
       domainPurpose = domainMetadata.domainPurpose || null;
     }
   } catch (error) {


### PR DESCRIPTION
## Description

This pr fixes problem with action page not loading correctly when no color was set up. We need to return null instead of undefined for graphql to be happy