### PR TITLE
Fix: update force toggle condition in the `Permissions` modal

### DIFF
--- a/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementForm.tsx
+++ b/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementForm.tsx
@@ -265,7 +265,7 @@ const PermissionManagementForm = ({
               text={MSG.title}
               textValues={{ domain: domain?.name }}
             />
-            {(canEditPermissions || isVotingExtensionEnabled) && (
+            {canEditPermissions && isVotingExtensionEnabled && (
               <Toggle label={{ id: 'label.force' }} name="forceAction" />
             )}
           </div>


### PR DESCRIPTION
## Description

This PR fixes Permissions modal force toggle appearance: it is now there when the voting extensions is enabled and not there without the voting extension.

**Changes** 🏗

- update force toggle condition in Permissions modal

Resolves #2619
