### PR TITLE
Wire up Enable Whitelist extension

### DIFF
--- a/src/data/staticData/extensionData.ts
+++ b/src/data/staticData/extensionData.ts
@@ -544,7 +544,7 @@ const extensions: { [key: string]: ExtensionData } = {
       },
       {
         paramName: 'agreement',
-        validation: yup.string(),
+        validation: yup.string().min(100),
         defaultValue: '',
         title: MSG.agreementTitle,
         description: MSG.agreementDescription,

--- a/src/data/staticData/extensionData.ts
+++ b/src/data/staticData/extensionData.ts
@@ -29,6 +29,7 @@ export interface ExtensionInitParams {
   validation: object;
   type: ExtensionParamType;
   options?: CustomRadioProps[];
+  disabled?: (props: any) => boolean;
 }
 
 export interface ExtensionData {
@@ -550,18 +551,19 @@ const extensions: { [key: string]: ExtensionData } = {
       },
       {
         paramName: 'agreement',
-        validation: yup.string().when(
-          'policy', {
-            is: (policy) => policy === PolicyType.AgreementOnly || policy === PolicyType.KycAndAgreement,
-            then: yup.string().required().min(100),
-            otherwise: false,
-          }
-        ),
+        validation: yup.string().when('policy', {
+          is: (policy) =>
+            policy === PolicyType.AgreementOnly ||
+            policy === PolicyType.KycAndAgreement,
+          then: yup.string().required().min(100),
+          otherwise: false,
+        }),
         defaultValue: '',
         title: MSG.agreementTitle,
         description: MSG.agreementDescription,
         type: ExtensionParamType.Textarea,
-        disabled: (values) => !values.policy || values.policy === PolicyType.KycOnly
+        disabled: (values) =>
+          !values.policy || values.policy === PolicyType.KycOnly,
       },
     ],
     uninstallable: true,

--- a/src/data/staticData/extensionData.ts
+++ b/src/data/staticData/extensionData.ts
@@ -15,6 +15,12 @@ export enum ExtensionParamType {
   ColonyPolicySelector = 'ColonyPolicySelector',
 }
 
+export enum PolicyType {
+  KycOnly = 0,
+  AgreementOnly = 1,
+  KycAndAgreement = 2,
+}
+
 export interface ExtensionInitParams {
   title: string | MessageDescriptor;
   description?: string | MessageDescriptor;
@@ -514,7 +520,7 @@ const extensions: { [key: string]: ExtensionData } = {
         type: ExtensionParamType.ColonyPolicySelector,
         options: [
           {
-            value: 1,
+            value: PolicyType.AgreementOnly,
             label: MSG.whitelistColonyPolicySelectorAgreementOnly,
             name: 'policy',
             appearance: {
@@ -523,7 +529,7 @@ const extensions: { [key: string]: ExtensionData } = {
             checked: false,
           },
           {
-            value: 0,
+            value: PolicyType.KycOnly,
             label: MSG.whitelistColonyPolicySelectorKYCOnly,
             name: 'policy',
             appearance: {
@@ -532,7 +538,7 @@ const extensions: { [key: string]: ExtensionData } = {
             checked: false,
           },
           {
-            value: 2,
+            value: PolicyType.KycAndAgreement,
             label: MSG.whitelistColonyPolicySelectorAgreementAndKYC,
             name: 'policy',
             appearance: {
@@ -546,7 +552,7 @@ const extensions: { [key: string]: ExtensionData } = {
         paramName: 'agreement',
         validation: yup.string().when(
           'policy', {
-            is: (policy) => policy === 1 || policy === 2,
+            is: (policy) => policy === PolicyType.AgreementOnly || policy === PolicyType.KycAndAgreement,
             then: yup.string().required().min(100),
             otherwise: false,
           }
@@ -555,7 +561,7 @@ const extensions: { [key: string]: ExtensionData } = {
         title: MSG.agreementTitle,
         description: MSG.agreementDescription,
         type: ExtensionParamType.Textarea,
-        disabled: (values) => !values.policy || values.policy === 0
+        disabled: (values) => !values.policy || values.policy === PolicyType.KycOnly
       },
     ],
     uninstallable: true,

--- a/src/data/staticData/extensionData.ts
+++ b/src/data/staticData/extensionData.ts
@@ -544,11 +544,18 @@ const extensions: { [key: string]: ExtensionData } = {
       },
       {
         paramName: 'agreement',
-        validation: yup.string().min(100),
+        validation: yup.string().when(
+          'policy', {
+            is: (policy) => policy === 1 || policy === 2,
+            then: yup.string().required().min(100),
+            otherwise: false,
+          }
+        ),
         defaultValue: '',
         title: MSG.agreementTitle,
         description: MSG.agreementDescription,
         type: ExtensionParamType.Textarea,
+        disabled: (values) => !values.policy || values.policy === 0
       },
     ],
     uninstallable: true,

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -158,6 +158,7 @@
     "transaction.group.enableExtension.description": "Enable Colony Extension",
     "transaction.CoinMachineClient.initialise.title": "Initialize CoinMachine Extension",
     "transaction.VotingReputationClient.initialise.title": "Initialize Voting Reputation Extension",
+    "transaction.WhitelistClient.initialise.title": "Initialize Whitelist Extension",
     "transaction.ColonyClient.uninstallExtension.title": "Uninstall Colony Extension",
     "transaction.ColonyClient.uninstallExtension.description": "Uninstall Colony Extension",
     "transaction.ColonyClient.deprecateExtension.title": "Deprecate Colony Extension",

--- a/src/lib/ColonyManager/ColonyManager.ts
+++ b/src/lib/ColonyManager/ColonyManager.ts
@@ -192,13 +192,8 @@ export default class ColonyManager {
       }
       case ClientType.WhitelistClient: {
         if (!identifier)
-          throw new Error(
-            'Need colony identifier to get the WhitelistClient',
-          );
-        return this.getColonyExtensionClient(
-          identifier,
-          Extension.Whitelist,
-        );
+          throw new Error('Need colony identifier to get the WhitelistClient');
+        return this.getColonyExtensionClient(identifier, Extension.Whitelist);
       }
       default: {
         throw new Error('A valid contract client type has to be specified');

--- a/src/lib/ColonyManager/ColonyManager.ts
+++ b/src/lib/ColonyManager/ColonyManager.ts
@@ -190,6 +190,16 @@ export default class ColonyManager {
           Extension.VotingReputation,
         );
       }
+      case ClientType.WhitelistClient: {
+        if (!identifier)
+          throw new Error(
+            'Need colony identifier to get the WhitelistClient',
+          );
+        return this.getColonyExtensionClient(
+          identifier,
+          Extension.Whitelist,
+        );
+      }
       default: {
         throw new Error('A valid contract client type has to be specified');
       }

--- a/src/modules/dashboard/components/Extensions/ExtensionSetup.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionSetup.tsx
@@ -147,7 +147,12 @@ const ExtensionSetup = ({
       onSuccess={handleFormSuccess}
       transform={transform}
     >
-      {({ handleSubmit, isSubmitting, isValid, values }: FormikProps<object>) => (
+      {({
+        handleSubmit,
+        isSubmitting,
+        isValid,
+        values,
+      }: FormikProps<object>) => (
         <div className={styles.main}>
           <Heading
             appearance={{ size: 'medium', margin: 'none' }}

--- a/src/modules/dashboard/components/Extensions/ExtensionSetup.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionSetup.tsx
@@ -147,7 +147,7 @@ const ExtensionSetup = ({
       onSuccess={handleFormSuccess}
       transform={transform}
     >
-      {({ handleSubmit, isSubmitting, isValid }: FormikProps<object>) => (
+      {({ handleSubmit, isSubmitting, isValid, values }: FormikProps<object>) => (
         <div className={styles.main}>
           <Heading
             appearance={{ size: 'medium', margin: 'none' }}
@@ -156,7 +156,7 @@ const ExtensionSetup = ({
           <FormattedMessage {...MSG.description} />
           <div className={styles.inputContainer}>
             {initializationParams.map(
-              ({ paramName, title, description, type, options }) => (
+              ({ paramName, title, description, type, options, disabled }) => (
                 <div key={paramName}>
                   {type === ExtensionParamType.Input && (
                     <div className={styles.input}>
@@ -193,6 +193,7 @@ const ExtensionSetup = ({
                         appearance={{ colorSchema: 'grey' }}
                         label={title}
                         name={paramName}
+                        disabled={disabled && disabled(values)}
                       />
                       {description && (
                         <p className={styles.textAreaDescription}>

--- a/src/modules/dashboard/sagas/extensions.ts
+++ b/src/modules/dashboard/sagas/extensions.ts
@@ -22,7 +22,7 @@ import {
   NetworkExtensionVersionQueryVariables,
   NetworkExtensionVersionDocument,
 } from '~data/index';
-import extensionData from '~data/staticData/extensionData';
+import extensionData, { PolicyType } from '~data/staticData/extensionData';
 import {
   ContextModule,
   TEMP_getContext,
@@ -171,7 +171,7 @@ function* colonyExtensionEnable({
      * Upload whitelist policy to IPFS
      */
     let agreementHash = '';
-    if (extensionId === Extension.Whitelist && payload?.policy !== 0) {
+    if (extensionId === Extension.Whitelist && payload?.policy !== PolicyType.KycOnly) {
       agreementHash = yield call(
         ipfsUpload,
         JSON.stringify({
@@ -183,12 +183,12 @@ function* colonyExtensionEnable({
       address,
       details: { initialized, missingPermissions },
     } = data.colonyExtension;
-    
+
     if (!initialized && extension.initializationParams) {
       let initParams = [] as any[];
 
       if (extensionId === Extension.Whitelist) {
-        initParams = [payload?.policy !== 1, agreementHash];
+        initParams = [payload?.policy !== PolicyType.AgreementOnly, agreementHash];
       } else {
         initParams = extension.initializationParams.map(({ paramName }) => {
           if (typeof payload[paramName] === 'number') {

--- a/src/modules/dashboard/sagas/extensions.ts
+++ b/src/modules/dashboard/sagas/extensions.ts
@@ -171,7 +171,10 @@ function* colonyExtensionEnable({
      * Upload whitelist policy to IPFS
      */
     let agreementHash = '';
-    if (extensionId === Extension.Whitelist && payload?.policy !== PolicyType.KycOnly) {
+    if (
+      extensionId === Extension.Whitelist &&
+      payload?.policy !== PolicyType.KycOnly
+    ) {
       agreementHash = yield call(
         ipfsUpload,
         JSON.stringify({
@@ -188,7 +191,10 @@ function* colonyExtensionEnable({
       let initParams = [] as any[];
 
       if (extensionId === Extension.Whitelist) {
-        initParams = [payload?.policy !== PolicyType.AgreementOnly, agreementHash];
+        initParams = [
+          payload?.policy !== PolicyType.AgreementOnly,
+          agreementHash,
+        ];
       } else {
         initParams = extension.initializationParams.map(({ paramName }) => {
           if (typeof payload[paramName] === 'number') {

--- a/src/modules/dashboard/sagas/extensions.ts
+++ b/src/modules/dashboard/sagas/extensions.ts
@@ -171,7 +171,7 @@ function* colonyExtensionEnable({
      * Upload whitelist policy to IPFS
      */
     let agreementHash = '';
-    if (extensionId === Extension.Whitelist && payload?.agreement?.length) {
+    if (extensionId === Extension.Whitelist && payload?.policy !== 0) {
       agreementHash = yield call(
         ipfsUpload,
         JSON.stringify({
@@ -179,17 +179,16 @@ function* colonyExtensionEnable({
         }),
       );
     }
-
     const {
       address,
       details: { initialized, missingPermissions },
     } = data.colonyExtension;
-
+    
     if (!initialized && extension.initializationParams) {
       let initParams = [] as any[];
 
       if (extensionId === Extension.Whitelist) {
-        initParams = [true, agreementHash];
+        initParams = [payload?.policy !== 1, agreementHash];
       } else {
         initParams = extension.initializationParams.map(({ paramName }) => {
           if (typeof payload[paramName] === 'number') {

--- a/src/modules/dashboard/sagas/extensions.ts
+++ b/src/modules/dashboard/sagas/extensions.ts
@@ -171,11 +171,11 @@ function* colonyExtensionEnable({
      * Upload whitelist policy to IPFS
      */
     let agreementHash = '';
-    if (extensionId === Extension.Whitelist) {
+    if (extensionId === Extension.Whitelist && payload?.agreement?.length) {
       agreementHash = yield call(
         ipfsUpload,
         JSON.stringify({
-          agreement: '',
+          agreement: payload.agreement,
         }),
       );
     }


### PR DESCRIPTION
## Description

This PR wire up enabling whitelist extension

**New stuff** ✨

* Added WhitelistClient to ColonyManager
* Added message descriptors for whitelist initialisation
* Added validation for texarea & policy selector combo
* Added PolicyType enum

**Changes** 🏗

* Updated colonyExtensionEnable saga to handle Whitelist extension


Resolves DEV-438
