### PR TITLE
Update copy for motion finalized event

### DIFF
--- a/src/i18n/en-events.ts
+++ b/src/i18n/en-events.ts
@@ -15,7 +15,7 @@ const eventsMessageDescriptors = {
       ${ColonyAndExtensionsEvents.RecoveryModeExited} {{initiator} exited Recovery Mode}
       ${ColonyAndExtensionsEvents.MotionCreated} {{initiator} created a {motionTag}}
       ${ColonyAndExtensionsEvents.MotionStaked} {{staker} backed the {backedSideTag} by staking {amountTag}}
-      ${ColonyAndExtensionsEvents.MotionFinalized} {{initiator} finalized this {motionTag}. Stakes may be claimed.}
+      ${ColonyAndExtensionsEvents.MotionFinalized} {{motionTag} was finalized. Stakes may be claimed.}
       ${ColonyAndExtensionsEvents.MotionVoteRevealed} {{staker} revealed vote for {voteSide}.}
       ${ColonyAndExtensionsEvents.ObjectionRaised} {{staker} raised an {objectionTag}}
       ${ColonyAndExtensionsEvents.MotionRewardClaimed} {{staker} claimed their stake.}


### PR DESCRIPTION
## Description

This PR changes copy for MotionFinalizedEvent. This event doesn't keep information about person which fire this action, so we can't display userName/userAddress in copy

**Changes** 🏗

* Updated copy for MotionFinalizedEvent

<img width="525" alt="Screenshot 2021-06-01 at 17 10 04" src="https://user-images.githubusercontent.com/13069555/120347422-8db61680-c2fc-11eb-9a05-75b2033e4fa0.png">

Resolves DEV-377
