### PR TITLE
Force OneTxPayment Extension Upgrade to v2

### DIFF
--- a/src/modules/dashboard/checks.ts
+++ b/src/modules/dashboard/checks.ts
@@ -6,18 +6,24 @@ import { hasRoot } from '../users/checks';
 /*
  * Colony
  */
-export const canBeUpgraded = (colony?: Colony, networkVersion?: string) =>
+export const colonyCanBeUpgraded = (colony?: Colony, networkVersion?: string) =>
   colony?.version &&
   networkVersion &&
   parseInt(networkVersion, 10) > parseInt(colony.version, 10);
 
-export const mustBeUpgraded = (colony?: Colony, networkVersion?: string) =>
-  canBeUpgraded(colony, networkVersion) &&
+export const colonyMustBeUpgraded = (
+  colony?: Colony,
+  networkVersion?: string,
+) =>
+  colonyCanBeUpgraded(colony, networkVersion) &&
   colony?.version &&
   parseInt(colony.version, 10) < ColonyVersion.LightweightSpaceship;
 
-export const shouldBeUpgraded = (colony?: Colony, networkVersion?: string) =>
-  canBeUpgraded(colony, networkVersion) &&
+export const colonyShouldBeUpgraded = (
+  colony?: Colony,
+  networkVersion?: string,
+) =>
+  colonyCanBeUpgraded(colony, networkVersion) &&
   colony?.version &&
   parseInt(colony.version, 10) >= ColonyVersion.LightweightSpaceship;
 

--- a/src/modules/dashboard/checks.ts
+++ b/src/modules/dashboard/checks.ts
@@ -1,6 +1,10 @@
-import { ColonyVersion } from '@colony/colony-js';
+import {
+  ColonyVersion,
+  Extension,
+  OneTxPaymentExtensionVersion,
+} from '@colony/colony-js';
 
-import { Colony } from '~data/index';
+import { Colony, ColonyExtension } from '~data/index';
 import { hasRoot } from '../users/checks';
 
 /*
@@ -28,3 +32,21 @@ export const colonyShouldBeUpgraded = (
   parseInt(colony.version, 10) >= ColonyVersion.LightweightSpaceship;
 
 export const canRecoverColony = hasRoot;
+
+/*
+ * Extension
+ */
+
+export const oneTxMustBeUpgraded = (extension?: ColonyExtension) => {
+  if (extension) {
+    const {
+      extensionId: extensionName,
+      details: { version },
+    } = extension;
+    return (
+      extensionName === Extension.OneTxPayment &&
+      version < OneTxPaymentExtensionVersion.DandelionLightweightSpaceship
+    );
+  }
+  return false;
+};

--- a/src/modules/dashboard/components/ColonyHome/ColonyFinishDeployment/ColonyFinishDeployment.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyFinishDeployment/ColonyFinishDeployment.tsx
@@ -9,7 +9,7 @@ import { useLoggedInUser } from '~data/helpers';
 import { useTransformer } from '~utils/hooks';
 import { ActionTypes } from '~redux/index';
 import { mapPayload } from '~utils/actions';
-import { canBeUpgraded } from '../../../checks';
+import { colonyCanBeUpgraded } from '../../../checks';
 import { hasRoot, canEnterRecoveryMode } from '../../../../users/checks';
 import { getAllUserRoles } from '../../../../transformers';
 
