### PR TITLE
Disable coin machine UI when not logged in & add sold out logic

### DIFF
--- a/src/modules/core/components/CommentInput/CommentInput.css
+++ b/src/modules/core/components/CommentInput/CommentInput.css
@@ -28,8 +28,8 @@
 }
 
 .commentBox textarea:disabled {
-  border-color: rgb(200, 214, 245);
-  background-color: var(--text-disabled);
+  border: 1px solid color-mod(var(--temp-grey-4) alpha(50%));
+  background-color: color-mod(var(--temp-grey-4) alpha(10%));
 }
 
 .sendInstructions {

--- a/src/modules/core/components/CommentInput/CommentInput.css
+++ b/src/modules/core/components/CommentInput/CommentInput.css
@@ -28,8 +28,8 @@
 }
 
 .commentBox textarea:disabled {
-  border: 1px solid color-mod(var(--temp-grey-4) alpha(50%));
-  background-color: color-mod(var(--temp-grey-4) alpha(10%));
+  border-color: rgb(200, 214, 245);
+  background-color: var(--text-disabled);
 }
 
 .sendInstructions {

--- a/src/modules/core/components/CommentInput/CommentInput.tsx
+++ b/src/modules/core/components/CommentInput/CommentInput.tsx
@@ -64,6 +64,7 @@ interface Props {
   colonyAddress: Address;
   disabled?: boolean;
   callback?: (message: string) => void;
+  disabledInputPlaceholder?: boolean;
 }
 
 const handleKeyboardSubmit = (
@@ -87,6 +88,7 @@ const CommentInput = ({
   colonyAddress,
   callback,
   disabled,
+  disabledInputPlaceholder,
 }: Props) => {
   const commentBoxRef = useRef<HTMLInputElement>(null);
 
@@ -146,7 +148,9 @@ const CommentInput = ({
               elementOnly
               label={MSG.commentInputPlaceholder}
               name="message"
-              placeholder={disabled ? '' : MSG.commentInputPlaceholder}
+              placeholder={
+                disabledInputPlaceholder ? '' : MSG.commentInputPlaceholder
+              }
               minRows={1}
               maxRows={6}
               onKeyDown={(event) => handleKeyboardSubmit(event, handleSubmit)}

--- a/src/modules/core/components/CommentInput/CommentInput.tsx
+++ b/src/modules/core/components/CommentInput/CommentInput.tsx
@@ -62,6 +62,7 @@ type FormValues = {
 interface Props {
   transactionHash: string;
   colonyAddress: Address;
+  disabled?: boolean;
   callback?: (message: string) => void;
 }
 
@@ -81,7 +82,12 @@ const handleKeyboardSubmit = (
   return false;
 };
 
-const CommentInput = ({ transactionHash, colonyAddress, callback }: Props) => {
+const CommentInput = ({
+  transactionHash,
+  colonyAddress,
+  callback,
+  disabled,
+}: Props) => {
   const commentBoxRef = useRef<HTMLInputElement>(null);
 
   const [sendTransactionMessage] = useSendTransactionMessageMutation();
@@ -140,11 +146,11 @@ const CommentInput = ({ transactionHash, colonyAddress, callback }: Props) => {
               elementOnly
               label={MSG.commentInputPlaceholder}
               name="message"
-              placeholder={MSG.commentInputPlaceholder}
+              placeholder={disabled ? '' : MSG.commentInputPlaceholder}
               minRows={1}
               maxRows={6}
               onKeyDown={(event) => handleKeyboardSubmit(event, handleSubmit)}
-              disabled={isSubmitting}
+              disabled={isSubmitting || disabled}
             />
             {isSubmitting && (
               <div className={styles.submitting}>

--- a/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
+++ b/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
@@ -79,12 +79,17 @@ const MSG = defineMessages({
     id: 'dashbord.CoinMachine.BuyWidget.accountWhitelisted',
     defaultMessage: 'Your account is whitelisted. 😎',
   },
+  soldOut: {
+    id: 'dashbord.CoinMachine.BuyWidget.soldOut',
+    defaultMessage: 'Sold Out',
+  },
 });
 
 const TELL_ME_MORE_LINK = '';
 
 type Props = {
   colony: Colony;
+  isSoldOut: boolean;
   /*
    * @NOTE This acts like an indicator that the sale is not currently active
    */
@@ -105,6 +110,7 @@ const validationSchema = (userBalance: number) =>
 const BuyTokens = ({
   colony: { colonyAddress, colonyName },
   isCurrentlyOnSale,
+  isSoldOut,
 }: Props) => {
   const { username, ethereal, walletAddress } = useLoggedInUser();
   const history = useHistory();
@@ -254,7 +260,7 @@ const BuyTokens = ({
   return (
     <div
       className={getMainClasses({}, styles, {
-        disabled: globalDisable,
+        disabled: isSoldOut,
       })}
     >
       <div className={styles.heading}>
@@ -323,7 +329,7 @@ const BuyTokens = ({
                       }}
                       label={MSG.amountLabel}
                       name="amount"
-                      disabled={globalDisable}
+                      disabled={globalDisable || isSoldOut}
                       elementOnly
                     />
                     {errors?.amount && (
@@ -353,6 +359,7 @@ const BuyTokens = ({
                           onClick={(event) =>
                             handleSetMaxAmount(event, setFieldValue)
                           }
+                          disabled={isSoldOut}
                         />
                       </div>
                     )}
@@ -370,7 +377,7 @@ const BuyTokens = ({
                       <FormattedMessage {...MSG.priceLabel} />
                     </div>
                     <div className={styles.amountsValues}>
-                      <div>{isCurrentlyOnSale ? currentSalePrice : 'N/A'}</div>
+                      <div>{!isSoldOut ? currentSalePrice : 'N/A'}</div>
                       {
                         /*
                          * @NOTE only show the exchange rate if the token is XDAI/ETH
@@ -387,9 +394,7 @@ const BuyTokens = ({
                                  * Just entering the decimal point will pass it through to EthUsd
                                  * and that will try to fetch the balance for, which, obviously, will fail
                                  */
-                                isCurrentlyOnSale
-                                  ? parseFloat(currentSalePrice)
-                                  : 0
+                                !isSoldOut ? parseFloat(currentSalePrice) : 0
                               }
                             />
                           </div>
@@ -407,7 +412,7 @@ const BuyTokens = ({
                       <FormattedMessage {...MSG.costLabel} />
                     </div>
                     <div className={styles.amountsValues}>
-                      {isCurrentlyOnSale ? (
+                      {!isSoldOut ? (
                         <div>
                           {values.amount
                             ? (
@@ -460,12 +465,13 @@ const BuyTokens = ({
                   ) : (
                     <Button
                       type="submit"
-                      text={MSG.buyLabel}
+                      text={isSoldOut ? MSG.soldOut : MSG.buyLabel}
                       appearance={{ theme: 'primary', size: 'large' }}
                       onClick={() => handleSubmit()}
                       loading={isSubmitting}
                       disabled={
                         globalDisable ||
+                        isSoldOut ||
                         !isValid ||
                         parseFloat(values.amount) <= 0
                       }

--- a/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
+++ b/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
@@ -85,10 +85,11 @@ const TELL_ME_MORE_LINK = '';
 
 type Props = {
   colony: Colony;
+  userHasProfile: boolean;
   /*
    * @NOTE This acts like an indicator that the sale is not currently active
    */
-  disabled?: boolean;
+  isCurrentlyOnSale: boolean;
 };
 
 interface FormValues {
@@ -104,10 +105,12 @@ const validationSchema = (userBalance: number) =>
 
 const BuyTokens = ({
   colony: { colonyAddress, colonyName },
-  disabled,
+  isCurrentlyOnSale,
 }: Props) => {
   const { username, ethereal, walletAddress } = useLoggedInUser();
   const history = useHistory();
+
+  const userHasProfile = !!username && !ethereal;
 
   const {
     data: saleTokensData,
@@ -130,8 +133,6 @@ const BuyTokens = ({
 
   const isUserWhitelisted =
     userWhitelistStatusData?.userWhitelistStatus?.userIsWhitelisted;
-  /* Wire in is sale started logic */
-  const isSale = true;
   const { data: userTokenData, loading: loadingUserToken } = useUserTokensQuery(
     {
       variables: { address: walletAddress },
@@ -169,7 +170,7 @@ const BuyTokens = ({
     salePriceData?.coinMachineCurrentPeriodPrice || '0',
   );
 
-  const globalDisable = disabled || !username || ethereal;
+  const globalDisable = !isCurrentlyOnSale || !userHasProfile;
 
   const handleInputFocus = useCallback(
     ({ amount }, setFieldValue) => {
@@ -277,7 +278,7 @@ const BuyTokens = ({
         }}
         tooltipClassName={styles.tooltip}
       />
-      {isSale ? (
+      {isCurrentlyOnSale ? (
         <div className={styles.form}>
           <ActionForm
             initialValues={{
@@ -370,7 +371,7 @@ const BuyTokens = ({
                       <FormattedMessage {...MSG.priceLabel} />
                     </div>
                     <div className={styles.amountsValues}>
-                      <div>{!disabled ? currentSalePrice : 'N/A'}</div>
+                      <div>{isCurrentlyOnSale ? currentSalePrice : 'N/A'}</div>
                       {
                         /*
                          * @NOTE only show the exchange rate if the token is XDAI/ETH
@@ -387,7 +388,9 @@ const BuyTokens = ({
                                  * Just entering the decimal point will pass it through to EthUsd
                                  * and that will try to fetch the balance for, which, obviously, will fail
                                  */
-                                !disabled ? parseFloat(currentSalePrice) : 0
+                                isCurrentlyOnSale
+                                  ? parseFloat(currentSalePrice)
+                                  : 0
                               }
                             />
                           </div>
@@ -405,7 +408,7 @@ const BuyTokens = ({
                       <FormattedMessage {...MSG.costLabel} />
                     </div>
                     <div className={styles.amountsValues}>
-                      {!disabled ? (
+                      {isCurrentlyOnSale ? (
                         <div>
                           {values.amount
                             ? (

--- a/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
+++ b/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
@@ -365,7 +365,7 @@ const BuyTokens = ({
                       <FormattedMessage {...MSG.priceLabel} />
                     </div>
                     <div className={styles.amountsValues}>
-                      <div>{isCurrentlyOnSale ? currentSalePrice : 'N/A'}</div>
+                      <div>{currentSalePrice}</div>
                       {
                         /*
                          * @NOTE only show the exchange rate if the token is XDAI/ETH
@@ -382,9 +382,7 @@ const BuyTokens = ({
                                  * Just entering the decimal point will pass it through to EthUsd
                                  * and that will try to fetch the balance for, which, obviously, will fail
                                  */
-                                isCurrentlyOnSale
-                                  ? parseFloat(currentSalePrice)
-                                  : 0
+                                parseFloat(currentSalePrice)
                               }
                             />
                           </div>
@@ -402,18 +400,14 @@ const BuyTokens = ({
                       <FormattedMessage {...MSG.costLabel} />
                     </div>
                     <div className={styles.amountsValues}>
-                      {isCurrentlyOnSale ? (
-                        <div>
-                          {values.amount
-                            ? (
-                                parseInt(values.amount, 10) *
-                                parseFloat(currentSalePrice)
-                              ).toFixed(2)
-                            : ''}
-                        </div>
-                      ) : (
-                        <div>N/A</div>
-                      )}
+                      <div>
+                        {values.amount
+                          ? (
+                              parseInt(values.amount, 10) *
+                              parseFloat(currentSalePrice)
+                            ).toFixed(2)
+                          : ''}
+                      </div>
                       {
                         /*
                          * @NOTE only show the exchange rate if the token is XDAI/ETH

--- a/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
+++ b/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
@@ -27,6 +27,7 @@ import {
 } from '~data/index';
 import { ActionTypes } from '~redux/index';
 import { getTokenDecimalsWithFallback } from '~utils/tokens';
+import { getMainClasses } from '~utils/css';
 import { mapPayload, withMeta, pipe } from '~utils/actions';
 
 import GetWhitelisted from '../GetWhitelisted';
@@ -251,7 +252,11 @@ const BuyTokens = ({
   }
 
   return (
-    <div className={styles.main}>
+    <div
+      className={getMainClasses({}, styles, {
+        disabled: globalDisable,
+      })}
+    >
       <div className={styles.heading}>
         <Heading
           appearance={{

--- a/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
+++ b/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
@@ -365,7 +365,7 @@ const BuyTokens = ({
                       <FormattedMessage {...MSG.priceLabel} />
                     </div>
                     <div className={styles.amountsValues}>
-                      <div>{currentSalePrice}</div>
+                      <div>{isCurrentlyOnSale ? currentSalePrice : 'N/A'}</div>
                       {
                         /*
                          * @NOTE only show the exchange rate if the token is XDAI/ETH
@@ -382,7 +382,9 @@ const BuyTokens = ({
                                  * Just entering the decimal point will pass it through to EthUsd
                                  * and that will try to fetch the balance for, which, obviously, will fail
                                  */
-                                parseFloat(currentSalePrice)
+                                isCurrentlyOnSale
+                                  ? parseFloat(currentSalePrice)
+                                  : 0
                               }
                             />
                           </div>
@@ -400,14 +402,18 @@ const BuyTokens = ({
                       <FormattedMessage {...MSG.costLabel} />
                     </div>
                     <div className={styles.amountsValues}>
-                      <div>
-                        {values.amount
-                          ? (
-                              parseInt(values.amount, 10) *
-                              parseFloat(currentSalePrice)
-                            ).toFixed(2)
-                          : ''}
-                      </div>
+                      {isCurrentlyOnSale ? (
+                        <div>
+                          {values.amount
+                            ? (
+                                parseInt(values.amount, 10) *
+                                parseFloat(currentSalePrice)
+                              ).toFixed(2)
+                            : ''}
+                        </div>
+                      ) : (
+                        <div>N/A</div>
+                      )}
                       {
                         /*
                          * @NOTE only show the exchange rate if the token is XDAI/ETH

--- a/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
+++ b/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
@@ -84,7 +84,6 @@ const TELL_ME_MORE_LINK = '';
 
 type Props = {
   colony: Colony;
-  userHasProfile: boolean;
   /*
    * @NOTE This acts like an indicator that the sale is not currently active
    */

--- a/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
+++ b/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
@@ -27,7 +27,6 @@ import {
 } from '~data/index';
 import { ActionTypes } from '~redux/index';
 import { getTokenDecimalsWithFallback } from '~utils/tokens';
-import { getMainClasses } from '~utils/css';
 import { mapPayload, withMeta, pipe } from '~utils/actions';
 
 import GetWhitelisted from '../GetWhitelisted';
@@ -253,11 +252,7 @@ const BuyTokens = ({
   }
 
   return (
-    <div
-      className={getMainClasses({}, styles, {
-        disabled: globalDisable,
-      })}
-    >
+    <div className={styles.main}>
       <div className={styles.heading}>
         <Heading
           appearance={{

--- a/src/modules/dashboard/components/CoinMachine/Chat/Chat.css
+++ b/src/modules/dashboard/components/CoinMachine/Chat/Chat.css
@@ -19,6 +19,11 @@
   padding: 0 16px;
 }
 
+.inputBox textarea:disabled {
+  border: 1px solid rgb(200, 214, 245);
+  background-color: var(--text-disabled);
+}
+
 .loading, .empty {
   padding: 16px;
 }

--- a/src/modules/dashboard/components/CoinMachine/Chat/Chat.tsx
+++ b/src/modules/dashboard/components/CoinMachine/Chat/Chat.tsx
@@ -5,11 +5,7 @@ import Comment from '~core/Comment';
 import CommentInput from '~core/CommentInput';
 import { MiniSpinnerLoader } from '~core/Preloaders';
 
-import {
-  useLoggedInUser,
-  Colony,
-  useTransactionMessagesQuery,
-} from '~data/index';
+import { Colony, useTransactionMessagesQuery } from '~data/index';
 
 import styles from './Chat.css';
 
@@ -35,12 +31,16 @@ const MSG = defineMessages({
 interface Props {
   colony: Colony;
   transactionHash: string;
+  userHasProfile: boolean;
 }
 
 const displayName = 'dashboard.CoinMachine.Chat';
 
-const Chat = ({ colony: { colonyAddress }, transactionHash }: Props) => {
-  const { username, ethereal } = useLoggedInUser();
+const Chat = ({
+  colony: { colonyAddress },
+  transactionHash,
+  userHasProfile,
+}: Props) => {
   const scrollElmRef = useRef<HTMLDivElement | null>(null);
 
   /*
@@ -111,13 +111,12 @@ const Chat = ({ colony: { colonyAddress }, transactionHash }: Props) => {
         <div ref={scrollElmRef} />
       </div>
       <div className={styles.inputBox}>
-        {username && !ethereal && (
-          <CommentInput
-            colonyAddress={colonyAddress}
-            transactionHash={transactionHash}
-            callback={scrollComments}
-          />
-        )}
+        <CommentInput
+          colonyAddress={colonyAddress}
+          transactionHash={transactionHash}
+          callback={scrollComments}
+          disabled={!userHasProfile}
+        />
       </div>
     </div>
   );

--- a/src/modules/dashboard/components/CoinMachine/Chat/Chat.tsx
+++ b/src/modules/dashboard/components/CoinMachine/Chat/Chat.tsx
@@ -116,6 +116,7 @@ const Chat = ({
           transactionHash={transactionHash}
           callback={scrollComments}
           disabled={!userHasProfile}
+          disabledInputPlaceholder
         />
       </div>
     </div>

--- a/src/modules/dashboard/components/CoinMachine/Chat/Chat.tsx
+++ b/src/modules/dashboard/components/CoinMachine/Chat/Chat.tsx
@@ -5,7 +5,11 @@ import Comment from '~core/Comment';
 import CommentInput from '~core/CommentInput';
 import { MiniSpinnerLoader } from '~core/Preloaders';
 
-import { Colony, useTransactionMessagesQuery } from '~data/index';
+import {
+  Colony,
+  useTransactionMessagesQuery,
+  useLoggedInUser,
+} from '~data/index';
 
 import styles from './Chat.css';
 
@@ -31,17 +35,15 @@ const MSG = defineMessages({
 interface Props {
   colony: Colony;
   transactionHash: string;
-  userHasProfile: boolean;
 }
 
 const displayName = 'dashboard.CoinMachine.Chat';
 
-const Chat = ({
-  colony: { colonyAddress },
-  transactionHash,
-  userHasProfile,
-}: Props) => {
+const Chat = ({ colony: { colonyAddress }, transactionHash }: Props) => {
   const scrollElmRef = useRef<HTMLDivElement | null>(null);
+
+  const { username, ethereal } = useLoggedInUser();
+  const userHasProfile = !!username && !ethereal;
 
   /*
    * @NOTE This is needed in order to make the scroll effect trigger after

--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -168,7 +168,7 @@ const CoinMachine = ({
     </div>,
   ];
   // @TODO: Remove once the tokens remaining logic is wired in.
-  const tokensRemaining = 10;
+  const isSoldOut = false;
   return (
     <div className={styles.main}>
       <BreadCrumb elements={breadCrumbs} />
@@ -195,13 +195,13 @@ const CoinMachine = ({
                  * And only disable it if it insn't
                  */
                 isCurrentlyOnSale
-                isSoldOut={false}
+                isSoldOut={isSoldOut}
               />
             </div>
             <div className={styles.timeRemaining}>
               <RemainingDisplayWidget
                 displayType={DataDisplayType.Time}
-                appearance={{ theme: tokensRemaining > 0 ? 'white' : 'danger' }}
+                appearance={{ theme: !isSoldOut ? 'white' : 'danger' }}
                 value={timeRemaining}
                 periodLength={periodLength}
                 colonyAddress={colonyAddress}

--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -109,6 +109,13 @@ const CoinMachine = ({
     };
   }, [periodTokensData, saleTokensData, isSale]);
 
+  const isSoldOut = useMemo(
+    () =>
+      periodTokens !== undefined &&
+      periodTokens.soldPeriodTokens.gte(periodTokens.maxPeriodTokens),
+    [periodTokens],
+  );
+
   if (
     loading ||
     saleTokensLoading ||
@@ -167,8 +174,7 @@ const CoinMachine = ({
       />
     </div>,
   ];
-  // @TODO: Remove once the tokens remaining logic is wired in.
-  const isSoldOut = false;
+
   return (
     <div className={styles.main}>
       <BreadCrumb elements={breadCrumbs} />

--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -14,6 +14,7 @@ import {
   useCurrentPeriodTokensQuery,
   Colony,
   useCoinMachineSalePeriodQuery,
+  useLoggedInUser,
 } from '~data/index';
 
 import Chat from './Chat';
@@ -59,6 +60,9 @@ const CoinMachine = ({
 }: Props) => {
   /* To add proper states later */
   const isSale = true;
+
+  const { username, ethereal } = useLoggedInUser();
+  const userHasProfile = !!username && !ethereal;
 
   const { data, loading } = useColonyExtensionsQuery({
     variables: { address: colonyAddress },
@@ -190,11 +194,12 @@ const CoinMachine = ({
             <div className={styles.buy}>
               <BuyTokens
                 colony={colony}
+                userHasProfile={userHasProfile}
                 /*
                  * @TODO Determine if the sale is currently ongoing
                  * And only disable it if it insn't
                  */
-                disabled={false}
+                isCurrentlyOnSale={false}
               />
             </div>
             <div className={styles.timeRemaining}>
@@ -222,6 +227,7 @@ const CoinMachine = ({
           <Chat
             colony={colony}
             transactionHash={coinMachineExtension.address}
+            userHasProfile={userHasProfile}
           />
         </div>
       </div>

--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -57,7 +57,7 @@ const CoinMachine = ({
   colony: { colonyAddress, colonyName },
   colony,
 }: Props) => {
-  /* To add proper states later */
+  /* To add proper logic later */
   const isSale = true;
 
   const { data, loading } = useColonyExtensionsQuery({
@@ -200,7 +200,7 @@ const CoinMachine = ({
                  * @TODO Determine if the sale is currently ongoing
                  * And only disable it if it insn't
                  */
-                isCurrentlyOnSale
+                isCurrentlyOnSale={isSale}
                 isSoldOut={isSoldOut}
               />
             </div>

--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -195,6 +195,7 @@ const CoinMachine = ({
                  * And only disable it if it insn't
                  */
                 isCurrentlyOnSale
+                isSoldOut={false}
               />
             </div>
             <div className={styles.timeRemaining}>

--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -14,7 +14,6 @@ import {
   useCurrentPeriodTokensQuery,
   Colony,
   useCoinMachineSalePeriodQuery,
-  useLoggedInUser,
 } from '~data/index';
 
 import Chat from './Chat';
@@ -60,9 +59,6 @@ const CoinMachine = ({
 }: Props) => {
   /* To add proper states later */
   const isSale = true;
-
-  const { username, ethereal } = useLoggedInUser();
-  const userHasProfile = !!username && !ethereal;
 
   const { data, loading } = useColonyExtensionsQuery({
     variables: { address: colonyAddress },
@@ -194,12 +190,11 @@ const CoinMachine = ({
             <div className={styles.buy}>
               <BuyTokens
                 colony={colony}
-                userHasProfile={userHasProfile}
                 /*
                  * @TODO Determine if the sale is currently ongoing
                  * And only disable it if it insn't
                  */
-                isCurrentlyOnSale={false}
+                isCurrentlyOnSale
               />
             </div>
             <div className={styles.timeRemaining}>
@@ -227,7 +222,6 @@ const CoinMachine = ({
           <Chat
             colony={colony}
             transactionHash={coinMachineExtension.address}
-            userHasProfile={userHasProfile}
           />
         </div>
       </div>

--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidget/RemainingDisplayWidget.tsx
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidget/RemainingDisplayWidget.tsx
@@ -187,7 +187,7 @@ const RemainingDisplayWidget = ({
   }, [periodTokens]);
 
   useEffect(() => {
-    if (timeLeft === 0 && colonyAddress !== undefined) {
+    if (timeLeft <= 0 && colonyAddress !== undefined) {
       dispatch({
         type: ActionTypes.COIN_MACHINE_PERIOD_UPDATE,
         payload: { colonyAddress },


### PR DESCRIPTION
## Description

This PR disables coin machine UI when the user is not logged in.

I also tried to harmonise the props & a bit of logic across coin machine  & its child components.

I kept the dark grey color in the disabled state of the Buy Tokens widget that was done by Raul but is not in the figma specs. I am happy to remove it but I wanted to align with Alicja first (as Raul is not around).

**New stuff**

- add isSoldOut logic

**Changes** 🏗

- add additional props to `CommentInput`
- update BuyTokens props & disabled state
- update Chat props & disabled state
- update CoinMachine component
- 


Resolves DEV-461
Resolves DEV-473

Sold out state:

<img width="1056" alt="Screenshot 2021-08-18 at 15 21 13" src="https://user-images.githubusercontent.com/34057551/129898244-7a58bda3-7a99-4af8-8a25-bb7195e0ef07.png">

