### PR TITLE
Fix avatar count on ColonyHome page

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.tsx
@@ -58,7 +58,11 @@ const ColonyMembers = ({
   const {
     avatarsDisplaySplitRules,
     remainingAvatarsCount,
-  } = useAvatarDisplayCounter(maxAvatars, members?.colonyMembersWithReputation);
+  } = useAvatarDisplayCounter(
+    maxAvatars,
+    members?.colonyMembersWithReputation,
+    false,
+  );
 
   const BASE_MEMBERS_ROUTE = `/colony/${colonyName}/members`;
   const membersPageRoute =

--- a/src/utils/hooks/useAvatarDisplayCounter.ts
+++ b/src/utils/hooks/useAvatarDisplayCounter.ts
@@ -14,7 +14,7 @@ const useAvatarDisplayCounter = (
       return members.length;
     }
 
-    return maxAvatars;
+    return maxAvatars - 1;
   }, [members, maxAvatars]);
 
   const remainingAvatarsCount = useMemo(() => {
@@ -25,7 +25,7 @@ const useAvatarDisplayCounter = (
     if (members.length <= maxAvatars) {
       return 0;
     }
-    return members.length - maxAvatars;
+    return members.length - maxAvatars + 1;
   }, [members, maxAvatars]);
 
   return {

--- a/src/utils/hooks/useAvatarDisplayCounter.ts
+++ b/src/utils/hooks/useAvatarDisplayCounter.ts
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 const useAvatarDisplayCounter = (
   maxAvatars: number,
   members: Maybe<string[]>,
+  isLastAvatarIncluded = true,
 ) => {
   const avatarsDisplaySplitRules = useMemo(() => {
     if (!members?.length) {
@@ -14,8 +15,8 @@ const useAvatarDisplayCounter = (
       return members.length;
     }
 
-    return maxAvatars - 1;
-  }, [members, maxAvatars]);
+    return isLastAvatarIncluded ? maxAvatars : maxAvatars - 1;
+  }, [members, maxAvatars, isLastAvatarIncluded]);
 
   const remainingAvatarsCount = useMemo(() => {
     if (!members?.length) {
@@ -25,8 +26,10 @@ const useAvatarDisplayCounter = (
     if (members.length <= maxAvatars) {
       return 0;
     }
-    return members.length - maxAvatars + 1;
-  }, [members, maxAvatars]);
+    return (
+      members.length - (isLastAvatarIncluded ? maxAvatars : maxAvatars - 1)
+    );
+  }, [members, maxAvatars, isLastAvatarIncluded]);
 
   return {
     avatarsDisplaySplitRules,


### PR DESCRIPTION
## Description

This PR fixes math logic in `useAvatarDisplayCounter` to display avatars correctly.

To test you need either to have 16 or more members in your colony or just manually provide an array of 16 or more addresses in the `ColonyMembers` component (i just use the same address over & over again) instead of manually fetching it:
```
const members = {
  colonyMembersWithReputation: ['<user address>' (repeat 16 times)]
}
```

Resolves DEV-440
