### PR TITLE
Display whitelist in available extensions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4348,9 +4348,9 @@
       }
     },
     "@colony/colony-js": {
-      "version": "4.1.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-4.1.0-beta.1.tgz",
-      "integrity": "sha512-pFxr8ppVXDiW3Q8A8BJEtY7HKAEAlqHnHN6rkD8T64wVXBRAODl94G1VWl/mpL4XpxuCVuuk599fzp0UWx9pRg==",
+      "version": "4.1.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-4.1.0-beta.2.tgz",
+      "integrity": "sha512-s0MiS0kR/J0AFud9LqaiS+YUHgMCRYhitTAQJr122S2lfzCpMuthUUpkwObKdCMRaWV09npUIjb17p2HW9rW+g==",
       "requires": {
         "isomorphic-fetch": "^2.2.1",
         "lodash.isequal": "^4.5.0"

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.0.2",
-    "@colony/colony-js": "^4.1.0-beta.1",
+    "@colony/colony-js": "^4.1.0-beta.2",
     "@colony/redux-promise-listener": "^1.2.0",
     "@formatjs/intl-pluralrules": "^1.5.7",
     "@formatjs/intl-relativetimeformat": "^4.5.14",

--- a/src/data/staticData/extensionData.ts
+++ b/src/data/staticData/extensionData.ts
@@ -10,7 +10,7 @@ import { Address } from '~types/index';
 export enum ExtensionParamType {
   Input = 'Input',
   Radio = 'Radio',
-  Textarea = 'Textarea'
+  Textarea = 'Textarea',
 }
 
 export interface ExtensionInitParams {
@@ -254,7 +254,7 @@ const whitelistMessages = {
   },
   whitelistInfo: {
     id: 'extensions.whitelist.info',
-    defaultMessage: 'The responsibility is on the issuer to ensure being compliant with the local rules. {link}',
+    defaultMessage: `The responsibility is on the issuer to ensure being compliant with the local rules. {link}`,
   },
 };
 

--- a/src/data/staticData/extensionData.ts
+++ b/src/data/staticData/extensionData.ts
@@ -26,8 +26,11 @@ export interface ExtensionData {
   address?: Address;
   extensionId: Extension | 'Unknown';
   name: string | MessageDescriptor;
+  header?: string | MessageDescriptor;
   descriptionShort: string | MessageDescriptor;
   descriptionLong: string | MessageDescriptor;
+  info?: string | MessageDescriptor;
+  termsCondition?: string | MessageDescriptor;
   currentVersion: number;
   createdAt: number;
   neededColonyPermissions: ColonyRole[];
@@ -233,9 +236,13 @@ const whitelistMessages = {
     id: 'extensions.whitelist.name',
     defaultMessage: 'Whitelist',
   },
+  whitelistHeader: {
+    id: 'extensions.whitelist.header',
+    defaultMessage: 'What is the Whitelist extension?',
+  },
   whitelistDescriptionShort: {
     id: 'extensions.whitelist.description',
-    defaultMessage: `Reputation weighted decentralized governance with a minimum of voting.`,
+    defaultMessage: `Curate a list of addresses permitted to participate in your Coin Machine sale.`,
   },
   whitelistDescriptionLong: {
     id: 'extensions.whitelist.descriptionLong',
@@ -247,7 +254,7 @@ const whitelistMessages = {
   },
   whitelistInfo: {
     id: 'extensions.whitelist.info',
-    defaultMessage: 'The responsibility is on the issuer to ensure being compliant with the local rules.',
+    defaultMessage: 'The responsibility is on the issuer to ensure being compliant with the local rules. {link}',
   },
 };
 
@@ -456,8 +463,11 @@ const extensions: { [key: string]: ExtensionData } = {
   Whitelist: {
     extensionId: Extension.Whitelist,
     name: MSG.whitelistName,
+    header: MSG.whitelistHeader,
     descriptionShort: MSG.whitelistDescriptionShort,
     descriptionLong: MSG.whitelistDescriptionLong,
+    info: MSG.whitelistInfo,
+    termsCondition: MSG.whitelistTermsCondition,
     currentVersion: 1,
     createdAt: 1603915271852, // find out how to get this value
     neededColonyPermissions: [

--- a/src/data/staticData/extensionData.ts
+++ b/src/data/staticData/extensionData.ts
@@ -228,11 +228,35 @@ const votingReputationMessages = {
   },
 };
 
+const whitelistMessages = {
+  whitelistName: {
+    id: 'extensions.whitelist.name',
+    defaultMessage: 'Whitelist',
+  },
+  whitelistDescriptionShort: {
+    id: 'extensions.whitelist.description',
+    defaultMessage: `Reputation weighted decentralized governance with a minimum of voting.`,
+  },
+  whitelistDescriptionLong: {
+    id: 'extensions.whitelist.descriptionLong',
+    defaultMessage: `The Whitelist extension is an utility which can be used for whitelisting wallet addresses.`,
+  },
+  whitelistTermsCondition: {
+    id: 'extensions.whitelist.termsCondition',
+    defaultMessage: `Terms and Conditions.`,
+  },
+  whitelistInfo: {
+    id: 'extensions.whitelist.info',
+    defaultMessage: 'The responsibility is on the issuer to ensure being compliant with the local rules.',
+  },
+};
+
 const MSG = defineMessages({
   ...unknownExtensionMessages,
   ...oneTransactionPaymentMessages,
   ...coinMachineMessages,
   ...votingReputationMessages,
+  ...whitelistMessages,
 });
 
 const extensions: { [key: string]: ExtensionData } = {
@@ -427,6 +451,24 @@ const extensions: { [key: string]: ExtensionData } = {
         type: ExtensionParamType.Input,
       },
     ],
+    uninstallable: true,
+  },
+  Whitelist: {
+    extensionId: Extension.Whitelist,
+    name: MSG.whitelistName,
+    descriptionShort: MSG.whitelistDescriptionShort,
+    descriptionLong: MSG.whitelistDescriptionLong,
+    currentVersion: 1,
+    createdAt: 1603915271852, // find out how to get this value
+    neededColonyPermissions: [
+      ColonyRole.Root,
+      ColonyRole.Administration,
+      ColonyRole.Arbitration,
+      ColonyRole.Architecture,
+      ColonyRole.Funding,
+    ],
+    enabledExtensionBody: WhitelistExtensionBody,
+    initializationParams: [],
     uninstallable: true,
   },
   Unknown: {

--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.css
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.css
@@ -13,6 +13,13 @@
   white-space: pre-line;
 }
 
+.extensionSubtext {
+  display: block;
+  font-size: var(--size-tiny);
+  font-weight: var(--weight-bold);
+  margin-top: 38px;
+}
+
 .extensionDetails {
   width: 340px;
 }

--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.css
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.css
@@ -15,9 +15,9 @@
 
 .extensionSubtext {
   display: block;
+  margin-top: 38px;
   font-size: var(--size-tiny);
   font-weight: var(--weight-bold);
-  margin-top: 38px;
 }
 
 .extensionDetails {

--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.css.d.ts
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.css.d.ts
@@ -1,6 +1,7 @@
 export const main: string;
 export const headerLine: string;
 export const extensionText: string;
+export const extensionSubtext: string;
 export const extensionDetails: string;
 export const buttonWrapper: string;
 export const cellLabel: string;

--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
@@ -340,7 +340,7 @@ const ExtensionDetails = ({
                   <Heading
                     tagName="h3"
                     appearance={{ size: 'medium', margin: 'small' }}
-                    text={extension.name}
+                    text={extension.header || extension.name}
                   />
                   <FormattedMessage
                     {...extension.descriptionLong}
@@ -354,6 +354,19 @@ const ExtensionDetails = ({
                       ),
                     }}
                   />
+                  {extension.info && (
+                    <div className={styles.extensionSubtext}><FormattedMessage
+                      {...extension.info}
+                      values={{
+                        link: (
+                          <ExternalLink
+                            text={extension.termsCondition}
+                            href=""
+                          />
+                        ),
+                      }}
+                    /></div>
+                  )}
                   {extensionEnabled && extension.enabledExtensionBody && extension.enabledExtensionBody()}
                 </div>
               )}

--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
@@ -339,7 +339,7 @@ const ExtensionDetails = ({
                 <div className={styles.extensionText}>
                   <Heading
                     tagName="h3"
-                    appearance={{ size: 'medium', margin: 'small' }}
+                    appearance={{ size: 'medium', margin: 'small', theme: 'dark' }}
                     text={extension.header || extension.name}
                   />
                   <FormattedMessage

--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
@@ -212,7 +212,7 @@ const ExtensionDetails = ({
     !(extesionCanBeInstalled || extesionCanBeEnabled) &&
     latestNetworkExtensionVersion > extension.currentVersion;
 
-  const extensionEnabled = 
+  const extensionEnabled =
     installedExtension &&
     installedExtension.details.initialized &&
     !installedExtension.details.deprecated;
@@ -339,7 +339,11 @@ const ExtensionDetails = ({
                 <div className={styles.extensionText}>
                   <Heading
                     tagName="h3"
-                    appearance={{ size: 'medium', margin: 'small', theme: 'dark' }}
+                    appearance={{
+                      size: 'medium',
+                      margin: 'small',
+                      theme: 'dark',
+                    }}
                     text={extension.header || extension.name}
                   />
                   <FormattedMessage
@@ -355,19 +359,23 @@ const ExtensionDetails = ({
                     }}
                   />
                   {extension.info && (
-                    <div className={styles.extensionSubtext}><FormattedMessage
-                      {...extension.info}
-                      values={{
-                        link: (
-                          <ExternalLink
-                            text={extension.termsCondition}
-                            href=""
-                          />
-                        ),
-                      }}
-                    /></div>
+                    <div className={styles.extensionSubtext}>
+                      <FormattedMessage
+                        {...extension.info}
+                        values={{
+                          link: (
+                            <ExternalLink
+                              text={extension.termsCondition}
+                              href=""
+                            />
+                          ),
+                        }}
+                      />
+                    </div>
                   )}
-                  {extensionEnabled && extension.enabledExtensionBody && extension.enabledExtensionBody()}
+                  {extensionEnabled &&
+                    extension.enabledExtensionBody &&
+                    extension.enabledExtensionBody()}
                 </div>
               )}
             />

--- a/src/modules/dashboard/components/Extensions/ExtensionSetup.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionSetup.tsx
@@ -11,7 +11,10 @@ import { Input, ActionForm } from '~core/Fields';
 import Heading from '~core/Heading';
 import { ActionTypes } from '~redux/index';
 import { ColonyExtension } from '~data/index';
-import { ExtensionData, ExtensionParamType } from '~data/staticData/extensionData';
+import {
+  ExtensionData,
+  ExtensionParamType,
+} from '~data/staticData/extensionData';
 import { mergePayload, mapPayload, pipe } from '~utils/actions';
 import { Address } from '~types/index';
 
@@ -150,37 +153,39 @@ const ExtensionSetup = ({
           />
           <FormattedMessage {...MSG.description} />
           <div className={styles.inputContainer}>
-            {initializationParams.map(({ paramName, title, description, type }) => (
-              <div key={paramName}>
-                {type === ExtensionParamType.Input && (
-                <div className={styles.input}>
-                  <Input
-                    appearance={{ size: 'medium', theme: 'minimal' }}
-                    label={title}
-                    name={paramName}
-                  />
-                  <FormattedMessage
-                    {...description}
-                    values={{
-                      span: (chunks) => (
-                        <span className={styles.descriptionExample}>
-                          {chunks}
-                        </span>
-                      ),
-                    }}
-                  />
-                  {extensionId === Extension.VotingReputation && (
-                    <span className={styles.complementaryLabel}>
-                      <FormattedMessage
-                        {...MSG.complementaryLabel}
-                        values={{ isPeriod: endsWith(paramName, 'Period') }}
+            {initializationParams.map(
+              ({ paramName, title, description, type }) => (
+                <div key={paramName}>
+                  {type === ExtensionParamType.Input && (
+                    <div className={styles.input}>
+                      <Input
+                        appearance={{ size: 'medium', theme: 'minimal' }}
+                        label={title}
+                        name={paramName}
                       />
-                    </span>
+                      <FormattedMessage
+                        {...description}
+                        values={{
+                          span: (chunks) => (
+                            <span className={styles.descriptionExample}>
+                              {chunks}
+                            </span>
+                          ),
+                        }}
+                      />
+                      {extensionId === Extension.VotingReputation && (
+                        <span className={styles.complementaryLabel}>
+                          <FormattedMessage
+                            {...MSG.complementaryLabel}
+                            values={{ isPeriod: endsWith(paramName, 'Period') }}
+                          />
+                        </span>
+                      )}
+                    </div>
                   )}
                 </div>
-                )}
-              </div>
-            ))}
+              ),
+            )}
           </div>
           <IconButton
             appearance={{ theme: 'primary', size: 'large' }}

--- a/src/modules/dashboard/components/Extensions/WhitelistExtensionBody/WhitelistExtensionBody.tsx
+++ b/src/modules/dashboard/components/Extensions/WhitelistExtensionBody/WhitelistExtensionBody.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 
 const WhitelistExtensionBody = () => {
-  return (
-    <div>Content</div>
-  );
+  return <div>Content</div>;
 };
 
 export default WhitelistExtensionBody;


### PR DESCRIPTION
## Description

This PR displaying Whitelist extension in available extension

**New stuff** ✨

* All needed translations for whitelist
* Added info/terms&condition props to ExtensionData type

**Changes** 🏗

* Updated ExtensionDetails component to take name only if header not provided
* Displayed terms and condition text conditionally

<img width="595" alt="Screenshot 2021-07-05 at 11 26 50" src="https://user-images.githubusercontent.com/13069555/124449773-11dc3d80-dd84-11eb-824c-81f8f98b7ac3.png">
<img width="626" alt="Screenshot 2021-07-05 at 11 26 33" src="https://user-images.githubusercontent.com/13069555/124449784-143e9780-dd84-11eb-8fb9-eaee08f62022.png">


## TODO

- Find out from where comes createdAt hardcoded value in ExtensionData
- Updated extension formatting when product will be ready
- Sync with updates colonyjs

**Hacky way of testing, before colonyjs ready** ✨
In Extensions.tsx file, add to extensions array Extension.Whitelist

Resolves DEV-416
