### PR TITLE
Feat: add voting progress bar tooltip

### DIFF
--- a/src/modules/core/components/QuestionMarkTooltip/QuestionMarkTooltip.tsx
+++ b/src/modules/core/components/QuestionMarkTooltip/QuestionMarkTooltip.tsx
@@ -16,6 +16,7 @@ interface Props {
   className?: string;
   tooltipClassName?: string;
   iconTitle?: string;
+  showArrow?: boolean;
 }
 
 const QuestionMarkTooltip = ({
@@ -35,6 +36,7 @@ const QuestionMarkTooltip = ({
   },
   tooltipText,
   className,
+  showArrow,
 }: Props) => {
   return (
     <>
@@ -50,6 +52,7 @@ const QuestionMarkTooltip = ({
           )
         }
         trigger="hover"
+        showArrow={showArrow}
         popperProps={tooltipPopperProps}
       >
         <div className={className}>

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultAction.css
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultAction.css
@@ -78,7 +78,7 @@
 .countdownContainer {
   composes: details;
   display: flex;
-  align-items: center;
+  align-items: baseline;
 }
 
 .addressInTitle div {

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.css
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.css
@@ -29,3 +29,15 @@
   border: 1px solid var(--text-disabled);
   border-radius: var(--radius-large);
 }
+
+.help {
+  display: inline-block;
+  align-self: center;
+  margin-left: 7px;
+  cursor: pointer;
+}
+
+.tooltip {
+  padding: 5px;
+  width: 220px;
+}

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.css.d.ts
@@ -4,3 +4,5 @@ export const annotation: string;
 export const text: string;
 export const progressBarContainer: string;
 export const voteResultsWrapper: string;
+export const help: string;
+export const tooltip: string;

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
@@ -321,8 +321,7 @@ const DefaultMotion = ({
             state={motionState as MotionState}
             motionId={motionId}
           />
-          {/* {motionState === MotionState.Voting && votingStateData && ( */}
-          {true && (
+          {motionState === MotionState.Voting && votingStateData && (
             <>
               <span className={motionSpecificStyles.text}>
                 <FormattedMessage {...MSG.or} />
@@ -343,6 +342,7 @@ const DefaultMotion = ({
                 tooltipText={MSG.votingProgressBarTooltip}
                 className={motionSpecificStyles.help}
                 tooltipClassName={motionSpecificStyles.tooltip}
+                showArrow={false}
                 tooltipPopperProps={{
                   placement: 'top-end',
                   modifiers: [

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
@@ -29,6 +29,7 @@ import Tag, { Appearance as TagAppearance } from '~core/Tag';
 import FriendlyName from '~core/FriendlyName';
 import MemberReputation from '~core/MemberReputation';
 import ProgressBar from '~core/ProgressBar';
+import QuestionMarkTooltip from '~core/QuestionMarkTooltip';
 import { getFormattedTokenValue } from '~utils/tokens';
 import {
   MotionState,
@@ -57,6 +58,10 @@ const MSG = defineMessages({
   or: {
     id: 'dashboard.ActionsPage.DefaultMotion.or',
     defaultMessage: `OR`,
+  },
+  votingProgressBarTooltip: {
+    id: 'dashboard.ActionsPage.DefaultMotion.or',
+    defaultMessage: `Voting ends at the sooner of either time-out, or the reputation threshold being reached.`,
   },
 });
 
@@ -316,7 +321,8 @@ const DefaultMotion = ({
             state={motionState as MotionState}
             motionId={motionId}
           />
-          {motionState === MotionState.Voting && votingStateData && (
+          {/* {motionState === MotionState.Voting && votingStateData && ( */}
+          {true && (
             <>
               <span className={motionSpecificStyles.text}>
                 <FormattedMessage {...MSG.or} />
@@ -333,6 +339,22 @@ const DefaultMotion = ({
                   }}
                 />
               </div>
+              <QuestionMarkTooltip
+                tooltipText={MSG.votingProgressBarTooltip}
+                className={motionSpecificStyles.help}
+                tooltipClassName={motionSpecificStyles.tooltip}
+                tooltipPopperProps={{
+                  placement: 'top-end',
+                  modifiers: [
+                    {
+                      name: 'offset',
+                      options: {
+                        offset: [0, 10],
+                      },
+                    },
+                  ],
+                }}
+              />
             </>
           )}
         </div>

--- a/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteDetails.tsx
+++ b/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteDetails.tsx
@@ -40,7 +40,7 @@ const MSG = defineMessages({
   },
   votingMethodTooltip: {
     id: 'dashboard.ActionsPage.VoteWidget.votingMethodTooltip',
-    defaultMessage: `Colony makes it possible to utilize different voting methods. Selected voting method depends on installed extensions. You can change voting method in Governance Policy.`,
+    defaultMessage: `Votes are weighted by reputation in the team in which the vote is happening.`,
   },
   reputationTeamLabel: {
     id: 'dashboard.ActionsPage.VoteWidget.reputationTeamLabel',
@@ -48,7 +48,7 @@ const MSG = defineMessages({
   },
   reputationTeamTooltip: {
     id: 'dashboard.ActionsPage.VoteWidget.reputationTeamTooltip',
-    defaultMessage: `Displays users own reputation in a domain. For example, for reputation 3.5%, user vote is going to be counted as 3.5. Users without reputation, couldn’t vote.`,
+    defaultMessage: `This is the % of the reputation you have in this team.`,
   },
   rewardLabel: {
     id: 'dashboard.ActionsPage.VoteWidget.rewardLabel',
@@ -56,7 +56,7 @@ const MSG = defineMessages({
   },
   rewardTooltip: {
     id: 'dashboard.ActionsPage.VoteWidget.rewardTooltip',
-    defaultMessage: `Displays possible reward range for an individual user. If prediction aligns with the winning outcome, then user receives reward. Final value depends on [TO BE ADDED]`,
+    defaultMessage: `This is the range of values between which your reward for voting will be, subject to the number of people that participate in the vote.`,
   },
   rulesLabel: {
     id: 'dashboard.ActionsPage.VoteWidget.rulesLabel',
@@ -64,7 +64,7 @@ const MSG = defineMessages({
   },
   rulesTooltip: {
     id: 'dashboard.ActionsPage.VoteWidget.rulesTooltip',
-    defaultMessage: `Voting process goes in stages. User selects option to vote upon. Then reveals the own vote before the ‘Reveal’ stage passes. Later on, user has to claim tokens and finalize transaction.`,
+    defaultMessage: `Votes are secret and must be revealed at the end of the voting period to count.`,
   },
   loading: {
     id: 'dashboard.ActionsPage.VoteWidget.loading',


### PR DESCRIPTION
## Description

This PR adds a tooltip for the voting progress bar & updates VoteWidget tooltip copies

**New stuff** ✨

- add tooltip for the voting progress bar

**Changes** 🏗

- updated alignment of the progress bar & countdown timer (on my machine it was not aligned as per figma)
- added `showArrow` prop to `QuestionmarkTooltip`
- updated copies of the VoteWidget tooltips

Resolves DEV-376
