### PR TITLE
Replace feedback.fish widget with External link

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,9 +32,6 @@ SUBGRAPH_WS_ENDPOINT=ws://127.0.0.1:8001/subgraphs/name/joinColony/subgraph
 # otherwise you'll pollute your account with random data
 # PINATA_API_SECRET=
 
-# feedback.fish project ID
-FEEDBACK_FISH_PROJECT_ID=
-
 # Used in non-local network deployments to customize the network address
 # NETWORK_CONTRACT_ADDRESS=
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4566,11 +4566,6 @@
         "@ethersproject/logger": "^5.0.5"
       }
     },
-    "@feedback-fish/react": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@feedback-fish/react/-/react-1.2.1.tgz",
-      "integrity": "sha512-4YFD2hE93xBIT/Ko0x0l6UB0OyaxJcWKLGrnznsUVoLE5Q9vB8I1LEbMySYyuvbU9ul3yM3FjGkVZhYVPdwEyA=="
-    },
     "@formatjs/intl-displaynames": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-1.2.8.tgz",

--- a/package.json
+++ b/package.json
@@ -137,7 +137,6 @@
     "@apollo/client": "^3.0.2",
     "@colony/colony-js": "^4.0.0-rc.10",
     "@colony/redux-promise-listener": "^1.2.0",
-    "@feedback-fish/react": "^1.2.1",
     "@formatjs/intl-pluralrules": "^1.5.7",
     "@formatjs/intl-relativetimeformat": "^4.5.14",
     "@formatjs/intl-unified-numberformat": "^3.3.5",

--- a/src/modules/core/components/FeedbackWidget/FeedbackWidget.css
+++ b/src/modules/core/components/FeedbackWidget/FeedbackWidget.css
@@ -1,21 +1,24 @@
-.button {
-  padding: 0;
-  padding-right: 9px;
-  width: 320px;
+.main {
   position: fixed;
-  right: 25px;
+  right: 16px;
   bottom: 16px;
-  border: none;
   background-color: transparent;
   font-size: var(--size-tiny);
   font-weight: var(--weight-bold);
   text-align: right;
-  color: color-mod(var(--temp-grey-blue-7) alpha(85%));
-  cursor: pointer;
 
   &:focus {
     outline: none;
   }
+}
+
+.link {
+  padding: 9px;
+  color: color-mod(var(--temp-grey-blue-7) alpha(85%));
+}
+
+.link:hover {
+  color: var(--text);
 }
 
 .heart {

--- a/src/modules/core/components/FeedbackWidget/FeedbackWidget.css.d.ts
+++ b/src/modules/core/components/FeedbackWidget/FeedbackWidget.css.d.ts
@@ -1,2 +1,3 @@
-export const button: string;
+export const main: string;
+export const link: string;
 export const heart: string;

--- a/src/modules/core/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/src/modules/core/components/FeedbackWidget/FeedbackWidget.tsx
@@ -1,15 +1,9 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
-import { FeedbackFish } from '@feedback-fish/react';
 
-import Button from '~core/Button';
-import { useLoggedInUser } from '~data/index';
+import ExternalLink from '~core/ExternalLink';
 
 import styles from './FeedbackWidget.css';
-
-/* can add real project id from personal account if need to test.
-I've tested the feedback.fish process - works very well */
-const PROJECT_ID = '';
 
 const MSG = {
   loveFeedback: {
@@ -18,36 +12,23 @@ const MSG = {
   },
 };
 
-const FeedbackWidget = () => {
-  const { username } = useLoggedInUser();
+const FEEDBACK_LINK = `https://colony.canny.io`;
 
-  const isDevelopment = process.env.NODE_ENV === 'development';
-
-  return (
-    <FeedbackFish
-      projectId={
-        /* the second check is for the types
-        if the projectId is an empty string the feedback won't be sent */
-        isDevelopment || process.env.FEEDBACK_FISH_PROJECT_ID === undefined
-          ? PROJECT_ID
-          : process.env.FEEDBACK_FISH_PROJECT_ID
-      }
-      userId={username === null ? undefined : username}
-    >
-      <Button appearance={{ theme: 'no-style' }} className={styles.button}>
-        <FormattedMessage
-          {...MSG.loveFeedback}
-          values={{
-            heart: (
-              <span role="img" className={styles.heart} aria-label="">
-                ♥️
-              </span>
-            ),
-          }}
-        />
-      </Button>
-    </FeedbackFish>
-  );
-};
+const FeedbackWidget = () => (
+  <div className={styles.main}>
+    <ExternalLink className={styles.link} href={FEEDBACK_LINK}>
+      <FormattedMessage
+        {...MSG.loveFeedback}
+        values={{
+          heart: (
+            <span role="img" className={styles.heart} aria-label="">
+              ♥️
+            </span>
+          ),
+        }}
+      />
+    </ExternalLink>
+  </div>
+);
 
 export default FeedbackWidget;


### PR DESCRIPTION
## Description

This PR replaces the `feeback.fish` service's widget with just an external link to a `Canny` board.

Note: that this also updates the dapp's docker image in [JoinColony//colony-docker-images](https://github.com/JoinColony//colony-docker-images) so that we stop deploying the env variable

**Changes** 

- [x] Remove `FEEDBACK_FISH_PROJECT_ID` env var
- [x] Remove `@feedback-fish/react` dependency
- [x] Refactor `core` `FeedbackWidget` to just use `ExternalLink`

**Screenshots**

![Screenshot from 2021-06-29 16-13-58](https://user-images.githubusercontent.com/1193222/123803953-6c454c00-d8f5-11eb-9689-4ed5ac625bdf.png)
![Screenshot from 2021-06-29 16-14-00](https://user-images.githubusercontent.com/1193222/123803956-6cdde280-d8f5-11eb-914d-4358993643df.png)

Resolves DEV-448
