### PR TITLE
Remove XDAI conversion to USD

### DIFF
--- a/src/modules/core/components/EthUsd/EthUsd.tsx
+++ b/src/modules/core/components/EthUsd/EthUsd.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { BigNumber, parseUnits } from 'ethers/utils';
 import { defineMessages, useIntl } from 'react-intl';
+import { Network } from '@colony/colony-js';
 
 import Numeral, { Props as NumeralProps } from '~core/Numeral/Numeral';
 import { SpinnerLoader } from '~core/Preloaders';
 import { getEthToUsd } from '~utils/external';
-import { DEFAULT_TOKEN_DECIMALS } from '~constants';
+import { DEFAULT_NETWORK, DEFAULT_TOKEN_DECIMALS } from '~constants';
 
 const MSG = defineMessages({
   usdAbbreviation: {
@@ -86,6 +87,10 @@ const EthUsd = ({
       didCancel = true;
     };
   }, [unit, value]);
+
+  if (DEFAULT_NETWORK === Network.Xdai) {
+    return null;
+  }
 
   if (isLoading) {
     return <SpinnerLoader />;


### PR DESCRIPTION
## Description

This PR removes conversion of XDAI to USD from several dialogs & `UnclaimedTransfers`.

Testing it is difficult as it is the logical check if the network is xdai. You can just change the check to local and if the conversion to ETH (addressZero for the local) is not there it's working.

**Deletions** ⚰️

- remove XDAI to USD conversion in the `EthUds` components

Resolves DEV-428
