### PR TITLE
Update slider error message logic

### DIFF
--- a/src/modules/dashboard/components/ActionsPage/StakingValidationError/StakingValidationError.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingValidationError/StakingValidationError.tsx
@@ -4,7 +4,12 @@ import { defineMessage, FormattedMessage } from 'react-intl';
 import styles from './StakingValidationError.css';
 
 interface Props {
-  stakeType: 'tokens' | 'reputation' | 'stakeMoreTokens' | 'cantStakeMore';
+  stakeType:
+    | 'tokens'
+    | 'reputation'
+    | 'stakeMoreTokens'
+    | 'cantStakeMore'
+    | 'stakeMoreReputation';
 }
 
 const stakeValidationMSG = defineMessage({
@@ -19,6 +24,10 @@ const stakeValidationMSG = defineMessage({
   stakeMoreTokens: {
     id: 'dashboard.ActionsPage.StakingValidationError.stakeMore',
     defaultMessage: 'You do not have enough active tokens to stake more.',
+  },
+  stakeMoreReputation: {
+    id: 'dashboard.ActionsPage.StakingValidationError.reputation',
+    defaultMessage: 'You do not have enough reputation to stake more.',
   },
   cantStakeMore: {
     id: 'dashboard.ActionsPage.StakingValidationError.stakeMore',

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { Decimal } from 'decimal.js';
 
@@ -99,6 +99,18 @@ const StakingSlider = ({
     nativeToken?.decimals,
   );
 
+  const errorStakeType = useMemo(() => {
+    if (remainingToStake.lte(minUserStake)) {
+      return 'cantStakeMore';
+    }
+
+    if (userActivatedTokens.gt(maxStake)) {
+      return 'stakeMoreReputation';
+    }
+
+    return 'stakeMoreTokens';
+  }, [remainingToStake, minUserStake, maxStake, userActivatedTokens]);
+
   return (
     <>
       <div className={styles.title}>
@@ -129,15 +141,7 @@ const StakingSlider = ({
           exceedLimit={exceedLimit}
         />
       </div>
-      {showError && (
-        <StakingValidationError
-          stakeType={
-            remainingToStake.lte(minUserStake)
-              ? 'cantStakeMore'
-              : 'stakeMoreTokens'
-          }
-        />
-      )}
+      {showError && <StakingValidationError stakeType={errorStakeType} />}
     </>
   );
 };


### PR DESCRIPTION
## Description

This PR adds another validation error message when there is not enough reputation to stake more

**New stuff** ✨

- add another option to StakingValidationError

**Changes** 🏗

- update error logic in `StakingSlider`

Resolves github issue2603

here are 3 types of errors:
<img width="513" alt="Screenshot 2021-07-15 at 17 36 26" src="https://user-images.githubusercontent.com/34057551/125808202-e0975f38-5abd-41d7-9102-10e97ceed5a4.png">


<img width="493" alt="Screenshot 2021-07-15 at 17 37 01" src="https://user-images.githubusercontent.com/34057551/125808203-6c35b02f-8341-4f11-8c0e-4f345318116a.png">


<img width="624" alt="Screenshot 2021-07-15 at 17 33 33" src="https://user-images.githubusercontent.com/34057551/125808196-dbd592bc-4544-42e0-854d-485b3f6c3c2e.png">
