### PR TITLE
Update motion tags and some message copies

### DIFF
--- a/src/i18n/en-system-messages.ts
+++ b/src/i18n/en-system-messages.ts
@@ -11,8 +11,8 @@ const systemMessagesMessageDescriptors = {
       ${SystemMessagesName.MotionHasFailedFinalizable} {{motionTag} has {failedTag} and may be finalized.}
       ${SystemMessagesName.MotionVotingPhase} {{votingTag} has started! Voting is secret 😀, and weighted by Reputation.}
       ${SystemMessagesName.MotionFullyStaked} {{motionTag} is fully staked; Staking period has reset. As long as there is no {objectionTag} , the motion will pass.}
-      ${SystemMessagesName.MotionRevealResultObjectionWon} {{objectionTag} sustained! {voteResultsWidget} The motion will fail at the end of the escalation period unless the dispute is escalated to a higher domain.}
-      ${SystemMessagesName.MotionRevealResultMotionWon} {{motionTag} sustained! {voteResultsWidget} The motion will pass at the end of the escalation period unless the dispute is escalated to a higher domain.}
+      ${SystemMessagesName.MotionRevealResultObjectionWon} {{motionTag} failed. {voteResultsWidget} The motion will fail at the end of the escalation period unless the dispute is escalated to a higher domain.}
+      ${SystemMessagesName.MotionRevealResultMotionWon} {{motionTag} passed! {voteResultsWidget} The motion will pass at the end of the escalation period unless the dispute is escalated to a higher domain.}
       ${SystemMessagesName.MotionCanBeEscalated} {{escalateTag} period started. {spaceBreak}{spaceBreak} If you believe this result was unfair, and would be different if more people were involved, you may escalate it to a higher domain.}
       other {Generic system message}
     }`,

--- a/src/modules/core/components/ActionsList/ActionsListItem.tsx
+++ b/src/modules/core/components/ActionsList/ActionsListItem.tsx
@@ -21,6 +21,7 @@ import { FormattedAction, ColonyActions, ColonyMotions } from '~types/index';
 import { useDataFetcher } from '~utils/hooks';
 import { parseDomainMetadata } from '~utils/colonyActions';
 import { useFormatRolesTitle } from '~utils/hooks/useFormatRolesTitle';
+import { useEnabledExtensions } from '~utils/hooks/useEnabledExtensions';
 import {
   getUpdatedDecodedMotionRoles,
   MotionState,
@@ -95,6 +96,10 @@ const ActionsListItem = ({
     [metadata],
   );
 
+  const { isVotingExtensionEnabled } = useEnabledExtensions({
+    colonyAddress: colony.colonyAddress,
+  });
+
   const initiatorUserProfile = useUser(createAddress(initiator || AddressZero));
   const recipientAddress = createAddress(recipient);
   const isColonyAddress = recipientAddress === colony.colonyAddress;
@@ -140,7 +145,14 @@ const ActionsListItem = ({
     const domainObject = parseDomainMetadata(metadataJSON);
     domainName = domainObject.domainName;
   }
-  const motionStyles = MOTION_TAG_MAP[motionState || MotionState.Invalid];
+  const motionStyles =
+    MOTION_TAG_MAP[
+      motionState ||
+        (isVotingExtensionEnabled &&
+          !actionType.endsWith('Motion') &&
+          MotionState.Forced) ||
+        MotionState.Invalid
+    ];
 
   return (
     <li>
@@ -230,7 +242,7 @@ const ActionsListItem = ({
                 newVersion: newVersion || '0',
               }}
             />
-            {motionState && (
+            {(motionState || isVotingExtensionEnabled) && (
               <div className={styles.motionTagWrapper}>
                 <Tag
                   text={motionStyles.name}

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultAction.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultAction.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
+import Tag, { Appearance as TagAppareance } from '~core/Tag';
 import FriendlyName from '~core/FriendlyName';
 import { EventValue } from '~data/resolvers/colonyActions';
 import { parseDomainMetadata } from '~utils/colonyActions';
@@ -21,11 +22,13 @@ import {
 } from '~data/index';
 import { ColonyActions, ColonyAndExtensionsEvents } from '~types/index';
 import { useFormatRolesTitle } from '~utils/hooks/useFormatRolesTitle';
+import { useEnabledExtensions } from '~utils/hooks/useEnabledExtensions';
 import {
   getFormattedTokenValue,
   getTokenDecimalsWithFallback,
 } from '~utils/tokens';
 import { useDataFetcher } from '~utils/hooks';
+import { MotionState, MOTION_TAG_MAP } from '~utils/colonyMotions';
 import { ipfsDataFetcher } from '../../../../core/fetchers';
 
 import DetailsWidget from '../DetailsWidget';
@@ -66,6 +69,8 @@ const DefaultAction = ({
   initiator,
 }: Props) => {
   const { username: currentUserName, ethereal } = useLoggedInUser();
+
+  const { isVotingExtensionEnabled } = useEnabledExtensions({ colonyAddress });
 
   const { roleMessageDescriptorId, roleTitle } = useFormatRolesTitle(
     roles,
@@ -163,8 +168,24 @@ const DefaultAction = ({
     roles,
   };
 
+  const motionStyles = MOTION_TAG_MAP[MotionState.Forced];
+
   return (
     <div className={styles.main}>
+      {isVotingExtensionEnabled && (
+        <div className={styles.upperContainer}>
+          <p className={styles.tagWrapper}>
+            <Tag
+              text={motionStyles.name}
+              appearance={{
+                theme: motionStyles.theme as TagAppareance['theme'],
+                // eslint-disable-next-line max-len
+                colorSchema: motionStyles.colorSchema as TagAppareance['colorSchema'],
+              }}
+            />
+          </p>
+        </div>
+      )}
       <hr className={styles.dividerTop} />
       <div className={styles.container}>
         <div className={styles.content}>

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
@@ -313,8 +313,8 @@ const DefaultMotion = ({
   const motionState = motionStatusData?.motionStatus;
   const motionStyles = MOTION_TAG_MAP[motionState || MotionState.Invalid];
   const isStakingPhase =
-    motionState === MotionState.StakeRequired ||
-    motionState === MotionState.Motion ||
+    motionState === MotionState.Staking ||
+    motionState === MotionState.Staked ||
     motionState === MotionState.Objection;
 
   const objectionAnnotationUser = useUser(

--- a/src/modules/dashboard/components/ActionsPage/CountDownTimer/CountDownTimer.tsx
+++ b/src/modules/dashboard/components/ActionsPage/CountDownTimer/CountDownTimer.tsx
@@ -74,8 +74,8 @@ const CountDownTimer = ({
 
   const currentStatePeriod = useCallback(() => {
     switch (state) {
-      case MotionState.StakeRequired:
-      case MotionState.Motion:
+      case MotionState.Staking:
+      case MotionState.Staked:
       case MotionState.Objection:
         return data?.motionTimeoutPeriods?.timeLeftToStake || -1;
       case MotionState.Voting:

--- a/src/utils/colonyMotions.ts
+++ b/src/utils/colonyMotions.ts
@@ -8,11 +8,12 @@ import { Colony, AnyUser } from '~data/index';
 import { ActionUserRoles } from '~types/index';
 
 export enum MotionState {
-  Motion = 'Motion',
-  StakeRequired = 'StakeRequired',
+  Staked = 'Staked',
+  Staking = 'Staking',
   Voting = 'Voting',
   Reveal = 'Reveal',
   Objection = 'Objection',
+  Motion = 'Motion',
   Failed = 'Failed',
   Passed = 'Passed',
   FailedNoFinalizable = 'FailedNoFinalizable',
@@ -26,13 +27,13 @@ export enum MotionVote {
 }
 
 const MSG = defineMessage({
-  motionTag: {
-    id: 'dashboard.ActionsPage.motionTag',
-    defaultMessage: 'Motion',
+  stakedTag: {
+    id: 'dashboard.ActionsPage.stakedTag',
+    defaultMessage: 'Staked',
   },
-  stakeRequiredTag: {
-    id: 'dashboard.ActionsPage.stakeRequiredTag',
-    defaultMessage: 'Stake required',
+  stakingTag: {
+    id: 'dashboard.ActionsPage.stakingTag',
+    defaultMessage: 'Staking',
   },
   votingTag: {
     id: 'dashboard.ActionsPage.votingTag',
@@ -45,6 +46,10 @@ const MSG = defineMessage({
   objectionTag: {
     id: 'dashboard.ActionsPage.objectionTag',
     defaultMessage: 'Objection',
+  },
+  motionTag: {
+    id: 'dashboard.ActionsPage.motionTag',
+    defaultMessage: 'Motion',
   },
   failedTag: {
     id: 'dashboard.ActionsPage.failedTag',
@@ -65,17 +70,23 @@ const MSG = defineMessage({
 });
 
 export const MOTION_TAG_MAP = {
-  [MotionState.Motion]: {
+  [MotionState.Staked]: {
     theme: 'primary',
     colorSchema: 'fullColor',
-    name: MSG.motionTag,
+    name: MSG.stakedTag,
     tagName: 'motionTag',
   },
-  [MotionState.StakeRequired]: {
-    theme: 'pink',
+  [MotionState.Staked]: {
+    theme: 'primary',
     colorSchema: 'fullColor',
-    name: MSG.stakeRequiredTag,
-    tagName: 'stakeRequiredTag',
+    name: MSG.stakedTag,
+    tagName: 'motionTag',
+  },
+  [MotionState.Staking]: {
+    theme: 'pink',
+    colorSchema: 'inverted',
+    name: MSG.stakingTag,
+    tagName: 'stakingTag',
   },
   [MotionState.Voting]: {
     theme: 'golden',
@@ -94,6 +105,12 @@ export const MOTION_TAG_MAP = {
     colorSchema: 'fullColor',
     name: MSG.objectionTag,
     tagName: 'objectionTag',
+  },
+  [MotionState.Motion]: {
+    theme: 'primary',
+    colorSchema: 'fullColor',
+    name: MSG.motionTag,
+    tagName: 'motionTag',
   },
   [MotionState.Failed]: {
     theme: 'pink',

--- a/src/utils/colonyMotions.ts
+++ b/src/utils/colonyMotions.ts
@@ -19,6 +19,7 @@ export enum MotionState {
   FailedNoFinalizable = 'FailedNoFinalizable',
   Invalid = 'Invalid',
   Escalation = 'Escalation',
+  Forced = 'Forced',
 }
 
 export enum MotionVote {
@@ -67,15 +68,13 @@ const MSG = defineMessage({
     id: 'dashboard.ActionsPage.escalateTag',
     defaultMessage: 'Escalate',
   },
+  forcedTag: {
+    id: 'dashboard.ActionsPage.forcedTag',
+    defaultMessage: 'Forced',
+  },
 });
 
 export const MOTION_TAG_MAP = {
-  [MotionState.Staked]: {
-    theme: 'primary',
-    colorSchema: 'fullColor',
-    name: MSG.stakedTag,
-    tagName: 'motionTag',
-  },
   [MotionState.Staked]: {
     theme: 'primary',
     colorSchema: 'fullColor',
@@ -141,6 +140,12 @@ export const MOTION_TAG_MAP = {
     colorSchema: 'plain',
     name: MSG.escalateTag,
     tagName: 'escalateTag',
+  },
+  [MotionState.Forced]: {
+    theme: 'blue',
+    colorSchema: 'inverted',
+    name: MSG.forcedTag,
+    tagName: 'forcedTag',
   },
 };
 

--- a/src/utils/events/index.ts
+++ b/src/utils/events/index.ts
@@ -526,9 +526,10 @@ export const getMotionState = async (
   ).sub(1);
   switch (motionNetworkState) {
     case NetworkMotionState.Staking:
-      return bigNumberify(motion.stakes[1]).gte(bigNumberify(requiredStakes))
-        ? MotionState.Motion
-        : MotionState.StakeRequired;
+      return bigNumberify(motion.stakes[1]).gte(bigNumberify(requiredStakes)) &&
+        bigNumberify(motion.stakes[0]).isZero()
+        ? MotionState.Staked
+        : MotionState.Staking;
     case NetworkMotionState.Submit:
       return MotionState.Voting;
     case NetworkMotionState.Reveal:


### PR DESCRIPTION
## Description

Update motion tags and voting widget system messages

**New stuff** ✨

* Added `Staked` tag for when the motion side is fully staked and there's no stake on the objection side
* Added `Forced` tag for normal actions when the voting reputation extension is enabled

**Changes** 🏗

* Changed `StakeRequired` tag to `Staking`
* Updated MotionRevealResultObjectionWon message copy
* Updated MotionRevealResultMotionWon message copy

![FireShot Capture 342 - Colony - localhost](https://user-images.githubusercontent.com/18473896/120699124-625f3300-c486-11eb-9cf7-81d3ebf7ff3e.png)
![FireShot Capture 343 - Colony - localhost](https://user-images.githubusercontent.com/18473896/120699126-63906000-c486-11eb-9eda-7bf3d53177cc.png)
![FireShot Capture 344 - Colony - localhost](https://user-images.githubusercontent.com/18473896/120699128-6428f680-c486-11eb-9852-8a371d3eb6ec.png)
![FireShot Capture 345 - Colony - localhost](https://user-images.githubusercontent.com/18473896/120699132-64c18d00-c486-11eb-8982-eb23afff05d3.png)
![FireShot Capture 347 - Colony - localhost](https://user-images.githubusercontent.com/18473896/120724116-8aac5900-c4a9-11eb-88e1-dfdc82e243b8.png)


Resolves DEV-381
