### PR TITLE
Fix Reputation Oracle Endpoint

### DIFF
--- a/src/modules/core/sagas/utils/getNetworkClient.ts
+++ b/src/modules/core/sagas/utils/getNetworkClient.ts
@@ -45,13 +45,16 @@ export default function* getNetworkClient() {
 
   const signer = new EthersSigner({ purserWallet: wallet, provider });
 
+  let reputationOracleUrl = new URL(`/reputation`, window.location.origin);
+
   if (
     process.env.NODE_ENV === 'development' &&
     DEFAULT_NETWORK === Network.Local
   ) {
+    reputationOracleUrl = new URL(`/reputation`, 'http://localhost:3001');
     return yield call(getColonyNetworkClient, network, signer, {
       networkAddress: getLocalContractAddress('EtherRouter'),
-      reputationOracleEndpoint: 'http://localhost:3001/reputation',
+      reputationOracleEndpoint: reputationOracleUrl.href,
     });
   }
 
@@ -63,5 +66,6 @@ export default function* getNetworkClient() {
      */
     networkAddress:
       process.env.NETWORK_CONTRACT_ADDRESS || colonyNetworkAddresses[network],
+    reputationOracleEndpoint: reputationOracleUrl.href,
   });
 }


### PR DESCRIPTION
## Description

This PR fixes the way we generate the reputation oracle endpoint when passing it down to the `getColonyNetworkClient` constructor.

This helps us use the correct url for the reputation oracle in the various environments that we deploy the Dapp to _(basically avoiding CORS issues)_

**Changes** 

- [x] Updated `getNetworkClient` saga helper to properly generate the reputation oracle URL
