### PR TITLE
Add Sale started/Sale paused logic to coin machine

### DIFF
--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -1211,6 +1211,7 @@ export type CurrentPeriodTokens = {
   maxPerPeriodTokens: Scalars['String'];
   activeSoldTokens: Scalars['String'];
   targetPerPeriodTokens: Scalars['String'];
+  tokenPeriodBalance: Scalars['String'];
 };
 
 export type BoughtTokens = {
@@ -2135,7 +2136,7 @@ export type CurrentPeriodTokensQueryVariables = Exact<{
 }>;
 
 
-export type CurrentPeriodTokensQuery = { currentPeriodTokens: Pick<CurrentPeriodTokens, 'maxPerPeriodTokens' | 'activeSoldTokens' | 'targetPerPeriodTokens'> };
+export type CurrentPeriodTokensQuery = { currentPeriodTokens: Pick<CurrentPeriodTokens, 'maxPerPeriodTokens' | 'activeSoldTokens' | 'targetPerPeriodTokens' | 'tokenPeriodBalance'> };
 
 export type SubscriptionSubgraphEventsSubscriptionVariables = Exact<{
   skip: Scalars['Int'];
@@ -5631,6 +5632,7 @@ export const CurrentPeriodTokensDocument = gql`
     maxPerPeriodTokens
     activeSoldTokens
     targetPerPeriodTokens
+    tokenPeriodBalance
   }
 }
     `;

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -274,6 +274,7 @@ export type Query = {
   coinMachineCurrentPeriodPrice: Scalars['String'];
   coinMachineSalePeriod: SalePeriod;
   coinMachineSaleTokens: SaleTokens;
+  coinMachineTokenBalance: Scalars['String'];
   coinMachineTransactionAmount: TrannsactionAmount;
   colonies: Array<SubgraphColony>;
   colony: SubgraphColony;
@@ -362,6 +363,11 @@ export type QueryCoinMachineSalePeriodArgs = {
 
 
 export type QueryCoinMachineSaleTokensArgs = {
+  colonyAddress: Scalars['String'];
+};
+
+
+export type QueryCoinMachineTokenBalanceArgs = {
   colonyAddress: Scalars['String'];
 };
 
@@ -1211,7 +1217,6 @@ export type CurrentPeriodTokens = {
   maxPerPeriodTokens: Scalars['String'];
   activeSoldTokens: Scalars['String'];
   targetPerPeriodTokens: Scalars['String'];
-  tokenPeriodBalance: Scalars['String'];
 };
 
 export type BoughtTokens = {
@@ -2136,7 +2141,14 @@ export type CurrentPeriodTokensQueryVariables = Exact<{
 }>;
 
 
-export type CurrentPeriodTokensQuery = { currentPeriodTokens: Pick<CurrentPeriodTokens, 'maxPerPeriodTokens' | 'activeSoldTokens' | 'targetPerPeriodTokens' | 'tokenPeriodBalance'> };
+export type CurrentPeriodTokensQuery = { currentPeriodTokens: Pick<CurrentPeriodTokens, 'maxPerPeriodTokens' | 'activeSoldTokens' | 'targetPerPeriodTokens'> };
+
+export type CoinMachineTokenBalanceQueryVariables = Exact<{
+  colonyAddress: Scalars['String'];
+}>;
+
+
+export type CoinMachineTokenBalanceQuery = Pick<Query, 'coinMachineTokenBalance'>;
 
 export type SubscriptionSubgraphEventsSubscriptionVariables = Exact<{
   skip: Scalars['Int'];
@@ -5632,7 +5644,6 @@ export const CurrentPeriodTokensDocument = gql`
     maxPerPeriodTokens
     activeSoldTokens
     targetPerPeriodTokens
-    tokenPeriodBalance
   }
 }
     `;
@@ -5662,6 +5673,37 @@ export function useCurrentPeriodTokensLazyQuery(baseOptions?: Apollo.LazyQueryHo
 export type CurrentPeriodTokensQueryHookResult = ReturnType<typeof useCurrentPeriodTokensQuery>;
 export type CurrentPeriodTokensLazyQueryHookResult = ReturnType<typeof useCurrentPeriodTokensLazyQuery>;
 export type CurrentPeriodTokensQueryResult = Apollo.QueryResult<CurrentPeriodTokensQuery, CurrentPeriodTokensQueryVariables>;
+export const CoinMachineTokenBalanceDocument = gql`
+    query CoinMachineTokenBalance($colonyAddress: String!) {
+  coinMachineTokenBalance(colonyAddress: $colonyAddress) @client
+}
+    `;
+
+/**
+ * __useCoinMachineTokenBalanceQuery__
+ *
+ * To run a query within a React component, call `useCoinMachineTokenBalanceQuery` and pass it any options that fit your needs.
+ * When your component renders, `useCoinMachineTokenBalanceQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useCoinMachineTokenBalanceQuery({
+ *   variables: {
+ *      colonyAddress: // value for 'colonyAddress'
+ *   },
+ * });
+ */
+export function useCoinMachineTokenBalanceQuery(baseOptions?: Apollo.QueryHookOptions<CoinMachineTokenBalanceQuery, CoinMachineTokenBalanceQueryVariables>) {
+        return Apollo.useQuery<CoinMachineTokenBalanceQuery, CoinMachineTokenBalanceQueryVariables>(CoinMachineTokenBalanceDocument, baseOptions);
+      }
+export function useCoinMachineTokenBalanceLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CoinMachineTokenBalanceQuery, CoinMachineTokenBalanceQueryVariables>) {
+          return Apollo.useLazyQuery<CoinMachineTokenBalanceQuery, CoinMachineTokenBalanceQueryVariables>(CoinMachineTokenBalanceDocument, baseOptions);
+        }
+export type CoinMachineTokenBalanceQueryHookResult = ReturnType<typeof useCoinMachineTokenBalanceQuery>;
+export type CoinMachineTokenBalanceLazyQueryHookResult = ReturnType<typeof useCoinMachineTokenBalanceLazyQuery>;
+export type CoinMachineTokenBalanceQueryResult = Apollo.QueryResult<CoinMachineTokenBalanceQuery, CoinMachineTokenBalanceQueryVariables>;
 export const SubscriptionSubgraphEventsDocument = gql`
     subscription SubscriptionSubgraphEvents($skip: Int!, $first: Int!, $colonyAddress: String!) {
   events(skip: $skip, first: $first, where: {associatedColony: $colonyAddress}) {

--- a/src/data/graphql/queries/coinMachine.graphql
+++ b/src/data/graphql/queries/coinMachine.graphql
@@ -53,5 +53,6 @@ query CurrentPeriodTokens($colonyAddress: String!) {
     maxPerPeriodTokens
     activeSoldTokens
     targetPerPeriodTokens
+    tokenPeriodBalance
   }
 }

--- a/src/data/graphql/queries/coinMachine.graphql
+++ b/src/data/graphql/queries/coinMachine.graphql
@@ -53,6 +53,9 @@ query CurrentPeriodTokens($colonyAddress: String!) {
     maxPerPeriodTokens
     activeSoldTokens
     targetPerPeriodTokens
-    tokenPeriodBalance
   }
+}
+
+query CoinMachineTokenBalance($colonyAddress: String!) {
+  coinMachineTokenBalance(colonyAddress: $colonyAddress) @client
 }

--- a/src/data/graphql/typeDefs/coinMachine.ts
+++ b/src/data/graphql/typeDefs/coinMachine.ts
@@ -21,6 +21,7 @@ export default gql`
     maxPerPeriodTokens: String!
     activeSoldTokens: String!
     targetPerPeriodTokens: String!
+    tokenPeriodBalance: String!
   }
 
   type BoughtTokens {

--- a/src/data/graphql/typeDefs/coinMachine.ts
+++ b/src/data/graphql/typeDefs/coinMachine.ts
@@ -21,7 +21,6 @@ export default gql`
     maxPerPeriodTokens: String!
     activeSoldTokens: String!
     targetPerPeriodTokens: String!
-    tokenPeriodBalance: String!
   }
 
   type BoughtTokens {
@@ -51,5 +50,6 @@ export default gql`
     ): String!
     coinMachineSalePeriod(colonyAddress: String!): SalePeriod!
     currentPeriodTokens(colonyAddress: String!): CurrentPeriodTokens!
+    coinMachineTokenBalance(colonyAddress: String!): String!
   }
 `;

--- a/src/data/resolvers/coinMachine.ts
+++ b/src/data/resolvers/coinMachine.ts
@@ -198,8 +198,6 @@ export const coinMachineResolvers = ({
         // eslint-disable-next-line max-len
         const targetPerPeriodTokens = await coinMachineClient.getTargetPerPeriod();
 
-        const tokenPeriodBalance = await coinMachineClient.getTokenBalance();
-
         return {
           maxPerPeriodTokens: maxPerPeriodTokens.toString(),
           activeSoldTokens:
@@ -207,8 +205,21 @@ export const coinMachineResolvers = ({
               ? activeSoldTokens.toString()
               : '',
           targetPerPeriodTokens: targetPerPeriodTokens.toString(),
-          tokenPeriodBalance: tokenPeriodBalance.toString(),
         };
+      } catch (error) {
+        console.error(error);
+        return null;
+      }
+    },
+    async coinMachineTokenBalance(_, { colonyAddress }) {
+      try {
+        const coinMachineClient = await colonyManager.getClient(
+          ClientType.CoinMachineClient,
+          colonyAddress,
+        );
+        const tokenBalance = await coinMachineClient.getTokenBalance();
+
+        return tokenBalance.toString();
       } catch (error) {
         console.error(error);
         return null;

--- a/src/data/resolvers/coinMachine.ts
+++ b/src/data/resolvers/coinMachine.ts
@@ -198,6 +198,8 @@ export const coinMachineResolvers = ({
         // eslint-disable-next-line max-len
         const targetPerPeriodTokens = await coinMachineClient.getTargetPerPeriod();
 
+        const tokenPeriodBalance = await coinMachineClient.getTokenBalance();
+
         return {
           maxPerPeriodTokens: maxPerPeriodTokens.toString(),
           activeSoldTokens:
@@ -205,6 +207,7 @@ export const coinMachineResolvers = ({
               ? activeSoldTokens.toString()
               : '',
           targetPerPeriodTokens: targetPerPeriodTokens.toString(),
+          tokenPeriodBalance: tokenPeriodBalance.toString(),
         };
       } catch (error) {
         console.error(error);

--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -14,6 +14,7 @@ import {
   useCurrentPeriodTokensQuery,
   Colony,
   useCoinMachineSalePeriodQuery,
+  useCoinMachineTokenBalanceQuery,
 } from '~data/index';
 
 import Chat from './Chat';
@@ -87,8 +88,17 @@ const CoinMachine = ({
     variables: { colonyAddress },
     fetchPolicy: 'network-only',
   });
+
+  const {
+    data: coinMachineTokenBalanceData,
+    loading: coinMachineTokenBalanceLoading,
+  } = useCoinMachineTokenBalanceQuery({
+    variables: { colonyAddress },
+    fetchPolicy: 'network-only',
+  });
+
   const hasSaleStarted = !bigNumberify(
-    periodTokensData?.currentPeriodTokens.tokenPeriodBalance || 0,
+    coinMachineTokenBalanceData?.coinMachineTokenBalance || 0,
   ).isZero();
 
   const periodTokens = useMemo(() => {
@@ -106,9 +116,6 @@ const CoinMachine = ({
       targetPeriodTokens: bigNumberify(
         periodTokensData.currentPeriodTokens.targetPerPeriodTokens,
       ),
-      tokenPeriodBalance: bigNumberify(
-        periodTokensData.currentPeriodTokens.tokenPeriodBalance,
-      ),
     };
   }, [periodTokensData, saleTokensData, hasSaleStarted]);
 
@@ -124,7 +131,8 @@ const CoinMachine = ({
     saleTokensLoading ||
     salePeriodLoading ||
     !data?.processedColony?.installedExtensions ||
-    periodTokensLoading
+    periodTokensLoading ||
+    coinMachineTokenBalanceLoading
   ) {
     return (
       <div className={styles.loadingSpinner}>

--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -90,9 +90,12 @@ const CoinMachine = ({
     variables: { colonyAddress },
     fetchPolicy: 'network-only',
   });
+  const saleStarted = !bigNumberify(
+    periodTokensData?.currentPeriodTokens.tokenPeriodBalance || 0
+  ).isZero();
 
   const periodTokens = useMemo(() => {
-    if (!saleTokensData || !periodTokensData || !isSale) {
+    if (!saleTokensData || !periodTokensData || !saleStarted) {
       return undefined;
     }
     return {
@@ -106,8 +109,12 @@ const CoinMachine = ({
       targetPeriodTokens: bigNumberify(
         periodTokensData.currentPeriodTokens.targetPerPeriodTokens,
       ),
+      tokenPeriodBalance: bigNumberify(
+        periodTokensData.currentPeriodTokens.tokenPeriodBalance,
+      ),
     };
-  }, [periodTokensData, saleTokensData, isSale]);
+  }, [periodTokensData, saleTokensData, saleStarted]);
+
 
   const isSoldOut = useMemo(
     () =>
@@ -196,11 +203,7 @@ const CoinMachine = ({
             <div className={styles.buy}>
               <BuyTokens
                 colony={colony}
-                /*
-                 * @TODO Determine if the sale is currently ongoing
-                 * And only disable it if it insn't
-                 */
-                isCurrentlyOnSale={isSale}
+                isCurrentlyOnSale={saleStarted}
                 isSoldOut={isSoldOut}
               />
             </div>
@@ -208,7 +211,7 @@ const CoinMachine = ({
               <RemainingDisplayWidget
                 displayType={DataDisplayType.Time}
                 appearance={{ theme: !isSoldOut ? 'white' : 'danger' }}
-                value={timeRemaining}
+                value={saleStarted ? timeRemaining : null}
                 periodLength={periodLength}
                 colonyAddress={colonyAddress}
               />

--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -87,12 +87,12 @@ const CoinMachine = ({
     variables: { colonyAddress },
     fetchPolicy: 'network-only',
   });
-  const saleStarted = !bigNumberify(
+  const hasSaleStarted = !bigNumberify(
     periodTokensData?.currentPeriodTokens.tokenPeriodBalance || 0,
   ).isZero();
 
   const periodTokens = useMemo(() => {
-    if (!saleTokensData || !periodTokensData || !saleStarted) {
+    if (!saleTokensData || !periodTokensData || !hasSaleStarted) {
       return undefined;
     }
     return {
@@ -110,7 +110,7 @@ const CoinMachine = ({
         periodTokensData.currentPeriodTokens.tokenPeriodBalance,
       ),
     };
-  }, [periodTokensData, saleTokensData, saleStarted]);
+  }, [periodTokensData, saleTokensData, hasSaleStarted]);
 
   const isSoldOut = useMemo(
     () =>
@@ -199,7 +199,7 @@ const CoinMachine = ({
             <div className={styles.buy}>
               <BuyTokens
                 colony={colony}
-                isCurrentlyOnSale={saleStarted}
+                isCurrentlyOnSale={hasSaleStarted}
                 isSoldOut={isSoldOut}
               />
             </div>
@@ -207,17 +207,15 @@ const CoinMachine = ({
               <RemainingDisplayWidget
                 displayType={DataDisplayType.Time}
                 appearance={{ theme: !isSoldOut ? 'white' : 'danger' }}
-                value={saleStarted ? timeRemaining : null}
+                value={hasSaleStarted ? timeRemaining : null}
                 periodLength={periodLength}
                 colonyAddress={colonyAddress}
-                saleStarted={saleStarted}
               />
             </div>
             <div className={styles.tokensRemaining}>
               <RemainingDisplayWidget
                 displayType={DataDisplayType.Tokens}
                 periodTokens={periodTokens}
-                saleStarted={saleStarted}
               />
             </div>
           </>

--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -57,9 +57,6 @@ const CoinMachine = ({
   colony: { colonyAddress, colonyName },
   colony,
 }: Props) => {
-  /* To add proper logic later */
-  const isSale = true;
-
   const { data, loading } = useColonyExtensionsQuery({
     variables: { address: colonyAddress },
   });
@@ -91,7 +88,7 @@ const CoinMachine = ({
     fetchPolicy: 'network-only',
   });
   const saleStarted = !bigNumberify(
-    periodTokensData?.currentPeriodTokens.tokenPeriodBalance || 0
+    periodTokensData?.currentPeriodTokens.tokenPeriodBalance || 0,
   ).isZero();
 
   const periodTokens = useMemo(() => {
@@ -114,7 +111,6 @@ const CoinMachine = ({
       ),
     };
   }, [periodTokensData, saleTokensData, saleStarted]);
-
 
   const isSoldOut = useMemo(
     () =>

--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -214,12 +214,14 @@ const CoinMachine = ({
                 value={saleStarted ? timeRemaining : null}
                 periodLength={periodLength}
                 colonyAddress={colonyAddress}
+                saleStarted={saleStarted}
               />
             </div>
             <div className={styles.tokensRemaining}>
               <RemainingDisplayWidget
                 displayType={DataDisplayType.Tokens}
                 periodTokens={periodTokens}
+                saleStarted={saleStarted}
               />
             </div>
           </>

--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidget/RemainingDisplayWidget.tsx
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidget/RemainingDisplayWidget.tsx
@@ -32,7 +32,6 @@ type Appearance = {
 type Props = {
   colonyAddress?: Address;
   displayType: DataDisplayType;
-  saleStarted: boolean;
   value?: string | number | null;
   appearance?: Appearance;
   periodLength?: number;
@@ -92,13 +91,12 @@ const RemainingDisplayWidget = ({
   periodLength,
   periodTokens,
   colonyAddress,
-  saleStarted,
 }: Props) => {
   const dispatch = useDispatch();
 
   const displaysTimer = displayType === DataDisplayType.Time;
   const { splitTime, timeLeft } = useSplitTime(
-    displaysTimer && typeof value === 'number' ? value : 0,
+    displaysTimer && typeof value === 'number' ? value : -1,
     displaysTimer,
     periodLength,
   );
@@ -189,7 +187,7 @@ const RemainingDisplayWidget = ({
   }, [periodTokens]);
 
   useEffect(() => {
-    if (timeLeft <= 0 && colonyAddress !== undefined) {
+    if (value && timeLeft <= 0 && colonyAddress !== undefined) {
       dispatch({
         type: ActionTypes.COIN_MACHINE_PERIOD_UPDATE,
         payload: { colonyAddress },
@@ -219,13 +217,9 @@ const RemainingDisplayWidget = ({
           [styles.valueWarning]: isValueWarning || showValueWarning,
         })}
       >
-        {saleStarted ? (
-          displayedValue
-        ) : (
-          <FormattedMessage {...widgetText.placeholder} />
-        )}
+        {displayedValue}
       </p>
-      {saleStarted && periodTokens && widgetText.footerText && (
+      {periodTokens && widgetText.footerText && (
         <div className={styles.footer}>
           <p className={styles.footerText}>
             <FormattedMessage {...widgetText.footerText} />

--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidget/RemainingDisplayWidget.tsx
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidget/RemainingDisplayWidget.tsx
@@ -193,7 +193,7 @@ const RemainingDisplayWidget = ({
         payload: { colonyAddress },
       });
     }
-  }, [timeLeft, colonyAddress, dispatch]);
+  }, [timeLeft, colonyAddress, dispatch, value]);
 
   return (
     <div className={getMainClasses(appearance, styles)}>

--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidget/RemainingDisplayWidget.tsx
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidget/RemainingDisplayWidget.tsx
@@ -32,6 +32,7 @@ type Appearance = {
 type Props = {
   colonyAddress?: Address;
   displayType: DataDisplayType;
+  saleStarted: boolean;
   value?: string | number | null;
   appearance?: Appearance;
   periodLength?: number;
@@ -91,6 +92,7 @@ const RemainingDisplayWidget = ({
   periodLength,
   periodTokens,
   colonyAddress,
+  saleStarted,
 }: Props) => {
   const dispatch = useDispatch();
 
@@ -217,9 +219,13 @@ const RemainingDisplayWidget = ({
           [styles.valueWarning]: isValueWarning || showValueWarning,
         })}
       >
-        {displayedValue}
+        {saleStarted ? (
+          displayedValue
+        ) : (
+          <FormattedMessage {...widgetText.placeholder} />
+        )}
       </p>
-      {periodTokens && widgetText.footerText && (
+      {saleStarted && periodTokens && widgetText.footerText && (
         <div className={styles.footer}>
           <p className={styles.footerText}>
             <FormattedMessage {...widgetText.footerText} />


### PR DESCRIPTION
Added logic to detect if the sale started or was paused due to a lack of tokens to sell in Coin Machine

- [x] TODO: Update this PR once #2642 is merged, as that PR has reusable code for this one

* Coin machine with no token balance
![FireShot Capture 417 - Colony - localhost](https://user-images.githubusercontent.com/18473896/129945660-63c4c7eb-4252-4ef7-86bb-45bccb94539b.png)

Resolves DEV-469
