### PR TITLE
Fix ColonyFromName messing up Home, Funding and Members

### DIFF
--- a/src/data/resolvers/colony.ts
+++ b/src/data/resolvers/colony.ts
@@ -375,7 +375,7 @@ export const colonyResolvers = ({
           : null;
       } catch (error) {
         console.error(error);
-        return null;
+        return error;
       }
     },
     async historicColonyRoles(_, { colonyAddress, blockNumber }) {

--- a/src/modules/dashboard/components/ColonyFunding/ColonyFunding.tsx
+++ b/src/modules/dashboard/components/ColonyFunding/ColonyFunding.tsx
@@ -85,7 +85,12 @@ const ColonyFunding = ({ match }: Props) => {
     return typeof label === 'string' ? label : formatMessage(label);
   }, [domainChoices, formatMessage, selectedDomainId]);
 
-  if (loading) {
+  if (
+    loading ||
+    (data?.colonyAddress &&
+      !data.processedColony &&
+      !((data.colonyAddress as any) instanceof Error))
+  ) {
     return (
       <div className={styles.loadingWrapper}>
         <LoadingTemplate loadingText={MSG.loadingText} />

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
@@ -157,7 +157,10 @@ const ColonyHome = ({ match, location }: Props) => {
    */
   if (
     loading ||
-    (data?.processedColony && data.processedColony.colonyName !== colonyName)
+    (data?.processedColony && data.processedColony.colonyName !== colonyName) ||
+    (data?.colonyAddress &&
+      !data?.processedColony &&
+      !((data.colonyAddress as any) instanceof Error))
   ) {
     return (
       <div className={styles.loadingWrapper}>

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -59,7 +59,12 @@ const ColonyMembers = () => {
     ColonyVersion.LightweightSpaceship;
   const isNetworkAllowed = !!ALLOWED_NETWORKS[networkId || 1];
 
-  if (loading) {
+  if (
+    loading ||
+    (colonyData?.colonyAddress &&
+      !colonyData.processedColony &&
+      !((colonyData.colonyAddress as any) instanceof Error))
+  ) {
     return (
       <div className={styles.loadingWrapper}>
         <LoadingTemplate loadingText={MSG.loadingText} />

--- a/src/modules/pages/components/BackTexts/ColonyBackText.tsx
+++ b/src/modules/pages/components/BackTexts/ColonyBackText.tsx
@@ -21,7 +21,7 @@ const ColonyBackText = () => {
     // We have to define an empty address here for type safety, will be replaced by the query
     variables: { name: colonyName, address: '' },
   });
-  if (!data) return null;
+  if (!data?.processedColony) return null;
   const { displayName, colonyName: ensName } = data.processedColony;
   return (
     <FormattedMessage


### PR DESCRIPTION
The ColonyFromName query uses a `@export` directive in order to get and use the colony's address to get the `processedColony` data. The problem is that the query's fields are async (and are also executed in no particular order) so it would execute the `processedColony` field before the colony address is retrieved and/or exported. 

In that case, the first result (and the one that crashes the pages) would be `data: { colonyAddress: ..., processedColony: null }`. Technically there's data, but `processedColony` is `null` so what Home, Funding, and Members do is redirect to the 404 Page, even though the colony exists.

To combat this, we could check in the `Loading` state check if we have a colony address but  `processedColony` is `falsy`, from that we could assume that the colony exists but the `processedColony` is not loaded in yet.

Resolves DEV-379
