### PR TITLE
Add missing Terms and Condition link

### DIFF
--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
@@ -55,6 +55,8 @@ import ExtensionUpgrade from './ExtensionUpgrade';
 import ExtensionUninstallConfirmDialog from './ExtensionUninstallConfirmDialog';
 import { ExtensionsMSG } from './extensionsMSG';
 
+const TERMS_AND_CONDITIONS_LINK = 'https://colony.io/pdf/terms.pdf';
+
 const MSG = defineMessages({
   title: {
     id: 'dashboard.Extensions.ExtensionDetails.title',
@@ -372,7 +374,7 @@ const ExtensionDetails = ({
                           link: (
                             <ExternalLink
                               text={extension.termsCondition}
-                              href=""
+                              href={TERMS_AND_CONDITIONS_LINK}
                             />
                           ),
                         }}

--- a/src/modules/dashboard/components/Whitelist/AgreementDialog/AgreementDialog.tsx
+++ b/src/modules/dashboard/components/Whitelist/AgreementDialog/AgreementDialog.tsx
@@ -21,7 +21,7 @@ const MSG = defineMessages({
   },
   ipfsError: {
     id: 'dashboard.Extensions.WhitelisExtension.AgreementDialog.ipfsError',
-    defaultMessage: `There is a problem loading the agreement. Please, try again or contact colony admins.`,
+    defaultMessage: `Failed to retrieve data from IPFS. Please try again.`,
   },
 });
 


### PR DESCRIPTION
1. Added missing "Terms and conditions" link to subtext info of the Whitelist extension
2. Updated IPFS error message of AgreementModal

Resolves #2624 
