### PR TITLE
Fix motion feed comment box margin

### DIFF
--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
@@ -471,7 +471,7 @@ const DefaultMotion = ({
           />
 
           {userHasProfile && (
-            <div ref={bottomElementRef}>
+            <div ref={bottomElementRef} className={styles.commentBox}>
               <CommentInput
                 transactionHash={transactionHash}
                 colonyAddress={colony.colonyAddress}


### PR DESCRIPTION
## Description

This PR fixes the margin between the motion feed & the comment box

**Changes** 🏗

- added margin to the comment box in the motion feed

For the change to work I had to restart the webpack - just in case you can't see it straight away.

Resolves issue 2627

<img width="575" alt="Screenshot 2021-07-29 at 15 08 07" src="https://user-images.githubusercontent.com/34057551/127490540-cbe7b343-ad63-4121-937c-4d94ef7dc991.png">