@@ -59,7 +59,10 @@ const ColonyFinishDeployment = ({
    * which versions *must* be upgraded, and which can function as-is, even with
    * an older version
    */
-  const mustUpgradeColony = canBeUpgraded(colony, networkVersion as string);
+  const mustUpgradeColony = colonyCanBeUpgraded(
+    colony,
+    networkVersion as string,
+  );
 
   return !mustUpgradeColony && !isDeploymentFinished && canFinishDeployment ? (
     <div className={styles.finishDeploymentBannerContainer}>

--- a/src/modules/dashboard/components/ColonyHome/ColonyHomeLayout.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHomeLayout.tsx
@@ -12,6 +12,7 @@ import ColonyExtensions from './ColonyExtensions';
 import ColonyDomainDescription from './ColonyDomainDescription';
 import ColonyUpgrade from './ColonyUpgrade';
 import ColonyFinishDeployment from './ColonyFinishDeployment';
+import ExtensionUpgrade from './ExtensionUpgrade';
 
 import { Colony } from '~data/index';
 
@@ -87,6 +88,7 @@ const ColonyHomeLayout = ({
       )}
     </div>
     <ColonyUpgrade colony={colony} />
+    <ExtensionUpgrade colony={colony} />
     <ColonyFinishDeployment colony={colony} />
   </div>
 );

--- a/src/modules/dashboard/components/ColonyHome/ColonyUpgrade/ColonyUpgrade.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyUpgrade/ColonyUpgrade.tsx
@@ -13,7 +13,7 @@ import { useTransformer } from '~utils/hooks';
 import { getNetworkRelaseLink } from '~utils/external';
 import { useEnabledExtensions } from '~utils/hooks/useEnabledExtensions';
 
-import { mustBeUpgraded, shouldBeUpgraded } from '../../../checks';
+import { colonyMustBeUpgraded, colonyShouldBeUpgraded } from '../../../checks';
 import { hasRoot } from '../../../../users/checks';
 import { getAllUserRoles } from '../../../../transformers';
 
@@ -63,8 +63,11 @@ const ColonyUpgrade = ({ colony }: Props) => {
   const hasRegisteredProfile = !!username && !ethereal;
   const canUpgradeColony = hasRegisteredProfile && hasRoot(allUserRoles);
 
-  const mustUpgrade = mustBeUpgraded(colony, networkVersion as string);
-  const shouldUpdgrade = shouldBeUpgraded(colony, networkVersion as string);
+  const mustUpgrade = colonyMustBeUpgraded(colony, networkVersion as string);
+  const shouldUpdgrade = colonyShouldBeUpgraded(
+    colony,
+    networkVersion as string,
+  );
 
   if (mustUpgrade) {
     return (

--- a/src/modules/dashboard/components/ColonyHome/ExtensionUpgrade/ExtensionUpgrade.css
+++ b/src/modules/dashboard/components/ColonyHome/ExtensionUpgrade/ExtensionUpgrade.css
@@ -1,0 +1,29 @@
+.upgradeBannerContainer {
+  width: 100%;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  z-index: 2;
+  font-weight: var(--weight-bold);
+  text-align: center;
+}
+
+.controls {
+  margin-top: -38px;
+  float: right;
+}
+
+.controls a {
+  margin: 0;
+  padding: 5px 0;
+  width: 140px;
+  font-size: var(--size-small);
+}
+
+.controls a:nth-child(2) {
+  margin-left: 20px;
+}
+
+.upgradeBanner {
+  padding: 15px 0;
+}

--- a/src/modules/dashboard/components/ColonyHome/ExtensionUpgrade/ExtensionUpgrade.css.d.ts
+++ b/src/modules/dashboard/components/ColonyHome/ExtensionUpgrade/ExtensionUpgrade.css.d.ts
@@ -1,0 +1,3 @@
+export const upgradeBannerContainer: string;
+export const controls: string;
+export const upgradeBanner: string;

--- a/src/modules/dashboard/components/ColonyHome/ExtensionUpgrade/ExtensionUpgrade.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ExtensionUpgrade/ExtensionUpgrade.tsx
@@ -6,12 +6,8 @@ import { useParams } from 'react-router';
 import Alert from '~core/Alert';
 import Button from '~core/Button';
 
-import {
-  Colony,
-  useNetworkContracts,
-  useColonyExtensionsQuery,
-} from '~data/index';
-import { colonyMustBeUpgraded } from '../../../checks';
+import { Colony, useColonyExtensionsQuery } from '~data/index';
+import { oneTxMustBeUpgraded } from '../../../checks';
 
 import styles from './ExtensionUpgrade.css';
 
@@ -32,11 +28,7 @@ type Props = {
 
 const displayName = 'dashboard.ColonyHome.ExtensionUpgrade';
 
-const ExtensionUpgrade = ({
-  colony: { colonyName, colonyAddress },
-  colony,
-}: Props) => {
-  const { version: networkVersion } = useNetworkContracts();
+const ExtensionUpgrade = ({ colony: { colonyName, colonyAddress } }: Props) => {
   const { colonyName: colonyNameEntry, extensionId } = useParams<{
     colonyName: string;
     extensionId: string;
@@ -46,7 +38,6 @@ const ExtensionUpgrade = ({
     variables: { address: colonyAddress },
   });
 
-  const mustUpgrade = colonyMustBeUpgraded(colony, networkVersion as string);
   const isExtensionDetailsRoute =
     colonyNameEntry === colonyName && extensionId === Extension.OneTxPayment;
 
@@ -59,8 +50,9 @@ const ExtensionUpgrade = ({
       !missingPermissions.length &&
       extensionName === Extension.OneTxPayment,
   );
+  const mustUpgrade = oneTxMustBeUpgraded(oneTxPaymentExtension);
 
-  if (oneTxPaymentExtension && true) {
+  if (mustUpgrade) {
     return (
       <div className={styles.upgradeBannerContainer}>
         <Alert

--- a/src/modules/dashboard/components/ColonyHome/ExtensionUpgrade/ExtensionUpgrade.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ExtensionUpgrade/ExtensionUpgrade.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import { Extension } from '@colony/colony-js';
+import { useParams } from 'react-router';
+
+import Alert from '~core/Alert';
+import Button from '~core/Button';
+
+import { Colony, useNetworkContracts } from '~data/index';
+import { useLoggedInUser } from '~data/helpers';
+import { useTransformer } from '~utils/hooks';
+
+import { colonyMustBeUpgraded } from '../../../checks';
+import { hasRoot } from '../../../../users/checks';
+import { getAllUserRoles } from '../../../../transformers';
+
+import styles from './ExtensionUpgrade.css';
+
+const MSG = defineMessages({
+  upgradeMessage: {
+    id: `dashboard.ColonyHome.ExtensionUpgrade.upgradeMessage`,
+    defaultMessage: `This colony uses a version of the OneTx Payment Extension that is no longer supported. You must upgrade to continue using this application.`,
+  },
+  goToExtensionButton: {
+    id: `dashboard.ColonyHome.ExtensionUpgrade.goToExtensionButton`,
+    defaultMessage: `Go to Extension`,
+  },
+});
+
+type Props = {
+  colony: Colony;
+};
+
+const displayName = 'dashboard.ColonyHome.ExtensionUpgrade';
+
+const ExtensionUpgrade = ({ colony: { colonyName }, colony }: Props) => {
+  const { version: networkVersion } = useNetworkContracts();
+  const { walletAddress, username, ethereal } = useLoggedInUser();
+  const { colonyName: colonyNameEntry, extensionId } = useParams<{
+    colonyName: string;
+    extensionId: string;
+  }>();
+
+  const allUserRoles = useTransformer(getAllUserRoles, [colony, walletAddress]);
+
+  const hasRegisteredProfile = !!username && !ethereal;
+  const canUpgradeColony = hasRegisteredProfile && hasRoot(allUserRoles);
+
+  const mustUpgrade = colonyMustBeUpgraded(colony, networkVersion as string);
+  const isExtensionDetailsRoute =
+    colonyNameEntry === colonyName && extensionId === Extension.OneTxPayment;
+
+  if (true) {
+    return (
+      <div className={styles.upgradeBannerContainer}>
+        <Alert
+          appearance={{
+            theme: 'danger',
+            margin: 'none',
+            borderRadius: 'none',
+          }}
+        >
+          <div className={styles.upgradeBanner}>
+            <FormattedMessage {...MSG.upgradeMessage} />
+          </div>
+          {!isExtensionDetailsRoute && (
+            <div className={styles.controls}>
+              <Button
+                appearance={{ theme: 'primary', size: 'medium' }}
+                text={MSG.goToExtensionButton}
+                // eslint-disable-next-line max-len
+                linkTo={`/colony/${colonyName}/extensions/${Extension.OneTxPayment}`}
+                disabled={!canUpgradeColony}
+              />
+            </div>
+          )}
+        </Alert>
+      </div>
+    );
+  }
+
+  return null;
+};
+
+ExtensionUpgrade.displayName = displayName;
+
+export default ExtensionUpgrade;

--- a/src/modules/dashboard/components/ColonyHome/ExtensionUpgrade/index.ts
+++ b/src/modules/dashboard/components/ColonyHome/ExtensionUpgrade/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ExtensionUpgrade';

--- a/src/modules/dashboard/components/ColonyHomeActions/ColonyHomeActions.tsx
+++ b/src/modules/dashboard/components/ColonyHomeActions/ColonyHomeActions.tsx
@@ -23,7 +23,7 @@ import { useEnabledExtensions } from '~utils/hooks/useEnabledExtensions';
 import { useNaiveBranchingDialogWizard } from '~utils/hooks';
 import { Colony, useLoggedInUser, useNetworkContracts } from '~data/index';
 import { ALLOWED_NETWORKS } from '~constants';
-import { mustBeUpgraded } from '../../checks';
+import { colonyMustBeUpgraded } from '../../checks';
 
 const displayName = 'dashboard.ColonyHomeCreateActionsButton';
 
@@ -195,7 +195,7 @@ const ColonyHomeActions = ({ colony, ethDomainId }: Props) => {
 
   const hasRegisteredProfile = !!username && !ethereal;
   const isNetworkAllowed = !!ALLOWED_NETWORKS[networkId || 1];
-  const mustUpgrade = mustBeUpgraded(colony, networkVersion as string);
+  const mustUpgrade = colonyMustBeUpgraded(colony, networkVersion as string);
 
   return (
     <Button

--- a/src/modules/dashboard/components/ColonyHomeActions/ColonyHomeActions.tsx
+++ b/src/modules/dashboard/components/ColonyHomeActions/ColonyHomeActions.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { defineMessages } from 'react-intl';
+import { Extension } from '@colony/colony-js';
 
 import Button from '~core/Button';
 import ColonyActionsDialog from '~dashboard/ColonyActionsDialog';
@@ -21,9 +22,14 @@ import ColonyTokenManagementDialog from '~dashboard/ColonyTokenManagementDialog'
 import { useEnabledExtensions } from '~utils/hooks/useEnabledExtensions';
 
 import { useNaiveBranchingDialogWizard } from '~utils/hooks';
-import { Colony, useLoggedInUser, useNetworkContracts } from '~data/index';
+import {
+  Colony,
+  useLoggedInUser,
+  useNetworkContracts,
+  useColonyExtensionsQuery,
+} from '~data/index';
 import { ALLOWED_NETWORKS } from '~constants';
-import { colonyMustBeUpgraded } from '../../checks';
+import { colonyMustBeUpgraded, oneTxMustBeUpgraded } from '../../checks';
 
 const displayName = 'dashboard.ColonyHomeCreateActionsButton';
 
@@ -45,6 +51,10 @@ const ColonyHomeActions = ({ colony, ethDomainId }: Props) => {
 
   const { isVotingExtensionEnabled } = useEnabledExtensions({
     colonyAddress: colony.colonyAddress,
+  });
+
+  const { data } = useColonyExtensionsQuery({
+    variables: { address: colony.colonyAddress },
   });
 
   const startWizardFlow = useNaiveBranchingDialogWizard([
@@ -193,6 +203,16 @@ const ColonyHomeActions = ({ colony, ethDomainId }: Props) => {
     },
   ]);
 
+  const oneTxPaymentExtension = data?.processedColony?.installedExtensions.find(
+    ({
+      details: { initialized, missingPermissions },
+      extensionId: extensionName,
+    }) =>
+      initialized &&
+      !missingPermissions.length &&
+      extensionName === Extension.OneTxPayment,
+  );
+  const mustUpgradeOneTx = oneTxMustBeUpgraded(oneTxPaymentExtension);
   const hasRegisteredProfile = !!username && !ethereal;
   const isNetworkAllowed = !!ALLOWED_NETWORKS[networkId || 1];
   const mustUpgrade = colonyMustBeUpgraded(colony, networkVersion as string);
@@ -206,7 +226,8 @@ const ColonyHomeActions = ({ colony, ethDomainId }: Props) => {
         mustUpgrade ||
         !isNetworkAllowed ||
         !hasRegisteredProfile ||
-        !colony?.isDeploymentFinished
+        !colony?.isDeploymentFinished ||
+        mustUpgradeOneTx
       }
     />
   );

--- a/src/modules/dashboard/components/NetworkContractUpgradeDialog/NetworkContractUpgradeDialogForm.tsx
+++ b/src/modules/dashboard/components/NetworkContractUpgradeDialog/NetworkContractUpgradeDialogForm.tsx
@@ -25,7 +25,7 @@ import { useDialogActionPermissions } from '~utils/hooks/useDialogActionPermissi
 
 import { getAllUserRoles } from '../../../transformers';
 import { hasRoot } from '../../../users/checks';
-import { canBeUpgraded } from '../../../dashboard/checks';
+import { colonyCanBeUpgraded } from '../../../dashboard/checks';
 
 import { FormValues } from './NetworkContractUpgradeDialog';
 
@@ -128,7 +128,7 @@ const NetworkContractUpgradeDialogForm = ({
     values.forceAction,
   );
   const canUpgradeVersion =
-    userHasPermission && !!canBeUpgraded(colony, newVersion as string);
+    userHasPermission && !!colonyCanBeUpgraded(colony, newVersion as string);
 
   const inputDisabled = !canUpgradeVersion || onlyForceAction;
 


### PR DESCRIPTION
## Description

This PR forces a colony that has a `OneTxPayment` extension `v1` installed, to upgrade to version `2` before being allowed to do any more actions on said colony _(colony version upgrades take precendence)_

This is because `v1` of `OneTxPayment` is incompatible with motions and disputes _(ie: `VotingReputation`)_

This is not a problem for newly created colonies, since they will all install `v2` by default, with no option to fall back to `v1`.

**Testing**:

Just replace the version returned by the resolver to return `1`, if the extension is `OneTxPayment` in here: https://github.com/JoinColony/colonyDapp/blob/77ee839925fc68f03b5e8d170d488a9be93ff1fc/src/data/resolvers/extensions.ts#L127
With:
```js
version: extensionId === Extension.OneTxPayment ? 1 : version.toNumber(),
```

**Changes**

- [x] Added `ExtensionUpgrade` component
- [x] Added `oneTxMustBeUpgraded` check
- [x] Refactored: `colonyUpgrade` checks
- [x] Wired above upgrade checks into `ColonyFundingMenu`, `ColonyDomainSelector`, `ColonyMembers`, `ColonyHomeActions`

**Demo**

![Screenshot from 2021-07-04 16-19-03](https://user-images.githubusercontent.com/1193222/124386685-3c76b980-dce4-11eb-89ec-c0d2b86cbeaf.png)

![Screenshot from 2021-07-04 16-19-15](https://user-images.githubusercontent.com/1193222/124386686-3d0f5000-dce4-11eb-9207-f9bc5e7406e1.png)

DEV-415
