### PR TITLE
Add extra condition for motion failed system message

### DIFF
--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -403,6 +403,12 @@ export const motionsResolvers = ({
               ),
             });
           }
+        } else if (motion.votes[0].gte(motion.votes[1])) {
+          systemMessages.push({
+            type: ActionsPageFeedType.SystemMessage,
+            name: SystemMessagesName.MotionHasFailedFinalizable,
+            createdAt: motion.events[2].toNumber() * 1000,
+          });
         }
       }
 


### PR DESCRIPTION
Fixes bug where if the motion failed and nobody voted then the "motion failed" system message doesn't appear.

### To test:

1. Stake both sides of a motion
2. Don't vote and just let the motion fail due to timeout
3. Check if the system message for motion failed appears

Resolves DEV-384
