### PR TITLE
Feat: add missing events on the sugraph branch

### DIFF
--- a/src/i18n/en-events.ts
+++ b/src/i18n/en-events.ts
@@ -66,7 +66,12 @@ const eventsMessageDescriptors = {
       ${ColonyAndExtensionsEvents.RecoveryModeExited} {{agent} exited the colony from Recovery Mode}
       ${ColonyAndExtensionsEvents.MotionCreated} {{agent} created motion {motionId} in {domain}}
       ${ColonyAndExtensionsEvents.MotionStaked} {{agent} {voteSide} motion {motionId} for {amount} {tokenSymbol}}
+      ${ColonyAndExtensionsEvents.MotionVoteSubmitted} {{agent} voted in motion {motionId}}
+      ${ColonyAndExtensionsEvents.MotionVoteRevealed} {{agent} revealed his vote in motion {motionId}}
+      ${ColonyAndExtensionsEvents.MotionFinalized} {Motion {motionId} in {domain} was finalized}
       ${ColonyAndExtensionsEvents.MotionEscalated} {{agent} escalated motion {motionId} from {domain} to {newDomain}}
+      ${ColonyAndExtensionsEvents.MotionRewardClaimed} {{agent} claimed their stake in motion {motionId}}
+      ${ColonyAndExtensionsEvents.MotionEventSet} {Motion {motionId} fast-forwarded to the next lifecycle}
       other {{eventName} emmited with values: {displayValues}}
     }`,
   [`eventList.${ColonyAndExtensionsEvents.ColonyRoleSet}.assign`]: `{agent} assigned the {role} permission in the {domain} team to {recipient}`,


### PR DESCRIPTION
## Description

This PR adds missing events to the events list.

It uses a new branch/commit of the subgraph, so you need to run npm i, provision & restart the dev environment.

There is also a separate PR for the subgraph part - https://github.com/JoinColony/subgraph/pull/26

**New stuff** ✨

- added new events & event handlers in subgraph
- added copies for missing events

Resolves DEV-425

<img width="951" alt="Screenshot 2021-06-22 at 21 40 26" src="https://user-images.githubusercontent.com/34057551/122982461-cf356100-d392-11eb-96d1-cee672964b8b.png">
