### PR TITLE
Improve token activation navigation button styles

### DIFF
--- a/src/modules/pages/components/RouteLayouts/UserNavigation.css
+++ b/src/modules/pages/components/RouteLayouts/UserNavigation.css
@@ -118,7 +118,7 @@
 
 .walletAddress span {
   font-size: var(--size-smallish);
-  font-weight: var(--weight-medium);
+  font-weight: var(--weight-bold);
 }
 
 .walletAddress:hover {
@@ -135,7 +135,7 @@
 
 .buttonsWrapper {
   margin-right: 12px;
-  padding: 1px;
+  padding: 2px;
   height: 26px;
   position: relative;
   border-radius: var(--radius-normal);

--- a/src/modules/users/components/UserTokenActivationButton/UserTokenActivationButton.css
+++ b/src/modules/users/components/UserTokenActivationButton/UserTokenActivationButton.css
@@ -1,5 +1,5 @@
 .tokens {
-  margin-right: -5px;
+  padding: 0 8px;
   border: 0;
   background: transparent;
   font-size: var(--size-smallish);

--- a/src/modules/users/components/UserTokenActivationButton/UserTokenActivationButton.css
+++ b/src/modules/users/components/UserTokenActivationButton/UserTokenActivationButton.css
@@ -1,6 +1,8 @@
 .tokens {
-  padding: 0 8px;
-  border: 0;
+  padding: 2px 8px 3px;
+  height: 100%;
+  border: none;
+  border-radius: var(--radius-normal);
   background: transparent;
   font-size: var(--size-smallish);
   font-weight: var(--weight-bold);


### PR DESCRIPTION
Fix minor style bugs on the "token activation area" of the navigation bar

* Added more space between token activation toggle button and wallet address
* Added more padding to button wrapper of token activation toggle and wallet address
* Added bold font weight to wallet address of UserNavigation

Resolves DEV-324
