### PR TITLE
Update copy of voting extension uninstallation

### DIFF
--- a/src/modules/core/components/Warning/Warning.css
+++ b/src/modules/core/components/Warning/Warning.css
@@ -10,6 +10,7 @@
 
 .content {
   padding: 13px 22px;
+  white-space: pre-line;
 }
 
 .warning button {

--- a/src/modules/dashboard/components/Extensions/extensionsMSG.ts
+++ b/src/modules/dashboard/components/Extensions/extensionsMSG.ts
@@ -15,7 +15,7 @@ export const ExtensionsMSG = defineMessages({
   },
   textVotingUninstall: {
     id: 'dashboard.Extensions.ExtensionDetails.textVotingUninstall',
-    defaultMessage: `Please ensure that all funds in processes associated with this extension are claimed by their owners before uninstalling. Not doing so will result in permanent loss of the unclaimed funds.`,
+    defaultMessage: `Uninstalling this extension will permanently delete all actions associated with this extension from this colony. They will disappear from the application and can never be recovered.\n\nPlease ensure that all funds in processes associated with this extension are claimed by their owners before uninstalling. Not doing so will result in permanent loss of the unclaimed funds.`,
   },
   typeInBox: {
     id: 'dashboard.Extensions.ExtensionDetails.typeInBox',


### PR DESCRIPTION
Self-explanatory title, this is an update to the copy of the warning that appears when you are going to uninstall the voting reputation extension.

![FireShot Capture 348 - Colony - localhost](https://user-images.githubusercontent.com/18473896/120856636-8722db80-c556-11eb-9f10-78e3e97dc18d.png)

Resolves DEV-388
