### PR TITLE
Finalize Motion Manual Gas Estimation

### DIFF
--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
@@ -503,7 +503,6 @@ const DefaultMotion = ({
               colony={colony}
               actionType={actionType}
               motionId={motionId}
-              motionDomain={motionDomain}
               scrollToRef={bottomElementRef}
               motionState={motionState}
             />

--- a/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useMemo, RefObject } from 'react';
 import { FormikProps } from 'formik';
 import { defineMessages, FormattedMessage } from 'react-intl';
-import { ROOT_DOMAIN_ID } from '@colony/colony-js';
 import { bigNumberify } from 'ethers/utils';
 import moveDecimal from 'move-decimal-point';
 
@@ -34,7 +33,6 @@ interface Props {
   colony: Colony;
   motionId: number;
   actionType: string;
-  motionDomain: number;
   scrollToRef?: RefObject<HTMLInputElement>;
   motionState: MotionState;
 }
@@ -67,7 +65,7 @@ export const MSG = defineMessages({
   finalizeTooltip: {
     id: 'dashboard.ActionsPage.FinalizeMotionAndClaimWidget.finalizeTooltip',
     defaultMessage: `Finalize completes a motion, allows stakes to be
-    reclaimed, and if applicable, takes the action the motion was 
+    reclaimed, and if applicable, takes the action the motion was
     created to authorise.`,
   },
   finalizeButton: {
@@ -115,7 +113,6 @@ const FinalizeMotionAndClaimWidget = ({
   colony,
   motionId,
   actionType,
-  motionDomain = ROOT_DOMAIN_ID,
   scrollToRef,
   motionState,
 }: Props) => {
@@ -236,8 +233,7 @@ const FinalizeMotionAndClaimWidget = ({
   const showFinalizeButton =
     voteResults?.motionVoteResults &&
     !finalized?.motionFinalized &&
-    !motionNotFinalizable &&
-    motionDomain === ROOT_DOMAIN_ID;
+    !motionNotFinalizable;
 
   const canClaimStakes =
     (bigNumberify(stakerRewards?.motionStakerReward?.stakesYay || 0).gt(0) ||

--- a/src/modules/dashboard/sagas/motions/finalizeMotion.ts
+++ b/src/modules/dashboard/sagas/motions/finalizeMotion.ts
@@ -51,13 +51,13 @@ function* finalizeMotion({
     });
 
     /*
-     * Increase the estimate by 55k WEI. This is a flat increase for all networks
+     * Increase the estimate by 80k WEI. This is a flat increase for all networks
      *
      * @NOTE This will need to be increased further for `setExpenditureState` since
      * that requires even more gas, but since we don't use that one yet, there's
      * no reason to account for it just yet
      */
-    const estimate = bigNumberify(networkEstimate).add(bigNumberify(55000));
+    const estimate = bigNumberify(networkEstimate).add(bigNumberify(80000));
 
     const {
       finalizeMotionTransaction,


### PR DESCRIPTION
## Description

This problem is very subtle and happens behind the scenes. If you don't provide a big enough gas limit to the _finalize motion_ transaction, while the transaction goes successfully, the contracts, behind the scenes won't actually create your action. So even though you finished your motion successfully, you don't get your action on the other side.

The fix for this is to manually estimate the gas, not for the _finalize motion_ transaction, but for the actual action that the motion will be creating. For this we add a flat rate of `55k` `WEI` to the estimation, to provide a large enough overhead to cover both the _Finalize Motion_ transaction as well as the actual action transaction that will happen behind the scenes.

The problem with testing this is that while you can check that the _finalize motion_ transaction fires, it's not really relevant since this problem only shows up on QA, since the estimation mechanism on the QA / production networks are different from the local ganache one. That's why we found about his so late.

Resolves DEV-406