### PR TITLE
Colony Members Subscriptions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,13 +18,12 @@ NODE_ENV=development
 # HTTP endpoint for graphql server
 SERVER_ENDPOINT=http://127.0.0.1:3000
 
-# WebSocket endpoint for our own graphql server
-SERVER_WS_ENDPOINT=ws://127.0.0.1:3000
-
 # HTTP endpoint for "The Graphs" graphql server
 SUBGRAPH_ENDPOINT=http://127.0.0.1:8000/subgraphs/name/joinColony/subgraph
 
 # WebSocket endpoint for "The Graphs" graphql server
+# @NOTE This is only be needed locally when running the dev build
+# In a production/qa environment this variable will not be avaiable
 SUBGRAPH_WS_ENDPOINT=ws://127.0.0.1:8001/subgraphs/name/joinColony/subgraph
 
 # Pinata.cloud API. Only use it on local if you want to test this specifically,

--- a/package-lock.json
+++ b/package-lock.json
@@ -21075,8 +21075,7 @@
     "is-absolute-url": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
-      "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==",
-      "dev": true
+      "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q=="
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -21462,6 +21461,14 @@
       "dev": true,
       "requires": {
         "is-unc-path": "^1.0.0"
+      }
+    },
+    "is-relative-url": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative-url/-/is-relative-url-3.0.0.tgz",
+      "integrity": "sha512-U1iSYRlY2GIMGuZx7gezlB5dp1Kheaym7zKzO1PV06mOihiWTXejLwm4poEJysPyXF+HtK/BEd0DVlcCh30pEA==",
+      "requires": {
+        "is-absolute-url": "^3.0.0"
       }
     },
     "is-root": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21075,7 +21075,8 @@
     "is-absolute-url": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
