### PR TITLE
Improve tag base styles

### DIFF
--- a/src/modules/core/components/Tag/Tag.css
+++ b/src/modules/core/components/Tag/Tag.css
@@ -7,10 +7,6 @@
   color: var(--colony-white);
 }
 
-.baseStyles + .baseStyles {
-  margin-left: 10px;
-}
-
 .themePrimary {
   composes: baseStyles;
   background-color: var(--primary);

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.css
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.css
@@ -3,10 +3,6 @@
   margin-left: 4px;
 }
 
-.tagWrapper > span {
-  margin-left: 0;
-}
-
 .annotation {
   margin-bottom: 7px;
 }

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.css.d.ts
@@ -1,5 +1,4 @@
 export const reputation: string;
-export const tagWrapper: string;
 export const annotation: string;
 export const text: string;
 export const progressBarContainer: string;

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
@@ -284,18 +284,10 @@ const DefaultMotion = ({
         autoShrinkAddress
       />
     ),
-    passedTag: (
-      <span className={motionSpecificStyles.tagWrapper}>{passedTag}</span>
-    ),
-    failedTag: (
-      <span className={motionSpecificStyles.tagWrapper}>{failedTag}</span>
-    ),
-    objectionTag: (
-      <span className={motionSpecificStyles.tagWrapper}>{objectionTag}</span>
-    ),
-    escalateTag: (
-      <span className={motionSpecificStyles.tagWrapper}>{escalateTag}</span>
-    ),
+    passedTag,
+    failedTag,
+    objectionTag,
+    escalateTag,
     ...tags,
     voteResultsWidget: (
       <div className={motionSpecificStyles.voteResultsWrapper}>

--- a/src/modules/dashboard/components/Extensions/ExtensionStatus.css
+++ b/src/modules/dashboard/components/Extensions/ExtensionStatus.css
@@ -1,3 +1,7 @@
+.tagContainer {
+  display: inline-block;
+}
+
 .tagContainer span + span {
   margin-left: 10px;
 }

--- a/src/modules/dashboard/components/Extensions/ExtensionStatus.css
+++ b/src/modules/dashboard/components/Extensions/ExtensionStatus.css
@@ -1,0 +1,3 @@
+.tagContainer span + span {
+  margin-left: 10px;
+}

--- a/src/modules/dashboard/components/Extensions/ExtensionStatus.css.d.ts
+++ b/src/modules/dashboard/components/Extensions/ExtensionStatus.css.d.ts
@@ -1,0 +1,1 @@
+export const tagContainer: string;

--- a/src/modules/dashboard/components/Extensions/ExtensionStatus.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionStatus.tsx
@@ -5,6 +5,8 @@ import Tag from '~core/Tag';
 
 import { ColonyExtension } from '~data/index';
 
+import styles from './ExtensionStatus.css';
+
 const MSG = defineMessages({
   installed: {
     id: 'dashboard.Extensions.ExtensionStatus.installed',
@@ -59,12 +61,12 @@ const ExtensionStatus = ({
     status = MSG.installed;
   }
   return (
-    <>
+    <div className={styles.tagContainer}>
       {!deprecatedOnly ? <Tag appearance={{ theme }} text={status} /> : null}
       {installedExtension && installedExtension.details.deprecated ? (
         <Tag appearance={{ theme: 'danger' }} text={MSG.deprecated} />
       ) : null}
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
Removed base margin styles of the Tag component as those margins are right now really only used in 1 instance and for every other instance where we use the tags we don't want them.

![FireShot Capture 358 - Colony - localhost](https://user-images.githubusercontent.com/18473896/122956384-5533b680-d357-11eb-98df-0a73414eec49.png)

![FireShot Capture 359 - Colony - localhost](https://user-images.githubusercontent.com/18473896/122956396-57961080-d357-11eb-9f35-f2e621410649.png)

Resolves DEV-422
