### PR TITLE
Fix permission modal UI

### DIFF
--- a/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementDialog.css
+++ b/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementDialog.css
@@ -32,6 +32,10 @@
   color: var(--dark);
 }
 
+.domainSelectContainer > div > div > ul {
+  z-index: var(--z-index-positioning);
+}
+
 .permissionChoiceContainer {
   margin-bottom: 50px;
   border-top: 1px solid color-mod(var(--grey-2) alpha(15%));


### PR DESCRIPTION
## Description

This PR fixes the overlapping dropdowns of the PermissinManagement dialog.

**Changes** 🏗

Change z-index of the domain dropdown from 2 to 1.

Resolves DEV-382

<img width="1010" alt="Screenshot 2021-06-03 at 19 04 48" src="https://user-images.githubusercontent.com/34057551/120676489-fbde1300-c48d-11eb-85b0-fb61a2909409.png">
