### PR TITLE
Comments Subscriptions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,9 @@ NODE_ENV=development
 # HTTP endpoint for graphql server
 SERVER_ENDPOINT=http://127.0.0.1:3000
 
+# WebSocket endpoint for our own graphql server
+SERVER_WS_ENDPOINT=ws://127.0.0.1:3000
+
 # HTTP endpoint for "The Graphs" graphql server
 SUBGRAPH_ENDPOINT=http://127.0.0.1:8000/subgraphs/name/joinColony/subgraph
 

--- a/.env.example
+++ b/.env.example
@@ -18,13 +18,12 @@ NODE_ENV=development
 # HTTP endpoint for graphql server
 SERVER_ENDPOINT=http://127.0.0.1:3000
 
-# WebSocket endpoint for our own graphql server
-SERVER_WS_ENDPOINT=ws://127.0.0.1:3000
-
 # HTTP endpoint for "The Graphs" graphql server
 SUBGRAPH_ENDPOINT=http://127.0.0.1:8000/subgraphs/name/joinColony/subgraph
 
 # WebSocket endpoint for "The Graphs" graphql server
+# @NOTE This is only be needed locally when running the dev build
+# In a production/qa environment this variable will not be avaiable
 SUBGRAPH_WS_ENDPOINT=ws://127.0.0.1:8001/subgraphs/name/joinColony/subgraph
 
 # Pinata.cloud API. Only use it on local if you want to test this specifically,

--- a/codegen.yml
+++ b/codegen.yml
@@ -6,6 +6,7 @@ schema:
 documents:
   - 'src/data/graphql/*.graphql'
   - 'src/data/graphql/queries/*.graphql'
+  - 'src/data/graphql/subscriptions/*.graphql'
 generates:
   src/data/generated.ts:
     schema:

--- a/codegen.yml
+++ b/codegen.yml
@@ -3,10 +3,14 @@ schema:
   - 'http://localhost:3000/graphql':
       headers:
         'authorization': 'codegen'
-documents: 'src/data/graphql/*.graphql'
+documents:
+  - 'src/data/graphql/*.graphql'
+  - 'src/data/graphql/queries/*.graphql'
 generates:
   src/data/generated.ts:
-    schema: 'src/data/graphql/*.ts'
+    schema:
+      - 'src/data/graphql/*.ts'
+      - 'src/data/graphql/typeDefs/*.ts'
     config:
       skipTypename: true
     plugins:

--- a/package-lock.json
+++ b/package-lock.json
@@ -21075,8 +21075,7 @@
     "is-absolute-url": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
-      "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==",
-      "dev": true
+      "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q=="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -21462,6 +21461,14 @@
       "dev": true,
       "requires": {
         "is-unc-path": "^1.0.0"
+      }
+    },
+    "is-relative-url": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative-url/-/is-relative-url-3.0.0.tgz",
+      "integrity": "sha512-U1iSYRlY2GIMGuZx7gezlB5dp1Kheaym7zKzO1PV06mOihiWTXejLwm4poEJysPyXF+HtK/BEd0DVlcCh30pEA==",
+      "requires": {
+        "is-absolute-url": "^3.0.0"
       }
     },
     "is-root": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21075,7 +21075,8 @@
     "is-absolute-url": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
-      "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q=="
+      "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==",
+      "dev": true
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -21461,14 +21462,6 @@
       "dev": true,
       "requires": {
         "is-unc-path": "^1.0.0"
-      }
-    },
-    "is-relative-url": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-relative-url/-/is-relative-url-3.0.0.tgz",
-      "integrity": "sha512-U1iSYRlY2GIMGuZx7gezlB5dp1Kheaym7zKzO1PV06mOihiWTXejLwm4poEJysPyXF+HtK/BEd0DVlcCh30pEA==",
-      "requires": {
-        "is-absolute-url": "^3.0.0"
       }
     },
     "is-root": {

--- a/package.json
+++ b/package.json
@@ -162,7 +162,6 @@
     "graphql-tag": "^2.10.1",
     "immutable": "^4.0.0-rc.12",
     "ipfs": "^0.43.1",
-    "is-relative-url": "^3.0.0",
     "jwt-decode": "^2.2.0",
     "linkify-it": "^3.0.0",
     "localforage": "^1.7.3",

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "graphql-tag": "^2.10.1",
     "immutable": "^4.0.0-rc.12",
     "ipfs": "^0.43.1",
+    "is-relative-url": "^3.0.0",
     "jwt-decode": "^2.2.0",
     "linkify-it": "^3.0.0",
     "localforage": "^1.7.3",

--- a/src/data/cache.ts
+++ b/src/data/cache.ts
@@ -48,9 +48,6 @@ export default new InMemoryCache({
     },
     Query: {
       fields: {
-        subscribedUsers: {
-          merge: false,
-        },
         colonyMembersWithReputation: {
           merge: false,
         },
@@ -65,6 +62,13 @@ export default new InMemoryCache({
     Event: {
       fields: {
         associatedColony: {
+          merge: false,
+        },
+      },
+    },
+    Subscription: {
+      fields: {
+        subscribedUsers: {
           merge: false,
         },
       },

--- a/src/data/cacheUpdates.ts
+++ b/src/data/cacheUpdates.ts
@@ -5,12 +5,6 @@ import { Address } from '~types/index';
 import { log } from '~utils/debug';
 import apolloCache from './cache';
 import {
-  ColonySubscribedUsersDocument,
-  ColonySubscribedUsersQuery,
-  ColonySubscribedUsersQueryVariables,
-  UserDocument,
-  UserQuery,
-  UserQueryVariables,
   UnsubscribeFromColonyMutationResult,
   SubscribeToColonyMutationResult,
   UserColoniesQuery,
@@ -123,58 +117,6 @@ const cacheUpdates = {
               },
             });
           }
-        }
-      } catch (e) {
-        log.verbose(e);
-        log.verbose(
-          'Cannot update the colony subscriptions cache - not loaded yet',
-        );
-      }
-      /*
-       * Update the list of colony subscribed users
-       * This is in use in the User Picker (right now we're only using that in
-       * the permissions Dialog)
-       */
-      try {
-        const cacheData = cache.readQuery<
-          ColonySubscribedUsersQuery,
-          ColonySubscribedUsersQueryVariables
-        >({
-          query: ColonySubscribedUsersDocument,
-          variables: {
-            colonyAddress,
-          },
-        });
-        if (cacheData && data && data.unsubscribeFromColony) {
-          const {
-            id: unsubscribedUserWalletAddress,
-          } = data.unsubscribeFromColony;
-          const { subscribedUsers } = cacheData;
-          const updatedColonySubscription = subscribedUsers.filter(
-            /*
-             * Prop `id` does exist, it's just that TS doesn't recognize for
-             * some reason
-             */
-            // @ts-ignore
-            ({ id: userWalletAddress }) =>
-              /*
-               * Remove the unsubscribed user from the subscribers array
-               */
-              userWalletAddress !== unsubscribedUserWalletAddress,
-          );
-          cache.writeQuery<
-            ColonySubscribedUsersQuery,
-            ColonySubscribedUsersQueryVariables
-          >({
-            query: ColonySubscribedUsersDocument,
-            data: {
-              ...cacheData,
-              subscribedUsers: updatedColonySubscription,
-            },
-            variables: {
-              colonyAddress,
-            },
-          });
         }
       } catch (e) {
         log.verbose(e);
@@ -300,59 +242,6 @@ const cacheUpdates = {
                 },
               });
             }
-          }
-        }
-      } catch (e) {
-        log.verbose(e);
-        log.verbose(
-          'Cannot update the colony subscriptions cache - not loaded yet',
-        );
-      }
-      /*
-       * Update the list of colony subscribed users
-       * This is in use in the User Picker (right now we're only using that in
-       * the permissions Dialog)
-       */
-      try {
-        const cacheData = cache.readQuery<
-          ColonySubscribedUsersQuery,
-          ColonySubscribedUsersQueryVariables
-        >({
-          query: ColonySubscribedUsersDocument,
-          variables: {
-            colonyAddress,
-          },
-        });
-        if (cacheData && data && data.subscribeToColony) {
-          const { id: subscribedUserAddress } = data.subscribeToColony;
-          const { subscribedUsers } = cacheData;
-          const newlySubscribedUser = cache.readQuery<
-            UserQuery,
-            UserQueryVariables
-          >({
-            query: UserDocument,
-            variables: {
-              address: subscribedUserAddress,
-            },
-          });
-          if (newlySubscribedUser?.user) {
-            const updatedSubscribedUsers = [
-              ...subscribedUsers,
-              newlySubscribedUser.user,
-            ];
-            cache.writeQuery<
-              ColonySubscribedUsersQuery,
-              ColonySubscribedUsersQueryVariables
-            >({
-              query: ColonySubscribedUsersDocument,
-              data: {
-                ...cacheData,
-                subscribedUsers: updatedSubscribedUsers,
-              },
-              variables: {
-                colonyAddress,
-              },
-            });
           }
         }
       } catch (e) {

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -2068,7 +2068,7 @@ export type SubgraphEventsThatAreActionsSubscription = { events: Array<(
     ), processedValues: Pick<EventProcessedValues, 'agent' | 'who' | 'fromPot' | 'fromDomain' | 'toPot' | 'toDomain' | 'domainId' | 'amount' | 'token' | 'metadata' | 'user' | 'oldVersion' | 'newVersion' | 'storageSlot' | 'storageSlotValue'> }
   )> };
 
