### PR TITLE
Auto filled whitelist address in coin machine init params

### DIFF
--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
@@ -153,7 +153,7 @@ const ExtensionDetails = ({
 
   const openUpgradeVersionDialog = useDialog(NetworkContractUpgradeDialog);
 
-  const { isVotingExtensionEnabled, isWhitelistExtensionEnabled, whitelistAddress } = useEnabledExtensions({
+  const { isVotingExtensionEnabled } = useEnabledExtensions({
     colonyAddress,
   });
 

--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
@@ -153,7 +153,7 @@ const ExtensionDetails = ({
 
   const openUpgradeVersionDialog = useDialog(NetworkContractUpgradeDialog);
 
-  const { isVotingExtensionEnabled } = useEnabledExtensions({
+  const { isVotingExtensionEnabled, isWhitelistExtensionEnabled, whitelistAddress } = useEnabledExtensions({
     colonyAddress,
   });
 

--- a/src/modules/dashboard/components/Extensions/ExtensionSetup.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionSetup.tsx
@@ -133,7 +133,13 @@ const ExtensionSetup = ({
       };
     }
     return defaultValues;
-  }, [extensionId, initializationParams, nativeTokenAddress]);
+  }, [
+    extensionId,
+    initializationParams,
+    nativeTokenAddress,
+    isWhitelistExtensionEnabled,
+    whitelistAddress,
+  ]);
 
   if (
     installedExtension.details.deprecated ||

--- a/src/modules/dashboard/components/Extensions/ExtensionSetup.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionSetup.tsx
@@ -2,21 +2,25 @@ import { FormikProps } from 'formik';
 import React, { useCallback, useMemo } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { useHistory, useParams, Redirect } from 'react-router';
+
 import { endsWith } from 'lodash';
 import { Extension } from '@colony/colony-js';
 import Decimal from 'decimal.js';
 import { bigNumberify } from 'ethers/utils';
+import { AddressZero } from 'ethers/constants';
 
 import { IconButton, ActionButton } from '~core/Button';
 import { Input, ActionForm, Textarea } from '~core/Fields';
 import Heading from '~core/Heading';
 import { ActionTypes } from '~redux/index';
 import { ColonyExtension } from '~data/index';
+
 import {
   ExtensionData,
   ExtensionParamType,
 } from '~data/staticData/extensionData';
 import { mergePayload, mapPayload, pipe } from '~utils/actions';
+import { useEnabledExtensions } from '~utils/hooks/useEnabledExtensions';
 import { Address } from '~types/index';
 
 import { ColonyPolicySelector } from '../Whitelist';
@@ -108,6 +112,13 @@ const ExtensionSetup = ({
     [colonyAddress, extensionId, initializationParams],
   );
 
+  const {
+    isWhitelistExtensionEnabled,
+    whitelistAddress,
+  } = useEnabledExtensions({
+    colonyAddress,
+  });
+
   const initialValues = useMemo(() => {
     if (!initializationParams) {
       return {};
@@ -116,13 +127,8 @@ const ExtensionSetup = ({
     if (extensionId === Extension.CoinMachine) {
       return {
         ...defaultValues,
-        /*
-         * @TODO The same needs to be done for the Whitelist Extension address,
-         * once that gets merged in.
-         *
-         * Please note to only add it, if the Whitelist extension is actually
-         * installed on the current colony.
-         */
+        whitelistAddress:
+          (isWhitelistExtensionEnabled && whitelistAddress) || AddressZero,
         tokenToBeSold: nativeTokenAddress,
       };
     }

--- a/src/utils/hooks/useEnabledExtensions.tsx
+++ b/src/utils/hooks/useEnabledExtensions.tsx
@@ -19,6 +19,11 @@ export const useEnabledExtensions = ({ colonyAddress }: Props) => {
   const installedOneTxPaymentExtension = installedExtensions.find(
     ({ extensionId }) => extensionId === Extension.OneTxPayment,
   );
+
+  const installedWhitelistExtension = installedExtensions.find(
+    ({ extensionId }) => extensionId === Extension.Whitelist,
+  );
+
   const isVotingExtensionEnabled = !!(
     installedVotingExtension &&
     installedVotingExtension.details.initialized &&
@@ -30,8 +35,15 @@ export const useEnabledExtensions = ({ colonyAddress }: Props) => {
     !installedOneTxPaymentExtension.details.deprecated
   );
 
+  const isWhitelistExtensionEnabled = !!(
+    installedWhitelistExtension &&
+    installedWhitelistExtension.details.initialized &&
+    !installedWhitelistExtension.details.deprecated
+  );
+
   return {
     isVotingExtensionEnabled,
     isOneTxPaymentExtensionEnabled,
+    isWhitelistExtensionEnabled
   };
 };

--- a/src/utils/hooks/useEnabledExtensions.tsx
+++ b/src/utils/hooks/useEnabledExtensions.tsx
@@ -44,6 +44,7 @@ export const useEnabledExtensions = ({ colonyAddress }: Props) => {
   return {
     isVotingExtensionEnabled,
     isOneTxPaymentExtensionEnabled,
-    isWhitelistExtensionEnabled
+    isWhitelistExtensionEnabled,
+    whitelistAddress: installedWhitelistExtension?.address,
   };
 };


### PR DESCRIPTION
## Description

This PR updates init params of coin machine extension. It fills whitelistAddress for coin machine extension IF whitelist extension was installed&enabled, if not it set whitelistAddress to AddressZero

**Changes** 🏗

* Updated useEnabledExtension hook
* Updated ExtensionSetup component

Resolves #2631
