### PR TITLE
New action domain preselection

### DIFF
--- a/src/modules/dashboard/components/ColonyFundingMenu/ColonyFundingMenu.tsx
+++ b/src/modules/dashboard/components/ColonyFundingMenu/ColonyFundingMenu.tsx
@@ -76,7 +76,7 @@ const ColonyFundingMenu = ({
       openTokensMoveDialog({
         colony,
         isVotingExtensionEnabled,
-        fromDomain: selectedDomainId,
+        ethDomainId: selectedDomainId,
       }),
     [colony, openTokensMoveDialog, selectedDomainId, isVotingExtensionEnabled],
   );

--- a/src/modules/dashboard/components/ColonyHome/ColonyDomainSelector/ColonyDomainSelector.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyDomainSelector/ColonyDomainSelector.tsx
@@ -41,7 +41,7 @@ const ColonyDomainSelector = ({
   const handleEditDomain = useCallback(
     (ethDomainId: number) =>
       openEditDialog({
-        selectedDomainId: String(ethDomainId),
+        ethDomainId,
         colony,
         isVotingExtensionEnabled,
       }),

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
@@ -129,6 +129,7 @@ const ColonyHome = ({ match, location }: Props) => {
                 colony={colony}
                 filteredDomainId={filteredDomainId}
                 onDomainChange={setDomainIdFilter}
+                ethDomainId={filteredDomainId}
               >
                 <ColonyActions colony={colony} ethDomainId={filteredDomainId} />
               </ColonyHomeLayout>

--- a/src/modules/dashboard/components/ColonyHome/ColonyHomeLayout.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHomeLayout.tsx
@@ -30,6 +30,7 @@ type Props = {
   showNavigation?: boolean;
   showSidebar?: boolean;
   showActions?: boolean;
+  ethDomainId?: number;
 };
 
 const displayName = 'dashboard.ColonyHome.ColonyHomeLayout';
@@ -43,6 +44,7 @@ const ColonyHomeLayout = ({
   showSidebar = true,
   showActions = true,
   onDomainChange = () => null,
+  ethDomainId,
 }: Props) => (
   <div className={styles.main}>
     <div className={showSidebar ? styles.mainContentGrid : styles.minimalGrid}>
@@ -62,7 +64,9 @@ const ColonyHomeLayout = ({
                   colony={colony}
                 />
               </div>
-              {showActions && <ColonyHomeActions colony={colony} />}
+              {showActions && (
+                <ColonyHomeActions colony={colony} ethDomainId={ethDomainId} />
+              )}
             </div>
           </>
         )}

--- a/src/modules/dashboard/components/ColonyHomeActions/ColonyHomeActions.tsx
+++ b/src/modules/dashboard/components/ColonyHomeActions/ColonyHomeActions.tsx
@@ -93,6 +93,7 @@ const ColonyHomeActions = ({ colony, ethDomainId }: Props) => {
         prevStep: 'dashboard.ManageFundsDialog',
         colony,
         isVotingExtensionEnabled,
+        ethDomainId,
       },
     },
     {

--- a/src/modules/dashboard/components/ColonyHomeActions/ColonyHomeActions.tsx
+++ b/src/modules/dashboard/components/ColonyHomeActions/ColonyHomeActions.tsx
@@ -147,6 +147,7 @@ const ColonyHomeActions = ({ colony, ethDomainId }: Props) => {
         prevStep: 'dashboard.AdvancedDialog',
         colony,
         isVotingExtensionEnabled,
+        ethDomainId,
       },
     },
     {

--- a/src/modules/dashboard/components/ColonyHomeActions/ColonyHomeActions.tsx
+++ b/src/modules/dashboard/components/ColonyHomeActions/ColonyHomeActions.tsx
@@ -36,9 +36,10 @@ const MSG = defineMessages({
 
 interface Props {
   colony: Colony;
+  ethDomainId?: number;
 }
 
-const ColonyHomeActions = ({ colony }: Props) => {
+const ColonyHomeActions = ({ colony, ethDomainId }: Props) => {
   const { networkId, username, ethereal } = useLoggedInUser();
   const { version: networkVersion } = useNetworkContracts();
 
@@ -71,6 +72,7 @@ const ColonyHomeActions = ({ colony }: Props) => {
         colony,
         prevStep: 'dashboard.ExpendituresDialog',
         isVotingExtensionEnabled,
+        ethDomainId,
       },
     },
     {

--- a/src/modules/dashboard/components/ColonyHomeActions/ColonyHomeActions.tsx
+++ b/src/modules/dashboard/components/ColonyHomeActions/ColonyHomeActions.tsx
@@ -127,6 +127,7 @@ const ColonyHomeActions = ({ colony, ethDomainId }: Props) => {
         prevStep: 'dashboard.ManageDomainsDialog',
         colony,
         isVotingExtensionEnabled,
+        ethDomainId,
       },
     },
     {

--- a/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialog.tsx
+++ b/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialog.tsx
@@ -41,7 +41,9 @@ export interface FormValues {
 
 type Props = Required<DialogProps> &
   WizardDialogType<object> &
-  ActionDialogProps;
+  ActionDialogProps & {
+    ethDomainId?: number;
+  };
 
 const displayName = 'dashboard.CreatePaymentDialog';
 
@@ -53,6 +55,7 @@ const CreatePaymentDialog = ({
   prevStep,
   cancel,
   close,
+  ethDomainId,
 }: Props) => {
   const [isForce, setIsForce] = useState(false);
   const history = useHistory();
@@ -138,7 +141,10 @@ const CreatePaymentDialog = ({
     <ActionForm
       initialValues={{
         forceAction: false,
-        domainId: ROOT_DOMAIN_ID.toString(),
+        domainId: (ethDomainId === 0 || ethDomainId === undefined
+          ? ROOT_DOMAIN_ID
+          : ethDomainId
+        ).toString(),
         recipient: undefined,
         amount: undefined,
         tokenAddress: nativeTokenAddress,
@@ -164,6 +170,7 @@ const CreatePaymentDialog = ({
               isVotingExtensionEnabled={isVotingExtensionEnabled}
               back={() => callStep(prevStep)}
               subscribedUsers={subscribedUsersData.subscribedUsers}
+              ethDomainId={ethDomainId}
             />
           </Dialog>
         );

--- a/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialogForm.tsx
+++ b/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialogForm.tsx
@@ -128,14 +128,14 @@ const CreatePaymentDialogForm = ({
   values,
   ethDomainId: preselectedDomainId,
 }: Props & FormikProps<FormValues>) => {
-  const preselectedDomain =
+  const selectedDomain =
     preselectedDomainId === 0 || preselectedDomainId === undefined
       ? ROOT_DOMAIN_ID
       : preselectedDomainId;
 
   const domainId = values.domainId
     ? parseInt(values.domainId, 10)
-    : preselectedDomain;
+    : selectedDomain;
   /*
    * Custom error state tracking
    */

--- a/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialogForm.tsx
+++ b/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialogForm.tsx
@@ -106,6 +106,7 @@ const MSG = defineMessages({
 });
 interface Props extends ActionDialogProps {
   subscribedUsers: AnyUser[];
+  ethDomainId?: number;
 }
 
 const UserAvatar = HookedUserAvatar({ fetchUser: false });
@@ -125,10 +126,16 @@ const CreatePaymentDialogForm = ({
   isSubmitting,
   isValid,
   values,
+  ethDomainId: preselectedDomainId,
 }: Props & FormikProps<FormValues>) => {
+  const preselectedDomain =
+    preselectedDomainId === 0 || preselectedDomainId === undefined
+      ? ROOT_DOMAIN_ID
+      : preselectedDomainId;
+
   const domainId = values.domainId
     ? parseInt(values.domainId, 10)
-    : ROOT_DOMAIN_ID;
+    : preselectedDomain;
   /*
    * Custom error state tracking
    */
@@ -325,6 +332,7 @@ const CreatePaymentDialogForm = ({
                  * create a payment from that subdomain
                  */
                 filterDomains={handleFilterMotionDomains}
+                initialSelectedDomain={domainId}
               />
             </div>
           )}

--- a/src/modules/dashboard/components/EditDomainDialog/EditDomainDialog.tsx
+++ b/src/modules/dashboard/components/EditDomainDialog/EditDomainDialog.tsx
@@ -44,11 +44,6 @@ const EditDomainDialog = ({
   isVotingExtensionEnabled,
   ethDomainId: preselectedDomainId,
 }: Props) => {
-  // const selectedDomainId =
-  //   preselectedDomainId === 0 || preselectedDomainId === undefined
-  //     ? ROOT_DOMAIN_ID
-  //     : preselectedDomainId;
-
   const selectedDomainId = useMemo(
     () =>
       preselectedDomainId === 0 ||

--- a/src/modules/dashboard/components/EditDomainDialog/EditDomainDialog.tsx
+++ b/src/modules/dashboard/components/EditDomainDialog/EditDomainDialog.tsx
@@ -44,17 +44,6 @@ const EditDomainDialog = ({
   isVotingExtensionEnabled,
   ethDomainId: preselectedDomainId,
 }: Props) => {
-  const selectedDomainId = useMemo(
-    () =>
-      preselectedDomainId === 0 ||
-      preselectedDomainId === undefined ||
-      preselectedDomainId === ROOT_DOMAIN_ID
-        ? domains.find(({ ethDomainId }) => ethDomainId !== ROOT_DOMAIN_ID)
-            ?.ethDomainId
-        : preselectedDomainId,
-    [preselectedDomainId, domains],
-  );
-
   const selectedDomain = useMemo(
     () =>
       domains.find(({ ethDomainId }) =>
@@ -111,7 +100,7 @@ const EditDomainDialog = ({
         domainColor: undefined,
         domainPurpose: undefined,
         annotationMessage: undefined,
-        domainId: selectedDomainId?.toString(),
+        domainId: selectedDomain?.ethDomainId.toString(),
         motionDomainId: selectedDomain?.ethDomainId,
       }}
       submit={getFormAction('SUBMIT')}

--- a/src/modules/dashboard/components/EditDomainDialog/EditDomainDialog.tsx
+++ b/src/modules/dashboard/components/EditDomainDialog/EditDomainDialog.tsx
@@ -55,6 +55,18 @@ const EditDomainDialog = ({
     [preselectedDomainId, domains],
   );
 
+  const selectedDomain = useMemo(
+    () =>
+      domains.find(({ ethDomainId }) =>
+        preselectedDomainId === 0 ||
+        preselectedDomainId === undefined ||
+        preselectedDomainId === ROOT_DOMAIN_ID
+          ? ethDomainId !== ROOT_DOMAIN_ID
+          : ethDomainId === preselectedDomainId,
+      ),
+    [preselectedDomainId, domains],
+  );
+
   const [isForce, setIsForce] = useState(false);
   const history = useHistory();
 
@@ -95,14 +107,12 @@ const EditDomainDialog = ({
     <ActionForm
       initialValues={{
         forceAction: false,
-        domainName: domains.find(
-          ({ ethDomainId }) => ethDomainId === selectedDomainId,
-        )?.name,
+        domainName: selectedDomain?.name,
         domainColor: undefined,
         domainPurpose: undefined,
         annotationMessage: undefined,
         domainId: selectedDomainId?.toString(),
-        motionDomainId: selectedDomainId || ROOT_DOMAIN_ID,
+        motionDomainId: selectedDomain?.ethDomainId,
       }}
       submit={getFormAction('SUBMIT')}
       error={getFormAction('ERROR')}

--- a/src/modules/dashboard/components/EditDomainDialog/EditDomainDialog.tsx
+++ b/src/modules/dashboard/components/EditDomainDialog/EditDomainDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, useMemo } from 'react';
 import { FormikProps } from 'formik';
 import * as yup from 'yup';
 import { useHistory } from 'react-router-dom';
@@ -25,7 +25,7 @@ export interface FormValues {
 }
 
 interface CustomWizardDialogProps extends ActionDialogProps {
-  selectedDomainId?: string;
+  ethDomainId?: number;
 }
 
 type Props = DialogProps &
@@ -41,9 +41,25 @@ const EditDomainDialog = ({
   close,
   colony,
   colony: { colonyAddress, colonyName, domains },
-  selectedDomainId,
   isVotingExtensionEnabled,
+  ethDomainId: preselectedDomainId,
 }: Props) => {
+  // const selectedDomainId =
+  //   preselectedDomainId === 0 || preselectedDomainId === undefined
+  //     ? ROOT_DOMAIN_ID
+  //     : preselectedDomainId;
+
+  const selectedDomainId = useMemo(
+    () =>
+      preselectedDomainId === 0 ||
+      preselectedDomainId === undefined ||
+      preselectedDomainId === ROOT_DOMAIN_ID
+        ? domains.find(({ ethDomainId }) => ethDomainId !== ROOT_DOMAIN_ID)
+            ?.ethDomainId
+        : preselectedDomainId,
+    [preselectedDomainId, domains],
+  );
+
   const [isForce, setIsForce] = useState(false);
   const history = useHistory();
 
@@ -84,20 +100,14 @@ const EditDomainDialog = ({
     <ActionForm
       initialValues={{
         forceAction: false,
-        domainName: domains.find(({ ethDomainId }) =>
-          selectedDomainId
-            ? ethDomainId.toString() === selectedDomainId
-            : ethDomainId !== ROOT_DOMAIN_ID,
+        domainName: domains.find(
+          ({ ethDomainId }) => ethDomainId === selectedDomainId,
         )?.name,
         domainColor: undefined,
         domainPurpose: undefined,
         annotationMessage: undefined,
-        domainId:
-          selectedDomainId ||
-          domains
-            .find(({ ethDomainId }) => ethDomainId !== ROOT_DOMAIN_ID)
-            ?.ethDomainId.toString(),
-        motionDomainId: ROOT_DOMAIN_ID,
+        domainId: selectedDomainId?.toString(),
+        motionDomainId: selectedDomainId || ROOT_DOMAIN_ID,
       }}
       submit={getFormAction('SUBMIT')}
       error={getFormAction('ERROR')}

--- a/src/modules/dashboard/components/EditDomainDialog/EditDomainDialogForm.tsx
+++ b/src/modules/dashboard/components/EditDomainDialog/EditDomainDialogForm.tsx
@@ -187,6 +187,11 @@ const EditDomainDialogForm = ({
                  * create a payment from that subdomain
                  */
                 filterDomains={handleFilterMotionDomains}
+                initialSelectedDomain={
+                  motionDomainId === undefined
+                    ? motionDomainId
+                    : Number(motionDomainId)
+                }
               />
             </div>
           )}

--- a/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementDialog.tsx
+++ b/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementDialog.tsx
@@ -76,7 +76,9 @@ export interface FormValues {
 
 type Props = DialogProps &
   Partial<WizardDialogType<object>> &
-  ActionDialogProps;
+  ActionDialogProps & {
+    ethDomainId?: number;
+  };
 
 const PermissionManagementDialog = ({
   colony: { colonyAddress, colonyName, domains },
@@ -86,6 +88,7 @@ const PermissionManagementDialog = ({
   callStep,
   prevStep,
   isVotingExtensionEnabled,
+  ethDomainId: preselectedDomainId,
 }: Props) => {
   const [isForce, setIsForce] = useState(false);
   const history = useHistory();
@@ -107,10 +110,12 @@ const PermissionManagementDialog = ({
   const [selectedUser, setSelectedUser] = useState<AnyUser>(loggedInUser);
 
   const [selectedDomainId, setSelectedDomainId] = useState<number>(
-    ROOT_DOMAIN_ID,
+    preselectedDomainId === 0 || preselectedDomainId === undefined
+      ? ROOT_DOMAIN_ID
+      : preselectedDomainId,
   );
   const [selectedMotionDomainId, setSelectedMoitonDomainId] = useState<number>(
-    ROOT_DOMAIN_ID,
+    selectedDomainId,
   );
 
   const currentUserRoles = useTransformer(getUserRolesForDomain, [

--- a/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialog.tsx
+++ b/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialog.tsx
@@ -146,7 +146,11 @@ const TransferFundsDialog = ({
         fromDomain: selectedDomainId
           ? String(selectedDomainId)
           : ROOT_DOMAIN_ID.toString(),
-        toDomain: domainOptions[1]?.value || ROOT_DOMAIN_ID.toString(),
+        // toDomain: domainOptions[1]?.value || ROOT_DOMAIN_ID.toString(),
+        toDomain:
+          domainOptions.find(
+            (domain) => domain.value !== selectedDomainId?.toString(),
+          )?.value || ROOT_DOMAIN_ID.toString(),
         amount: '',
         tokenAddress: nativeTokenAddress,
         annotation: undefined,

--- a/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialog.tsx
+++ b/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialog.tsx
@@ -31,7 +31,7 @@ const MSG = defineMessages({
 
 export interface FormValues {
   forceAction: boolean;
-  fromDomain?: string;
+  ethDomainId?: string;
   toDomain?: string;
   amount: string;
   tokenAddress?: Address;
@@ -39,7 +39,7 @@ export interface FormValues {
 }
 
 interface CustomWizardDialogProps extends ActionDialogProps {
-  fromDomain?: number;
+  ethDomainId?: number;
 }
 
 type Props = DialogProps &
@@ -58,7 +58,7 @@ const TransferFundsDialog = ({
     domains,
   },
   colony,
-  fromDomain,
+  ethDomainId: selectedDomainId,
   callStep,
   prevStep,
   cancel,
@@ -143,7 +143,9 @@ const TransferFundsDialog = ({
     <ActionForm
       initialValues={{
         forceAction: false,
-        fromDomain: fromDomain ? String(fromDomain) : ROOT_DOMAIN_ID.toString(),
+        fromDomain: selectedDomainId
+          ? String(selectedDomainId)
+          : ROOT_DOMAIN_ID.toString(),
         toDomain: domainOptions[1]?.value || ROOT_DOMAIN_ID.toString(),
         amount: '',
         tokenAddress: nativeTokenAddress,

--- a/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialog.tsx
+++ b/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialog.tsx
@@ -146,7 +146,6 @@ const TransferFundsDialog = ({
         fromDomain: selectedDomainId
           ? String(selectedDomainId)
           : ROOT_DOMAIN_ID.toString(),
-        // toDomain: domainOptions[1]?.value || ROOT_DOMAIN_ID.toString(),
         toDomain:
           domainOptions.find(
             (domain) => domain.value !== selectedDomainId?.toString(),

--- a/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialog.tsx
+++ b/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialog.tsx
@@ -31,7 +31,7 @@ const MSG = defineMessages({
 
 export interface FormValues {
   forceAction: boolean;
-  ethDomainId?: string;
+  fromDomain?: string;
   toDomain?: string;
   amount: string;
   tokenAddress?: Address;


### PR DESCRIPTION
## Description

This PR adds preselection of domain & motion domain on relevant actions (Create payment, Edit Domain, Permission management) when clicking on New action with a different domain than root.

I've talked to the product and it's ok if sometimes the dialogs are disabled (e.g. when there is no reputation in the selected domain).

**New stuff** ✨

- add domain id preselection to the relevant dialogs

Resolves DEV-404
