### PR TITLE
Remove reveal vote event from events

### DIFF
--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -47,13 +47,6 @@ const getMotionEvents = async (
     votingReputationClient.filters.MotionStaked(motionId, null, null, null),
   );
 
-  const motionVoteRevealedLogs = await getLogs(
-    votingReputationClient,
-    // @TODO Add missing types to colonyjs
-    // @ts-ignore
-    votingReputationClient.filters.MotionVoteRevealed(motionId, null, null),
-  );
-
   const motionFinalizedLogs = await getLogs(
     votingReputationClient,
     // @TODO Add missing types to colonyjs
@@ -71,7 +64,6 @@ const getMotionEvents = async (
   const parsedMotionEvents = await Promise.all(
     [
       ...motionStakedLogs,
-      ...motionVoteRevealedLogs,
       ...motionFinalizedLogs,
       ...motionStakeClaimedLogs,
     ].map(async (log) => {

--- a/src/i18n/en-events.ts
+++ b/src/i18n/en-events.ts
@@ -16,7 +16,6 @@ const eventsMessageDescriptors = {
       ${ColonyAndExtensionsEvents.MotionCreated} {{initiator} created a {motionTag}}
       ${ColonyAndExtensionsEvents.MotionStaked} {{staker} backed the {backedSideTag} by staking {amountTag}}
       ${ColonyAndExtensionsEvents.MotionFinalized} {{motionTag} was finalized. Stakes may be claimed.}
-      ${ColonyAndExtensionsEvents.MotionVoteRevealed} {{staker} revealed vote for {voteSide}.}
       ${ColonyAndExtensionsEvents.ObjectionRaised} {{staker} raised an {objectionTag}}
       ${ColonyAndExtensionsEvents.MotionRewardClaimed} {{staker} claimed their stake.}
       other {{eventNameDecorated} emmited by {clientOrExtensionType}}

--- a/src/modules/dashboard/components/ActionsPage/staticMaps.ts
+++ b/src/modules/dashboard/components/ActionsPage/staticMaps.ts
@@ -104,7 +104,6 @@ export const STATUS_MAP: { [key in number]: STATUS } = {
 const MOTION_EVENTS = [
   ColonyAndExtensionsEvents.MotionCreated,
   ColonyAndExtensionsEvents.MotionStaked,
-  ColonyAndExtensionsEvents.MotionVoteRevealed,
   ColonyAndExtensionsEvents.ObjectionRaised,
   ColonyAndExtensionsEvents.MotionFinalized,
   ColonyAndExtensionsEvents.MotionRewardClaimed,


### PR DESCRIPTION
## Description

This PR removing vote reveal events from logs 

**Changes** 🏗

* Removed motionVoteRevealed Log from motion events
* Removed message descriptors for motionVoteRevealed event
* MotionVoteRevealed removed from events static map 

<img width="533" alt="Screenshot 2021-06-04 at 15 50 50" src="https://user-images.githubusercontent.com/13069555/120812580-66a25380-c54d-11eb-9145-a2dbd2095ec6.png">


Resolves DEV-391
