### PR TITLE
Allow upgrade only if new version is supported (by colonyJS)

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyUpgrade/ColonyUpgrade.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyUpgrade/ColonyUpgrade.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
+import { ColonyVersion } from '@colony/colony-js';
 
 import { useDialog } from '~core/Dialog';
 import NetworkContractUpgradeDialog from '~dashboard/NetworkContractUpgradeDialog';
@@ -63,11 +64,13 @@ const ColonyUpgrade = ({ colony }: Props) => {
   const hasRegisteredProfile = !!username && !ethereal;
   const canUpgradeColony = hasRegisteredProfile && hasRoot(allUserRoles);
 
-  const mustUpgrade = colonyMustBeUpgraded(colony, networkVersion as string);
-  const shouldUpdgrade = colonyShouldBeUpgraded(
-    colony,
-    networkVersion as string,
-  );
+  const networkVersionIsSupported = !!ColonyVersion[networkVersion as string];
+  const mustUpgrade =
+    networkVersionIsSupported &&
+    colonyMustBeUpgraded(colony, networkVersion as string);
+  const shouldUpdgrade =
+    networkVersionIsSupported &&
+    colonyShouldBeUpgraded(colony, networkVersion as string);
 
   if (mustUpgrade) {
     return (

--- a/src/modules/dashboard/components/NetworkContractUpgradeDialog/NetworkContractUpgradeDialogForm.tsx
+++ b/src/modules/dashboard/components/NetworkContractUpgradeDialog/NetworkContractUpgradeDialogForm.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FormattedMessage, defineMessages } from 'react-intl';
 import { FormikProps } from 'formik';
-import { ColonyRole } from '@colony/colony-js';
+import { ColonyRole, ColonyVersion } from '@colony/colony-js';
 
 import Button from '~core/Button';
 import { ActionDialogProps } from '~core/Dialog';
@@ -33,39 +33,33 @@ import styles from './NetworkContractUpgradeDialogForm.css';
 
 const MSG = defineMessages({
   title: {
-    id:
-      // eslint-disable-next-line max-len
-      'dashboard.NetworkContractUpgradeDialog.NetworkContractUpgradeDialogForm.title',
+    id: `dashboard.NetworkContractUpgradeDialog.NetworkContractUpgradeDialogForm.title`,
     defaultMessage: 'Upgrade Colony',
   },
   currentVersion: {
-    id:
-      // eslint-disable-next-line max-len
-      'dashboard.NetworkContractUpgradeDialog.NetworkContractUpgradeDialogForm.currentVersion',
+    id: `dashboard.NetworkContractUpgradeDialog.NetworkContractUpgradeDialogForm.currentVersion`,
     defaultMessage: 'Current version',
   },
   newVersion: {
-    id:
-      // eslint-disable-next-line max-len
-      'dashboard.NetworkContractUpgradeDialog.NetworkContractUpgradeDialogForm.newVersion',
+    id: `dashboard.NetworkContractUpgradeDialog.NetworkContractUpgradeDialogForm.newVersion`,
     defaultMessage: 'New version',
   },
   annotation: {
-    id:
-      // eslint-disable-next-line max-len
-      'dashboard.NetworkContractUpgradeDialog.NetworkContractUpgradeDialogForm.annotation',
+    id: `dashboard.NetworkContractUpgradeDialog.NetworkContractUpgradeDialogForm.annotation`,
     defaultMessage: 'Explain why you are upgrading this colony (optional)',
   },
   noPermissionText: {
-    id:
-      // eslint-disable-next-line max-len
-      'dashboard.NetworkContractUpgradeDialog.NetworkContractUpgradeDialogForm.noPermissionText',
+    id: `dashboard.NetworkContractUpgradeDialog.NetworkContractUpgradeDialogForm.noPermissionText`,
     defaultMessage: `You do not have the {requiredRole} permission required
       to take this action.`,
   },
   legacyPermissionsWarningTitle: {
     id: `dashboard.NetworkContractUpgradeDialog.NetworkContractUpgradeDialogForm.legacyPermissionsWarningTitle`,
     defaultMessage: `Upgrade to the next colony version is prevented while more than one colony member has the {recoveryRole} role.`,
+  },
+  upgradeVersionNotSupported: {
+    id: `dashboard.NetworkContractUpgradeDialog.NetworkContractUpgradeDialogForm.upgradeVersionNotSupported`,
+    defaultMessage: `The newly deployed version of the contract is not yet supported by the Dapp`,
   },
   legacyPermissionsWarningDescription: {
     id: `dashboard.NetworkContractUpgradeDialog.NetworkContractUpgradeDialogForm.legacyPermissionsWarningDescription`,
@@ -115,6 +109,7 @@ const NetworkContractUpgradeDialogForm = ({
 
   const { version: newVersion } = useNetworkContracts();
 
+  const networkVersionIsSupported = !!ColonyVersion[newVersion as string];
   const currentVersion = parseInt(version, 10);
   const nextVersion = currentVersion + 1;
   const networkVersion = parseInt(newVersion || '1', 10);
@@ -128,7 +123,9 @@ const NetworkContractUpgradeDialogForm = ({
     values.forceAction,
   );
   const canUpgradeVersion =
-    userHasPermission && !!colonyCanBeUpgraded(colony, newVersion as string);
+    networkVersionIsSupported &&
+    userHasPermission &&
+    !!colonyCanBeUpgraded(colony, newVersion as string);
 
   const inputDisabled = !canUpgradeVersion || onlyForceAction;
 
@@ -259,6 +256,13 @@ const NetworkContractUpgradeDialogForm = ({
                 ),
               }}
             />
+          </div>
+        </DialogSection>
+      )}
+      {networkVersion > currentVersion && !networkVersionIsSupported && (
+        <DialogSection appearance={{ theme: 'sidePadding' }}>
+          <div className={styles.noPermissionMessage}>
+            <FormattedMessage {...MSG.upgradeVersionNotSupported} />
           </div>
         </DialogSection>
       )}


### PR DESCRIPTION
## Description

This PR refactors the Dapp to only allow upgrades _(allow in the modal, or show the upgrade banner)_ if the version is actually supported by colonyJS _(ie: it has a client for it already)_

Otherwise, after the upgrade, the colony breaks and cannot be accessed trough the dapp. _(until the dapp is re-deployed with a `colonyJS` version that supports said version)_

This is needed so that the network can freely deploy versions in the background without affecting the dapp.

**Testing**

Just change the `networkVersion` _(or `newVersion` for `NetworkContractUpgrade`)_ to something larger than the current version _(`'8'`, `'9'`, `'10'` -- note it must be a string)_, as you are testing the logic inside the component, not the way we actually fetch the version value.

If you don't see nothing _(as the version is not yet supported by `colonyJS`)_, it means all is good.

**Changes** 

- [x] `ColonyUpgrade` component check if version is supported before showing the upgrade banner
- [x] `NetworkContractUpgrade` component check if version is supported before allowing the upgrade
- [x] `NetworkContractUpgrade` component add error message if version is available, but not supported

Resolves #2588 