### PR TITLE
Remove Required Stake Off-by-one Compensation Hack

### DIFF
--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -146,7 +146,6 @@ export const motionsResolvers = ({
           ClientType.VotingReputationClient,
           colonyAddress,
         );
-        const tokenDecimals = await colonyClient.tokenClient.decimals();
         const {
           skillRep,
           stakes,
@@ -166,10 +165,11 @@ export const motionsResolvers = ({
         const userMinStakeFraction = await votingReputationClient.getUserMinStakeFraction();
 
         const [totalNAYStakes, totalYAYStaked] = stakes;
-        const requiredStake = skillRep
-          .mul(totalStakeFraction)
-          .div(bigNumberify(10).pow(tokenDecimals))
-          .add(1);
+        const requiredStake = getMotionRequiredStake(
+          skillRep,
+          totalStakeFraction,
+          18,
+        );
         const remainingToFullyYayStaked = requiredStake.sub(totalYAYStaked);
         const remainingToFullyNayStaked = requiredStake.sub(totalNAYStakes);
         const userMinStakeAmount = skillRep
@@ -291,7 +291,7 @@ export const motionsResolvers = ({
           motion.skillRep,
           totalStakeFraction,
           18,
-        ).sub(1);
+        );
 
         if (motion.stakes[MotionVote.Yay].gte(requiredStake)) {
           systemMessages.push({

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidgetFlow.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidgetFlow.tsx
@@ -87,13 +87,11 @@ const StakingWidgetFlow = ({ colony, motionId, scrollToRef }: Props) => {
     : 1;
 
   const yayPercentage = bigNumberify(totalStaked.YAY || 0)
-    .add(1)
     .mul(100)
     .div(divisibleRequiredStake)
     .toNumber();
 
   const nayPercentage = bigNumberify(totalStaked.NAY || 0)
-    .add(1)
     .mul(100)
     .div(divisibleRequiredStake)
     .toNumber();

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/SingleTotalStake.tsx
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/SingleTotalStake.tsx
@@ -50,7 +50,6 @@ const SingleTotalStake = ({
   tokenSymbol,
 }: Props) => {
   const userStakePercentage = bigNumberify(userStake || 0)
-    .add(1)
     .mul(100)
     .div(requiredStake)
     .toNumber();

--- a/src/utils/colonyMotions.ts
+++ b/src/utils/colonyMotions.ts
@@ -156,9 +156,7 @@ export const getMotionRequiredStake = (
 ): BigNumber => {
   const requiredStake = skillRep
     .mul(totalStakeFraction)
-    .div(bigNumberify(10).pow(decimals))
-    .add(1);
-
+    .div(bigNumberify(10).pow(decimals));
   return requiredStake;
 };
 

--- a/src/utils/events/index.ts
+++ b/src/utils/events/index.ts
@@ -523,7 +523,7 @@ export const getMotionState = async (
     motion.skillRep,
     totalStakeFraction,
     18,
-  ).sub(1);
+  );
   switch (motionNetworkState) {
     case NetworkMotionState.Staking:
       return bigNumberify(motion.stakes[1]).gte(bigNumberify(requiredStakes)) &&


### PR DESCRIPTION
## Description

This PR removes all instances where we added `1`, then subtracted `1` to the `requiredStake` value, in order to compensate to a bug in the contracts that was present in `v1` of the Voting Reputation extension.

This is no longer needed since all colonies will be running Voting Reputation V2

My fix was tested against the Xdai QA environment, started from my local machine. 

Please take some time and test it locally, and if the stake value is not calculated correctly, let me know.