-      "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q=="
+      "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==",
+      "dev": true
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
@@ -21461,14 +21462,6 @@
       "dev": true,
       "requires": {
         "is-unc-path": "^1.0.0"
-      }
-    },
-    "is-relative-url": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-relative-url/-/is-relative-url-3.0.0.tgz",
-      "integrity": "sha512-U1iSYRlY2GIMGuZx7gezlB5dp1Kheaym7zKzO1PV06mOihiWTXejLwm4poEJysPyXF+HtK/BEd0DVlcCh30pEA==",
-      "requires": {
-        "is-absolute-url": "^3.0.0"
       }
     },
     "is-root": {

--- a/package.json
+++ b/package.json
@@ -162,7 +162,6 @@
     "graphql-tag": "^2.10.1",
     "immutable": "^4.0.0-rc.12",
     "ipfs": "^0.43.1",
-    "is-relative-url": "^3.0.0",
     "jwt-decode": "^2.2.0",
     "linkify-it": "^3.0.0",
     "localforage": "^1.7.3",

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "graphql-tag": "^2.10.1",
     "immutable": "^4.0.0-rc.12",
     "ipfs": "^0.43.1",
+    "is-relative-url": "^3.0.0",
     "jwt-decode": "^2.2.0",
     "linkify-it": "^3.0.0",
     "localforage": "^1.7.3",

--- a/src/data/cache.ts
+++ b/src/data/cache.ts
@@ -48,9 +48,6 @@ export default new InMemoryCache({
     },
     Query: {
       fields: {
-        subscribedUsers: {
-          merge: false,
-        },
         colonyMembersWithReputation: {
           merge: false,
         },
@@ -65,6 +62,13 @@ export default new InMemoryCache({
     Event: {
       fields: {
         associatedColony: {
+          merge: false,
+        },
+      },
+    },
+    Subscription: {
+      fields: {
+        subscribedUsers: {
           merge: false,
         },
       },

--- a/src/data/cacheUpdates.ts
+++ b/src/data/cacheUpdates.ts
@@ -5,12 +5,6 @@ import { Address } from '~types/index';
 import { log } from '~utils/debug';
 import apolloCache from './cache';
 import {
-  ColonySubscribedUsersDocument,
-  ColonySubscribedUsersQuery,
-  ColonySubscribedUsersQueryVariables,
-  UserDocument,
-  UserQuery,
-  UserQueryVariables,
   UnsubscribeFromColonyMutationResult,
   SubscribeToColonyMutationResult,
   UserColoniesQuery,
@@ -123,58 +117,6 @@ const cacheUpdates = {
               },
             });
           }
-        }
-      } catch (e) {
-        log.verbose(e);
-        log.verbose(
-          'Cannot update the colony subscriptions cache - not loaded yet',
-        );
-      }
-      /*
-       * Update the list of colony subscribed users
-       * This is in use in the User Picker (right now we're only using that in
-       * the permissions Dialog)
-       */
-      try {
-        const cacheData = cache.readQuery<
-          ColonySubscribedUsersQuery,
-          ColonySubscribedUsersQueryVariables
-        >({
-          query: ColonySubscribedUsersDocument,
-          variables: {
-            colonyAddress,
-          },
-        });
-        if (cacheData && data && data.unsubscribeFromColony) {
-          const {
-            id: unsubscribedUserWalletAddress,
-          } = data.unsubscribeFromColony;
-          const { subscribedUsers } = cacheData;
-          const updatedColonySubscription = subscribedUsers.filter(
-            /*
-             * Prop `id` does exist, it's just that TS doesn't recognize for
-             * some reason
-             */
-            // @ts-ignore
-            ({ id: userWalletAddress }) =>
-              /*
-               * Remove the unsubscribed user from the subscribers array
-               */
-              userWalletAddress !== unsubscribedUserWalletAddress,
-          );
-          cache.writeQuery<
-            ColonySubscribedUsersQuery,
-            ColonySubscribedUsersQueryVariables
-          >({
-            query: ColonySubscribedUsersDocument,
-            data: {
-              ...cacheData,
-              subscribedUsers: updatedColonySubscription,
-            },
-            variables: {
-              colonyAddress,
-            },
-          });
         }
       } catch (e) {
         log.verbose(e);
@@ -300,59 +242,6 @@ const cacheUpdates = {
                 },
               });
             }
-          }
-        }
-      } catch (e) {
-        log.verbose(e);
-        log.verbose(
-          'Cannot update the colony subscriptions cache - not loaded yet',
-        );
-      }
-      /*
-       * Update the list of colony subscribed users
-       * This is in use in the User Picker (right now we're only using that in
-       * the permissions Dialog)
-       */
-      try {
-        const cacheData = cache.readQuery<
-          ColonySubscribedUsersQuery,
-          ColonySubscribedUsersQueryVariables
-        >({
-          query: ColonySubscribedUsersDocument,
-          variables: {
-            colonyAddress,
-          },
-        });
-        if (cacheData && data && data.subscribeToColony) {
-          const { id: subscribedUserAddress } = data.subscribeToColony;
-          const { subscribedUsers } = cacheData;
-          const newlySubscribedUser = cache.readQuery<
-            UserQuery,
-            UserQueryVariables
-          >({
-            query: UserDocument,
-            variables: {
-              address: subscribedUserAddress,
-            },
-          });
-          if (newlySubscribedUser?.user) {
-            const updatedSubscribedUsers = [
-              ...subscribedUsers,
-              newlySubscribedUser.user,
-            ];
-            cache.writeQuery<
-              ColonySubscribedUsersQuery,
-              ColonySubscribedUsersQueryVariables
-            >({
-              query: ColonySubscribedUsersDocument,
-              data: {
-                ...cacheData,
-                subscribedUsers: updatedSubscribedUsers,
-              },
-              variables: {
-                colonyAddress,
-              },
-            });
           }
         }
       } catch (e) {

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -1989,6 +1989,16 @@ export type TransactionMessagesCountQueryVariables = Exact<{
 
 export type TransactionMessagesCountQuery = { transactionMessagesCount: { colonyTransactionMessages: Array<Pick<TransactionCount, 'transactionHash' | 'count'>> } };
 
+export type ColonyMembersQueryVariables = Exact<{
+  colonyAddress: Scalars['String'];
+}>;
+
+
+export type ColonyMembersQuery = { subscribedUsers: Array<(
+    Pick<User, 'id'>
+    & { profile: Pick<UserProfile, 'avatarHash' | 'displayName' | 'username' | 'walletAddress'> }
+  )> };
+
 export type SubgraphEventsSubscriptionVariables = Exact<{
   skip: Scalars['Int'];
   first: Scalars['Int'];
@@ -2106,12 +2116,12 @@ export type CommentsSubscription = { transactionMessages: (
     & { messages: Array<TransactionMessageFragment> }
   ) };
 
-export type ColonyMembersSubscriptionVariables = Exact<{
+export type MembersSubscriptionVariables = Exact<{
   colonyAddress: Scalars['String'];
 }>;
 
 
-export type ColonyMembersSubscription = { subscribedUsers: Array<(
+export type MembersSubscription = { subscribedUsers: Array<(
     Pick<User, 'id'>
     & { profile: Pick<UserProfile, 'avatarHash' | 'displayName' | 'username' | 'walletAddress'> }
   )> };
@@ -5215,6 +5225,45 @@ export function useTransactionMessagesCountLazyQuery(baseOptions?: Apollo.LazyQu
 export type TransactionMessagesCountQueryHookResult = ReturnType<typeof useTransactionMessagesCountQuery>;
 export type TransactionMessagesCountLazyQueryHookResult = ReturnType<typeof useTransactionMessagesCountLazyQuery>;
 export type TransactionMessagesCountQueryResult = Apollo.QueryResult<TransactionMessagesCountQuery, TransactionMessagesCountQueryVariables>;
+export const ColonyMembersDocument = gql`
+    query ColonyMembers($colonyAddress: String!) {
+  subscribedUsers(colonyAddress: $colonyAddress) {
+    id
+    profile {
+      avatarHash
+      displayName
+      username
+      walletAddress
+    }
+  }
+}
+    `;
+
+/**
+ * __useColonyMembersQuery__
+ *
+ * To run a query within a React component, call `useColonyMembersQuery` and pass it any options that fit your needs.
+ * When your component renders, `useColonyMembersQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useColonyMembersQuery({
+ *   variables: {
+ *      colonyAddress: // value for 'colonyAddress'
+ *   },
+ * });
+ */
+export function useColonyMembersQuery(baseOptions?: Apollo.QueryHookOptions<ColonyMembersQuery, ColonyMembersQueryVariables>) {
+        return Apollo.useQuery<ColonyMembersQuery, ColonyMembersQueryVariables>(ColonyMembersDocument, baseOptions);
+      }
+export function useColonyMembersLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ColonyMembersQuery, ColonyMembersQueryVariables>) {
+          return Apollo.useLazyQuery<ColonyMembersQuery, ColonyMembersQueryVariables>(ColonyMembersDocument, baseOptions);
+        }
+export type ColonyMembersQueryHookResult = ReturnType<typeof useColonyMembersQuery>;
+export type ColonyMembersLazyQueryHookResult = ReturnType<typeof useColonyMembersLazyQuery>;
+export type ColonyMembersQueryResult = Apollo.QueryResult<ColonyMembersQuery, ColonyMembersQueryVariables>;
 export const SubgraphEventsDocument = gql`
     subscription SubgraphEvents($skip: Int!, $first: Int!, $colonyAddress: String!) {
   events(skip: $skip, first: $first, where: {associatedColony: $colonyAddress}) {
@@ -5528,8 +5577,8 @@ export function useCommentsSubscription(baseOptions?: Apollo.SubscriptionHookOpt
       }
 export type CommentsSubscriptionHookResult = ReturnType<typeof useCommentsSubscription>;
 export type CommentsSubscriptionResult = Apollo.SubscriptionResult<CommentsSubscription>;
-export const ColonyMembersDocument = gql`
-    subscription ColonyMembers($colonyAddress: String!) {
+export const MembersDocument = gql`
+    subscription Members($colonyAddress: String!) {
   subscribedUsers(colonyAddress: $colonyAddress) {
     id
     profile {
@@ -5543,23 +5592,23 @@ export const ColonyMembersDocument = gql`
     `;
 
 /**
- * __useColonyMembersSubscription__
+ * __useMembersSubscription__
  *
- * To run a query within a React component, call `useColonyMembersSubscription` and pass it any options that fit your needs.
- * When your component renders, `useColonyMembersSubscription` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useMembersSubscription` and pass it any options that fit your needs.
+ * When your component renders, `useMembersSubscription` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the subscription, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useColonyMembersSubscription({
+ * const { data, loading, error } = useMembersSubscription({
  *   variables: {
  *      colonyAddress: // value for 'colonyAddress'
  *   },
  * });
  */
-export function useColonyMembersSubscription(baseOptions?: Apollo.SubscriptionHookOptions<ColonyMembersSubscription, ColonyMembersSubscriptionVariables>) {
-        return Apollo.useSubscription<ColonyMembersSubscription, ColonyMembersSubscriptionVariables>(ColonyMembersDocument, baseOptions);
+export function useMembersSubscription(baseOptions?: Apollo.SubscriptionHookOptions<MembersSubscription, MembersSubscriptionVariables>) {
+        return Apollo.useSubscription<MembersSubscription, MembersSubscriptionVariables>(MembersDocument, baseOptions);
       }
-export type ColonyMembersSubscriptionHookResult = ReturnType<typeof useColonyMembersSubscription>;
-export type ColonyMembersSubscriptionResult = Apollo.SubscriptionResult<ColonyMembersSubscription>;
+export type MembersSubscriptionHookResult = ReturnType<typeof useMembersSubscription>;
+export type MembersSubscriptionResult = Apollo.SubscriptionResult<MembersSubscription>;

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -1924,16 +1924,6 @@ export type ColonyProfileQueryVariables = Exact<{
 
 export type ColonyProfileQuery = { processedColony: ColonyProfileFragment };
 
-export type ColonySubscribedUsersQueryVariables = Exact<{
-  colonyAddress: Scalars['String'];
-}>;
-
-
-export type ColonySubscribedUsersQuery = { subscribedUsers: Array<(
-    Pick<User, 'id'>
-    & { profile: Pick<UserProfile, 'avatarHash' | 'displayName' | 'username' | 'walletAddress'> }
-  )> };
-
 export type ColonyMembersWithReputationQueryVariables = Exact<{
   colonyAddress: Scalars['String'];
   domainId?: Maybe<Scalars['Int']>;
@@ -2115,6 +2105,16 @@ export type CommentsSubscription = { transactionMessages: (
     Pick<TransactionMessages, 'transactionHash'>
     & { messages: Array<TransactionMessageFragment> }
   ) };
+
+export type ColonyMembersSubscriptionVariables = Exact<{
+  colonyAddress: Scalars['String'];
+}>;
+
+
+export type ColonyMembersSubscription = { subscribedUsers: Array<(
+    Pick<User, 'id'>
+    & { profile: Pick<UserProfile, 'avatarHash' | 'displayName' | 'username' | 'walletAddress'> }
+  )> };
 
 export const ColonyProfileFragmentDoc = gql`
     fragment ColonyProfile on ProcessedColony {
@@ -4948,45 +4948,6 @@ export function useColonyProfileLazyQuery(baseOptions?: Apollo.LazyQueryHookOpti
 export type ColonyProfileQueryHookResult = ReturnType<typeof useColonyProfileQuery>;
 export type ColonyProfileLazyQueryHookResult = ReturnType<typeof useColonyProfileLazyQuery>;
 export type ColonyProfileQueryResult = Apollo.QueryResult<ColonyProfileQuery, ColonyProfileQueryVariables>;
-export const ColonySubscribedUsersDocument = gql`
-    query ColonySubscribedUsers($colonyAddress: String!) {
-  subscribedUsers(colonyAddress: $colonyAddress) {
-    id
-    profile {
-      avatarHash
-      displayName
-      username
-      walletAddress
-    }
-  }
-}
-    `;
-
-/**
- * __useColonySubscribedUsersQuery__
- *
- * To run a query within a React component, call `useColonySubscribedUsersQuery` and pass it any options that fit your needs.
- * When your component renders, `useColonySubscribedUsersQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useColonySubscribedUsersQuery({
- *   variables: {
- *      colonyAddress: // value for 'colonyAddress'
- *   },
- * });
- */
-export function useColonySubscribedUsersQuery(baseOptions?: Apollo.QueryHookOptions<ColonySubscribedUsersQuery, ColonySubscribedUsersQueryVariables>) {
-        return Apollo.useQuery<ColonySubscribedUsersQuery, ColonySubscribedUsersQueryVariables>(ColonySubscribedUsersDocument, baseOptions);
-      }
-export function useColonySubscribedUsersLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ColonySubscribedUsersQuery, ColonySubscribedUsersQueryVariables>) {
-          return Apollo.useLazyQuery<ColonySubscribedUsersQuery, ColonySubscribedUsersQueryVariables>(ColonySubscribedUsersDocument, baseOptions);
-        }
-export type ColonySubscribedUsersQueryHookResult = ReturnType<typeof useColonySubscribedUsersQuery>;
-export type ColonySubscribedUsersLazyQueryHookResult = ReturnType<typeof useColonySubscribedUsersLazyQuery>;
-export type ColonySubscribedUsersQueryResult = Apollo.QueryResult<ColonySubscribedUsersQuery, ColonySubscribedUsersQueryVariables>;
 export const ColonyMembersWithReputationDocument = gql`
     query ColonyMembersWithReputation($colonyAddress: String!, $domainId: Int) {
   colonyMembersWithReputation(colonyAddress: $colonyAddress, domainId: $domainId) @client
@@ -5567,3 +5528,38 @@ export function useCommentsSubscription(baseOptions?: Apollo.SubscriptionHookOpt
       }
 export type CommentsSubscriptionHookResult = ReturnType<typeof useCommentsSubscription>;
 export type CommentsSubscriptionResult = Apollo.SubscriptionResult<CommentsSubscription>;
+export const ColonyMembersDocument = gql`
+    subscription ColonyMembers($colonyAddress: String!) {
+  subscribedUsers(colonyAddress: $colonyAddress) {
+    id
+    profile {
+      avatarHash
+      displayName
+      username
+      walletAddress
+    }
+  }
+}
+    `;
+
+/**
+ * __useColonyMembersSubscription__
+ *
+ * To run a query within a React component, call `useColonyMembersSubscription` and pass it any options that fit your needs.
+ * When your component renders, `useColonyMembersSubscription` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the subscription, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useColonyMembersSubscription({
+ *   variables: {
+ *      colonyAddress: // value for 'colonyAddress'
+ *   },
+ * });
+ */
+export function useColonyMembersSubscription(baseOptions?: Apollo.SubscriptionHookOptions<ColonyMembersSubscription, ColonyMembersSubscriptionVariables>) {
+        return Apollo.useSubscription<ColonyMembersSubscription, ColonyMembersSubscriptionVariables>(ColonyMembersDocument, baseOptions);
+      }
+export type ColonyMembersSubscriptionHookResult = ReturnType<typeof useColonyMembersSubscription>;
+export type ColonyMembersSubscriptionResult = Apollo.SubscriptionResult<ColonyMembersSubscription>;

--- a/src/data/graphql/queries.graphql
+++ b/src/data/graphql/queries.graphql
@@ -681,18 +681,6 @@ query ColonyProfile($address: String!) {
   }
 }
 
-query ColonySubscribedUsers($colonyAddress: String!) {
-  subscribedUsers(colonyAddress: $colonyAddress) {
-    id
-    profile {
-      avatarHash
-      displayName
-      username
-      walletAddress
-    }
-  }
-}
-
 query ColonyMembersWithReputation($colonyAddress: String!, $domainId: Int) {
   colonyMembersWithReputation(colonyAddress: $colonyAddress, domainId: $domainId) @client
 }

--- a/src/data/graphql/queries/members.graphql
+++ b/src/data/graphql/queries/members.graphql
@@ -1,0 +1,18 @@
+
+#
+# @NOTE Queries need to be declared, even though we only use the subscriptions,
+# otherwise it will cause an invariant violation (due to the way the auto-generator
+# generates the hooks)
+#
+
+query ColonyMembers($colonyAddress: String!) {
+  subscribedUsers(colonyAddress: $colonyAddress) {
+    id
+    profile {
+      avatarHash
+      displayName
+      username
+      walletAddress
+    }
+  }
+}

--- a/src/data/graphql/subscriptions/members.graphql
+++ b/src/data/graphql/subscriptions/members.graphql
@@ -1,0 +1,11 @@
+subscription ColonyMembers($colonyAddress: String!) {
+  subscribedUsers(colonyAddress: $colonyAddress) {
+    id
+    profile {
+      avatarHash
+      displayName
+      username
+      walletAddress
+    }
+  }
+}

--- a/src/data/graphql/subscriptions/members.graphql
+++ b/src/data/graphql/subscriptions/members.graphql
@@ -1,4 +1,4 @@
-subscription ColonyMembers($colonyAddress: String!) {
+subscription Members($colonyAddress: String!) {
   subscribedUsers(colonyAddress: $colonyAddress) {
     id
     profile {

--- a/src/data/resolvers/recovery.ts
+++ b/src/data/resolvers/recovery.ts
@@ -18,9 +18,9 @@ import {
   RecoveryEventsForSessionQuery,
   RecoveryEventsForSessionQueryVariables,
   RecoveryEventsForSessionDocument,
-  ColonySubscribedUsersQuery,
-  ColonySubscribedUsersQueryVariables,
-  ColonySubscribedUsersDocument,
+  ColonyMembersQuery,
+  ColonyMembersQueryVariables,
+  ColonyMembersDocument,
   RecoveryRolesUsersQuery,
   RecoveryRolesUsersQueryVariables,
   RecoveryRolesUsersDocument,
@@ -273,10 +273,10 @@ export const recoveryModeResolvers = ({
     async recoveryRolesUsers(_, { colonyAddress, endBlockNumber }) {
       try {
         const subscribedUsers = await apolloClient.query<
-          ColonySubscribedUsersQuery,
-          ColonySubscribedUsersQueryVariables
+          ColonyMembersQuery,
+          ColonyMembersQueryVariables
         >({
-          query: ColonySubscribedUsersDocument,
+          query: ColonyMembersDocument,
           variables: {
             colonyAddress,
           },

--- a/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.tsx
@@ -9,7 +9,7 @@ import useAvatarDisplayCounter from '~utils/hooks/useAvatarDisplayCounter';
 import {
   Colony,
   useColonyMembersWithReputationQuery,
-  useColonyMembersSubscription,
+  useMembersSubscription,
 } from '~data/index';
 import { Address } from '~types/index';
 import { COLONY_TOTAL_BALANCE_DOMAIN_ID } from '~constants';
@@ -59,10 +59,7 @@ const ColonyMembers = ({
     },
   });
 
-  const {
-    data: members,
-    loading: loadingMembers,
-  } = useColonyMembersSubscription({
+  const { data: members, loading: loadingMembers } = useMembersSubscription({
     variables: {
       colonyAddress,
     },

--- a/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
 import NavLink from '~core/NavLink';
@@ -6,7 +6,11 @@ import Heading from '~core/Heading';
 import HookedUserAvatar from '~users/HookedUserAvatar';
 import { MiniSpinnerLoader } from '~core/Preloaders';
 import useAvatarDisplayCounter from '~utils/hooks/useAvatarDisplayCounter';
-import { Colony, useColonyMembersWithReputationQuery } from '~data/index';
+import {
+  Colony,
+  useColonyMembersWithReputationQuery,
+  useColonyMembersSubscription,
+} from '~data/index';
 import { Address } from '~types/index';
 import { COLONY_TOTAL_BALANCE_DOMAIN_ID } from '~constants';
 
@@ -46,7 +50,7 @@ const ColonyMembers = ({
   maxAvatars = 15,
 }: Props) => {
   const {
-    data: members,
+    data: membersWithReputation,
     loading: loadingColonyMembersWithReputation,
   } = useColonyMembersWithReputationQuery({
     variables: {
@@ -56,13 +60,27 @@ const ColonyMembers = ({
   });
 
   const {
+    data: members,
+    loading: loadingMembers,
+  } = useColonyMembersSubscription({
+    variables: {
+      colonyAddress,
+    },
+  });
+
+  const colonyMembers = useMemo(() => {
+    if (currentDomainId === COLONY_TOTAL_BALANCE_DOMAIN_ID) {
+      return members?.subscribedUsers?.map(
+        ({ profile: { walletAddress } }) => walletAddress,
+      );
+    }
+    return membersWithReputation?.colonyMembersWithReputation;
+  }, [members, membersWithReputation, currentDomainId]);
+
+  const {
     avatarsDisplaySplitRules,
     remainingAvatarsCount,
-  } = useAvatarDisplayCounter(
-    maxAvatars,
-    members?.colonyMembersWithReputation,
-    false,
-  );
+  } = useAvatarDisplayCounter(maxAvatars, colonyMembers, false);
 
   const BASE_MEMBERS_ROUTE = `/colony/${colonyName}/members`;
   const membersPageRoute =
@@ -70,7 +88,7 @@ const ColonyMembers = ({
       ? BASE_MEMBERS_ROUTE
       : `${BASE_MEMBERS_ROUTE}/${currentDomainId}`;
 
-  if (loadingColonyMembersWithReputation) {
+  if (loadingColonyMembersWithReputation || loadingMembers) {
     return (
       <MiniSpinnerLoader
         className={styles.main}
@@ -81,7 +99,7 @@ const ColonyMembers = ({
     );
   }
 
-  if (!members || !members.colonyMembersWithReputation) {
+  if (!colonyMembers) {
     return (
       <div className={styles.main}>
         <Heading
@@ -96,8 +114,6 @@ const ColonyMembers = ({
     );
   }
 
-  const { colonyMembersWithReputation } = members;
-
   return (
     <div className={styles.main}>
       <NavLink to={membersPageRoute}>
@@ -105,13 +121,13 @@ const ColonyMembers = ({
           appearance={{ size: 'normal', weight: 'bold' }}
           text={MSG.title}
           textValues={{
-            count: colonyMembersWithReputation.length,
+            count: colonyMembers.length,
             hasCounter: true,
           }}
         />
       </NavLink>
       <ul className={styles.userAvatars}>
-        {(colonyMembersWithReputation as Address[])
+        {(colonyMembers as Address[])
           .slice(0, avatarsDisplaySplitRules)
           .map((userAddress: Address) => (
             <li className={styles.userAvatar} key={userAddress}>

--- a/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialog.tsx
+++ b/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialog.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import { FormikProps } from 'formik';
 import * as yup from 'yup';
-import { useQuery } from '@apollo/client';
 import { ROOT_DOMAIN_ID } from '@colony/colony-js';
 import { defineMessages } from 'react-intl';
 import { useHistory } from 'react-router-dom';
@@ -11,7 +10,7 @@ import { ActionForm } from '~core/Fields';
 
 import { Address } from '~types/index';
 import { ActionTypes } from '~redux/index';
-import { ColonySubscribedUsersDocument } from '~data/index';
+import { useMembersSubscription } from '~data/index';
 import { getTokenDecimalsWithFallback } from '~utils/tokens';
 import { pipe, withMeta, mapPayload } from '~utils/actions';
 import { WizardDialogType } from '~utils/hooks';
@@ -88,10 +87,9 @@ const CreatePaymentDialog = ({
     motionDomainId: yup.number(),
   });
 
-  const { data: subscribedUsersData } = useQuery(
-    ColonySubscribedUsersDocument,
-    { variables: { colonyAddress } },
-  );
+  const { data: colonyMembers } = useMembersSubscription({
+    variables: { colonyAddress },
+  });
 
   const transform = useCallback(
     pipe(
@@ -165,7 +163,7 @@ const CreatePaymentDialog = ({
               colony={colony}
               isVotingExtensionEnabled={isVotingExtensionEnabled}
               back={() => callStep(prevStep)}
-              subscribedUsers={subscribedUsersData.subscribedUsers}
+              subscribedUsers={colonyMembers?.subscribedUsers || []}
               ethDomainId={ethDomainId}
             />
           </Dialog>

--- a/src/modules/dashboard/components/Members/Members.tsx
+++ b/src/modules/dashboard/components/Members/Members.tsx
@@ -17,7 +17,7 @@ import {
   AnyUser,
   Colony,
   useColonyMembersWithReputationQuery,
-  useColonyMembersSubscription,
+  useMembersSubscription,
 } from '~data/index';
 import {
   COLONY_TOTAL_BALANCE_DOMAIN_ID,
@@ -98,7 +98,7 @@ const Members = ({ colony: { colonyAddress }, colony }: Props) => {
   const {
     data: allMembers,
     loading: loadingAllMembers,
-  } = useColonyMembersSubscription({
+  } = useMembersSubscription({
     variables: {
       colonyAddress,
     },

--- a/src/modules/dashboard/components/Members/Members.tsx
+++ b/src/modules/dashboard/components/Members/Members.tsx
@@ -17,6 +17,7 @@ import {
   AnyUser,
   Colony,
   useColonyMembersWithReputationQuery,
+  useColonyMembersSubscription,
 } from '~data/index';
 import {
   COLONY_TOTAL_BALANCE_DOMAIN_ID,
@@ -95,8 +96,17 @@ const Members = ({ colony: { colonyAddress }, colony }: Props) => {
     selectedDomain || {};
 
   const {
-    data,
-    loading: loadingColonyMembers,
+    data: allMembers,
+    loading: loadingAllMembers,
+  } = useColonyMembersSubscription({
+    variables: {
+      colonyAddress,
+    },
+  });
+
+  const {
+    data: membersWithReputation,
+    loading: loadingColonyMembersWithReputation,
   } = useColonyMembersWithReputationQuery({
     variables: {
       colonyAddress,
@@ -120,14 +130,19 @@ const Members = ({ colony: { colonyAddress }, colony }: Props) => {
    * or cannot be subscribers to the colony).
    */
   const skelethonUsers = useMemo(() => {
-    if (!data || !data.colonyMembersWithReputation) {
-      return [];
+    let displayMembers =
+      allMembers?.subscribedUsers.map(
+        ({ profile: { walletAddress } }) => walletAddress,
+      ) || [];
+    if (currentDomainId !== COLONY_TOTAL_BALANCE_DOMAIN_ID) {
+      displayMembers = membersWithReputation?.colonyMembersWithReputation || [];
     }
-    return data.colonyMembersWithReputation.map((walletAddress) => ({
+
+    return displayMembers.map((walletAddress) => ({
       id: walletAddress,
       profile: { walletAddress },
     }));
-  }, [data]);
+  }, [allMembers, membersWithReputation, currentDomainId]);
 
   const domainRoles = useTransformer(getAllUserRolesForDomain, [
     colony,
@@ -196,7 +211,7 @@ const Members = ({ colony: { colonyAddress }, colony }: Props) => {
       });
   }, [directDomainRoles, domainRoles, inheritedDomainRoles]);
 
-  if (loadingColonyMembers) {
+  if (loadingAllMembers || loadingColonyMembersWithReputation) {
     return (
       <div className={styles.main}>
         <SpinnerLoader

--- a/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementForm.tsx
+++ b/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementForm.tsx
@@ -16,7 +16,7 @@ import MotionDomainSelect from '~dashboard/MotionDomainSelect';
 import HookedUserAvatar from '~users/HookedUserAvatar';
 
 import { Address } from '~types/index';
-import { useColonySubscribedUsersQuery, AnyUser, Colony } from '~data/index';
+import { useMembersSubscription, AnyUser, Colony } from '~data/index';
 import { useTransformer } from '~utils/hooks';
 import { getAllUserRolesForDomain } from '../../../transformers';
 import { availableRoles } from './constants';
@@ -93,7 +93,7 @@ const PermissionManagementForm = ({
   onChangeSelectedUser,
   values,
 }: Props & FormikProps<FormValues>) => {
-  const { data: colonySubscribedUsers } = useColonySubscribedUsersQuery({
+  const { data: colonyMembers } = useMembersSubscription({
     variables: {
       colonyAddress,
     },
@@ -183,9 +183,7 @@ const PermissionManagementForm = ({
     [directDomainRoles, domainRoles],
   );
 
-  const subscribedUsers = colonySubscribedUsers?.subscribedUsers || [];
-
-  const members = subscribedUsers.map((user) => {
+  const members = (colonyMembers?.subscribedUsers || []).map((user) => {
     const {
       profile: { walletAddress },
     } = user;


### PR DESCRIPTION
## Description

This PR integrates the newly added server GraphQL subscriptions for the colony members so that users joining or leaving a colony will update instantly in the UI

Note that this makes use of the GrapQL Subscriptions PR from [JoinColony/colonyServer#139](https://github.com/JoinColony/colonyServer/pull/139)

**Installing**
- Run `npm run provision` since the server submodule was updated

**Testing**
- Just join/leave a colony and see it update in real time in a different browser window

**Changes** 

- [x] Added `ColonyMembers` subscription
- [x] Refactored `colonyMembersWithReputation` resolver
- [x] Fixed `recoverySystemMessagesForSession` resolver
- [x] Removed subscribed users cache updates that are no longer necesarry
- [x] `ColonyMembers` use subscriptions query
- [x] `Members` use subscriptions query
- [x] `PermissionsManagementModal` use subscriptions query
- [x] `CreatePaymentDialog` use subscriptions query

**Demo**

![demo-subscriptions-colony-members](https://user-images.githubusercontent.com/1193222/131259166-c6a52d07-28bf-4af9-933c-903ac7e9c8f3.gif)
![demo-subscriptions-members-page](https://user-images.githubusercontent.com/1193222/131259167-2717f057-4e12-49dd-b00f-8250046326ef.gif)
![demo-subscriptions-members-payment](https://user-images.githubusercontent.com/1193222/131259169-777adf04-76f5-4c8e-9f83-5ebebfbed9a2.gif)
![demo-subscriptions-members-permissions](https://user-images.githubusercontent.com/1193222/131259170-037db3b1-b0fd-4b76-a888-570ea4e4e3bb.gif)

