### PR TITLE
Fix CountdownTimer copies

### DIFF
--- a/src/modules/dashboard/components/ActionsPage/CountDownTimer/CountDownTimer.tsx
+++ b/src/modules/dashboard/components/ActionsPage/CountDownTimer/CountDownTimer.tsx
@@ -122,14 +122,16 @@ const CountDownTimer = ({
    */
   useEffect(() => {
     if (
-      (prevStateRef.current === null && isStakingPhaseState) ||
-      !isStakingPhaseState
+      data &&
+      state &&
+      ((prevStateRef.current === null && isStakingPhaseState) ||
+        !isStakingPhaseState)
     ) {
       const period = currentStatePeriod() / 1000;
       setTimeLeft(period > 0 ? period + 5 : period);
-      prevStateRef.current = state || null;
+      prevStateRef.current = state;
     }
-  }, [currentStatePeriod, prevStateRef, state, isStakingPhaseState]);
+  }, [data, currentStatePeriod, prevStateRef, state, isStakingPhaseState]);
 
   /*
    * Count it down

--- a/src/modules/dashboard/components/ActionsPage/CountDownTimer/CountDownTimer.tsx
+++ b/src/modules/dashboard/components/ActionsPage/CountDownTimer/CountDownTimer.tsx
@@ -25,8 +25,8 @@ const MSG = defineMessage({
   title: {
     id: 'dashboard.ActionsPage.CountDownTimer.title',
     defaultMessage: `{motionState, select,
-      StakeRequired {Time left to stake}
-      Motion {Motion will pass in}
+      Staking {Time left to stake}
+      Staked {Motion will pass in}
       Objection {Motion will fail in}
       Voting {Voting ends in}
       Reveal {Reveal ends in}


### PR DESCRIPTION
- Fix CountdownTimer select for copies not being updated to the latest MotionState changes
- Also an attempt to fix the countdown timer sometimes not appearing on the QA env. From what I managed to debug from QA, it may be due to it not being fast enough sometimes, and that would get the `useEffect` in charge of updating the period stuck when on a staking phase. I've updated the conditional of that `useEffect` to prevent that from happening.

Resolves DEV-400
