### PR TITLE
Update domain description styles on DetailsWidget

### DIFF
--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.css
@@ -23,6 +23,10 @@
   color: color-mod(var(--dark) alpha(85%));
 }
 
+.descriptionValue {
+  white-space: pre-line;
+}
+
 .value i {
   display: inline-block;
   margin: -3px 6px 0 0;
@@ -46,10 +50,9 @@
 }
 
 .domainDescription {
-  composes: multiLineEllipsis from '~styles/text.css';
   width: 190px;
   text-align: right;
-  word-break: break-all;
+  word-break: break-word;
 }
 
 .roleSettingItem {

--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.css
@@ -24,6 +24,7 @@
 }
 
 .descriptionValue {
+  composes: value;
   white-space: pre-line;
 }
 

--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.css.d.ts
@@ -1,6 +1,7 @@
 export const item: string;
 export const value: string;
 export const label: string;
+export const descriptionValue: string;
 export const transactionHashLink: string;
 export const domainDescriptionItem: string;
 export const domainDescription: string;

--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.tsx
@@ -189,7 +189,7 @@ const DetailsWidget = ({
           <div className={styles.label}>
             <FormattedMessage {...MSG.domainDescription} />
           </div>
-          <div className={styles.value}>
+          <div className={`${styles.value} ${styles.descriptionValue}`}>
             <div
               className={styles.domainDescription}
               title={values.fromDomain.description || ''}

--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.tsx
@@ -189,7 +189,7 @@ const DetailsWidget = ({
           <div className={styles.label}>
             <FormattedMessage {...MSG.domainDescription} />
           </div>
-          <div className={`${styles.value} ${styles.descriptionValue}`}>
+          <div className={styles.descriptionValue}>
             <div
               className={styles.domainDescription}
               title={values.fromDomain.description || ''}


### PR DESCRIPTION
Update styles of DetailsWidget to allow the domain description to be shown completely

![FireShot Capture 361 - Colony - localhost](https://user-images.githubusercontent.com/18473896/122970395-3f78be00-d364-11eb-957f-65d36933700a.png)

Resolves DEV-429
