### PR TITLE
Improve formatting of TokenActivationPopover

### DIFF
--- a/src/modules/constants.ts
+++ b/src/modules/constants.ts
@@ -141,3 +141,5 @@ export const ALLDOMAINS_DOMAIN_SELECTION = {
 export const TOKEN_LOGOS_REPO_URL = `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains`;
 
 export const NETWORK_RELEASES_URL = `https://github.com/JoinColony/colonyNetwork/releases/tag`;
+
+export const SMALL_TOKEN_AMOUNT_FORMAT = '0.00000...';

--- a/src/modules/core/components/Fields/Input/InputComponent.tsx
+++ b/src/modules/core/components/Fields/Input/InputComponent.tsx
@@ -10,9 +10,9 @@ import { defineMessages } from 'react-intl';
 import Cleave from 'cleave.js/react';
 import { CleaveOptions } from 'cleave.js/options';
 import { ChangeEvent } from 'cleave.js/react/props';
-
 import { isNil } from 'lodash';
 import Decimal from 'decimal.js';
+
 import Button from '~core/Button';
 
 import { getMainClasses } from '~utils/css';
@@ -141,11 +141,18 @@ const InputComponent = ({
               maxButtonParams?.fieldName,
               maxButtonParams.maxAmount,
             );
-            cleave?.setRawValue(
-              new Decimal(maxButtonParams.maxAmount)
-                .toDP(5, Decimal.ROUND_DOWN)
-                .toNumber(),
-            );
+            const decimalValue = new Decimal(maxButtonParams.maxAmount);
+            if (decimalValue.lt(0.00001) && decimalValue.gt(0)) {
+              cleave?.setRawValue(
+                decimalValue.toSD(5, Decimal.ROUND_DOWN).toNumber(),
+              );
+            } else {
+              cleave?.setRawValue(
+                new Decimal(maxButtonParams.maxAmount)
+                  .toDP(5, Decimal.ROUND_DOWN)
+                  .toNumber(),
+              );
+            }
           }}
         />
         <Cleave

--- a/src/modules/core/components/Fields/Input/InputComponent.tsx
+++ b/src/modules/core/components/Fields/Input/InputComponent.tsx
@@ -12,6 +12,7 @@ import { CleaveOptions } from 'cleave.js/options';
 import { ChangeEvent } from 'cleave.js/react/props';
 
 import { isNil } from 'lodash';
+import Decimal from 'decimal.js';
 import Button from '~core/Button';
 
 import { getMainClasses } from '~utils/css';
