### PR TITLE
Increase limit of objection annotation

### DIFF
--- a/src/modules/dashboard/components/RaiseObjectionDialog/RaiseObjectionDialog.tsx
+++ b/src/modules/dashboard/components/RaiseObjectionDialog/RaiseObjectionDialog.tsx
@@ -41,7 +41,7 @@ const RaiseObjectionDialog = ({
 
   const validationSchema = yup.object().shape({
     amount: yup.number().required(),
-    annotation: yup.string().max(90),
+    annotation: yup.string().max(4000),
   });
 
   const transform = useCallback(

--- a/src/modules/dashboard/components/RaiseObjectionDialog/RaiseObjectionDialogForm.tsx
+++ b/src/modules/dashboard/components/RaiseObjectionDialog/RaiseObjectionDialogForm.tsx
@@ -102,7 +102,7 @@ const RaiseObjectionDialogForm = ({
         <Annotations
           label={MSG.annotation}
           name="annotation"
-          maxLength={90}
+          maxLength={4000}
           disabled={!canUserStake}
         />
       </DialogSection>


### PR DESCRIPTION
Supposedly, the limit was originally 4000 instead of 90

Resolves DEV-411
