### PR TITLE
Update fetch policy of useWhitelistedUsers query

### DIFF
--- a/src/modules/dashboard/components/Whitelist/Whitelist.tsx
+++ b/src/modules/dashboard/components/Whitelist/Whitelist.tsx
@@ -21,6 +21,7 @@ interface Props {
 const Whitelist = ({ colony: { colonyAddress }, colony }: Props) => {
   const { data: usersData, loading: usersLoading } = useWhitelistedUsersQuery({
     variables: { colonyAddress },
+    fetchPolicy: 'network-only',
   });
 
   return (


### PR DESCRIPTION
Updated fetch policy to `network-only` to avoid the list not updating when you uninstall the extension and install it again without reloading the page. 

Hypothetically, it also wouldn't update in cases where another user apart from yourself adds an address to the list and you don't reload the page when re-entering the extension page to see the added users.

Resolves #2630 