@@ -140,7 +141,11 @@ const InputComponent = ({
               maxButtonParams?.fieldName,
               maxButtonParams.maxAmount,
             );
-            cleave?.setRawValue(Number(maxButtonParams.maxAmount));
+            cleave?.setRawValue(
+              new Decimal(maxButtonParams.maxAmount)
+                .toDP(5, Decimal.ROUND_DOWN)
+                .toNumber(),
+            );
           }}
         />
         <Cleave

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
@@ -95,7 +95,7 @@ const StakingSlider = ({
     ? new Decimal(minUserStake)
     : stake;
   const displayStake = getFormattedTokenValue(
-    stakeWithMin.toString(),
+    stakeWithMin.round().toString(),
     nativeToken?.decimals,
   );
 

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
@@ -98,7 +98,7 @@ const StakingSlider = ({
     .div(
       new Decimal(10).pow(getTokenDecimalsWithFallback(nativeToken?.decimals)),
     )
-    .toFixed(2);
+    .toDP(2, Decimal.ROUND_DOWN);
 
   return (
     <>

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
@@ -7,7 +7,7 @@ import Slider, { Appearance } from '~core/Slider';
 import StakingValidationError from '~dashboard/ActionsPage/StakingValidationError';
 
 import { Colony } from '~data/index';
-import { getTokenDecimalsWithFallback } from '~utils/tokens';
+import { getFormattedTokenValue } from '~utils/tokens';
 
 import styles from './StakingWidget.css';
 
@@ -94,11 +94,10 @@ const StakingSlider = ({
   const stakeWithMin = new Decimal(minUserStake).gte(stake)
     ? new Decimal(minUserStake)
     : stake;
-  const displayStake = stakeWithMin
-    .div(
-      new Decimal(10).pow(getTokenDecimalsWithFallback(nativeToken?.decimals)),
-    )
-    .toDP(2, Decimal.ROUND_DOWN);
+  const displayStake = getFormattedTokenValue(
+    stakeWithMin.toString(),
+    nativeToken?.decimals,
+  );
 
   return (
     <>

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
@@ -251,7 +251,7 @@ const StakingWidget = ({
                 type="submit"
                 disabled={
                   !canBeStaked ||
-                  userActivatedTokens.lt(getDecimalStake(values.amount))
+                  userActivatedTokens.lte(getDecimalStake(values.amount))
                 }
                 text={MSG.stakeButton}
               />

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/GroupedTotalStake.tsx
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/GroupedTotalStake.tsx
@@ -10,7 +10,7 @@ import QuestionMarkTooltip from '~core/QuestionMarkTooltip';
 import Icon from '~core/Icon';
 import Button from '~core/Button';
 
-import { getTokenDecimalsWithFallback } from '~utils/tokens';
+import { getFormattedTokenValue } from '~utils/tokens';
 
 import styles from './TotalStakeWidget.css';
 
@@ -81,6 +81,10 @@ const GroupedTotalStake = ({
   const validationSchema = yup.object().shape({
     stakeSide: yup.string().required(),
   });
+  const formattedRequiredStake = getFormattedTokenValue(
+    requiredStake,
+    tokenDecimals,
+  );
 
   return (
     <Form
@@ -121,10 +125,8 @@ const GroupedTotalStake = ({
                 totalPercentage: formattedYAYPercentage,
                 requiredStake: (
                   <Numeral
-                    value={requiredStake}
-                    unit={getTokenDecimalsWithFallback(tokenDecimals)}
+                    value={formattedRequiredStake}
                     suffix={` ${tokenSymbol}`}
-                    truncate={2}
                   />
                 ),
               }}
@@ -150,10 +152,8 @@ const GroupedTotalStake = ({
                 totalPercentage: formattedNAYPercentage,
                 requiredStake: (
                   <Numeral
-                    value={requiredStake}
-                    unit={getTokenDecimalsWithFallback(tokenDecimals)}
+                    value={formattedRequiredStake}
                     suffix={` ${tokenSymbol}`}
-                    truncate={2}
                   />
                 ),
               }}

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/SingleTotalStake.tsx
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/SingleTotalStake.tsx
@@ -2,11 +2,10 @@ import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import formatNumber from 'format-number';
 import { bigNumberify } from 'ethers/utils';
-import { Decimal } from 'decimal.js';
 
 import Heading from '~core/Heading';
 import ProgressBar from '~core/ProgressBar';
-import { getTokenDecimalsWithFallback } from '~utils/tokens';
+import { getFormattedTokenValue } from '~utils/tokens';
 
 import styles from './TotalStakeWidget.css';
 
@@ -57,13 +56,14 @@ const SingleTotalStake = ({
     truncate: 2,
   })(userStakePercentage);
 
-  const requiredStakeDisplay = new Decimal(requiredStake)
-    .div(new Decimal(10).pow(getTokenDecimalsWithFallback(tokenDecimals)))
-    .toFixed(2);
-
-  const userStakeDisplay = new Decimal(userStake || 0)
-    .div(new Decimal(10).pow(getTokenDecimalsWithFallback(tokenDecimals)))
-    .toFixed(2);
+  const requiredStakeDisplay = getFormattedTokenValue(
+    requiredStake,
+    tokenDecimals,
+  );
+  const userStakeDisplay = getFormattedTokenValue(
+    userStake || 0,
+    tokenDecimals,
+  );
 
   return (
     <>

--- a/src/modules/dashboard/components/RaiseObjectionDialog/RaiseObjectionDialogForm.tsx
+++ b/src/modules/dashboard/components/RaiseObjectionDialog/RaiseObjectionDialogForm.tsx
@@ -58,11 +58,13 @@ const RaiseObjectionDialogForm = ({
   cancel,
   userActivatedTokens,
   remainingToFullyNayStaked,
+  minUserStake,
   ...props
 }: Props & FormikProps<FormValues>) => {
   const decimalAmount = new Decimal(values.amount)
-    .times(remainingToFullyNayStaked)
-    .div(100);
+    .times(new Decimal(remainingToFullyNayStaked).minus(minUserStake))
+    .div(100)
+    .plus(minUserStake);
   return (
     <>
       <DialogSection appearance={{ theme: 'heading' }}>
@@ -94,6 +96,7 @@ const RaiseObjectionDialogForm = ({
             isObjection
             remainingToFullyNayStaked={remainingToFullyNayStaked}
             userActivatedTokens={userActivatedTokens}
+            minUserStake={minUserStake}
             {...props}
           />
         </div>

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/ChangeTokenStateForm.tsx
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/ChangeTokenStateForm.tsx
@@ -15,6 +15,7 @@ import { useLoggedInUser } from '~data/index';
 import { ActionTypes } from '~redux/index';
 import { Address } from '~types/index';
 import { pipe, mapPayload } from '~utils/actions';
+import { getFormattedTokenValue } from '~utils/tokens';
 
 import styles from './TokenActivationContent.css';
 
@@ -81,9 +82,22 @@ const ChangeTokenStateForm = ({
 
   const { walletAddress } = useLoggedInUser();
 
+  const formattedActiveTokens = getFormattedTokenValue(
+    activeTokens,
+    token.decimals,
+  );
+  const formattedInactiveTokens = getFormattedTokenValue(
+    inactiveTokens,
+    token.decimals,
+  );
+  const formattedLockedTokens = getFormattedTokenValue(
+    lockedTokens,
+    token.decimals,
+  );
+
   const tokenBalance = useMemo(
-    () => (isActivate ? inactiveTokens : activeTokens),
-    [isActivate, activeTokens, inactiveTokens],
+    () => (isActivate ? formattedInactiveTokens : formattedActiveTokens),
+    [isActivate, formattedActiveTokens, formattedInactiveTokens],
   );
 
   const formAction = useCallback(
@@ -93,11 +107,6 @@ const ChangeTokenStateForm = ({
         : ActionTypes[`USER_WITHDRAW_TOKEN${actionType}`],
     [isActivate],
   );
-
-  const maxAmount = useMemo(() => moveDecimal(tokenBalance, -tokenDecimals), [
-    tokenDecimals,
-    tokenBalance,
-  ]);
 
   const transform = useCallback(
     pipe(
@@ -169,7 +178,7 @@ const ChangeTokenStateForm = ({
                 }}
                 maxButtonParams={{
                   setFieldValue,
-                  maxAmount,
+                  maxAmount: tokenBalance,
                   fieldName: 'amount',
                 }}
               />
@@ -189,8 +198,6 @@ const ChangeTokenStateForm = ({
                       <Numeral
                         value={tokenBalance}
                         suffix={` ${token?.symbol}`}
-                        unit={tokenDecimals}
-                        truncate={3}
                         className={styles.balanceAmount}
                       />
                     ),
@@ -214,10 +221,8 @@ const ChangeTokenStateForm = ({
                     values={{
                       lockedTokens: (
                         <Numeral
-                          value={lockedTokens}
+                          value={formattedLockedTokens}
                           suffix={` ${token?.symbol}`}
-                          unit={tokenDecimals}
-                          truncate={3}
                           className={styles.balanceAmount}
                         />
                       ),
@@ -232,7 +237,7 @@ const ChangeTokenStateForm = ({
               disabled={
                 !isValid ||
                 values.amount === undefined ||
-                values.amount > maxAmount
+                values.amount > Number(tokenBalance)
               }
             />
           </div>

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/ChangeTokenStateForm.tsx
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/ChangeTokenStateForm.tsx
@@ -94,6 +94,10 @@ const ChangeTokenStateForm = ({
     lockedTokens,
     token.decimals,
   );
+  const unformattedTokenBalance = moveDecimal(
+    isActivate ? inactiveTokens : activeTokens,
+    -tokenDecimals,
+  );
 
   const tokenBalance = useMemo(
     () => (isActivate ? formattedInactiveTokens : formattedActiveTokens),
@@ -112,12 +116,12 @@ const ChangeTokenStateForm = ({
     pipe(
       mapPayload(({ amount }) => {
         // Convert amount string with decimals to BigInt (eth to wei)
-        const formtattedAmount = bigNumberify(
+        const formattedAmount = bigNumberify(
           moveDecimal(amount, tokenDecimals),
         );
 
         return {
-          amount: formtattedAmount,
+          amount: formattedAmount,
           userAddress: walletAddress,
           colonyAddress,
           tokenAddress: token.address,
@@ -178,7 +182,7 @@ const ChangeTokenStateForm = ({
                 }}
                 maxButtonParams={{
                   setFieldValue,
-                  maxAmount: tokenBalance,
+                  maxAmount: unformattedTokenBalance,
                   fieldName: 'amount',
                 }}
               />
@@ -237,7 +241,7 @@ const ChangeTokenStateForm = ({
               disabled={
                 !isValid ||
                 values.amount === undefined ||
-                values.amount > Number(tokenBalance)
+                values.amount > unformattedTokenBalance
               }
             />
           </div>

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/SmallTokenAmountMessage.css
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/SmallTokenAmountMessage.css
@@ -1,0 +1,16 @@
+.container {
+  display: flex;
+  font-size: var(--size-tiny);
+  font-weight: var(--weight-bold);
+  line-height: 18px;
+  color: var(--danger);
+}
+
+.tooltipIcon {
+  margin-left: 30px;
+}
+
+.tooltip {
+  width: 195px;
+  font-size: var(--size-small);
+}

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/SmallTokenAmountMessage.css.d.ts
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/SmallTokenAmountMessage.css.d.ts
@@ -1,0 +1,3 @@
+export const container: string;
+export const tooltipIcon: string;
+export const tooltip: string;

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/SmallTokenAmountMessage.tsx
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/SmallTokenAmountMessage.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { defineMessage, FormattedMessage } from 'react-intl';
+
+import QuestionMarkTooltip from '~core/QuestionMarkTooltip';
+
+import styles from './SmallTokenAmountMessage.css';
+
+const MSG = defineMessage({
+  smallAmountHidden: {
+    id: `users.TokenActivation.TokenActivationContent.SmallTokenAmountMessage.smallAmountHidden`,
+    defaultMessage: 'Residual balance hidden',
+  },
+  tooltipText: {
+    id: `users.TokenActivation.TokenActivationContent.SmallTokenAmountMessage.tooltipText`,
+    defaultMessage: `There is a small token balance remaining that we couldn’t display. Please click the max button to select the entire balance.`,
+  },
+});
+
+const displayName = 'SmallTokenAmountMessage';
+
+const SmallTokenAmountMessage = () => (
+  <div className={styles.container}>
+    <FormattedMessage {...MSG.smallAmountHidden} />
+    <QuestionMarkTooltip
+      className={styles.tooltipIcon}
+      tooltipText={MSG.tooltipText}
+      tooltipClassName={styles.tooltip}
+      tooltipPopperProps={{
+        placement: 'right',
+      }}
+    />
+  </div>
+);
+
+SmallTokenAmountMessage.displayName = displayName;
+
+export default SmallTokenAmountMessage;

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/TokensTab.tsx
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/TokensTab.tsx
@@ -2,7 +2,7 @@ import React, { useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { FormattedMessage, defineMessages } from 'react-intl';
 import { BigNumber } from 'ethers/utils';
 
-import Numeral from '~core/Numeral';
+import { SMALL_TOKEN_AMOUNT_FORMAT } from '~constants';
 import Icon from '~core/Icon';
 import TokenIcon from '~dashboard/HookedTokenIcon';
 
@@ -16,6 +16,7 @@ import {
 import styles from './TokenActivationContent.css';
 import ChangeTokenStateForm from './ChangeTokenStateForm';
 import TokenTooltip from './TokenTooltip';
+import SmallTokenAmountMessage from './SmallTokenAmountMessage';
 
 const MSG = defineMessages({
   active: {
@@ -154,10 +155,12 @@ const TokensTab = ({
               />
             </TokenTooltip>
             <div className={styles.tokenNumbers}>
-              <Numeral
-                value={formattedActiveTokens}
-                suffix={` ${token?.symbol}`}
-              />
+              <span>
+                {formattedActiveTokens} {token.symbol}
+              </span>
+              {formattedActiveTokens === SMALL_TOKEN_AMOUNT_FORMAT && (
+                <SmallTokenAmountMessage />
+              )}
             </div>
             <TokenTooltip
               className={styles.lockedTokens}
@@ -168,10 +171,9 @@ const TokensTab = ({
           </li>
           <li>
             <div className={styles.tokenNumbersLocked}>
-              <Numeral
-                value={formattedLockedTokens}
-                suffix={` ${token?.symbol}`}
-              />
+              <span>
+                {formattedLockedTokens} {token.symbol}
+              </span>
             </div>
           </li>
           <li>
@@ -182,10 +184,12 @@ const TokensTab = ({
               <FormattedMessage {...MSG.inactive} />
             </TokenTooltip>
             <div className={styles.tokenNumbersInactive}>
-              <Numeral
-                value={formattedInactiveTokens}
-                suffix={` ${token?.symbol}`}
-              />
+              <span>
+                {formattedInactiveTokens} {token.symbol}
+              </span>
+              {formattedInactiveTokens === SMALL_TOKEN_AMOUNT_FORMAT && (
+                <SmallTokenAmountMessage />
+              )}
             </div>
             {!isPendingBalanceZero && (
               <div className={styles.pendingError}>

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/TokensTab.tsx
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/TokensTab.tsx
@@ -8,8 +8,10 @@ import TokenIcon from '~dashboard/HookedTokenIcon';
 
 import { UserToken } from '~data/generated';
 import { Address } from '~types/index';
-import { formatTokenValue } from '~utils/numbers';
-import { getTokenDecimalsWithFallback } from '~utils/tokens';
+import {
+  getFormattedTokenValue,
+  getTokenDecimalsWithFallback,
+} from '~utils/tokens';
 
 import styles from './TokenActivationContent.css';
 import ChangeTokenStateForm from './ChangeTokenStateForm';
@@ -97,12 +99,22 @@ const TokensTab = ({
     [token],
   );
 
-  const formattedTotalAmount = formatTokenValue({
-    value: totalTokens,
-    suffix: ` ${token?.symbol}`,
-    unit: tokenDecimals,
-    truncate: 3,
-  }).split(' ')[0];
+  const formattedTotalAmount = getFormattedTokenValue(
+    totalTokens,
+    token.decimals,
+  );
+  const formattedLockedTokens = getFormattedTokenValue(
+    lockedTokens,
+    token.decimals,
+  );
+  const formattedActiveTokens = getFormattedTokenValue(
+    activeTokens,
+    token.decimals,
+  );
+  const formattedInactiveTokens = getFormattedTokenValue(
+    inactiveTokens,
+    token.decimals,
+  );
 
   return (
     <>
@@ -143,10 +155,8 @@ const TokensTab = ({
             </TokenTooltip>
             <div className={styles.tokenNumbers}>
               <Numeral
-                value={activeTokens}
+                value={formattedActiveTokens}
                 suffix={` ${token?.symbol}`}
-                unit={tokenDecimals}
-                truncate={3}
               />
             </div>
             <TokenTooltip
@@ -159,10 +169,8 @@ const TokensTab = ({
           <li>
             <div className={styles.tokenNumbersLocked}>
               <Numeral
-                value={lockedTokens}
+                value={formattedLockedTokens}
                 suffix={` ${token?.symbol}`}
-                unit={tokenDecimals}
-                truncate={3}
               />
             </div>
           </li>
@@ -175,10 +183,8 @@ const TokensTab = ({
             </TokenTooltip>
             <div className={styles.tokenNumbersInactive}>
               <Numeral
-                value={inactiveTokens}
+                value={formattedInactiveTokens}
                 suffix={` ${token?.symbol}`}
-                unit={tokenDecimals}
-                truncate={3}
               />
             </div>
             {!isPendingBalanceZero && (

--- a/src/modules/users/components/UserTokenActivationButton/UserTokenActivationButton.tsx
+++ b/src/modules/users/components/UserTokenActivationButton/UserTokenActivationButton.tsx
@@ -3,7 +3,7 @@ import { bigNumberify } from 'ethers/utils';
 
 import { TokenActivationPopover } from '~users/TokenActivation';
 
-import { getTokenDecimalsWithFallback } from '~utils/tokens';
+import { getFormattedTokenValue } from '~utils/tokens';
 import Numeral from '~core/Numeral';
 
 import { UserLock, UserToken } from '~data/index';
@@ -33,6 +33,11 @@ const UserTokenActivationButton = ({
     userLock?.pendingBalance || 0,
   ).isZero();
 
+  const formattedTotalBalance = getFormattedTokenValue(
+    totalBalance,
+    nativeToken.decimals,
+  );
+
   return (
     <TokenActivationPopover
       activeTokens={activeBalance}
@@ -59,9 +64,7 @@ const UserTokenActivationButton = ({
             />
             <Numeral
               suffix={` ${nativeToken?.symbol} `}
-              unit={getTokenDecimalsWithFallback(nativeToken?.decimals)}
-              value={totalBalance}
-              truncate={3}
+              value={formattedTotalBalance}
             />
           </button>
         </>

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -2,7 +2,7 @@ import { bigNumberify, BigNumberish } from 'ethers/utils';
 import Decimal from 'decimal.js';
 
 import { TokenWithBalances } from '~data/index';
-import { DEFAULT_TOKEN_DECIMALS } from '~constants';
+import { DEFAULT_TOKEN_DECIMALS, SMALL_TOKEN_AMOUNT_FORMAT } from '~constants';
 
 export const getBalanceFromToken = (
   token: TokenWithBalances | undefined,
@@ -55,6 +55,13 @@ export const getFormattedTokenValue = (
   const safeDecimals = bigNumberify(10)
     .pow(getTokenDecimalsWithFallback(decimals))
     .toString();
+  const decimalValue = new Decimal(bigNumberify(value).toString()).div(
+    safeDecimals,
+  );
+
+  if (decimalValue.lt(0.00001) && decimalValue.gt(0)) {
+    return SMALL_TOKEN_AMOUNT_FORMAT;
+  }
   return new Decimal(bigNumberify(value).toString())
     .div(safeDecimals)
     .toDP(5, Decimal.ROUND_DOWN)


### PR DESCRIPTION
Improved token values formatting on the TokenActivationPopover.

The issue Jack reported about not being able to stake when he reached the limit it's not a bug inside the staking slider, more like a bug inside the TokenActivationPopover.

While testing the staking slider limit, I've encountered that the slider could have a limit of `3.96` based on the reputation of the user and the popover would show me that I've exactly `3.96` activated so I would believe that I can stake up to the limit but I can't, because that `3.96` is actually `3.959`, so less than `3.96` 

**What I did to reproduce the case above**
1. Create a colony
2. Have a total of 3 members
3. Pay 2 members `4` tokens each
4. Pay 1 member `2` tokens
5. Initialize the motion extension with a `50%` required stake and a `20%` minimum stake
6. Create motion and watch if the limit of the staking slider and the error that it shows corresponds with the amount of token that you have activated.

![FireShot Capture 370 - Colony - localhost](https://user-images.githubusercontent.com/18473896/124033676-a1729c80-d9d0-11eb-8c93-26d542f01f2a.png)

Resolves DEV-423
