### PR TITLE
Fix `Passed` tag

### DIFF
--- a/src/utils/events/index.ts
+++ b/src/utils/events/index.ts
@@ -523,7 +523,7 @@ export const getMotionState = async (
     motion.skillRep,
     totalStakeFraction,
     18,
-  );
+  ).sub(1);
   switch (motionNetworkState) {
     case NetworkMotionState.Staking:
       return bigNumberify(motion.stakes[1]).gte(bigNumberify(requiredStakes))


### PR DESCRIPTION
## Description

This PR fixes the `Passed` tag on the motions page

**Changes** 🏗

- subtract `1` from `requiredStake` in `getMotionState` function

Resolves DEV-374
