### PR TITLE
Update claim widget copy

### DIFF
--- a/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
@@ -100,6 +100,10 @@ export const MSG = defineMessages({
     id: 'dashboard.ActionsPage.FinalizeMotionAndClaimWidget.winningsLabel',
     defaultMessage: `Winnings`,
   },
+  penaltyLabel: {
+    id: 'dashboard.ActionsPage.FinalizeMotionAndClaimWidget.penaltyLabel',
+    defaultMessage: `Penalty`,
+  },
   totalLabel: {
     id: 'dashboard.ActionsPage.FinalizeMotionAndClaimWidget.totalLabel',
     defaultMessage: `Total`,
@@ -183,10 +187,11 @@ const FinalizeMotionAndClaimWidget = ({
     scrollToRef?.current?.scrollIntoView({ behavior: 'smooth' });
   }, [scrollToRef]);
 
-  const { userStake, userWinnings, userTotals } = useMemo(() => {
+  const { userStake, userWinnings, userTotals, isWinning } = useMemo(() => {
     let stake = bigNumberify(0);
     let winnings = bigNumberify(0);
     let totals = bigNumberify(0);
+
     if (stakerRewards?.motionStakerReward) {
       const {
         stakesYay,
@@ -204,6 +209,7 @@ const FinalizeMotionAndClaimWidget = ({
       userStake: moveDecimal(stake, -(nativeToken?.decimals || 0)),
       userWinnings: moveDecimal(winnings, -(nativeToken?.decimals || 0)),
       userTotals: moveDecimal(totals, -(nativeToken?.decimals || 0)),
+      isWinning: winnings.gte(0),
     };
   }, [stakerRewards, nativeToken]);
 
@@ -351,7 +357,10 @@ const FinalizeMotionAndClaimWidget = ({
                   <div className={styles.item}>
                     <div className={styles.label}>
                       <div>
-                        <FormattedMessage {...MSG.winningsLabel} />
+                        <FormattedMessage
+                          {...((isWinning && MSG.winningsLabel) ||
+                            MSG.penaltyLabel)}
+                        />
                       </div>
                     </div>
                     <div className={styles.value}>


### PR DESCRIPTION
## Description

This PR updates copy in claim widget

**Changes** 🏗

* "Penalty" copy when "winnings" value is negative

<img width="411" alt="Screenshot 2021-06-17 at 14 43 53" src="https://user-images.githubusercontent.com/13069555/122400849-627a2b00-cf7c-11eb-9be9-9a04639d438f.png">
<img width="447" alt="Screenshot 2021-06-17 at 14 34 28" src="https://user-images.githubusercontent.com/13069555/122400860-6443ee80-cf7c-11eb-93ee-73ba8ae432f7.png">


Resolves DEV-414
