### PR TITLE
Prevent Dapp Use if Wrong Network

### DIFF
--- a/src/modules/dashboard/components/ColonyFundingMenu/ColonyFundingMenu.tsx
+++ b/src/modules/dashboard/components/ColonyFundingMenu/ColonyFundingMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { defineMessages } from 'react-intl';
 import {
   ColonyRole,
@@ -12,6 +12,7 @@ import { useDialog } from '~core/Dialog';
 import TransferFundsDialog from '~dashboard/TransferFundsDialog';
 import ColonyTokenManagementDialog from '~dashboard/ColonyTokenManagementDialog';
 import TokenMintDialog from '~dashboard/TokenMintDialog';
+import WrongNetworkDialog from '~dashboard/ColonyHome/WrongNetworkDialog';
 
 import { Colony, useLoggedInUser, useColonyExtensionsQuery } from '~data/index';
 import { useEnabledExtensions } from '~utils/hooks/useEnabledExtensions';
@@ -52,6 +53,7 @@ const ColonyFundingMenu = ({
   selectedDomainId,
 }: Props) => {
   const { walletAddress, networkId, ethereal, username } = useLoggedInUser();
+  const isNetworkAllowed = !!ALLOWED_NETWORKS[networkId || 1];
   const { isVotingExtensionEnabled } = useEnabledExtensions({ colonyAddress });
   const { data } = useColonyExtensionsQuery({
     variables: { address: colonyAddress },
@@ -60,6 +62,13 @@ const ColonyFundingMenu = ({
   const openTokenManagementDialog = useDialog(ColonyTokenManagementDialog);
   const openTokenMintDialog = useDialog(TokenMintDialog);
   const openTokensMoveDialog = useDialog(TransferFundsDialog);
+  const openWrongNetworkDialog = useDialog(WrongNetworkDialog);
+
+  useEffect(() => {
+    if (!ethereal && !isNetworkAllowed) {
+      openWrongNetworkDialog();
+    }
+  }, [ethereal, isNetworkAllowed, openWrongNetworkDialog]);
 
   const rootRoles = useTransformer(getUserRolesForDomain, [
     colony,
@@ -110,7 +119,6 @@ const ColonyFundingMenu = ({
   const hasRegisteredProfile = !!username && !ethereal;
   const isSupportedColonyVersion =
     parseInt(version, 10) >= ColonyVersion.LightweightSpaceship;
-  const isNetworkAllowed = !!ALLOWED_NETWORKS[networkId || 1];
 
   return (
     <ul className={styles.main}>

--- a/src/modules/dashboard/components/ColonyHome/WrongNetworkDialog/WrongNetworkDialog.css
+++ b/src/modules/dashboard/components/ColonyHome/WrongNetworkDialog/WrongNetworkDialog.css
@@ -1,0 +1,7 @@
+.modalHeading {
+  padding: 18px 0 0;
+}
+
+.modalContent {
+  padding: 26px 0 32px;
+}

--- a/src/modules/dashboard/components/ColonyHome/WrongNetworkDialog/WrongNetworkDialog.css.d.ts
+++ b/src/modules/dashboard/components/ColonyHome/WrongNetworkDialog/WrongNetworkDialog.css.d.ts
@@ -1,0 +1,2 @@
+export const modalHeading: string;
+export const modalContent: string;

--- a/src/modules/dashboard/components/ColonyHome/WrongNetworkDialog/WrongNetworkDialog.tsx
+++ b/src/modules/dashboard/components/ColonyHome/WrongNetworkDialog/WrongNetworkDialog.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { FormattedMessage, defineMessages } from 'react-intl';
+
+import Dialog, { DialogProps, DialogSection } from '~core/Dialog';
+import Heading from '~core/Heading';
+
+import styles from './WrongNetworkDialog.css';
+
+const MSG = defineMessages({
+  title: {
+    id: 'dashboard.ColonyHome.WrongNetworkDialog.title',
+    defaultMessage: 'Wrong Network',
+  },
+  description: {
+    id: 'dashboard.ColonyHome.WrongNetworkDialog.description',
+    defaultMessage: 'Please connect to the appriopriate Ethereum network.',
+  },
+});
+
+const displayName = 'dashboard.ColonyHome.WrongNetworkDialog';
+
+const WrongNetworkDialog = ({ cancel }: DialogProps) => {
+  return (
+    <Dialog cancel={cancel}>
+      <DialogSection appearance={{ theme: 'sidePadding' }}>
+        <div className={styles.modalHeading}>
+          <Heading
+            appearance={{ size: 'medium', margin: 'none', theme: 'dark' }}
+            text={MSG.title}
+          />
+        </div>
+      </DialogSection>
+      <DialogSection appearance={{ theme: 'sidePadding' }}>
+        <div className={styles.modalContent}>
+          <FormattedMessage {...MSG.description} />
+        </div>
+      </DialogSection>
+    </Dialog>
+  );
+};
+
+WrongNetworkDialog.displayName = displayName;
+
+export default WrongNetworkDialog;

--- a/src/modules/dashboard/components/ColonyHome/WrongNetworkDialog/index.ts
+++ b/src/modules/dashboard/components/ColonyHome/WrongNetworkDialog/index.ts
@@ -1,0 +1,1 @@
+export { default } from './WrongNetworkDialog';

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -1,13 +1,15 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useParams, Redirect } from 'react-router-dom';
 import { defineMessages } from 'react-intl';
 import { ColonyVersion, Extension } from '@colony/colony-js';
 
 import Button from '~core/Button';
 import { useDialog } from '~core/Dialog';
+
 import LoadingTemplate from '~pages/LoadingTemplate';
 import Members from '~dashboard/Members';
 import PermissionManagementDialog from '~dashboard/PermissionManagementDialog';
+import WrongNetworkDialog from '~dashboard/ColonyHome/WrongNetworkDialog';
 
 import {
   useColonyFromNameQuery,
@@ -37,6 +39,8 @@ const MSG = defineMessages({
 
 const ColonyMembers = () => {
   const { networkId, username, ethereal } = useLoggedInUser();
+  const isNetworkAllowed = !!ALLOWED_NETWORKS[networkId || 1];
+  const openWrongNetworkDialog = useDialog(WrongNetworkDialog);
 
   const { colonyName } = useParams<{
     colonyName: string;
@@ -49,6 +53,12 @@ const ColonyMembers = () => {
   const { isVotingExtensionEnabled } = useEnabledExtensions({
     colonyAddress: colonyData?.processedColony?.colonyAddress,
   });
+
+  useEffect(() => {
+    if (!ethereal && !isNetworkAllowed) {
+      openWrongNetworkDialog();
+    }
+  }, [ethereal, isNetworkAllowed, openWrongNetworkDialog]);
 
   const {
     data: colonyExtensions,
@@ -82,7 +92,6 @@ const ColonyMembers = () => {
   const isSupportedColonyVersion =
     parseInt(colonyData?.processedColony?.version || '1', 10) >=
     ColonyVersion.LightweightSpaceship;
-  const isNetworkAllowed = !!ALLOWED_NETWORKS[networkId || 1];
 
   if (
     loading ||

--- a/src/modules/pages/components/LandingPage/LandingPage.tsx
+++ b/src/modules/pages/components/LandingPage/LandingPage.tsx
@@ -20,7 +20,7 @@ const MSG = defineMessages({
   },
   wrongNetwork: {
     id: 'pages.LandingPage.wrongNetwork',
-    defaultMessage: `You’re connected to the wrong network. Please connect to Ethereum mainnet, or xDai`,
+    defaultMessage: `You’re connected to the wrong network. Please connect to the appriopriate Ethereum network.`,
   },
   createColony: {
     id: 'pages.LandingPage.createColony',


### PR DESCRIPTION
## Description

This PR expands on the current functionality that prevents a user to use the Dapp if they are connected to the "wrong" network _(basically anything except xdai, mainnet and the local ganache, if in `dev` mode)_

This expands by adding a modal message to the colony home informing the user of the wrong network, as well as showing the warning _(and not allowing further action)_ on the create colony and create user routes

**Testing**
- Just change your metamask's network to Rinkeby _(or something that's not "allowed")_, even if you're connected with a ganache wallet _(as it uses Metamask's network detection behind the scenes)_ and you should see this message upon refreshing the page

**Changes** 

- [x] Added `WrongNetworkDialog` sub-component to `ColonyHome`
- [x] Wired up  `WrongNetworkDialog` inside `ColonyHomeLayout`
- [x] Wired up  `WrongNetworkDialog` inside `ColonyMembers`
- [x] Wired up  `WrongNetworkDialog` inside `ColonyFundingMenu`
- [x] Wired up  network checks inside `ExtensionDetails`

**Demo**

![Screenshot from 2021-07-13 17-22-04](https://user-images.githubusercontent.com/1193222/125469050-ccbea186-9ecc-49e3-bd28-ce351810469d.png)

Resolves #2593