### PR TITLE
Fix long action titles hiding the motion state tag

### DIFF
--- a/src/modules/core/components/ActionsList/ActionsListItem.css
+++ b/src/modules/core/components/ActionsList/ActionsListItem.css
@@ -88,6 +88,12 @@
   min-width: 0;
 }
 
+.titleWrapper {
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
 .title {
   composes: inlineEllipsis from '~styles/text.css';
 }

--- a/src/modules/core/components/ActionsList/ActionsListItem.css.d.ts
+++ b/src/modules/core/components/ActionsList/ActionsListItem.css.d.ts
@@ -8,6 +8,7 @@ export const stateNeedAction: string;
 export const stateNeedAttention: string;
 export const stateYellow: string;
 export const content: string;
+export const titleWrapper: string;
 export const title: string;
 export const meta: string;
 export const separator: string;

--- a/src/modules/core/components/ActionsList/ActionsListItem.tsx
+++ b/src/modules/core/components/ActionsList/ActionsListItem.tsx
@@ -203,45 +203,47 @@ const ActionsListItem = ({
           )}
         </div>
         <div className={styles.content}>
-          <div className={styles.title}>
-            <FormattedMessage
-              id={roleMessageDescriptorId || 'action.title'}
-              values={{
-                actionType,
-                initiator: (
-                  <span className={styles.titleDecoration}>
-                    <FriendlyName
-                      user={initiatorUserProfile}
-                      autoShrinkAddress
+          <div className={styles.titleWrapper}>
+            <span className={styles.title}>
+              <FormattedMessage
+                id={roleMessageDescriptorId || 'action.title'}
+                values={{
+                  actionType,
+                  initiator: (
+                    <span className={styles.titleDecoration}>
+                      <FriendlyName
+                        user={initiatorUserProfile}
+                        autoShrinkAddress
+                      />
+                    </span>
+                  ),
+                  /*
+                   * @TODO Add user mention popover back in
+                   */
+                  recipient: (
+                    <span className={styles.titleDecoration}>
+                      <FriendlyName
+                        user={fallbackRecipientProfile}
+                        autoShrinkAddress
+                        colony={colony}
+                      />
+                    </span>
+                  ),
+                  amount: (
+                    <Numeral
+                      value={amount}
+                      unit={getTokenDecimalsWithFallback(decimals)}
                     />
-                  </span>
-                ),
-                /*
-                 * @TODO Add user mention popover back in
-                 */
-                recipient: (
-                  <span className={styles.titleDecoration}>
-                    <FriendlyName
-                      user={fallbackRecipientProfile}
-                      autoShrinkAddress
-                      colony={colony}
-                    />
-                  </span>
-                ),
-                amount: (
-                  <Numeral
-                    value={amount}
-                    unit={getTokenDecimalsWithFallback(decimals)}
-                  />
-                ),
-                tokenSymbol: symbol,
-                decimals: getTokenDecimalsWithFallback(decimals),
-                fromDomain: domainName || fromDomain?.name || '',
-                toDomain: toDomain?.name || '',
-                roles: roleTitle,
-                newVersion: newVersion || '0',
-              }}
-            />
+                  ),
+                  tokenSymbol: symbol,
+                  decimals: getTokenDecimalsWithFallback(decimals),
+                  fromDomain: domainName || fromDomain?.name || '',
+                  toDomain: toDomain?.name || '',
+                  roles: roleTitle,
+                  newVersion: newVersion || '0',
+                }}
+              />
+            </span>
             {(motionState || isVotingExtensionEnabled) && (
               <div className={styles.motionTagWrapper}>
                 <Tag


### PR DESCRIPTION
Added title wrapper in order to stop long titles from hiding the motion state tag

![FireShot Capture 349 - Colony - localhost](https://user-images.githubusercontent.com/18473896/120860533-36ae7c80-c55c-11eb-8a6b-2378fdfcb3a6.png)

Resolves DEV-392
