### PR TITLE
Fix nay side staking calculation

### DIFF
--- a/src/modules/dashboard/components/RaiseObjectionDialog/RaiseObjectionDialog.tsx
+++ b/src/modules/dashboard/components/RaiseObjectionDialog/RaiseObjectionDialog.tsx
@@ -49,7 +49,10 @@ const RaiseObjectionDialog = ({
       mapPayload(({ amount, annotation: annotationMessage }) => {
         const { remainingToFullyNayStaked } = props;
         const remainingToStake = new Decimal(remainingToFullyNayStaked);
-        const stake = new Decimal(amount).times(remainingToStake).div(100);
+        const stake = new Decimal(amount)
+          .div(100)
+          .times(remainingToStake.minus(minUserStake))
+          .plus(minUserStake);
         const stakeWithMin = new Decimal(minUserStake).gte(stake)
           ? new Decimal(minUserStake)
           : stake;


### PR DESCRIPTION
The NAY staking amount on the `RaiseObjectionDialog` was being calculated differently from the way we do it in the `StakingWidget`, the result would be that staking the NAY side through the Dialog would have a really small difference (For example, in the widget 100% could be `100 000 006 000` and in the DIalog, it would be `100 000 005 000`) compared to the amount calculated on the widget, which would lead to cases like the 99% when you actually wanted to stake 100%

Resolves DEV-432
