### PR TITLE
Fix being able to claim when total is 0

### DIFF
--- a/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
@@ -241,7 +241,8 @@ const FinalizeMotionAndClaimWidget = ({
 
   const canClaimStakes =
     bigNumberify(stakerRewards?.motionStakerReward?.stakesYay || 0).gt(0) ||
-    bigNumberify(stakerRewards?.motionStakerReward?.stakesNay || 0).gt(0);
+    bigNumberify(stakerRewards?.motionStakerReward?.stakesNay || 0).gt(0) ||
+    userTotals === '0';
 
   const showClaimButton =
     finalized?.motionFinalized || (motionNotFinalizable && canClaimStakes);

--- a/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
@@ -240,9 +240,9 @@ const FinalizeMotionAndClaimWidget = ({
     motionDomain === ROOT_DOMAIN_ID;
 
   const canClaimStakes =
-    bigNumberify(stakerRewards?.motionStakerReward?.stakesYay || 0).gt(0) ||
-    bigNumberify(stakerRewards?.motionStakerReward?.stakesNay || 0).gt(0) ||
-    userTotals === '0';
+    (bigNumberify(stakerRewards?.motionStakerReward?.stakesYay || 0).gt(0) ||
+      bigNumberify(stakerRewards?.motionStakerReward?.stakesNay || 0).gt(0)) &&
+    userTotals !== '0';
 
   const showClaimButton =
     finalized?.motionFinalized || (motionNotFinalizable && canClaimStakes);


### PR DESCRIPTION
Self-explanatory title, now shouldn't be able to claim when your payout is 0, as that produces a transaction error.

Resolves DEV-397
