### PR TITLE
Update `TransferFundsDialog` form to avoid validation  error on `to` domain field

### DIFF
--- a/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialog.tsx
+++ b/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialog.tsx
@@ -1,10 +1,11 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { FormikProps } from 'formik';
 import * as yup from 'yup';
 import moveDecimal from 'move-decimal-point';
 import { bigNumberify } from 'ethers/utils';
 import { useHistory } from 'react-router-dom';
 import { defineMessages } from 'react-intl';
+import sortBy from 'lodash/sortBy';
 import { ROOT_DOMAIN_ID } from '@colony/colony-js';
 
 import { pipe, mapPayload, withMeta } from '~utils/actions';
@@ -54,6 +55,7 @@ const TransferFundsDialog = ({
     nativeTokenAddress,
     colonyName,
     version,
+    domains,
   },
   colony,
   fromDomain,
@@ -87,6 +89,18 @@ const TransferFundsDialog = ({
     tokenAddress: yup.string().address().required(),
     annotation: yup.string().max(4000),
   });
+
+  const domainOptions = useMemo(
+    () =>
+      sortBy(
+        domains.map(({ name, ethDomainId }) => ({
+          value: ethDomainId.toString(),
+          label: name,
+        })),
+        ['value'],
+      ),
+    [domains],
+  );
 
   const transform = useCallback(
     pipe(
@@ -130,7 +144,7 @@ const TransferFundsDialog = ({
       initialValues={{
         forceAction: false,
         fromDomain: fromDomain ? String(fromDomain) : ROOT_DOMAIN_ID.toString(),
-        toDomain: undefined,
+        toDomain: domainOptions[1]?.value || ROOT_DOMAIN_ID.toString(),
         amount: '',
         tokenAddress: nativeTokenAddress,
         annotation: undefined,
@@ -157,6 +171,7 @@ const TransferFundsDialog = ({
             <DialogForm
               {...formValues}
               colony={colony}
+              domainOptions={domainOptions}
               isVotingExtensionEnabled={isVotingExtensionEnabled}
               back={prevStep && callStep ? () => callStep(prevStep) : undefined}
             />

--- a/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialogForm.tsx
+++ b/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialogForm.tsx
@@ -3,14 +3,19 @@ import { FormikProps } from 'formik';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { bigNumberify } from 'ethers/utils';
 import moveDecimal from 'move-decimal-point';
-import sortBy from 'lodash/sortBy';
 import { ColonyRole, ROOT_DOMAIN_ID } from '@colony/colony-js';
 import { AddressZero } from 'ethers/constants';
 
 import { useTransformer } from '~utils/hooks';
 import Button from '~core/Button';
 import DialogSection from '~core/Dialog/DialogSection';
-import { Select, Input, Annotations, TokenSymbolSelector } from '~core/Fields';
+import {
+  Select,
+  Input,
+  Annotations,
+  TokenSymbolSelector,
+  SelectOption,
+} from '~core/Fields';
 import Heading from '~core/Heading';
 import PermissionRequiredInfo from '~core/PermissionRequiredInfo';
 import PermissionsLabel from '~core/PermissionsLabel';
@@ -18,7 +23,6 @@ import PermissionsLabel from '~core/PermissionsLabel';
 import {
   useLoggedInUser,
   useTokenBalancesForDomainsLazyQuery,
-  Colony,
 } from '~data/index';
 import { ActionDialogProps } from '~core/Dialog';
 import EthUsd from '~core/EthUsd';
@@ -95,14 +99,14 @@ const MSG = defineMessages({
 });
 
 interface Props {
-  back?: () => void;
-  colony: Colony;
+  domainOptions: SelectOption[];
 }
 
 const TransferFundsDialogForm = ({
   back,
   colony,
   colony: { colonyAddress, domains, tokens },
+  domainOptions,
   handleSubmit,
   isSubmitting,
   isValid,
@@ -111,7 +115,7 @@ const TransferFundsDialogForm = ({
   validateForm,
   errors,
   isVotingExtensionEnabled,
-}: ActionDialogProps & FormikProps<FormValues>) => {
+}: ActionDialogProps & FormikProps<FormValues> & Props) => {
   const { tokenAddress, amount } = values;
 
   const fromDomainId = values.fromDomain
@@ -149,19 +153,6 @@ const TransferFundsDialogForm = ({
   );
 
   const inputDisabled = !userHasPermission || onlyForceAction;
-
-  const domainOptions = useMemo(
-    () =>
-      sortBy(
-        domains.map(({ name, ethDomainId }) => ({
-          value: ethDomainId.toString(),
-          label: name,
-        })),
-        ['value'],
-      ),
-
-    [domains],
-  );
 
   const [
     loadTokenBalances,


### PR DESCRIPTION
## Description

This PR fixes the validation error in the `to domain` field.

Please, test both variants: when there is only root domain in the colony & when there are several domains.

**Changes** 🏗

- update `TransferFundsDialog`
- update `TransferFundsDialogForm`

Resolves DEV-394
