### PR TITLE
Extend agreement modal

### DIFF
--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -61,7 +61,6 @@ const CoinMachine = ({
 
   const { data: agreementHashData } = useWhitelistAgreementHashQuery({
     variables: { colonyAddress },
-    fetchPolicy: 'network-only',
   });
 
   const openDialog = useCallback(

--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { Redirect } from 'react-router-dom';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { Extension } from '@colony/colony-js';
@@ -6,11 +6,14 @@ import ExternalLink from '~core/ExternalLink';
 
 import { SpinnerLoader } from '~core/Preloaders';
 import BreadCrumb, { Crumb } from '~core/BreadCrumb';
+import { useDialog } from '~core/Dialog';
+import AgreementDialog from '~dashboard/Whitelist/AgreementDialog';
 
 import {
   useColonyExtensionsQuery,
   useCoinMachineSaleTokensQuery,
   Colony,
+  useWhitelistAgreementHashQuery,
 } from '~data/index';
 
 import Chat from './Chat';
@@ -54,6 +57,28 @@ const CoinMachine = ({
   colony: { colonyAddress, colonyName },
   colony,
 }: Props) => {
+  const openAgreementDialog = useDialog(AgreementDialog);
+
+  const { data: agreementHashData } = useWhitelistAgreementHashQuery({
+    variables: { colonyAddress },
+    fetchPolicy: 'network-only',
+  });
+
+  const openDialog = useCallback(
+    () =>
+      agreementHashData?.whitelistAgreementHash &&
+      openAgreementDialog({
+        agreementHash: agreementHashData?.whitelistAgreementHash,
+        isSignable: true,
+        back: () => {},
+      }),
+    [agreementHashData, openAgreementDialog],
+  );
+
+  useEffect(() => {
+    openDialog();
+  }, [openDialog]);
+
   const { data, loading } = useColonyExtensionsQuery({
     variables: { address: colonyAddress },
   });

--- a/src/modules/dashboard/components/Whitelist/AgreementDialog/AgreementDialog.css
+++ b/src/modules/dashboard/components/Whitelist/AgreementDialog/AgreementDialog.css
@@ -4,6 +4,8 @@
   font-weight: var(--weight-bold);
   line-height: 24px;
   color: var(--dark);
+
+  /* margin-bottom: 18px; */
 }
 
 .agreementContainer {
@@ -20,4 +22,22 @@
 
 .error {
   color: var(--danger);
+}
+
+.description {
+  margin-top: 30px;
+  color: var(--dark);
+}
+
+.readCarefullyText {
+  margin-bottom: 6px;
+  color: var(--temp-grey-blue-7);
+}
+
+.agreeToTermsText {
+  margin-top: 10px;
+  width: 100%;
+  font-weight: var(--weight-bold);
+  text-align: right;
+  color: var(--dark);
 }

--- a/src/modules/dashboard/components/Whitelist/AgreementDialog/AgreementDialog.css
+++ b/src/modules/dashboard/components/Whitelist/AgreementDialog/AgreementDialog.css
@@ -4,8 +4,6 @@
   font-weight: var(--weight-bold);
   line-height: 24px;
   color: var(--dark);
-
-  /* margin-bottom: 18px; */
 }
 
 .agreementContainer {

--- a/src/modules/dashboard/components/Whitelist/AgreementDialog/AgreementDialog.css.d.ts
+++ b/src/modules/dashboard/components/Whitelist/AgreementDialog/AgreementDialog.css.d.ts
@@ -1,3 +1,6 @@
 export const title: string;
 export const agreementContainer: string;
 export const error: string;
+export const description: string;
+export const readCarefullyText: string;
+export const agreeToTermsText: string;

--- a/src/modules/dashboard/components/Whitelist/AgreementDialog/AgreementDialog.tsx
+++ b/src/modules/dashboard/components/Whitelist/AgreementDialog/AgreementDialog.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
 import Dialog, { DialogSection } from '~core/Dialog';
@@ -15,13 +15,29 @@ const MSG = defineMessages({
     id: 'dashboard.Extensions.WhitelisExtension.AgreementDialog.title',
     defaultMessage: 'Sale agreement',
   },
+  agreementExplanation: {
+    id: `dashboard.Extensions.WhitelisExtension.AgreementDialog.agreementExplanation`,
+    defaultMessage: `Add to the whitelist wallet addresses which should be participating in the token sale. `,
+  },
+  readCarefully: {
+    id: 'dashboard.Extensions.WhitelisExtension.AgreementDialog.readCarefully',
+    defaultMessage: 'Read carefully',
+  },
   gotItButton: {
     id: 'dashboard.Extensions.WhitelisExtension.AgreementDialog.gotItButton',
     defaultMessage: 'Got it',
   },
+  iAgreeButton: {
+    id: 'dashboard.Extensions.WhitelisExtension.AgreementDialog.iAgreeButton',
+    defaultMessage: 'I agree',
+  },
   ipfsError: {
     id: 'dashboard.Extensions.WhitelisExtension.AgreementDialog.ipfsError',
     defaultMessage: `There is a problem loading the agreement. Please, try again or contact colony admins.`,
+  },
+  agreeToTerms: {
+    id: 'dashboard.Extensions.WhitelisExtension.AgreementDialog.agreeToTerms',
+    defaultMessage: 'By Signing you agree to the terms and conditions',
   },
 });
 
@@ -29,13 +45,43 @@ interface Props {
   cancel: () => void;
   close: () => void;
   agreementHash: string;
+  back?: () => void;
+  isSignable?: boolean;
 }
 
-const AgreementDialog = ({ cancel, close, agreementHash }: Props) => {
+const AgreementDialog = ({
+  cancel,
+  close,
+  agreementHash,
+  isSignable,
+  back,
+}: Props) => {
+  const [hasBeenScrolled, setHasBeenScrolled] = useState(false);
+
+  const ref = useRef<HTMLDivElement>(null);
+
   const { data, loading } = useWhitelistAgreementQuery({
     variables: { agreementHash },
     fetchPolicy: 'network-only',
   });
+
+  const handleScroll = (e) => {
+    const bottom =
+      e.target.scrollHeight - e.target.scrollTop <= e.target.clientHeight;
+
+    if (bottom) {
+      setHasBeenScrolled(true);
+    }
+  };
+
+  useEffect(() => {
+    if (
+      ref.current !== null &&
+      ref.current.clientHeight === ref.current.scrollHeight
+    ) {
+      setHasBeenScrolled(true);
+    }
+  }, [data]);
 
   return (
     <Dialog cancel={cancel}>
@@ -46,11 +92,27 @@ const AgreementDialog = ({ cancel, close, agreementHash }: Props) => {
           className={styles.title}
         />
       </DialogSection>
+      {isSignable && (
+        <div className={styles.description}>
+          <DialogSection appearance={{ theme: 'sidePadding' }}>
+            <FormattedMessage {...MSG.agreementExplanation} />
+          </DialogSection>
+        </div>
+      )}
       <DialogSection>
+        {isSignable && (
+          <div className={styles.readCarefullyText}>
+            <FormattedMessage {...MSG.readCarefully} />
+          </div>
+        )}
         {loading ? (
           <SpinnerLoader appearance={{ size: 'huge', theme: 'primary' }} />
         ) : (
-          <div className={styles.agreementContainer}>
+          <div
+            className={styles.agreementContainer}
+            ref={ref}
+            onScroll={handleScroll}
+          >
             {data?.whitelistAgreement || (
               <div className={styles.error}>
                 <FormattedMessage {...MSG.ipfsError} />
@@ -58,12 +120,27 @@ const AgreementDialog = ({ cancel, close, agreementHash }: Props) => {
             )}
           </div>
         )}
+        {isSignable && (
+          <div className={styles.agreeToTermsText}>
+            <FormattedMessage {...MSG.agreeToTerms} />
+          </div>
+        )}
       </DialogSection>
       <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
+        {back && (
+          <Button
+            appearance={{ theme: 'secondary', size: 'large' }}
+            onClick={back}
+            text={{ id: 'button.back' }}
+          />
+        )}
         <Button
           appearance={{ theme: 'primary', size: 'large' }}
           onClick={close}
-          text={MSG.gotItButton}
+          text={isSignable ? MSG.iAgreeButton : MSG.gotItButton}
+          {...(isSignable
+            ? { disabled: !data?.whitelistAgreement || !hasBeenScrolled }
+            : {})}
         />
       </DialogSection>
     </Dialog>

--- a/src/modules/dashboard/components/Whitelist/AgreementDialog/AgreementDialog.tsx
+++ b/src/modules/dashboard/components/Whitelist/AgreementDialog/AgreementDialog.tsx
@@ -53,7 +53,7 @@ const AgreementDialog = ({
   cancel,
   close,
   agreementHash,
-  isSignable,
+  isSignable = false,
   back,
 }: Props) => {
   const [hasBeenScrolled, setHasBeenScrolled] = useState(false);


### PR DESCRIPTION
## Description

This PR extends agreement modal added in the Whitelist branch for Coin machine functionality.

**PLEASE, NOTE**
I have added automatic opening of the Agreement modal when you are on the `Buy tokens` page. This is for testing only and I will either remove this code completely before merging (it's just reverting back 1 commit) or I will put this code minus the automatic opening into the appropriate place if it's ready.

**New stuff** ✨

- added additional css, html & functionality to be able to sign the agreement.

## TODO

- remove/move the opening of the dialog code

Resolves DEV-456

<img width="650" alt="Screenshot 2021-08-02 at 16 48 10" src="https://user-images.githubusercontent.com/34057551/127875900-c7c670e9-03d8-4506-b7ab-645de791f8c5.png">

