### PR TITLE
Update styles of StakingWidget

### DIFF
--- a/src/modules/core/components/Slider/Slider.tsx
+++ b/src/modules/core/components/Slider/Slider.tsx
@@ -150,7 +150,7 @@ const Slider = ({
           borderWidth: 6,
           height: 15,
           width: 15,
-          marginTop: -7,
+          marginTop: appearance?.size === 'thick' ? -6 : -7,
           backgroundColor: '#FFFFFF',
         }}
         dotStyle={{

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.css
@@ -75,3 +75,8 @@
 .loading {
   padding-top: 35px;
 }
+
+.backButtonWrapper button {
+  margin-left: 14px;
+  width: fit-content;
+}

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.css.d.ts
@@ -10,3 +10,4 @@ export const sliderContainer: string;
 export const help: string;
 export const tooltip: string;
 export const loading: string;
+export const backButtonWrapper: string;

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
@@ -231,7 +231,10 @@ const StakingWidget = ({
               colony={colony}
               canUserStake={canBeStaked}
               values={values}
-              appearance={{ theme: isObjection ? 'danger' : 'primary' }}
+              appearance={{
+                theme: isObjection ? 'danger' : 'primary',
+                size: 'thick',
+              }}
               isObjection={isObjection}
               remainingToFullyYayStaked={remainingToFullyYayStaked}
               remainingToFullyNayStaked={remainingToFullyNayStaked}
@@ -252,7 +255,13 @@ const StakingWidget = ({
                 }
                 text={MSG.stakeButton}
               />
-              <span className={isObjection ? '' : styles.objectButton}>
+              <span
+                className={
+                  !bigNumberify(totalNAYStakes).isZero()
+                    ? styles.backButtonWrapper
+                    : styles.objectButton
+                }
+              >
                 {isObjection || !bigNumberify(totalNAYStakes).isZero() ? (
                   <Button
                     appearance={{ theme: 'secondary', size: 'medium' }}

--- a/src/modules/dashboard/components/RaiseObjectionDialog/RaiseObjectionDialogForm.tsx
+++ b/src/modules/dashboard/components/RaiseObjectionDialog/RaiseObjectionDialogForm.tsx
@@ -90,7 +90,7 @@ const RaiseObjectionDialogForm = ({
             colony={colony}
             canUserStake={canUserStake}
             values={values}
-            appearance={{ theme: 'danger' }}
+            appearance={{ theme: 'danger', size: 'thick' }}
             isObjection
             remainingToFullyNayStaked={remainingToFullyNayStaked}
             userActivatedTokens={userActivatedTokens}


### PR DESCRIPTION
Updated some of the styles of the StakingWidget component according to suggestions

* Changed slider size from `thin` to `tick`
* Tweaked slider back button spacing styles

![FireShot Capture 365 - Colony - localhost](https://user-images.githubusercontent.com/18473896/122978221-a7330700-d36c-11eb-8374-4051bc088339.png)

![FireShot Capture 363 - Colony - localhost](https://user-images.githubusercontent.com/18473896/122978228-a8fcca80-d36c-11eb-871c-129bcdada6fa.png)

![FireShot Capture 362 - Colony - localhost](https://user-images.githubusercontent.com/18473896/122978238-ac905180-d36c-11eb-97b9-c73d6b6b4804.png)

Resolves DEV-420
