### PR TITLE
Fix wrongly represented big numbers while sending staking value

### DIFF
--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
@@ -23,6 +23,8 @@ import styles from './StakingWidget.css';
 import StakingSlider, { StakingAmounts } from './StakingSlider';
 import { Props as StakingFlowProps } from './StakingWidgetFlow';
 
+Decimal.set({ toExpPos: 78 });
+
 export interface Props extends StakingFlowProps {
   isObjection: boolean;
   handleWidgetState: (isObjection: boolean) => void;


### PR DESCRIPTION
## Description

This PR fixes wrongly sending big number values while staking. 

**Changes** 🏗

* Overrides Decimal constructor to handle bigger numbers. (now it handles values bigger than the biggest value on chain)

**How to test** 🏗
* You need to large value of active tokens before firing motion
* Run motion and stake fully for any side, you should not see any errors 

Resolves DEV-348