-export type SubraphMotionsSubscriptionVariables = Exact<{
+export type SubgraphMotionsSubscriptionVariables = Exact<{
   skip: Scalars['Int'];
   first: Scalars['Int'];
   colonyAddress: Scalars['String'];
@@ -2076,7 +2076,7 @@ export type SubraphMotionsSubscriptionVariables = Exact<{
 }>;
 
 
-export type SubraphMotionsSubscription = { motions: Array<(
+export type SubgraphMotionsSubscription = { motions: Array<(
     Pick<SubscriptionMotion, 'id' | 'fundamentalChainId' | 'extensionAddress' | 'agent' | 'stakes' | 'requiredStake' | 'escalated' | 'action' | 'state' | 'type'>
     & { associatedColony: (
       { colonyAddress: SubgraphColony['id'], id: SubgraphColony['colonyChainId'] }
@@ -5428,8 +5428,8 @@ export function useSubgraphEventsThatAreActionsSubscription(baseOptions?: Apollo
       }
 export type SubgraphEventsThatAreActionsSubscriptionHookResult = ReturnType<typeof useSubgraphEventsThatAreActionsSubscription>;
 export type SubgraphEventsThatAreActionsSubscriptionResult = Apollo.SubscriptionResult<SubgraphEventsThatAreActionsSubscription>;
-export const SubraphMotionsDocument = gql`
-    subscription SubraphMotions($skip: Int!, $first: Int!, $colonyAddress: String!, $extensionAddress: String!) {
+export const SubgraphMotionsDocument = gql`
+    subscription SubgraphMotions($skip: Int!, $first: Int!, $colonyAddress: String!, $extensionAddress: String!) {
   motions(skip: $skip, first: $first, where: {associatedColony: $colonyAddress, extensionAddress: $extensionAddress}) {
     id
     fundamentalChainId
@@ -5480,16 +5480,16 @@ export const SubraphMotionsDocument = gql`
     `;
 
 /**
- * __useSubraphMotionsSubscription__
+ * __useSubgraphMotionsSubscription__
  *
- * To run a query within a React component, call `useSubraphMotionsSubscription` and pass it any options that fit your needs.
- * When your component renders, `useSubraphMotionsSubscription` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useSubgraphMotionsSubscription` and pass it any options that fit your needs.
+ * When your component renders, `useSubgraphMotionsSubscription` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the subscription, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useSubraphMotionsSubscription({
+ * const { data, loading, error } = useSubgraphMotionsSubscription({
  *   variables: {
  *      skip: // value for 'skip'
  *      first: // value for 'first'
@@ -5498,11 +5498,11 @@ export const SubraphMotionsDocument = gql`
  *   },
  * });
  */
-export function useSubraphMotionsSubscription(baseOptions?: Apollo.SubscriptionHookOptions<SubraphMotionsSubscription, SubraphMotionsSubscriptionVariables>) {
-        return Apollo.useSubscription<SubraphMotionsSubscription, SubraphMotionsSubscriptionVariables>(SubraphMotionsDocument, baseOptions);
+export function useSubgraphMotionsSubscription(baseOptions?: Apollo.SubscriptionHookOptions<SubgraphMotionsSubscription, SubgraphMotionsSubscriptionVariables>) {
+        return Apollo.useSubscription<SubgraphMotionsSubscription, SubgraphMotionsSubscriptionVariables>(SubgraphMotionsDocument, baseOptions);
       }
-export type SubraphMotionsSubscriptionHookResult = ReturnType<typeof useSubraphMotionsSubscription>;
-export type SubraphMotionsSubscriptionResult = Apollo.SubscriptionResult<SubraphMotionsSubscription>;
+export type SubgraphMotionsSubscriptionHookResult = ReturnType<typeof useSubgraphMotionsSubscription>;
+export type SubgraphMotionsSubscriptionResult = Apollo.SubscriptionResult<SubgraphMotionsSubscription>;
 export const CommentCountDocument = gql`
     subscription CommentCount($colonyAddress: String!) {
   transactionMessagesCount(colonyAddress: $colonyAddress) {

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -613,6 +613,51 @@ export type QueryWhitelistedUsersArgs = {
   colonyAddress: Scalars['String'];
 };
 
+export type Subscription = {
+  events: Array<SubscriptionEvent>;
+  motions: Array<SubscriptionMotion>;
+  oneTxPayments: Array<OneTxPayment>;
+  subscribedUsers: Array<User>;
+  transactionMessages: TransactionMessages;
+  transactionMessagesCount: TransactionMessagesCount;
+};
+
+
+export type SubscriptionEventsArgs = {
+  skip: Scalars['Int'];
+  first: Scalars['Int'];
+  where: EventsFilter;
+};
+
+
+export type SubscriptionMotionsArgs = {
+  skip: Scalars['Int'];
+  first: Scalars['Int'];
+  where: MotionsFilter;
+};
+
+
+export type SubscriptionOneTxPaymentsArgs = {
+  skip: Scalars['Int'];
+  first: Scalars['Int'];
+  where: ActionsFilter;
+};
+
+
+export type SubscriptionSubscribedUsersArgs = {
+  colonyAddress: Scalars['String'];
+};
+
+
+export type SubscriptionTransactionMessagesArgs = {
+  transactionHash: Scalars['String'];
+};
+
+
+export type SubscriptionTransactionMessagesCountArgs = {
+  colonyAddress: Scalars['String'];
+};
+
 export enum SuggestionStatus {
   Open = 'Open',
   NotPlanned = 'NotPlanned',
@@ -1200,33 +1245,6 @@ export type SubscriptionMotion = {
 export type SubscriptionMotionArguments = {
   amount: Scalars['String'];
   token: SubgraphToken;
-};
-
-export type Subscription = {
-  oneTxPayments: Array<OneTxPayment>;
-  events: Array<SubscriptionEvent>;
-  motions: Array<SubscriptionMotion>;
-};
-
-
-export type SubscriptionOneTxPaymentsArgs = {
-  skip: Scalars['Int'];
-  first: Scalars['Int'];
-  where: ActionsFilter;
-};
-
-
-export type SubscriptionEventsArgs = {
-  skip: Scalars['Int'];
-  first: Scalars['Int'];
-  where: EventsFilter;
-};
-
-
-export type SubscriptionMotionsArgs = {
-  skip: Scalars['Int'];
-  first: Scalars['Int'];
-  where: MotionsFilter;
 };
 
 export type TokensFragment = (
@@ -1981,14 +1999,14 @@ export type HasKycPolicyQueryVariables = Exact<{
 
 export type HasKycPolicyQuery = Pick<Query, 'hasKycPolicy'>;
 
-export type SubscriptionSubgraphEventsSubscriptionVariables = Exact<{
+export type SubgraphEventsSubscriptionVariables = Exact<{
   skip: Scalars['Int'];
   first: Scalars['Int'];
   colonyAddress: Scalars['String'];
 }>;
 
 
-export type SubscriptionSubgraphEventsSubscription = { events: Array<(
+export type SubgraphEventsSubscription = { events: Array<(
     Pick<SubscriptionEvent, 'id' | 'address' | 'name' | 'args'>
     & { associatedColony: (
       { colonyAddress: SubgraphColony['id'], id: SubgraphColony['colonyChainId'] }
@@ -2002,14 +2020,14 @@ export type SubscriptionSubgraphEventsSubscription = { events: Array<(
     ) }
   )> };
 
-export type SubscriptionSubgraphOneTxSubscriptionVariables = Exact<{
+export type SubgraphOneTxSubscriptionVariables = Exact<{
   skip: Scalars['Int'];
   first: Scalars['Int'];
   colonyAddress: Scalars['String'];
 }>;
 
 
-export type SubscriptionSubgraphOneTxSubscription = { oneTxPayments: Array<(
+export type SubgraphOneTxSubscription = { oneTxPayments: Array<(
     Pick<OneTxPayment, 'id' | 'agent'>
     & { transaction: (
       { hash: SubgraphTransaction['id'] }
@@ -2029,14 +2047,14 @@ export type SubscriptionSubgraphOneTxSubscription = { oneTxPayments: Array<(
     ) }
   )> };
 
-export type SubscriptionSubgraphEventsThatAreActionsSubscriptionVariables = Exact<{
+export type SubgraphEventsThatAreActionsSubscriptionVariables = Exact<{
   skip: Scalars['Int'];
   first: Scalars['Int'];
   colonyAddress: Scalars['String'];
 }>;
 
 
-export type SubscriptionSubgraphEventsThatAreActionsSubscription = { events: Array<(
+export type SubgraphEventsThatAreActionsSubscription = { events: Array<(
     Pick<SubscriptionEvent, 'id' | 'address' | 'name' | 'args'>
     & { associatedColony: (
       { colonyAddress: SubgraphColony['id'], id: SubgraphColony['colonyChainId'] }
@@ -2050,7 +2068,7 @@ export type SubscriptionSubgraphEventsThatAreActionsSubscription = { events: Arr
     ), processedValues: Pick<EventProcessedValues, 'agent' | 'who' | 'fromPot' | 'fromDomain' | 'toPot' | 'toDomain' | 'domainId' | 'amount' | 'token' | 'metadata' | 'user' | 'oldVersion' | 'newVersion' | 'storageSlot' | 'storageSlotValue'> }
   )> };
 
-export type SubscriptionsMotionsSubscriptionVariables = Exact<{
+export type SubraphMotionsSubscriptionVariables = Exact<{
   skip: Scalars['Int'];
   first: Scalars['Int'];
   colonyAddress: Scalars['String'];
@@ -2058,7 +2076,7 @@ export type SubscriptionsMotionsSubscriptionVariables = Exact<{
 }>;
 
 
-export type SubscriptionsMotionsSubscription = { motions: Array<(
+export type SubraphMotionsSubscription = { motions: Array<(
     Pick<SubscriptionMotion, 'id' | 'fundamentalChainId' | 'extensionAddress' | 'agent' | 'stakes' | 'requiredStake' | 'escalated' | 'action' | 'state' | 'type'>
     & { associatedColony: (
       { colonyAddress: SubgraphColony['id'], id: SubgraphColony['colonyChainId'] }
@@ -5219,8 +5237,8 @@ export function useHasKycPolicyLazyQuery(baseOptions?: Apollo.LazyQueryHookOptio
 export type HasKycPolicyQueryHookResult = ReturnType<typeof useHasKycPolicyQuery>;
 export type HasKycPolicyLazyQueryHookResult = ReturnType<typeof useHasKycPolicyLazyQuery>;
 export type HasKycPolicyQueryResult = Apollo.QueryResult<HasKycPolicyQuery, HasKycPolicyQueryVariables>;
-export const SubscriptionSubgraphEventsDocument = gql`
-    subscription SubscriptionSubgraphEvents($skip: Int!, $first: Int!, $colonyAddress: String!) {
+export const SubgraphEventsDocument = gql`
+    subscription SubgraphEvents($skip: Int!, $first: Int!, $colonyAddress: String!) {
   events(skip: $skip, first: $first, where: {associatedColony: $colonyAddress}) {
     id
     address
@@ -5247,16 +5265,16 @@ export const SubscriptionSubgraphEventsDocument = gql`
     `;
 
 /**
- * __useSubscriptionSubgraphEventsSubscription__
+ * __useSubgraphEventsSubscription__
  *
- * To run a query within a React component, call `useSubscriptionSubgraphEventsSubscription` and pass it any options that fit your needs.
- * When your component renders, `useSubscriptionSubgraphEventsSubscription` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useSubgraphEventsSubscription` and pass it any options that fit your needs.
+ * When your component renders, `useSubgraphEventsSubscription` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the subscription, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useSubscriptionSubgraphEventsSubscription({
+ * const { data, loading, error } = useSubgraphEventsSubscription({
  *   variables: {
  *      skip: // value for 'skip'
  *      first: // value for 'first'
@@ -5264,13 +5282,13 @@ export const SubscriptionSubgraphEventsDocument = gql`
  *   },
  * });
  */
-export function useSubscriptionSubgraphEventsSubscription(baseOptions?: Apollo.SubscriptionHookOptions<SubscriptionSubgraphEventsSubscription, SubscriptionSubgraphEventsSubscriptionVariables>) {
-        return Apollo.useSubscription<SubscriptionSubgraphEventsSubscription, SubscriptionSubgraphEventsSubscriptionVariables>(SubscriptionSubgraphEventsDocument, baseOptions);
+export function useSubgraphEventsSubscription(baseOptions?: Apollo.SubscriptionHookOptions<SubgraphEventsSubscription, SubgraphEventsSubscriptionVariables>) {
+        return Apollo.useSubscription<SubgraphEventsSubscription, SubgraphEventsSubscriptionVariables>(SubgraphEventsDocument, baseOptions);
       }
-export type SubscriptionSubgraphEventsSubscriptionHookResult = ReturnType<typeof useSubscriptionSubgraphEventsSubscription>;
-export type SubscriptionSubgraphEventsSubscriptionResult = Apollo.SubscriptionResult<SubscriptionSubgraphEventsSubscription>;
-export const SubscriptionSubgraphOneTxDocument = gql`
-    subscription SubscriptionSubgraphOneTx($skip: Int!, $first: Int!, $colonyAddress: String!) {
+export type SubgraphEventsSubscriptionHookResult = ReturnType<typeof useSubgraphEventsSubscription>;
+export type SubgraphEventsSubscriptionResult = Apollo.SubscriptionResult<SubgraphEventsSubscription>;
+export const SubgraphOneTxDocument = gql`
+    subscription SubgraphOneTx($skip: Int!, $first: Int!, $colonyAddress: String!) {
   oneTxPayments(skip: $skip, first: $first, where: {payment_contains: $colonyAddress}) {
     id
     agent
@@ -5304,16 +5322,16 @@ export const SubscriptionSubgraphOneTxDocument = gql`
     `;
 
 /**
- * __useSubscriptionSubgraphOneTxSubscription__
+ * __useSubgraphOneTxSubscription__
  *
- * To run a query within a React component, call `useSubscriptionSubgraphOneTxSubscription` and pass it any options that fit your needs.
- * When your component renders, `useSubscriptionSubgraphOneTxSubscription` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useSubgraphOneTxSubscription` and pass it any options that fit your needs.
+ * When your component renders, `useSubgraphOneTxSubscription` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the subscription, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useSubscriptionSubgraphOneTxSubscription({
+ * const { data, loading, error } = useSubgraphOneTxSubscription({
  *   variables: {
  *      skip: // value for 'skip'
  *      first: // value for 'first'
@@ -5321,13 +5339,13 @@ export const SubscriptionSubgraphOneTxDocument = gql`
  *   },
  * });
  */
-export function useSubscriptionSubgraphOneTxSubscription(baseOptions?: Apollo.SubscriptionHookOptions<SubscriptionSubgraphOneTxSubscription, SubscriptionSubgraphOneTxSubscriptionVariables>) {
-        return Apollo.useSubscription<SubscriptionSubgraphOneTxSubscription, SubscriptionSubgraphOneTxSubscriptionVariables>(SubscriptionSubgraphOneTxDocument, baseOptions);
+export function useSubgraphOneTxSubscription(baseOptions?: Apollo.SubscriptionHookOptions<SubgraphOneTxSubscription, SubgraphOneTxSubscriptionVariables>) {
+        return Apollo.useSubscription<SubgraphOneTxSubscription, SubgraphOneTxSubscriptionVariables>(SubgraphOneTxDocument, baseOptions);
       }
-export type SubscriptionSubgraphOneTxSubscriptionHookResult = ReturnType<typeof useSubscriptionSubgraphOneTxSubscription>;
-export type SubscriptionSubgraphOneTxSubscriptionResult = Apollo.SubscriptionResult<SubscriptionSubgraphOneTxSubscription>;
-export const SubscriptionSubgraphEventsThatAreActionsDocument = gql`
-    subscription SubscriptionSubgraphEventsThatAreActions($skip: Int!, $first: Int!, $colonyAddress: String!) {
+export type SubgraphOneTxSubscriptionHookResult = ReturnType<typeof useSubgraphOneTxSubscription>;
+export type SubgraphOneTxSubscriptionResult = Apollo.SubscriptionResult<SubgraphOneTxSubscription>;
+export const SubgraphEventsThatAreActionsDocument = gql`
+    subscription SubgraphEventsThatAreActions($skip: Int!, $first: Int!, $colonyAddress: String!) {
   events(skip: $skip, first: $first, where: {associatedColony_contains: $colonyAddress, name_in: ["TokensMinted(address,address,uint256)", "DomainAdded(address,uint256)", "ColonyMetadata(address,string)", "ColonyFundsMovedBetweenFundingPots(address,uint256,uint256,uint256,address)", "DomainMetadata(address,uint256,string)", "ColonyRoleSet(address,address,uint256,uint8,bool)", "ColonyUpgraded(address,uint256,uint256)", "ColonyUpgraded(uint256,uint256)", "RecoveryModeEntered(address)"]}) {
     id
     address
@@ -5371,16 +5389,16 @@ export const SubscriptionSubgraphEventsThatAreActionsDocument = gql`
     `;
 
 /**
- * __useSubscriptionSubgraphEventsThatAreActionsSubscription__
+ * __useSubgraphEventsThatAreActionsSubscription__
  *
- * To run a query within a React component, call `useSubscriptionSubgraphEventsThatAreActionsSubscription` and pass it any options that fit your needs.
- * When your component renders, `useSubscriptionSubgraphEventsThatAreActionsSubscription` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useSubgraphEventsThatAreActionsSubscription` and pass it any options that fit your needs.
+ * When your component renders, `useSubgraphEventsThatAreActionsSubscription` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the subscription, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useSubscriptionSubgraphEventsThatAreActionsSubscription({
+ * const { data, loading, error } = useSubgraphEventsThatAreActionsSubscription({
  *   variables: {
  *      skip: // value for 'skip'
  *      first: // value for 'first'
@@ -5388,13 +5406,13 @@ export const SubscriptionSubgraphEventsThatAreActionsDocument = gql`
  *   },
  * });
  */
-export function useSubscriptionSubgraphEventsThatAreActionsSubscription(baseOptions?: Apollo.SubscriptionHookOptions<SubscriptionSubgraphEventsThatAreActionsSubscription, SubscriptionSubgraphEventsThatAreActionsSubscriptionVariables>) {
-        return Apollo.useSubscription<SubscriptionSubgraphEventsThatAreActionsSubscription, SubscriptionSubgraphEventsThatAreActionsSubscriptionVariables>(SubscriptionSubgraphEventsThatAreActionsDocument, baseOptions);
+export function useSubgraphEventsThatAreActionsSubscription(baseOptions?: Apollo.SubscriptionHookOptions<SubgraphEventsThatAreActionsSubscription, SubgraphEventsThatAreActionsSubscriptionVariables>) {
+        return Apollo.useSubscription<SubgraphEventsThatAreActionsSubscription, SubgraphEventsThatAreActionsSubscriptionVariables>(SubgraphEventsThatAreActionsDocument, baseOptions);
       }
-export type SubscriptionSubgraphEventsThatAreActionsSubscriptionHookResult = ReturnType<typeof useSubscriptionSubgraphEventsThatAreActionsSubscription>;
-export type SubscriptionSubgraphEventsThatAreActionsSubscriptionResult = Apollo.SubscriptionResult<SubscriptionSubgraphEventsThatAreActionsSubscription>;
-export const SubscriptionsMotionsDocument = gql`
-    subscription SubscriptionsMotions($skip: Int!, $first: Int!, $colonyAddress: String!, $extensionAddress: String!) {
+export type SubgraphEventsThatAreActionsSubscriptionHookResult = ReturnType<typeof useSubgraphEventsThatAreActionsSubscription>;
+export type SubgraphEventsThatAreActionsSubscriptionResult = Apollo.SubscriptionResult<SubgraphEventsThatAreActionsSubscription>;
+export const SubraphMotionsDocument = gql`
+    subscription SubraphMotions($skip: Int!, $first: Int!, $colonyAddress: String!, $extensionAddress: String!) {
   motions(skip: $skip, first: $first, where: {associatedColony: $colonyAddress, extensionAddress: $extensionAddress}) {
     id
     fundamentalChainId
@@ -5445,16 +5463,16 @@ export const SubscriptionsMotionsDocument = gql`
     `;
 
 /**
- * __useSubscriptionsMotionsSubscription__
+ * __useSubraphMotionsSubscription__
  *
- * To run a query within a React component, call `useSubscriptionsMotionsSubscription` and pass it any options that fit your needs.
- * When your component renders, `useSubscriptionsMotionsSubscription` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useSubraphMotionsSubscription` and pass it any options that fit your needs.
+ * When your component renders, `useSubraphMotionsSubscription` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the subscription, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useSubscriptionsMotionsSubscription({
+ * const { data, loading, error } = useSubraphMotionsSubscription({
  *   variables: {
  *      skip: // value for 'skip'
  *      first: // value for 'first'
@@ -5463,8 +5481,8 @@ export const SubscriptionsMotionsDocument = gql`
  *   },
  * });
  */
-export function useSubscriptionsMotionsSubscription(baseOptions?: Apollo.SubscriptionHookOptions<SubscriptionsMotionsSubscription, SubscriptionsMotionsSubscriptionVariables>) {
-        return Apollo.useSubscription<SubscriptionsMotionsSubscription, SubscriptionsMotionsSubscriptionVariables>(SubscriptionsMotionsDocument, baseOptions);
+export function useSubraphMotionsSubscription(baseOptions?: Apollo.SubscriptionHookOptions<SubraphMotionsSubscription, SubraphMotionsSubscriptionVariables>) {
+        return Apollo.useSubscription<SubraphMotionsSubscription, SubraphMotionsSubscriptionVariables>(SubraphMotionsDocument, baseOptions);
       }
-export type SubscriptionsMotionsSubscriptionHookResult = ReturnType<typeof useSubscriptionsMotionsSubscription>;
-export type SubscriptionsMotionsSubscriptionResult = Apollo.SubscriptionResult<SubscriptionsMotionsSubscription>;
+export type SubraphMotionsSubscriptionHookResult = ReturnType<typeof useSubraphMotionsSubscription>;
+export type SubraphMotionsSubscriptionResult = Apollo.SubscriptionResult<SubraphMotionsSubscription>;

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -1567,23 +1567,6 @@ export type ColonyActionQuery = { colonyAction: (
     & { events: Array<Pick<ParsedEvent, 'type' | 'name' | 'values' | 'createdAt' | 'emmitedBy' | 'transactionHash'>>, roles: Array<Pick<ColonyActionRoles, 'id' | 'setTo'>> }
   ) };
 
-export type TransactionMessagesQueryVariables = Exact<{
-  transactionHash: Scalars['String'];
-}>;
-
-
-export type TransactionMessagesQuery = { transactionMessages: (
-    Pick<TransactionMessages, 'transactionHash'>
-    & { messages: Array<TransactionMessageFragment> }
-  ) };
-
-export type TransactionMessagesCountQueryVariables = Exact<{
-  colonyAddress: Scalars['String'];
-}>;
-
-
-export type TransactionMessagesCountQuery = { transactionMessagesCount: { colonyTransactionMessages: Array<Pick<TransactionCount, 'transactionHash' | 'count'>> } };
-
 export type MetaColonyQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -1999,6 +1982,23 @@ export type HasKycPolicyQueryVariables = Exact<{
 
 export type HasKycPolicyQuery = Pick<Query, 'hasKycPolicy'>;
 
+export type TransactionMessagesQueryVariables = Exact<{
+  transactionHash: Scalars['String'];
+}>;
+
+
+export type TransactionMessagesQuery = { transactionMessages: (
+    Pick<TransactionMessages, 'transactionHash'>
+    & { messages: Array<TransactionMessageFragment> }
+  ) };
+
+export type TransactionMessagesCountQueryVariables = Exact<{
+  colonyAddress: Scalars['String'];
+}>;
+
+
+export type TransactionMessagesCountQuery = { transactionMessagesCount: { colonyTransactionMessages: Array<Pick<TransactionCount, 'transactionHash' | 'count'>> } };
+
 export type SubgraphEventsSubscriptionVariables = Exact<{
   skip: Scalars['Int'];
   first: Scalars['Int'];
@@ -2098,6 +2098,23 @@ export type SubraphMotionsSubscription = { motions: Array<(
       ) }
     ), timeoutPeriods: Pick<MotionTimeoutPeriods, 'timeLeftToStake' | 'timeLeftToSubmit' | 'timeLeftToReveal' | 'timeLeftToEscalate'> }
   )> };
+
+export type CommentCountSubscriptionVariables = Exact<{
+  colonyAddress: Scalars['String'];
+}>;
+
+
+export type CommentCountSubscription = { transactionMessagesCount: { colonyTransactionMessages: Array<Pick<TransactionCount, 'transactionHash' | 'count'>> } };
+
+export type CommentsSubscriptionVariables = Exact<{
+  transactionHash: Scalars['String'];
+}>;
+
+
+export type CommentsSubscription = { transactionMessages: (
+    Pick<TransactionMessages, 'transactionHash'>
+    & { messages: Array<TransactionMessageFragment> }
+  ) };
 
 export const ColonyProfileFragmentDoc = gql`
     fragment ColonyProfile on ProcessedColony {
@@ -3455,78 +3472,6 @@ export function useColonyActionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptio
 export type ColonyActionQueryHookResult = ReturnType<typeof useColonyActionQuery>;
 export type ColonyActionLazyQueryHookResult = ReturnType<typeof useColonyActionLazyQuery>;
 export type ColonyActionQueryResult = Apollo.QueryResult<ColonyActionQuery, ColonyActionQueryVariables>;
-export const TransactionMessagesDocument = gql`
-    query TransactionMessages($transactionHash: String!) {
-  transactionMessages(transactionHash: $transactionHash) {
-    transactionHash
-    messages {
-      ...TransactionMessage
-    }
-  }
-}
-    ${TransactionMessageFragmentDoc}`;
-
-/**
- * __useTransactionMessagesQuery__
- *
- * To run a query within a React component, call `useTransactionMessagesQuery` and pass it any options that fit your needs.
- * When your component renders, `useTransactionMessagesQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useTransactionMessagesQuery({
- *   variables: {
- *      transactionHash: // value for 'transactionHash'
- *   },
- * });
- */
-export function useTransactionMessagesQuery(baseOptions?: Apollo.QueryHookOptions<TransactionMessagesQuery, TransactionMessagesQueryVariables>) {
-        return Apollo.useQuery<TransactionMessagesQuery, TransactionMessagesQueryVariables>(TransactionMessagesDocument, baseOptions);
-      }
-export function useTransactionMessagesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<TransactionMessagesQuery, TransactionMessagesQueryVariables>) {
-          return Apollo.useLazyQuery<TransactionMessagesQuery, TransactionMessagesQueryVariables>(TransactionMessagesDocument, baseOptions);
-        }
-export type TransactionMessagesQueryHookResult = ReturnType<typeof useTransactionMessagesQuery>;
-export type TransactionMessagesLazyQueryHookResult = ReturnType<typeof useTransactionMessagesLazyQuery>;
-export type TransactionMessagesQueryResult = Apollo.QueryResult<TransactionMessagesQuery, TransactionMessagesQueryVariables>;
-export const TransactionMessagesCountDocument = gql`
-    query TransactionMessagesCount($colonyAddress: String!) {
-  transactionMessagesCount(colonyAddress: $colonyAddress) {
-    colonyTransactionMessages {
-      transactionHash
-      count
-    }
-  }
-}
-    `;
-
-/**
- * __useTransactionMessagesCountQuery__
- *
- * To run a query within a React component, call `useTransactionMessagesCountQuery` and pass it any options that fit your needs.
- * When your component renders, `useTransactionMessagesCountQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useTransactionMessagesCountQuery({
- *   variables: {
- *      colonyAddress: // value for 'colonyAddress'
- *   },
- * });
- */
-export function useTransactionMessagesCountQuery(baseOptions?: Apollo.QueryHookOptions<TransactionMessagesCountQuery, TransactionMessagesCountQueryVariables>) {
-        return Apollo.useQuery<TransactionMessagesCountQuery, TransactionMessagesCountQueryVariables>(TransactionMessagesCountDocument, baseOptions);
-      }
-export function useTransactionMessagesCountLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<TransactionMessagesCountQuery, TransactionMessagesCountQueryVariables>) {
-          return Apollo.useLazyQuery<TransactionMessagesCountQuery, TransactionMessagesCountQueryVariables>(TransactionMessagesCountDocument, baseOptions);
-        }
-export type TransactionMessagesCountQueryHookResult = ReturnType<typeof useTransactionMessagesCountQuery>;
-export type TransactionMessagesCountLazyQueryHookResult = ReturnType<typeof useTransactionMessagesCountLazyQuery>;
-export type TransactionMessagesCountQueryResult = Apollo.QueryResult<TransactionMessagesCountQuery, TransactionMessagesCountQueryVariables>;
 export const MetaColonyDocument = gql`
     query MetaColony {
   processedMetaColony @client {
@@ -5237,6 +5182,78 @@ export function useHasKycPolicyLazyQuery(baseOptions?: Apollo.LazyQueryHookOptio
 export type HasKycPolicyQueryHookResult = ReturnType<typeof useHasKycPolicyQuery>;
 export type HasKycPolicyLazyQueryHookResult = ReturnType<typeof useHasKycPolicyLazyQuery>;
 export type HasKycPolicyQueryResult = Apollo.QueryResult<HasKycPolicyQuery, HasKycPolicyQueryVariables>;
+export const TransactionMessagesDocument = gql`
+    query TransactionMessages($transactionHash: String!) {
+  transactionMessages(transactionHash: $transactionHash) {
+    transactionHash
+    messages {
+      ...TransactionMessage
+    }
+  }
+}
+    ${TransactionMessageFragmentDoc}`;
+
+/**
+ * __useTransactionMessagesQuery__
+ *
+ * To run a query within a React component, call `useTransactionMessagesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useTransactionMessagesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useTransactionMessagesQuery({
+ *   variables: {
+ *      transactionHash: // value for 'transactionHash'
+ *   },
+ * });
+ */
+export function useTransactionMessagesQuery(baseOptions?: Apollo.QueryHookOptions<TransactionMessagesQuery, TransactionMessagesQueryVariables>) {
+        return Apollo.useQuery<TransactionMessagesQuery, TransactionMessagesQueryVariables>(TransactionMessagesDocument, baseOptions);
+      }
+export function useTransactionMessagesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<TransactionMessagesQuery, TransactionMessagesQueryVariables>) {
+          return Apollo.useLazyQuery<TransactionMessagesQuery, TransactionMessagesQueryVariables>(TransactionMessagesDocument, baseOptions);
+        }
+export type TransactionMessagesQueryHookResult = ReturnType<typeof useTransactionMessagesQuery>;
+export type TransactionMessagesLazyQueryHookResult = ReturnType<typeof useTransactionMessagesLazyQuery>;
+export type TransactionMessagesQueryResult = Apollo.QueryResult<TransactionMessagesQuery, TransactionMessagesQueryVariables>;
+export const TransactionMessagesCountDocument = gql`
+    query TransactionMessagesCount($colonyAddress: String!) {
+  transactionMessagesCount(colonyAddress: $colonyAddress) {
+    colonyTransactionMessages {
+      transactionHash
+      count
+    }
+  }
+}
+    `;
+
+/**
+ * __useTransactionMessagesCountQuery__
+ *
+ * To run a query within a React component, call `useTransactionMessagesCountQuery` and pass it any options that fit your needs.
+ * When your component renders, `useTransactionMessagesCountQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useTransactionMessagesCountQuery({
+ *   variables: {
+ *      colonyAddress: // value for 'colonyAddress'
+ *   },
+ * });
+ */
+export function useTransactionMessagesCountQuery(baseOptions?: Apollo.QueryHookOptions<TransactionMessagesCountQuery, TransactionMessagesCountQueryVariables>) {
+        return Apollo.useQuery<TransactionMessagesCountQuery, TransactionMessagesCountQueryVariables>(TransactionMessagesCountDocument, baseOptions);
+      }
+export function useTransactionMessagesCountLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<TransactionMessagesCountQuery, TransactionMessagesCountQueryVariables>) {
+          return Apollo.useLazyQuery<TransactionMessagesCountQuery, TransactionMessagesCountQueryVariables>(TransactionMessagesCountDocument, baseOptions);
+        }
+export type TransactionMessagesCountQueryHookResult = ReturnType<typeof useTransactionMessagesCountQuery>;
+export type TransactionMessagesCountLazyQueryHookResult = ReturnType<typeof useTransactionMessagesCountLazyQuery>;
+export type TransactionMessagesCountQueryResult = Apollo.QueryResult<TransactionMessagesCountQuery, TransactionMessagesCountQueryVariables>;
 export const SubgraphEventsDocument = gql`
     subscription SubgraphEvents($skip: Int!, $first: Int!, $colonyAddress: String!) {
   events(skip: $skip, first: $first, where: {associatedColony: $colonyAddress}) {
@@ -5486,3 +5503,67 @@ export function useSubraphMotionsSubscription(baseOptions?: Apollo.SubscriptionH
       }
 export type SubraphMotionsSubscriptionHookResult = ReturnType<typeof useSubraphMotionsSubscription>;
 export type SubraphMotionsSubscriptionResult = Apollo.SubscriptionResult<SubraphMotionsSubscription>;
+export const CommentCountDocument = gql`
+    subscription CommentCount($colonyAddress: String!) {
+  transactionMessagesCount(colonyAddress: $colonyAddress) {
+    colonyTransactionMessages {
+      transactionHash
+      count
+    }
+  }
+}
+    `;
+
+/**
+ * __useCommentCountSubscription__
+ *
+ * To run a query within a React component, call `useCommentCountSubscription` and pass it any options that fit your needs.
+ * When your component renders, `useCommentCountSubscription` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the subscription, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useCommentCountSubscription({
+ *   variables: {
+ *      colonyAddress: // value for 'colonyAddress'
+ *   },
+ * });
+ */
+export function useCommentCountSubscription(baseOptions?: Apollo.SubscriptionHookOptions<CommentCountSubscription, CommentCountSubscriptionVariables>) {
+        return Apollo.useSubscription<CommentCountSubscription, CommentCountSubscriptionVariables>(CommentCountDocument, baseOptions);
+      }
+export type CommentCountSubscriptionHookResult = ReturnType<typeof useCommentCountSubscription>;
+export type CommentCountSubscriptionResult = Apollo.SubscriptionResult<CommentCountSubscription>;
+export const CommentsDocument = gql`
+    subscription Comments($transactionHash: String!) {
+  transactionMessages(transactionHash: $transactionHash) {
+    transactionHash
+    messages {
+      ...TransactionMessage
+    }
+  }
+}
+    ${TransactionMessageFragmentDoc}`;
+
+/**
+ * __useCommentsSubscription__
+ *
+ * To run a query within a React component, call `useCommentsSubscription` and pass it any options that fit your needs.
+ * When your component renders, `useCommentsSubscription` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the subscription, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useCommentsSubscription({
+ *   variables: {
+ *      transactionHash: // value for 'transactionHash'
+ *   },
+ * });
+ */
+export function useCommentsSubscription(baseOptions?: Apollo.SubscriptionHookOptions<CommentsSubscription, CommentsSubscriptionVariables>) {
+        return Apollo.useSubscription<CommentsSubscription, CommentsSubscriptionVariables>(CommentsDocument, baseOptions);
+      }
+export type CommentsSubscriptionHookResult = ReturnType<typeof useCommentsSubscription>;
+export type CommentsSubscriptionResult = Apollo.SubscriptionResult<CommentsSubscription>;

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -1924,16 +1924,6 @@ export type ColonyProfileQueryVariables = Exact<{
 
 export type ColonyProfileQuery = { processedColony: ColonyProfileFragment };
 
-export type ColonySubscribedUsersQueryVariables = Exact<{
-  colonyAddress: Scalars['String'];
-}>;
-
-
-export type ColonySubscribedUsersQuery = { subscribedUsers: Array<(
-    Pick<User, 'id'>
-    & { profile: Pick<UserProfile, 'avatarHash' | 'displayName' | 'username' | 'walletAddress'> }
-  )> };
-
 export type ColonyMembersWithReputationQueryVariables = Exact<{
   colonyAddress: Scalars['String'];
   domainId?: Maybe<Scalars['Int']>;
@@ -1998,6 +1988,16 @@ export type TransactionMessagesCountQueryVariables = Exact<{
 
 
 export type TransactionMessagesCountQuery = { transactionMessagesCount: { colonyTransactionMessages: Array<Pick<TransactionCount, 'transactionHash' | 'count'>> } };
+
+export type ColonyMembersQueryVariables = Exact<{
+  colonyAddress: Scalars['String'];
+}>;
+
+
+export type ColonyMembersQuery = { subscribedUsers: Array<(
+    Pick<User, 'id'>
+    & { profile: Pick<UserProfile, 'avatarHash' | 'displayName' | 'username' | 'walletAddress'> }
+  )> };
 
 export type SubgraphEventsSubscriptionVariables = Exact<{
   skip: Scalars['Int'];
@@ -2115,6 +2115,16 @@ export type CommentsSubscription = { transactionMessages: (
     Pick<TransactionMessages, 'transactionHash'>
     & { messages: Array<TransactionMessageFragment> }
   ) };
+
+export type MembersSubscriptionVariables = Exact<{
+  colonyAddress: Scalars['String'];
+}>;
+
+
+export type MembersSubscription = { subscribedUsers: Array<(
+    Pick<User, 'id'>
+    & { profile: Pick<UserProfile, 'avatarHash' | 'displayName' | 'username' | 'walletAddress'> }
+  )> };
 
 export const ColonyProfileFragmentDoc = gql`
     fragment ColonyProfile on ProcessedColony {
@@ -4948,45 +4958,6 @@ export function useColonyProfileLazyQuery(baseOptions?: Apollo.LazyQueryHookOpti
 export type ColonyProfileQueryHookResult = ReturnType<typeof useColonyProfileQuery>;
 export type ColonyProfileLazyQueryHookResult = ReturnType<typeof useColonyProfileLazyQuery>;
 export type ColonyProfileQueryResult = Apollo.QueryResult<ColonyProfileQuery, ColonyProfileQueryVariables>;
-export const ColonySubscribedUsersDocument = gql`
-    query ColonySubscribedUsers($colonyAddress: String!) {
-  subscribedUsers(colonyAddress: $colonyAddress) {
-    id
-    profile {
-      avatarHash
-      displayName
-      username
-      walletAddress
-    }
-  }
-}
-    `;
-
-/**
- * __useColonySubscribedUsersQuery__
- *
- * To run a query within a React component, call `useColonySubscribedUsersQuery` and pass it any options that fit your needs.
- * When your component renders, `useColonySubscribedUsersQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useColonySubscribedUsersQuery({
- *   variables: {
- *      colonyAddress: // value for 'colonyAddress'
- *   },
- * });
- */
-export function useColonySubscribedUsersQuery(baseOptions?: Apollo.QueryHookOptions<ColonySubscribedUsersQuery, ColonySubscribedUsersQueryVariables>) {
-        return Apollo.useQuery<ColonySubscribedUsersQuery, ColonySubscribedUsersQueryVariables>(ColonySubscribedUsersDocument, baseOptions);
-      }
-export function useColonySubscribedUsersLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ColonySubscribedUsersQuery, ColonySubscribedUsersQueryVariables>) {
-          return Apollo.useLazyQuery<ColonySubscribedUsersQuery, ColonySubscribedUsersQueryVariables>(ColonySubscribedUsersDocument, baseOptions);
-        }
-export type ColonySubscribedUsersQueryHookResult = ReturnType<typeof useColonySubscribedUsersQuery>;
-export type ColonySubscribedUsersLazyQueryHookResult = ReturnType<typeof useColonySubscribedUsersLazyQuery>;
-export type ColonySubscribedUsersQueryResult = Apollo.QueryResult<ColonySubscribedUsersQuery, ColonySubscribedUsersQueryVariables>;
 export const ColonyMembersWithReputationDocument = gql`
     query ColonyMembersWithReputation($colonyAddress: String!, $domainId: Int) {
   colonyMembersWithReputation(colonyAddress: $colonyAddress, domainId: $domainId) @client
@@ -5254,6 +5225,45 @@ export function useTransactionMessagesCountLazyQuery(baseOptions?: Apollo.LazyQu
 export type TransactionMessagesCountQueryHookResult = ReturnType<typeof useTransactionMessagesCountQuery>;
 export type TransactionMessagesCountLazyQueryHookResult = ReturnType<typeof useTransactionMessagesCountLazyQuery>;
 export type TransactionMessagesCountQueryResult = Apollo.QueryResult<TransactionMessagesCountQuery, TransactionMessagesCountQueryVariables>;
+export const ColonyMembersDocument = gql`
+    query ColonyMembers($colonyAddress: String!) {
+  subscribedUsers(colonyAddress: $colonyAddress) {
+    id
+    profile {
+      avatarHash
+      displayName
+      username
+      walletAddress
+    }
+  }
+}
+    `;
+
+/**
+ * __useColonyMembersQuery__
+ *
+ * To run a query within a React component, call `useColonyMembersQuery` and pass it any options that fit your needs.
+ * When your component renders, `useColonyMembersQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useColonyMembersQuery({
+ *   variables: {
+ *      colonyAddress: // value for 'colonyAddress'
+ *   },
+ * });
+ */
+export function useColonyMembersQuery(baseOptions?: Apollo.QueryHookOptions<ColonyMembersQuery, ColonyMembersQueryVariables>) {
+        return Apollo.useQuery<ColonyMembersQuery, ColonyMembersQueryVariables>(ColonyMembersDocument, baseOptions);
+      }
+export function useColonyMembersLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ColonyMembersQuery, ColonyMembersQueryVariables>) {
+          return Apollo.useLazyQuery<ColonyMembersQuery, ColonyMembersQueryVariables>(ColonyMembersDocument, baseOptions);
+        }
+export type ColonyMembersQueryHookResult = ReturnType<typeof useColonyMembersQuery>;
+export type ColonyMembersLazyQueryHookResult = ReturnType<typeof useColonyMembersLazyQuery>;
+export type ColonyMembersQueryResult = Apollo.QueryResult<ColonyMembersQuery, ColonyMembersQueryVariables>;
 export const SubgraphEventsDocument = gql`
     subscription SubgraphEvents($skip: Int!, $first: Int!, $colonyAddress: String!) {
   events(skip: $skip, first: $first, where: {associatedColony: $colonyAddress}) {
@@ -5567,3 +5577,38 @@ export function useCommentsSubscription(baseOptions?: Apollo.SubscriptionHookOpt
       }
 export type CommentsSubscriptionHookResult = ReturnType<typeof useCommentsSubscription>;
 export type CommentsSubscriptionResult = Apollo.SubscriptionResult<CommentsSubscription>;
+export const MembersDocument = gql`
+    subscription Members($colonyAddress: String!) {
+  subscribedUsers(colonyAddress: $colonyAddress) {
+    id
+    profile {
+      avatarHash
+      displayName
+      username
+      walletAddress
+    }
+  }
+}
+    `;
+
+/**
+ * __useMembersSubscription__
+ *
+ * To run a query within a React component, call `useMembersSubscription` and pass it any options that fit your needs.
+ * When your component renders, `useMembersSubscription` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the subscription, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useMembersSubscription({
+ *   variables: {
+ *      colonyAddress: // value for 'colonyAddress'
+ *   },
+ * });
+ */
+export function useMembersSubscription(baseOptions?: Apollo.SubscriptionHookOptions<MembersSubscription, MembersSubscriptionVariables>) {
+        return Apollo.useSubscription<MembersSubscription, MembersSubscriptionVariables>(MembersDocument, baseOptions);
+      }
+export type MembersSubscriptionHookResult = ReturnType<typeof useMembersSubscription>;
+export type MembersSubscriptionResult = Apollo.SubscriptionResult<MembersSubscription>;

--- a/src/data/graphql/queries.graphql
+++ b/src/data/graphql/queries.graphql
@@ -681,18 +681,6 @@ query ColonyProfile($address: String!) {
   }
 }
 
-query ColonySubscribedUsers($colonyAddress: String!) {
-  subscribedUsers(colonyAddress: $colonyAddress) {
-    id
-    profile {
-      avatarHash
-      displayName
-      username
-      walletAddress
-    }
-  }
-}
-
 query ColonyMembersWithReputation($colonyAddress: String!, $domainId: Int) {
   colonyMembersWithReputation(colonyAddress: $colonyAddress, domainId: $domainId) @client
 }

--- a/src/data/graphql/queries.graphql
+++ b/src/data/graphql/queries.graphql
@@ -273,24 +273,6 @@ query ColonyAction($transactionHash: String!, $colonyAddress: String!) {
   }
 }
 
-query TransactionMessages($transactionHash: String!) {
-  transactionMessages(transactionHash: $transactionHash) {
-    transactionHash
-    messages {
-    	...TransactionMessage
-    }
-  }
-}
-
-query TransactionMessagesCount($colonyAddress: String!) {
-  transactionMessagesCount(colonyAddress: $colonyAddress) {
-    colonyTransactionMessages {
-      transactionHash
-      count
-    }
-  }
-}
-
 query MetaColony {
   processedMetaColony @client {
     id

--- a/src/data/graphql/queries.graphql
+++ b/src/data/graphql/queries.graphql
@@ -1,4 +1,8 @@
 
+#
+# @TODO Split file into own /queries/*.graphql file based on purpouse
+#
+
 query LoggedInUser {
   loggedInUser @client {
     walletAddress

--- a/src/data/graphql/queries/comments.graphql
+++ b/src/data/graphql/queries/comments.graphql
@@ -1,0 +1,24 @@
+
+#
+# @NOTE Queries need to be declared, even though we only use the subscriptions,
+# otherwise it will cause an invariant violation (due to the way the auto-generator
+# generates the hooks)
+#
+
+query TransactionMessages($transactionHash: String!) {
+  transactionMessages(transactionHash: $transactionHash) {
+    transactionHash
+    messages {
+    	...TransactionMessage
+    }
+  }
+}
+
+query TransactionMessagesCount($colonyAddress: String!) {
+  transactionMessagesCount(colonyAddress: $colonyAddress) {
+    colonyTransactionMessages {
+      transactionHash
+      count
+    }
+  }
+}

--- a/src/data/graphql/queries/members.graphql
+++ b/src/data/graphql/queries/members.graphql
@@ -1,0 +1,18 @@
+
+#
+# @NOTE Queries need to be declared, even though we only use the subscriptions,
+# otherwise it will cause an invariant violation (due to the way the auto-generator
+# generates the hooks)
+#
+
+query ColonyMembers($colonyAddress: String!) {
+  subscribedUsers(colonyAddress: $colonyAddress) {
+    id
+    profile {
+      avatarHash
+      displayName
+      username
+      walletAddress
+    }
+  }
+}

--- a/src/data/graphql/subscriptions.graphql
+++ b/src/data/graphql/subscriptions.graphql
@@ -1,4 +1,4 @@
-subscription SubscriptionSubgraphEvents($skip: Int!, $first: Int!, $colonyAddress: String!) {
+subscription SubgraphEvents($skip: Int!, $first: Int!, $colonyAddress: String!) {
   events(skip: $skip, first: $first, where: { associatedColony: $colonyAddress }) {
     id
     address
@@ -23,7 +23,7 @@ subscription SubscriptionSubgraphEvents($skip: Int!, $first: Int!, $colonyAddres
   }
 }
 
-subscription SubscriptionSubgraphOneTx($skip: Int!, $first: Int!, $colonyAddress: String!) {
+subscription SubgraphOneTx($skip: Int!, $first: Int!, $colonyAddress: String!) {
   oneTxPayments(skip: $skip, first: $first, where: { payment_contains: $colonyAddress }) {
     id
     agent
@@ -55,7 +55,7 @@ subscription SubscriptionSubgraphOneTx($skip: Int!, $first: Int!, $colonyAddress
   }
 }
 
-subscription SubscriptionSubgraphEventsThatAreActions($skip: Int!, $first: Int!, $colonyAddress: String!) {
+subscription SubgraphEventsThatAreActions($skip: Int!, $first: Int!, $colonyAddress: String!) {
   events(
     skip: $skip,
     first: $first,
@@ -113,7 +113,7 @@ subscription SubscriptionSubgraphEventsThatAreActions($skip: Int!, $first: Int!,
   }
 }
 
-subscription SubscriptionsMotions($skip: Int!, $first: Int!, $colonyAddress: String!, $extensionAddress: String!) {
+subscription SubraphMotions($skip: Int!, $first: Int!, $colonyAddress: String!, $extensionAddress: String!) {
   motions(
     skip: $skip,
     first: $first,

--- a/src/data/graphql/subscriptions.graphql
+++ b/src/data/graphql/subscriptions.graphql
@@ -113,7 +113,7 @@ subscription SubgraphEventsThatAreActions($skip: Int!, $first: Int!, $colonyAddr
   }
 }
 
-subscription SubraphMotions($skip: Int!, $first: Int!, $colonyAddress: String!, $extensionAddress: String!) {
+subscription SubgraphMotions($skip: Int!, $first: Int!, $colonyAddress: String!, $extensionAddress: String!) {
   motions(
     skip: $skip,
     first: $first,

--- a/src/data/graphql/subscriptions/comments.graphql
+++ b/src/data/graphql/subscriptions/comments.graphql
@@ -1,0 +1,17 @@
+subscription CommentCount($colonyAddress: String!) {
+  transactionMessagesCount(colonyAddress: $colonyAddress) {
+    colonyTransactionMessages {
+      transactionHash
+      count
+    }
+  }
+}
+
+subscription Comments($transactionHash: String!) {
+  transactionMessages(transactionHash: $transactionHash) {
+    transactionHash
+    messages {
+    	...TransactionMessage
+    }
+  }
+}

--- a/src/data/graphql/subscriptions/members.graphql
+++ b/src/data/graphql/subscriptions/members.graphql
@@ -1,0 +1,11 @@
+subscription Members($colonyAddress: String!) {
+  subscribedUsers(colonyAddress: $colonyAddress) {
+    id
+    profile {
+      avatarHash
+      displayName
+      username
+      walletAddress
+    }
+  }
+}

--- a/src/data/graphql/typeDefs.ts
+++ b/src/data/graphql/typeDefs.ts
@@ -1,5 +1,9 @@
 import gql from 'graphql-tag';
 
+/*
+ * Split type defs into own /typedefs/*.ts file based on purpouse
+ */
+
 export default gql`
   input LoggedInUserInput {
     balance: String

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -39,6 +39,9 @@ import { eventsResolvers } from './resolvers/events';
 import { recoveryModeResolvers } from './resolvers/recovery';
 import { extensionsResolvers } from './resolvers/extensions';
 import { motionsResolvers } from './resolvers/motions';
+/*
+ * @TODO This needs to be merged with the motions resolvers
+ */
 import { stakesResolvers } from './resolvers/stakes';
 import { whitelistResolvers } from './resolvers/whitelist';
 

--- a/src/data/resolvers/recovery.ts
+++ b/src/data/resolvers/recovery.ts
@@ -18,9 +18,9 @@ import {
   RecoveryEventsForSessionQuery,
   RecoveryEventsForSessionQueryVariables,
   RecoveryEventsForSessionDocument,
-  ColonySubscribedUsersQuery,
-  ColonySubscribedUsersQueryVariables,
-  ColonySubscribedUsersDocument,
+  ColonyMembersQuery,
+  ColonyMembersQueryVariables,
+  ColonyMembersDocument,
   RecoveryRolesUsersQuery,
   RecoveryRolesUsersQueryVariables,
   RecoveryRolesUsersDocument,
@@ -273,10 +273,10 @@ export const recoveryModeResolvers = ({
     async recoveryRolesUsers(_, { colonyAddress, endBlockNumber }) {
       try {
         const subscribedUsers = await apolloClient.query<
-          ColonySubscribedUsersQuery,
-          ColonySubscribedUsersQueryVariables
+          ColonyMembersQuery,
+          ColonyMembersQueryVariables
         >({
-          query: ColonySubscribedUsersDocument,
+          query: ColonyMembersDocument,
           variables: {
             colonyAddress,
           },

--- a/src/modules/core/sagas/utils/getNetworkClient.ts
+++ b/src/modules/core/sagas/utils/getNetworkClient.ts
@@ -45,13 +45,16 @@ export default function* getNetworkClient() {
 
   const signer = new EthersSigner({ purserWallet: wallet, provider });
 
+  let reputationOracleUrl = new URL(`/reputation`, window.location.origin);
+
   if (
     process.env.NODE_ENV === 'development' &&
     DEFAULT_NETWORK === Network.Local
   ) {
+    reputationOracleUrl = new URL(`/reputation`, 'http://localhost:3001');
     return yield call(getColonyNetworkClient, network, signer, {
       networkAddress: getLocalContractAddress('EtherRouter'),
-      reputationOracleEndpoint: 'http://localhost:3001/reputation',
+      reputationOracleEndpoint: reputationOracleUrl.href,
     });
   }
 
@@ -63,5 +66,6 @@ export default function* getNetworkClient() {
      */
     networkAddress:
       process.env.NETWORK_CONTRACT_ADDRESS || colonyNetworkAddresses[network],
+    reputationOracleEndpoint: reputationOracleUrl.href,
   });
 }

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeed.tsx
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeed.tsx
@@ -8,7 +8,7 @@ import { MiniSpinnerLoader } from '~core/Preloaders';
 import { getEventsForActions } from '~utils/events';
 
 import {
-  useTransactionMessagesQuery,
+  useCommentsSubscription,
   AnyUser,
   OneDomain,
   ColonyAction,
@@ -112,7 +112,7 @@ const ActionsPageFeed = ({
     data: serverComments,
     loading: loadingServerComments,
     error,
-  } = useTransactionMessagesQuery({
+  } = useCommentsSubscription({
     variables: { transactionHash },
   });
 

--- a/src/modules/dashboard/components/ColonyActions/ColonyActions.tsx
+++ b/src/modules/dashboard/components/ColonyActions/ColonyActions.tsx
@@ -12,14 +12,14 @@ import { SpinnerLoader } from '~core/Preloaders';
 
 import {
   Colony,
-  useTransactionMessagesCountQuery,
-  useSubscriptionSubgraphOneTxSubscription,
-  useSubscriptionSubgraphEventsThatAreActionsSubscription,
+  useSubgraphOneTxSubscription,
+  useSubgraphEventsThatAreActionsSubscription,
   useActionsThatNeedAttentionQuery,
   useLoggedInUser,
   ActionThatNeedsAttention,
-  useSubscriptionsMotionsSubscription,
+  useSubgraphMotionsSubscription,
   useColonyExtensionsQuery,
+  useCommentCountSubscription,
 } from '~data/index';
 import { SortOptions, SortSelectOptions } from '../shared/sortOptions';
 import { getActionsListData } from '../../transformers';
@@ -89,7 +89,7 @@ const ColonyActions = ({
   const {
     data: oneTxActions,
     loading: oneTxActionsLoading,
-  } = useSubscriptionSubgraphOneTxSubscription({
+  } = useSubgraphOneTxSubscription({
     variables: {
       skip: 0,
       first: 100,
@@ -100,7 +100,7 @@ const ColonyActions = ({
   const {
     data: eventsActions,
     loading: eventsActionsLoading,
-  } = useSubscriptionSubgraphEventsThatAreActionsSubscription({
+  } = useSubgraphEventsThatAreActionsSubscription({
     variables: {
       skip: 0,
       first: 100,
@@ -111,7 +111,7 @@ const ColonyActions = ({
   const {
     data: commentCount,
     loading: commentCountLoading,
-  } = useTransactionMessagesCountQuery({
+  } = useCommentCountSubscription({
     variables: { colonyAddress },
   });
 
@@ -137,7 +137,7 @@ const ColonyActions = ({
     ({ extensionId }) => extensionId === Extension.VotingReputation,
   );
 
-  const { data: motions } = useSubscriptionsMotionsSubscription({
+  const { data: motions } = useSubgraphMotionsSubscription({
     variables: {
       skip: 0,
       first: 100,

--- a/src/modules/dashboard/components/ColonyEvents/ColonyEvents.tsx
+++ b/src/modules/dashboard/components/ColonyEvents/ColonyEvents.tsx
@@ -9,7 +9,7 @@ import LoadMoreButton from '~core/LoadMoreButton';
 
 import { SortOptions, SortSelectOptions } from '../shared/sortOptions';
 import { immutableSort } from '~utils/arrays';
-import { Colony, useSubscriptionSubgraphEventsSubscription } from '~data/index';
+import { Colony, useSubgraphEventsSubscription } from '~data/index';
 import { getEventsListData } from '../../transformers';
 import { useTransformer } from '~utils/hooks';
 
@@ -46,7 +46,7 @@ const ColonyEvents = ({
     data,
     loading: subgraphEventsLoading,
     error,
-  } = useSubscriptionSubgraphEventsSubscription({
+  } = useSubgraphEventsSubscription({
     variables: {
       skip: 0,
       first: 100,

--- a/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialog.tsx
+++ b/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialog.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import { FormikProps } from 'formik';
 import * as yup from 'yup';
-import { useQuery } from '@apollo/client';
 import { ROOT_DOMAIN_ID } from '@colony/colony-js';
 import { defineMessages } from 'react-intl';
 import { useHistory } from 'react-router-dom';
@@ -11,7 +10,7 @@ import { ActionForm } from '~core/Fields';
 
 import { Address } from '~types/index';
 import { ActionTypes } from '~redux/index';
-import { ColonySubscribedUsersDocument } from '~data/index';
+import { useMembersSubscription } from '~data/index';
 import { getTokenDecimalsWithFallback } from '~utils/tokens';
 import { pipe, withMeta, mapPayload } from '~utils/actions';
 import { WizardDialogType } from '~utils/hooks';
@@ -88,10 +87,9 @@ const CreatePaymentDialog = ({
     motionDomainId: yup.number(),
   });
 
-  const { data: subscribedUsersData } = useQuery(
-    ColonySubscribedUsersDocument,
-    { variables: { colonyAddress } },
-  );
+  const { data: colonyMembers } = useMembersSubscription({
+    variables: { colonyAddress },
+  });
 
   const transform = useCallback(
     pipe(
@@ -165,7 +163,7 @@ const CreatePaymentDialog = ({
               colony={colony}
               isVotingExtensionEnabled={isVotingExtensionEnabled}
               back={() => callStep(prevStep)}
-              subscribedUsers={subscribedUsersData.subscribedUsers}
+              subscribedUsers={colonyMembers?.subscribedUsers || []}
               ethDomainId={ethDomainId}
             />
           </Dialog>

--- a/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementForm.tsx
+++ b/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementForm.tsx
@@ -16,7 +16,7 @@ import MotionDomainSelect from '~dashboard/MotionDomainSelect';
 import HookedUserAvatar from '~users/HookedUserAvatar';
 
 import { Address } from '~types/index';
-import { useColonySubscribedUsersQuery, AnyUser, Colony } from '~data/index';
+import { useMembersSubscription, AnyUser, Colony } from '~data/index';
 import { useTransformer } from '~utils/hooks';
 import { getAllUserRolesForDomain } from '../../../transformers';
 import { availableRoles } from './constants';
@@ -93,7 +93,7 @@ const PermissionManagementForm = ({
   onChangeSelectedUser,
   values,
 }: Props & FormikProps<FormValues>) => {
-  const { data: colonySubscribedUsers } = useColonySubscribedUsersQuery({
+  const { data: colonyMembers } = useMembersSubscription({
     variables: {
       colonyAddress,
     },
@@ -183,9 +183,7 @@ const PermissionManagementForm = ({
     [directDomainRoles, domainRoles],
   );
 
-  const subscribedUsers = colonySubscribedUsers?.subscribedUsers || [];
-
-  const members = subscribedUsers.map((user) => {
+  const members = (colonyMembers?.subscribedUsers || []).map((user) => {
     const {
       profile: { walletAddress },
     } = user;

--- a/src/modules/dashboard/transformers.ts
+++ b/src/modules/dashboard/transformers.ts
@@ -3,10 +3,10 @@ import { bigNumberify } from 'ethers/utils';
 
 import {
   TransactionsMessagesCount,
-  SubscriptionSubgraphOneTxSubscription,
-  SubscriptionSubgraphEventsThatAreActionsSubscription,
-  SubscriptionSubgraphEventsSubscription,
-  SubscriptionsMotionsSubscription,
+  SubgraphOneTxSubscription,
+  SubgraphEventsThatAreActionsSubscription,
+  SubgraphEventsSubscription,
+  SubgraphMotionsSubscription,
 } from '~data/index';
 import {
   Address,
@@ -42,9 +42,9 @@ interface ActionsTransformerMetadata {
 
 export const getActionsListData = (
   unformattedActions?: {
-    oneTxPayments?: SubscriptionSubgraphOneTxSubscription['oneTxPayments'];
-    events?: SubscriptionSubgraphEventsThatAreActionsSubscription['events'];
-    motions?: SubscriptionsMotionsSubscription['motions'];
+    oneTxPayments?: SubgraphOneTxSubscription['oneTxPayments'];
+    events?: SubgraphEventsThatAreActionsSubscription['events'];
+    motions?: SubgraphMotionsSubscription['motions'];
   },
   transactionsCommentsCount?: TransactionsMessagesCount,
   {
@@ -384,7 +384,7 @@ export const getActionsListData = (
 };
 
 export const getEventsListData = (
-  unformattedEvents?: SubscriptionSubgraphEventsSubscription,
+  unformattedEvents?: SubgraphEventsSubscription,
 ): FormattedEvent[] | undefined =>
   unformattedEvents?.events?.reduce((processedEvents, event) => {
     if (!event) {


### PR DESCRIPTION
## Description

This PR integrates the newly added server GraphQL subscriptions for the comments so that actions, motions, as well as the colony home list will all update instantly once a new comment has been posted

Note that this makes use of the GrapQL Subscriptions PR from [JoinColony/colonyServer#139](https://github.com/JoinColony/colonyServer/pull/139)

**Installing**
- Run `npm run provision` since the server submodule was updated

**Testing**
Just comment on an action or motion, and, in a different browser window, see it update in real time

**Changes** 
- [x] Update the `colonyServer` submodule
- [x] Refactored the apollo client route spliting so that it now takes into account our server's WebSocket path
- [x] Refactored the graphql code structure so that we can have multiple files _(copied what I've implemented in #2407)_
- [x] Added `Comments` and `CommentCount` subscriptions
- [x] Refactored `ColonyActions`, `ActionPageFeed` and `ColonyEvents` to use the new comments subscriptions

**Demo**
![demo-subscription-comments](https://user-images.githubusercontent.com/1193222/131256988-37a2a553-dd53-4be0-93c4-a7aa234c2bce.gif)
