### PR TITLE
Use Blockscout GasStation Oracle for Xdai Gas Estimation

### DIFF
--- a/src/immutable/Transaction.ts
+++ b/src/immutable/Transaction.ts
@@ -1,7 +1,7 @@
 import { Record } from 'immutable';
-import { BigNumber, bigNumberify } from 'ethers/utils';
+import { BigNumber } from 'ethers/utils';
 import { TransactionReceipt } from 'ethers/providers';
-import { ClientType, TransactionOverrides, Network } from '@colony/colony-js';
+import { ClientType, TransactionOverrides } from '@colony/colony-js';
 
 import {
   Address,
@@ -10,7 +10,6 @@ import {
   MethodParams,
   RecordToJS,
 } from '~types/index';
-import { DEFAULT_NETWORK } from '~constants';
 
 export enum TRANSACTION_ERRORS {
   ESTIMATE = 'ESTIMATE',
@@ -86,10 +85,7 @@ const defaultValues: DefaultValues<TransactionRecordProps> = {
   eventData: undefined,
   from: undefined,
   gasLimit: undefined,
-  gasPrice:
-    DEFAULT_NETWORK === Network.Local || DEFAULT_NETWORK === Network.Xdai
-      ? bigNumberify('1000000000')
-      : undefined,
+  gasPrice: undefined,
   group: undefined,
   hash: undefined,
   id: undefined,

--- a/src/modules/core/sagas/transactions/estimateGasCost.ts
+++ b/src/modules/core/sagas/transactions/estimateGasCost.ts
@@ -1,6 +1,5 @@
 import { call, put } from 'redux-saga/effects';
 import { bigNumberify } from 'ethers/utils';
-import { Network } from '@colony/colony-js';
 
 import { ActionTypes, Action } from '~redux/index';
 import { selectAsJS } from '~utils/saga/effects';
@@ -14,8 +13,6 @@ import {
   transactionSend,
 } from '../../actionCreators';
 import { getGasPrices } from '../utils';
-
-import { DEFAULT_NETWORK } from '~constants';
 
 /*
  * @area: including a bit of buffer on the gas sent can be a good thing.
@@ -47,16 +44,9 @@ export default function* estimateGasCost({
       .div(SAFE_GAS_LIMIT_MULTIPLIER)
       .add(estimatedGas);
 
-    const { network, suggested, fixed } = yield call(getGasPrices);
+    const { network, suggested } = yield call(getGasPrices);
 
-    let gasPrice = suggested || network;
-
-    /**
-     * Setting gas price on local to 1 for the fun of it
-     */
-    if (DEFAULT_NETWORK === Network.Local) {
-      gasPrice = fixed;
-    }
+    const gasPrice = suggested || network;
 
     yield put(
       transactionUpdateGas(id, {

--- a/src/modules/core/sagas/transactions/estimateGasCost.ts
+++ b/src/modules/core/sagas/transactions/estimateGasCost.ts
@@ -11,6 +11,7 @@ import { oneTransaction } from '../../selectors';
 import {
   transactionUpdateGas,
   transactionEstimateError,
+  transactionSend,
 } from '../../actionCreators';
 import { getGasPrices } from '../utils';
 
@@ -51,7 +52,7 @@ export default function* estimateGasCost({
     let gasPrice = suggested || network;
 
     /**
-     * Setting gas price on local to 0 for the fun of it
+     * Setting gas price on local to 1 for the fun of it
      */
     if (DEFAULT_NETWORK === Network.Local || DEFAULT_NETWORK === Network.Xdai) {
       gasPrice = fixed;
@@ -63,6 +64,8 @@ export default function* estimateGasCost({
         gasPrice,
       }),
     );
+
+    yield put(transactionSend(id));
   } catch (error) {
     console.error(error);
     return yield put(transactionEstimateError(id, error));

--- a/src/modules/core/sagas/transactions/estimateGasCost.ts
+++ b/src/modules/core/sagas/transactions/estimateGasCost.ts
@@ -54,7 +54,7 @@ export default function* estimateGasCost({
     /**
      * Setting gas price on local to 1 for the fun of it
      */
-    if (DEFAULT_NETWORK === Network.Local || DEFAULT_NETWORK === Network.Xdai) {
+    if (DEFAULT_NETWORK === Network.Local) {
       gasPrice = fixed;
     }
 

--- a/src/modules/core/sagas/utils/getGasPrices.ts
+++ b/src/modules/core/sagas/utils/getGasPrices.ts
@@ -1,4 +1,4 @@
-import { ColonyNetworkClient } from '@colony/colony-js';
+import { ColonyNetworkClient, Network } from '@colony/colony-js';
 import { bigNumberify } from 'ethers/utils';
 import { call, put, select } from 'redux-saga/effects';
 
@@ -25,49 +25,99 @@ interface EthGasStationAPIResponse {
   speed: number;
 }
 
+interface BlockscoutGasStationAPIResponse {
+  average: number;
+  fast: number;
+  slow: number;
+}
+
 const ETH_GAS_STATION_ENDPOINT =
   'https://ethgasstation.info/json/ethgasAPI.json';
-const DEFAULT_GAS_PRICE = bigNumberify(1);
+const BLOCKSCOUNT_GAS_STATION_ENDPOINT =
+  'https://blockscout.com/xdai/mainnet/api/v1/gas-price-oracle';
+const DEFAULT_GAS_PRICE = bigNumberify('1000000000');
 
 const fetchGasPrices = async (
   networkClient: ColonyNetworkClient,
 ): Promise<GasPricesProps> => {
   let networkGasPrice = DEFAULT_GAS_PRICE;
 
+  const defaultGasPrices = {
+    timestamp: Date.now(),
+    network: networkGasPrice,
+
+    suggested: DEFAULT_GAS_PRICE,
+    cheaper: DEFAULT_GAS_PRICE,
+    faster: DEFAULT_GAS_PRICE,
+
+    suggestedWait: 60,
+    cheaperWait: 60,
+    fasterWait: 60,
+  };
+
   try {
     networkGasPrice = await networkClient.provider.getGasPrice();
 
-    const response = await fetch(ETH_GAS_STATION_ENDPOINT);
+    let response;
+
+    if (DEFAULT_NETWORK === Network.Mainnet) {
+      response = await fetch(ETH_GAS_STATION_ENDPOINT);
+    }
+    if (
+      DEFAULT_NETWORK === Network.Xdai ||
+      DEFAULT_NETWORK === Network.XdaiFork
+    ) {
+      response = await fetch(BLOCKSCOUNT_GAS_STATION_ENDPOINT);
+    }
 
     if (!response.ok) {
       throw new Error(response.statusText);
     }
 
-    const data: EthGasStationAPIResponse = await response.json();
+    if (DEFAULT_NETWORK === Network.Mainnet) {
+      const data: EthGasStationAPIResponse = await response.json();
+      // API prices are in 10Gwei, so they need to be normalised
+      const pointOneGwei = bigNumberify(10 ** 8);
 
-    // API prices are in 10Gwei, so they need to be normalised
-    const pointOneGwei = bigNumberify(10 ** 8);
+      return {
+        ...defaultGasPrices,
 
-    return {
-      timestamp: Date.now(),
-      network: networkGasPrice,
+        suggested: bigNumberify(data.average).mul(pointOneGwei),
+        cheaper: bigNumberify(data.safeLow).mul(pointOneGwei),
+        faster: bigNumberify(data.fast).mul(pointOneGwei),
 
-      suggested: bigNumberify(data.average).mul(pointOneGwei),
-      cheaper: bigNumberify(data.safeLow).mul(pointOneGwei),
-      faster: bigNumberify(data.fast).mul(pointOneGwei),
+        suggestedWait: data.avgWait * 60,
+        cheaperWait: data.safeLowWait * 60,
+        fasterWait: data.fastWait * 60,
+      };
+    }
 
-      suggestedWait: data.avgWait * 60,
-      cheaperWait: data.safeLowWait * 60,
-      fasterWait: data.fastWait * 60,
-    };
+    if (
+      DEFAULT_NETWORK === Network.Xdai ||
+      DEFAULT_NETWORK === Network.XdaiFork
+    ) {
+      const data: BlockscoutGasStationAPIResponse = await response.json();
+      // API prices are in Gwei, so they need to be normalised
+      const oneGwei = bigNumberify(10 ** 9);
+
+      return {
+        ...defaultGasPrices,
+
+        suggested: bigNumberify(Math.round(data.average)).mul(oneGwei),
+        cheaper: bigNumberify(Math.round(data.slow)).mul(oneGwei),
+        faster: bigNumberify(Math.round(data.fast)).mul(oneGwei),
+      };
+    }
+
+    return defaultGasPrices;
   } catch (caughtError) {
     log.warn(
       `Could not get ${DEFAULT_NETWORK} network gas prices: ${caughtError.message}`,
     );
     // Default values
     return {
+      ...defaultGasPrices,
       timestamp: -Infinity, // Do not cache this
-      suggested: bigNumberify(networkGasPrice),
     };
   }
 };

--- a/src/modules/users/components/GasStation/GasStationControls/GasStationControls.tsx
+++ b/src/modules/users/components/GasStation/GasStationControls/GasStationControls.tsx
@@ -9,10 +9,7 @@ import { ActionTypes } from '~redux/index';
 import { IconButton } from '~core/Button';
 import { ActionForm } from '~core/Fields';
 
-import {
-  transactionEstimateGas,
-  transactionSend,
-} from '../../../../core/actionCreators';
+import { transactionEstimateGas } from '../../../../core/actionCreators';
 
 import styles from './GasStationControls.css';
 
@@ -34,10 +31,6 @@ const GasStationControls = ({ transaction: { id, error } }: Props) => {
   const dispatch = useDispatch();
   const transform = useCallback(withId(id), [id]);
 
-  useEffect(() => {
-    dispatch(transactionEstimateGas(id));
-  }, [dispatch, id]);
-
   /*
    * @NOTE Automatically send the transaction
    * Since we're just using Metamask, we won't wait for the user to click the "Confirm"
@@ -49,7 +42,7 @@ const GasStationControls = ({ transaction: { id, error } }: Props) => {
    */
   useEffect(() => {
     if (!error) {
-      dispatch(transactionSend(id));
+      dispatch(transactionEstimateGas(id));
     }
   }, [dispatch, id, error]);
 


### PR DESCRIPTION
## Description

This PR refactors the fixed way we used to estimate gas on Xdai _(basically it was set to `1 Gwei`)_ due to increased transactions on Xdai, and `1` does not satisfy transactions anymore.

We make use of the [Blockscout Gas Price Oracle](https://www.xdaichain.com/for-developers/developer-resources/gas-price-oracle) to fetch the latest `average` prince and set that when sending a transaction on Xdai.

On `mainnet` we are still using the initial functionality which is exactly the same as this, just that it fetches it's data from ETHGasStation.

When running this locally, the gas prices is still manually set to a fixed `1 Gwei` value.

**Testing:**
- Use a metamask wallet
- Create a transaction locally (you should see the gas price being `1`)
- Manually change `estimateGasCost` and overwrite `DEFAULT_NETWORK` to point to `Network.Xdai`
- Refresh and create a new transaction
- Your gas cost should now be whatever the current blockscout oracle `average` value is

**Changes** 

- [x] Refactored: `fetchGasPrices` saga util
- [x] Refactored `estimateGasCost` core saga 


