### PR TITLE
Hide address upload when no kyc policy

### DIFF
--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -282,6 +282,7 @@ export type Query = {
   eventsForMotion: Array<ParsedEvent>;
   getRecoveryRequiredApprovals: Scalars['Int'];
   getRecoveryStorageSlot: Scalars['String'];
+  hasKycPolicy: Scalars['Boolean'];
   historicColonyRoles: Array<ProcessedRoles>;
   legacyNumberOfRecoveryRoles: Scalars['Int'];
   loggedInUser: LoggedInUser;
@@ -402,6 +403,11 @@ export type QueryGetRecoveryRequiredApprovalsArgs = {
 export type QueryGetRecoveryStorageSlotArgs = {
   colonyAddress: Scalars['String'];
   storageSlot: Scalars['String'];
+};
+
+
+export type QueryHasKycPolicyArgs = {
+  colonyAddress: Scalars['String'];
 };
 
 
@@ -1967,6 +1973,13 @@ export type WhitelistAgreementHashQueryVariables = Exact<{
 
 
 export type WhitelistAgreementHashQuery = Pick<Query, 'whitelistAgreementHash'>;
+
+export type HasKycPolicyQueryVariables = Exact<{
+  colonyAddress: Scalars['String'];
+}>;
+
+
+export type HasKycPolicyQuery = Pick<Query, 'hasKycPolicy'>;
 
 export type SubscriptionSubgraphEventsSubscriptionVariables = Exact<{
   skip: Scalars['Int'];
@@ -5175,6 +5188,37 @@ export function useWhitelistAgreementHashLazyQuery(baseOptions?: Apollo.LazyQuer
 export type WhitelistAgreementHashQueryHookResult = ReturnType<typeof useWhitelistAgreementHashQuery>;
 export type WhitelistAgreementHashLazyQueryHookResult = ReturnType<typeof useWhitelistAgreementHashLazyQuery>;
 export type WhitelistAgreementHashQueryResult = Apollo.QueryResult<WhitelistAgreementHashQuery, WhitelistAgreementHashQueryVariables>;
+export const HasKycPolicyDocument = gql`
+    query HasKycPolicy($colonyAddress: String!) {
+  hasKycPolicy(colonyAddress: $colonyAddress) @client
+}
+    `;
+
+/**
+ * __useHasKycPolicyQuery__
+ *
+ * To run a query within a React component, call `useHasKycPolicyQuery` and pass it any options that fit your needs.
+ * When your component renders, `useHasKycPolicyQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useHasKycPolicyQuery({
+ *   variables: {
+ *      colonyAddress: // value for 'colonyAddress'
+ *   },
+ * });
+ */
+export function useHasKycPolicyQuery(baseOptions?: Apollo.QueryHookOptions<HasKycPolicyQuery, HasKycPolicyQueryVariables>) {
+        return Apollo.useQuery<HasKycPolicyQuery, HasKycPolicyQueryVariables>(HasKycPolicyDocument, baseOptions);
+      }
+export function useHasKycPolicyLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<HasKycPolicyQuery, HasKycPolicyQueryVariables>) {
+          return Apollo.useLazyQuery<HasKycPolicyQuery, HasKycPolicyQueryVariables>(HasKycPolicyDocument, baseOptions);
+        }
+export type HasKycPolicyQueryHookResult = ReturnType<typeof useHasKycPolicyQuery>;
+export type HasKycPolicyLazyQueryHookResult = ReturnType<typeof useHasKycPolicyLazyQuery>;
+export type HasKycPolicyQueryResult = Apollo.QueryResult<HasKycPolicyQuery, HasKycPolicyQueryVariables>;
 export const SubscriptionSubgraphEventsDocument = gql`
     subscription SubscriptionSubgraphEvents($skip: Int!, $first: Int!, $colonyAddress: String!) {
   events(skip: $skip, first: $first, where: {associatedColony: $colonyAddress}) {

--- a/src/data/graphql/queries.graphql
+++ b/src/data/graphql/queries.graphql
@@ -732,3 +732,7 @@ query WhitelistAgreement($agreementHash: String!) {
 query WhitelistAgreementHash($colonyAddress: String!) {
   whitelistAgreementHash(colonyAddress: $colonyAddress) @client
 }
+
+query HasKycPolicy($colonyAddress: String!) {
+  hasKycPolicy(colonyAddress: $colonyAddress) @client
+}

--- a/src/data/graphql/typeDefs.ts
+++ b/src/data/graphql/typeDefs.ts
@@ -379,6 +379,7 @@ export default gql`
     motionStatus(motionId: Int!, colonyAddress: String!): String!
     whitelistAgreement(agreementHash: String!): String!
     whitelistAgreementHash(colonyAddress: String!): String
+    hasKycPolicy(colonyAddress: String!): Boolean!
   }
 
   extend type Mutation {

--- a/src/data/resolvers/whitelist.ts
+++ b/src/data/resolvers/whitelist.ts
@@ -38,5 +38,18 @@ export const whitelistResolvers = ({
         return null;
       }
     },
+    async hasKycPolicy(_, { colonyAddress }) {
+      try {
+        const whitelistClient = await colonyManager.getClient(
+          ClientType.WhitelistClient,
+          colonyAddress,
+        );
+
+        return whitelistClient.getUseApprovals();
+      } catch (error) {
+        console.error(error);
+        return error;
+      }
+    },
   },
 });

--- a/src/modules/dashboard/components/Whitelist/AgreementDialog/AgreementContainer.tsx
+++ b/src/modules/dashboard/components/Whitelist/AgreementDialog/AgreementContainer.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import { SpinnerLoader } from '~core/Preloaders';
+
+import styles from './AgreementDialog.css';
+
+const MSG = defineMessages({
+  title: {
+    id: 'dashboard.Extensions.WhitelisExtension.AgreementDialog.title',
+    defaultMessage: 'Sale agreement',
+  },
+  signedButton: {
+    id: 'dashboard.Extensions.WhitelisExtension.AgreementDialog.gotItButton',
+    defaultMessage: 'Signed',
+  },
+  ipfsError: {
+    id: 'dashboard.Extensions.WhitelisExtension.AgreementDialog.ipfsError',
+    defaultMessage: `There is a problem loading the agreement. Please, try again or contact colony admins.`,
+  },
+});
+
+interface Props {
+  loading: boolean;
+  text?: string;
+}
+
+const AgreementContainer = ({ loading, text }: Props) => {
+  return (
+    <div>
+      {loading ? (
+        <SpinnerLoader appearance={{ size: 'huge', theme: 'primary' }} />
+      ) : (
+        <div className={styles.agreementContainer}>
+          {text || (
+            <div className={styles.error}>
+              <FormattedMessage {...MSG.ipfsError} />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+AgreementContainer.displayName =
+  'dashboard.Whitelist.AgreementDialog.AgreementContainer';
+
+export default AgreementContainer;

--- a/src/modules/dashboard/components/Whitelist/AgreementDialog/AgreementContainer.tsx
+++ b/src/modules/dashboard/components/Whitelist/AgreementDialog/AgreementContainer.tsx
@@ -8,15 +8,16 @@ import styles from './AgreementDialog.css';
 
 const MSG = defineMessages({
   title: {
-    id: 'dashboard.Extensions.WhitelisExtension.AgreementDialog.title',
+    id:
+      'dashboard.Extensions.Whitelist.AgreementDialog.AgreementContainer.title',
     defaultMessage: 'Sale agreement',
   },
   signedButton: {
-    id: 'dashboard.Extensions.WhitelisExtension.AgreementDialog.gotItButton',
+    id: `dashboard.Extensions.Whitelist.AgreementDialog.AgreementContainer.gotItButton`,
     defaultMessage: 'Signed',
   },
   ipfsError: {
-    id: 'dashboard.Extensions.WhitelisExtension.AgreementDialog.ipfsError',
+    id: `dashboard.Extensions.Whitelist.AgreementDialog.AgreementContainer.ipfsError`,
     defaultMessage: `There is a problem loading the agreement. Please, try again or contact colony admins.`,
   },
 });

--- a/src/modules/dashboard/components/Whitelist/AgreementDialog/AgreementContainer.tsx
+++ b/src/modules/dashboard/components/Whitelist/AgreementDialog/AgreementContainer.tsx
@@ -27,17 +27,13 @@ interface Props {
 }
 
 const AgreementContainer = ({ loading, text }: Props) => {
-  return (
-    <div>
-      {loading ? (
-        <SpinnerLoader appearance={{ size: 'huge', theme: 'primary' }} />
-      ) : (
-        <div className={styles.agreementContainer}>
-          {text || (
-            <div className={styles.error}>
-              <FormattedMessage {...MSG.ipfsError} />
-            </div>
-          )}
+  return loading ? (
+    <SpinnerLoader appearance={{ size: 'huge', theme: 'primary' }} />
+  ) : (
+    <div className={styles.agreementContainer}>
+      {text || (
+        <div className={styles.error}>
+          <FormattedMessage {...MSG.ipfsError} />
         </div>
       )}
     </div>

--- a/src/modules/dashboard/components/Whitelist/AgreementDialog/AgreementContainer.tsx
+++ b/src/modules/dashboard/components/Whitelist/AgreementDialog/AgreementContainer.tsx
@@ -18,7 +18,7 @@ const MSG = defineMessages({
   },
   ipfsError: {
     id: `dashboard.Extensions.Whitelist.AgreementDialog.AgreementContainer.ipfsError`,
-    defaultMessage: `There is a problem loading the agreement. Please, try again or contact colony admins.`,
+    defaultMessage: `Failed to retrieve data from IPFS. Please try again.`,
   },
 });
 

--- a/src/modules/dashboard/components/Whitelist/AgreementDialog/AgreementDialog.tsx
+++ b/src/modules/dashboard/components/Whitelist/AgreementDialog/AgreementDialog.tsx
@@ -19,10 +19,6 @@ const MSG = defineMessages({
     id: 'dashboard.Extensions.Whitelist.AgreementDialog.gotItButton',
     defaultMessage: 'Got it',
   },
-  ipfsError: {
-    id: 'dashboard.Extensions.WhitelisExtension.AgreementDialog.ipfsError',
-    defaultMessage: `Failed to retrieve data from IPFS. Please try again.`,
-  },
 });
 
 interface Props {

--- a/src/modules/dashboard/components/Whitelist/AgreementDialog/AgreementDialog.tsx
+++ b/src/modules/dashboard/components/Whitelist/AgreementDialog/AgreementDialog.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import { defineMessages, FormattedMessage } from 'react-intl';
+import { defineMessages } from 'react-intl';
 
 import Dialog, { DialogSection } from '~core/Dialog';
 import Button from '~core/Button';
 import Heading from '~core/Heading';
-import { SpinnerLoader } from '~core/Preloaders';
 
 import { useWhitelistAgreementQuery } from '~data/index';
 
+import AgreementContainer from './AgreementContainer';
 import styles from './AgreementDialog.css';
 
 const MSG = defineMessages({
@@ -47,17 +47,7 @@ const AgreementDialog = ({ cancel, close, agreementHash }: Props) => {
         />
       </DialogSection>
       <DialogSection>
-        {loading ? (
-          <SpinnerLoader appearance={{ size: 'huge', theme: 'primary' }} />
-        ) : (
-          <div className={styles.agreementContainer}>
-            {data?.whitelistAgreement || (
-              <div className={styles.error}>
-                <FormattedMessage {...MSG.ipfsError} />
-              </div>
-            )}
-          </div>
-        )}
+        <AgreementContainer loading={loading} text={data?.whitelistAgreement} />
       </DialogSection>
       <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
         <Button

--- a/src/modules/dashboard/components/Whitelist/AgreementDialog/AgreementDialog.tsx
+++ b/src/modules/dashboard/components/Whitelist/AgreementDialog/AgreementDialog.tsx
@@ -12,11 +12,11 @@ import styles from './AgreementDialog.css';
 
 const MSG = defineMessages({
   title: {
-    id: 'dashboard.Extensions.WhitelisExtension.AgreementDialog.title',
+    id: 'dashboard.Extensions.Whitelist.AgreementDialog.title',
     defaultMessage: 'Sale agreement',
   },
   gotItButton: {
-    id: 'dashboard.Extensions.WhitelisExtension.AgreementDialog.gotItButton',
+    id: 'dashboard.Extensions.Whitelist.AgreementDialog.gotItButton',
     defaultMessage: 'Got it',
   },
   ipfsError: {

--- a/src/modules/dashboard/components/Whitelist/AgreementDialog/index.ts
+++ b/src/modules/dashboard/components/Whitelist/AgreementDialog/index.ts
@@ -1,1 +1,2 @@
 export { default } from './AgreementDialog';
+export { default as AgreementContainer } from './AgreementContainer';

--- a/src/modules/dashboard/components/Whitelist/AgreementEmbed/AgreementEmbed.css
+++ b/src/modules/dashboard/components/Whitelist/AgreementEmbed/AgreementEmbed.css
@@ -1,0 +1,17 @@
+.container {
+  margin-top: 30px;
+  border-radius: var(--radius-normal);
+  background: rgba(253, 253, 253);
+}
+
+.container > section > div {
+  background: rgba(249, 250, 250);
+}
+
+.title {
+  padding-top: 30px;
+  font-size: var(--size-medium-l);
+  font-weight: var(--weight-bold);
+  line-height: 24px;
+  color: var(--dark);
+}

--- a/src/modules/dashboard/components/Whitelist/AgreementEmbed/AgreementEmbed.css.d.ts
+++ b/src/modules/dashboard/components/Whitelist/AgreementEmbed/AgreementEmbed.css.d.ts
@@ -1,0 +1,2 @@
+export const container: string;
+export const title: string;

--- a/src/modules/dashboard/components/Whitelist/AgreementEmbed/AgreementEmbed.tsx
+++ b/src/modules/dashboard/components/Whitelist/AgreementEmbed/AgreementEmbed.tsx
@@ -3,7 +3,6 @@ import { defineMessage } from 'react-intl';
 
 import { useWhitelistAgreementQuery } from '~data/index';
 
-import Button from '~core/Button';
 import { DialogSection } from '~core/Dialog';
 import Heading from '~core/Heading';
 
@@ -15,10 +14,6 @@ const MSG = defineMessage({
   title: {
     id: 'dashboard.Extensions.Whitelist.AgreementEmbed.title',
     defaultMessage: 'Sale agreement',
-  },
-  signedButton: {
-    id: 'dashboard.Extensions.Whitelist.AgreementEmbed.signed',
-    defaultMessage: 'Signed',
   },
 });
 
@@ -43,13 +38,6 @@ const AgreementEmbed = ({ agreementHash }: Props) => {
       </DialogSection>
       <DialogSection>
         <AgreementContainer text={data?.whitelistAgreement} loading={loading} />
-      </DialogSection>
-      <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
-        <Button
-          appearance={{ theme: 'primary', size: 'large' }}
-          text={MSG.signedButton}
-          disabled
-        />
       </DialogSection>
     </div>
   );

--- a/src/modules/dashboard/components/Whitelist/AgreementEmbed/AgreementEmbed.tsx
+++ b/src/modules/dashboard/components/Whitelist/AgreementEmbed/AgreementEmbed.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { defineMessage } from 'react-intl';
+
+import { useWhitelistAgreementQuery } from '~data/index';
+
+import Button from '~core/Button';
+import { DialogSection } from '~core/Dialog';
+import Heading from '~core/Heading';
+
+import { AgreementContainer } from '../AgreementDialog';
+
+import styles from './AgreementEmbed.css';
+
+const MSG = defineMessage({
+  title: {
+    id: 'dashboard.Extensions.Whitelist.AgreementEmbed.title',
+    defaultMessage: 'Sale agreement',
+  },
+  signedButton: {
+    id: 'dashboard.Extensions.Whitelist.AgreementEmbed.signed',
+    defaultMessage: 'Signed',
+  },
+});
+
+interface Props {
+  agreementHash: string;
+}
+
+const AgreementEmbed = ({ agreementHash }: Props) => {
+  const { data, loading } = useWhitelistAgreementQuery({
+    variables: { agreementHash },
+    fetchPolicy: 'network-only',
+  });
+
+  return (
+    <div className={styles.container}>
+      <DialogSection appearance={{ theme: 'sidePadding' }}>
+        <Heading
+          appearance={{ size: 'medium', margin: 'none' }}
+          text={MSG.title}
+          className={styles.title}
+        />
+      </DialogSection>
+      <DialogSection>
+        <AgreementContainer text={data?.whitelistAgreement} loading={loading} />
+      </DialogSection>
+      <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
+        <Button
+          appearance={{ theme: 'primary', size: 'large' }}
+          text={MSG.signedButton}
+          disabled
+        />
+      </DialogSection>
+    </div>
+  );
+};
+
+AgreementEmbed.displayName = 'dashboard.Whitelist.AgreementEmbed';
+
+export default AgreementEmbed;

--- a/src/modules/dashboard/components/Whitelist/AgreementEmbed/index.ts
+++ b/src/modules/dashboard/components/Whitelist/AgreementEmbed/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AgreementEmbed';

--- a/src/modules/dashboard/components/Whitelist/UploadAddressesWidget/UploadAddressesWidget.tsx
+++ b/src/modules/dashboard/components/Whitelist/UploadAddressesWidget/UploadAddressesWidget.tsx
@@ -7,13 +7,8 @@ import { ActionForm, InputLabel, Input } from '~core/Fields';
 import Button from '~core/Button';
 import CSVUploader from '~core/CSVUploader';
 import { useDialog } from '~core/Dialog';
-import { MiniSpinnerLoader } from '~core/Preloaders';
 
-import {
-  Colony,
-  useWhitelistAgreementHashQuery,
-  useLoggedInUser,
-} from '~data/index';
+import { Colony, useLoggedInUser } from '~data/index';
 import { ActionTypes } from '~redux/index';
 import { pipe, mapPayload } from '~utils/actions';
 import { isAddress } from '~utils/web3';
@@ -94,11 +89,13 @@ const validationSchemaFile = yup.object({
 
 interface Props {
   colony: Colony;
+  whitelistAgreementHash?: string | null;
 }
 
 const UploadAddressesWidget = ({
   colony: { colonyAddress },
   colony,
+  whitelistAgreementHash,
 }: Props) => {
   const [showInput, setShowInput] = useState<boolean>(true);
   const toggleShowInput = () => setShowInput(!showInput);
@@ -110,21 +107,14 @@ const UploadAddressesWidget = ({
   const userHasPermission = hasRegisteredProfile && hasRoot(allUserRoles);
 
   const openAgreementDialog = useDialog(AgreementDialog);
-  const {
-    data: agreementHashData,
-    loading: agreementHashLoading,
-  } = useWhitelistAgreementHashQuery({
-    variables: { colonyAddress },
-    fetchPolicy: 'network-only',
-  });
 
   const openDialog = useCallback(
     () =>
-      agreementHashData?.whitelistAgreementHash &&
+      whitelistAgreementHash &&
       openAgreementDialog({
-        agreementHash: agreementHashData?.whitelistAgreementHash,
+        agreementHash: whitelistAgreementHash,
       }),
-    [openAgreementDialog, agreementHashData],
+    [openAgreementDialog, whitelistAgreementHash],
   );
 
   const transform = useCallback(
@@ -198,15 +188,13 @@ const UploadAddressesWidget = ({
           )}
           <div className={styles.buttonsContainer}>
             <div className={styles.agreeemntButton}>
-              {agreementHashLoading && <MiniSpinnerLoader />}
-              {!agreementHashLoading &&
-                agreementHashData?.whitelistAgreementHash && (
-                  <Button
-                    appearance={{ theme: 'blue' }}
-                    onClick={openDialog}
-                    text={MSG.agreement}
-                  />
-                )}
+              {whitelistAgreementHash && (
+                <Button
+                  appearance={{ theme: 'blue' }}
+                  onClick={openDialog}
+                  text={MSG.agreement}
+                />
+              )}
             </div>
             <Button
               appearance={{ theme: 'primary', size: 'large' }}

--- a/src/modules/dashboard/components/Whitelist/Whitelist.css
+++ b/src/modules/dashboard/components/Whitelist/Whitelist.css
@@ -1,0 +1,3 @@
+.loaderContainer {
+  margin-top: 50px;
+}

--- a/src/modules/dashboard/components/Whitelist/Whitelist.css.d.ts
+++ b/src/modules/dashboard/components/Whitelist/Whitelist.css.d.ts
@@ -1,0 +1,1 @@
+export const loaderContainer: string;

--- a/src/modules/dashboard/components/Whitelist/Whitelist.tsx
+++ b/src/modules/dashboard/components/Whitelist/Whitelist.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { defineMessage } from 'react-intl';
 
-import { useWhitelistedUsersQuery, Colony } from '~data/index';
+import {
+  useWhitelistedUsersQuery,
+  useHasKycPolicyQuery,
+  Colony,
+} from '~data/index';
 import { MiniSpinnerLoader } from '~core/Preloaders';
 
 import UploadAddressesWidget from './UploadAddressesWidget';
@@ -21,6 +25,14 @@ interface Props {
 const Whitelist = ({ colony: { colonyAddress }, colony }: Props) => {
   const { data: usersData, loading: usersLoading } = useWhitelistedUsersQuery({
     variables: { colonyAddress },
+  });
+
+  const {
+    data: kycPolicyData,
+    loading: kycPolicyLoading,
+  } = useHasKycPolicyQuery({
+    variables: { colonyAddress },
+    fetchPolicy: 'network-only',
   });
 
   return (


### PR DESCRIPTION
## Description

This PR hides addresses upload & addresses list when no KYC was selected.

Karl provided a separate UI mockup for this case (as per the link below). Please, note that we also discussed it with him and there shouldn't be any "footer" with Signed button like in the dialog.

https://www.figma.com/file/fw2pDIUlkhCkJE79ZyTbjp/CoinMachine?node-id=2565%3A22238

**New stuff** ✨

- extracted `AgreeementContainer` to a separate component
- add `AgreeementEmbed` component
- add `HasKycPolicy` query, typedefs & resolver

**Changes** 🏗

- extract `WhitelistAgreementHash` query from `UploadAddressesWidget` component to `Whitelist`
- update logic for `UploadAddressesWidget` in the `Whitelist`

## TODO

When this is merged to master I would like to rebase `coin-machine-redux` branch on master since there will be some conflicts which I know how to resolve and upgrade that branch based on what's done on master. So that it's done when by me and when it's still fresh (will be much quicker and more efficient).

Resolves issues #2637

<img width="516" alt="Screenshot 2021-08-09 at 15 44 40" src="https://user-images.githubusercontent.com/34057551/128708069-bed2b8c7-517e-430d-b85d-9fc57ca534e5.png">

