### PR TITLE
Fix Extension Installation on Allowed Networks

### DIFF
--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
@@ -196,7 +196,7 @@ const ExtensionDetails = ({
     hasRegisteredProfile &&
     hasRoot(allUserRoles) &&
     !ethereal &&
-    !isNetworkAllowed;
+    isNetworkAllowed;
   const installedExtension = data ? data.colonyExtension : null;
 
   const extensionInstallable = !onSetupRoute && canInstall;


### PR DESCRIPTION
## Description

This PR fixes a issue introduced in #2605 that prevents installation _(actually all control: install / enable / upgrade / uninstall)_ of Extensions, when the user has the wallet connected to one of the allowed networks: ethereum mainnet or xdai

**Changes**

- [x] Update `colonyNetwork` to the current `dwlss` release
- [x] Fix `ExtensionDetails` to allow extension controls when on an _"Allowed Network"_
