### PR TITLE
Add permissions section to MembersInfoPopover

### DIFF
--- a/src/modules/core/components/Heading/Heading.css
+++ b/src/modules/core/components/Heading/Heading.css
@@ -40,6 +40,11 @@
   color: var(--temp-grey-11);
 }
 
+.themeGrey {
+  composes: main;
+  color: var(--temp-grey-blue-7);
+}
+
 /*
  * Margins
  *

--- a/src/modules/core/components/Heading/Heading.css.d.ts
+++ b/src/modules/core/components/Heading/Heading.css.d.ts
@@ -3,6 +3,7 @@ export const themePrimary: string;
 export const themeDark: string;
 export const themeInvert: string;
 export const themeUppercase: string;
+export const themeGrey: string;
 export const marginNone: string;
 export const marginSmall: string;
 export const marginDouble: string;

--- a/src/modules/core/components/InfoPopover/InfoPopover.css
+++ b/src/modules/core/components/InfoPopover/InfoPopover.css
@@ -99,6 +99,7 @@
 .textContainer {
   display: flex;
   justify-content: center;
+  align-items: flex-start;
   flex-direction: column;
   margin-left: 12px;
 }

--- a/src/modules/core/components/InfoPopover/InfoPopover.tsx
+++ b/src/modules/core/components/InfoPopover/InfoPopover.tsx
@@ -2,8 +2,7 @@ import React, { ReactNode, useMemo } from 'react';
 import { PopperProps } from 'react-popper';
 
 import Popover from '~core/Popover';
-import { AnyUser, AnyToken } from '~data/index';
-import { Address } from '~types/index';
+import { AnyUser, AnyToken, Colony } from '~data/index';
 
 import MemberInfoPopover from './MemberInfoPopover';
 import TokenInfoPopover from './TokenInfoPopover';
@@ -19,7 +18,7 @@ interface BasicUserContentProps {
 }
 
 interface MemberContentProps {
-  colonyAddress?: Address;
+  colony?: Colony;
   domainId?: number | undefined;
   user?: AnyUser;
 }
@@ -51,16 +50,12 @@ const InfoPopover = ({
 }: Props) => {
   const renderContent = useMemo(() => {
     if (
-      'colonyAddress' in contentProps &&
-      typeof contentProps.colonyAddress !== 'undefined'
+      'colony' in contentProps &&
+      typeof contentProps.colony !== 'undefined'
     ) {
-      const { colonyAddress, domainId, user } = contentProps;
+      const { colony, domainId, user } = contentProps;
       return (
-        <MemberInfoPopover
-          colonyAddress={colonyAddress}
-          domainId={domainId}
-          user={user}
-        />
+        <MemberInfoPopover colony={colony} domainId={domainId} user={user} />
       );
     }
     if ('token' in contentProps && typeof contentProps.token !== 'undefined') {

--- a/src/modules/core/components/InfoPopover/MemberInfoPopover/MemberInfoPopover.css
+++ b/src/modules/core/components/InfoPopover/MemberInfoPopover/MemberInfoPopover.css
@@ -47,7 +47,8 @@
 }
 
 .permissionsContainer h4 {
-  color: var(--temp-grey-blue-7);
+  font-size: var(--size-smallish);
+  color: color-mod(var(--temp-grey-blue-7) alpha(85%));
 }
 
 .roleList {
@@ -55,5 +56,5 @@
 }
 
 .roleListItem + .roleListItem {
-  margin-top: 3px;
+  margin-top: 4px;
 }

--- a/src/modules/core/components/InfoPopover/MemberInfoPopover/MemberInfoPopover.css
+++ b/src/modules/core/components/InfoPopover/MemberInfoPopover/MemberInfoPopover.css
@@ -40,3 +40,20 @@
   align-items: center;
   height: 100px;
 }
+
+.permissionsContainer {
+  display: flex;
+  justify-content: space-between;
+}
+
+.permissionsContainer h4 {
+  color: var(--temp-grey-blue-7);
+}
+
+.roleList {
+  text-align: right;
+}
+
+.roleListItem + .roleListItem {
+  margin-top: 3px;
+}

--- a/src/modules/core/components/InfoPopover/MemberInfoPopover/MemberInfoPopover.css.d.ts
+++ b/src/modules/core/components/InfoPopover/MemberInfoPopover/MemberInfoPopover.css.d.ts
@@ -4,3 +4,6 @@ export const reputation: string;
 export const reputationHeading: string;
 export const reputationError: string;
 export const loadingSpinnerContainer: string;
+export const permissionsContainer: string;
+export const roleList: string;
+export const roleListItem: string;

--- a/src/modules/core/components/InfoPopover/MemberInfoPopover/MemberInfoPopover.tsx
+++ b/src/modules/core/components/InfoPopover/MemberInfoPopover/MemberInfoPopover.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
+import isEmpty from 'lodash/isEmpty';
 
 import Heading from '~core/Heading';
 import Numeral from '~core/Numeral';
@@ -9,15 +10,18 @@ import {
   useUserReputationQuery,
   useColonyNativeTokenQuery,
   useTokenInfoLazyQuery,
+  Colony,
 } from '~data/index';
-import { Address } from '~types/index';
+import { useTransformer } from '~utils/hooks';
 
+import { getAllUserRoles } from '../../../../transformers';
 import UserInfo from '../UserInfo';
+import UserPermissions from './UserPermissions';
 
 import styles from './MemberInfoPopover.css';
 
 interface Props {
-  colonyAddress: Address;
+  colony: Colony;
   domainId?: number;
   user?: AnyUser;
 }
@@ -40,7 +44,8 @@ const MSG = defineMessages({
 const displayName = 'InfoPopover.MemberInfoPopover';
 
 const MemberInfoPopover = ({
-  colonyAddress,
+  colony: { colonyAddress },
+  colony,
   domainId,
   user = { id: '', profile: { walletAddress: '' } },
 }: Props) => {
@@ -67,6 +72,8 @@ const MemberInfoPopover = ({
   } = useUserReputationQuery({
     variables: { address: walletAddress, colonyAddress, domainId },
   });
+
+  const allUserRoles = useTransformer(getAllUserRoles, [colony, walletAddress]);
 
   useEffect(() => {
     if (nativeTokenAddressData) {
@@ -133,6 +140,11 @@ const MemberInfoPopover = ({
           </p>
         )}
       </div>
+      {!isEmpty(allUserRoles) && (
+        <div className={styles.section}>
+          <UserPermissions roles={allUserRoles} />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/modules/core/components/InfoPopover/MemberInfoPopover/UserPermissions.tsx
+++ b/src/modules/core/components/InfoPopover/MemberInfoPopover/UserPermissions.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { ColonyRole } from '@colony/colony-js';
+import { defineMessages } from 'react-intl';
+
+import PermissionsLabel from '~core/PermissionsLabel';
+
+import styles from './MemberInfoPopover.css';
+import Heading from '~core/Heading';
+
+const displayName = `InfoPopover.MemberInfoPopover.UserPermissions`;
+
+interface Props {
+  roles: ColonyRole[];
+}
+
+const MSG = defineMessages({
+  labelText: {
+    id: 'InfoPopover.MemberInfoPopover.UserPermissions.labelText',
+    defaultMessage: 'Permissions',
+  },
+});
+
+const UserPermissions = ({ roles }: Props) => {
+  return (
+    <div className={styles.permissionsContainer}>
+      <Heading
+        appearance={{
+          size: 'normal',
+          margin: 'none',
+          theme: 'grey',
+          weight: 'bold',
+        }}
+        text={MSG.labelText}
+      />
+      <ul className={styles.roleList}>
+        {roles.map((role) => (
+          <li key={role} className={styles.roleListItem}>
+            <PermissionsLabel permission={role} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+UserPermissions.displayName = displayName;
+
+export default UserPermissions;

--- a/src/modules/core/components/MembersList/MembersList.tsx
+++ b/src/modules/core/components/MembersList/MembersList.tsx
@@ -1,12 +1,12 @@
 import React, { ReactNode } from 'react';
 
 import ListGroup, { ListGroupAppearance } from '~core/ListGroup';
-import { AnyUser } from '~data/index';
-import { Address } from '~types/index';
+import { AnyUser, Colony } from '~data/index';
+
 import MembersListItem from './MembersListItem';
 
 interface Props<U> {
-  colonyAddress: Address;
+  colony: Colony;
   extraItemContent?: (user: U) => ReactNode;
   onRowClick?: (user: U) => void;
   showUserInfo?: boolean;
@@ -19,7 +19,7 @@ interface Props<U> {
 const displayName = 'MembersList';
 
 const MembersList = <U extends AnyUser = AnyUser>({
-  colonyAddress,
+  colony,
   extraItemContent,
   onRowClick,
   showUserInfo = true,
@@ -31,7 +31,7 @@ const MembersList = <U extends AnyUser = AnyUser>({
   <ListGroup appearance={listGroupAppearance}>
     {users.map((user) => (
       <MembersListItem<U>
-        colonyAddress={colonyAddress}
+        colony={colony}
         extraItemContent={extraItemContent}
         key={user.id}
         onRowClick={onRowClick}

--- a/src/modules/core/components/MembersList/MembersListItem.tsx
+++ b/src/modules/core/components/MembersList/MembersListItem.tsx
@@ -5,8 +5,8 @@ import { createAddress } from '~utils/web3';
 import UserMention from '~core/UserMention';
 import { ListGroupItem } from '~core/ListGroup';
 import CopyableAddress from '~core/CopyableAddress';
-import { AnyUser, useUser } from '~data/index';
-import { Address, ENTER } from '~types/index';
+import { AnyUser, Colony, useUser } from '~data/index';
+import { ENTER } from '~types/index';
 import HookedUserAvatar from '~users/HookedUserAvatar';
 import { getMainClasses } from '~utils/css';
 import MemberReputation from '~core/MemberReputation';
@@ -15,7 +15,7 @@ import styles from './MembersListItem.css';
 
 interface Props<U> {
   extraItemContent?: (user: U) => ReactNode;
-  colonyAddress: Address;
+  colony: Colony;
   onRowClick?: (user: U) => void;
   showUserInfo: boolean;
   showUserReputation: boolean;
@@ -29,7 +29,7 @@ const componentDisplayName = 'MembersList.MembersListItem';
 
 const MembersListItem = <U extends AnyUser = AnyUser>(props: Props<U>) => {
   const {
-    colonyAddress,
+    colony,
     domainId,
     extraItemContent,
     onRowClick,
@@ -83,7 +83,7 @@ const MembersListItem = <U extends AnyUser = AnyUser>(props: Props<U>) => {
           <div className={styles.reputationSection}>
             <MemberReputation
               walletAddress={walletAddress}
-              colonyAddress={colonyAddress}
+              colonyAddress={colony.colonyAddress}
               domainId={domainId}
             />
           </div>
@@ -91,7 +91,7 @@ const MembersListItem = <U extends AnyUser = AnyUser>(props: Props<U>) => {
         <div className={styles.section}>
           <UserAvatar
             size="s"
-            colonyAddress={colonyAddress}
+            colony={colony}
             address={walletAddress}
             user={userProfile}
             showInfo={!onRowClick || showUserInfo}

--- a/src/modules/core/components/UserAvatar/UserAvatar.tsx
+++ b/src/modules/core/components/UserAvatar/UserAvatar.tsx
@@ -5,7 +5,7 @@ import Avatar from '~core/Avatar';
 import InfoPopover, { Props as InfoPopoverProps } from '~core/InfoPopover';
 import Link from '~core/NavLink';
 import { Address } from '~types/index';
-import { AnyUser } from '~data/index';
+import { AnyUser, Colony } from '~data/index';
 
 import { getUsername } from '../../../users/transformers';
 
@@ -43,7 +43,7 @@ interface BaseProps {
 
 /** Used for the infopopover */
 interface PropsForReputation extends BaseProps {
-  colonyAddress?: Address;
+  colony?: Colony;
   domainId?: number;
 }
 
@@ -73,11 +73,11 @@ const UserAvatar = ({
     user,
     showArrow: popperProps && popperProps.showArrow,
   };
-  if ('colonyAddress' in rest) {
-    const { colonyAddress, domainId } = rest;
+  if ('colony' in rest) {
+    const { colony, domainId } = rest;
     popoverProps = {
       ...popoverProps,
-      colonyAddress,
+      colony,
       domainId,
     };
   }

--- a/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.css
@@ -3,14 +3,11 @@
   margin-top: 40px;
 }
 
-.main h4 {
+.main a h4 {
+  display: inline-block;
   font-size: var(--size-smallish);
   color: var(--dark);
   letter-spacing: var(--spacing-medium);
-}
-
-.main a h4 {
-  display: inline-block;
 }
 
 .main a h4:hover, .main a h4:active {

--- a/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.tsx
@@ -42,6 +42,7 @@ const displayName = 'dashboard.ColonyHome.ColonyMembers';
 
 const ColonyMembers = ({
   colony: { colonyAddress, colonyName },
+  colony,
   currentDomainId = COLONY_TOTAL_BALANCE_DOMAIN_ID,
   maxAvatars = 15,
 }: Props) => {
@@ -117,7 +118,7 @@ const ColonyMembers = ({
             <li className={styles.userAvatar} key={userAddress}>
               <UserAvatar
                 size="xs"
-                colonyAddress={colonyAddress}
+                colony={colony}
                 address={userAddress}
                 showInfo
                 notSet={false}

--- a/src/modules/dashboard/components/Members/Members.tsx
+++ b/src/modules/dashboard/components/Members/Members.tsx
@@ -253,7 +253,7 @@ const Members = ({ colony: { colonyAddress }, colony }: Props) => {
       </div>
       {skelethonUsers.length ? (
         <MembersList<Member>
-          colonyAddress={colony.colonyAddress}
+          colony={colony}
           extraItemContent={({ roles, directRoles }) => (
             <UserPermissions roles={roles} directRoles={directRoles} />
           )}

--- a/src/modules/dashboard/components/Whitelist/Whitelist.tsx
+++ b/src/modules/dashboard/components/Whitelist/Whitelist.tsx
@@ -63,7 +63,7 @@ const Whitelist = ({ colony: { colonyAddress }, colony }: Props) => {
       {usersLoading && <MiniSpinnerLoader loadingText={MSG.loadingText} />}
       {(usersData?.whitelistedUsers?.length && !usersLoading && (
         <WhitelistAddresses
-          colonyAddress={colonyAddress}
+          colony={colony}
           users={usersData.whitelistedUsers}
         />
       )) ||

--- a/src/modules/dashboard/components/Whitelist/WhitelistAddresses/WhitelistAddresses.tsx
+++ b/src/modules/dashboard/components/Whitelist/WhitelistAddresses/WhitelistAddresses.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ROOT_DOMAIN_ID } from '@colony/colony-js';
 import { defineMessages } from 'react-intl';
 
-import { AnyUser } from '~data/index';
+import { AnyUser, Colony } from '~data/index';
 import MembersList from '~core/MembersList';
 import WhitelistMembersListExtraContent from './WhitelistMembersListExtraContent';
 
@@ -10,7 +10,7 @@ import styles from './WhitelistAddresses.css';
 import Heading from '~core/Heading';
 
 interface Props {
-  colonyAddress: string;
+  colony: Colony;
   users: AnyUser[];
 }
 
@@ -23,7 +23,7 @@ const MSG = defineMessages({
   },
 });
 
-const WhitelistAddresses = ({ colonyAddress, users }: Props) => {
+const WhitelistAddresses = ({ colony, users }: Props) => {
   return (
     <div className={styles.main}>
       <Heading
@@ -31,7 +31,7 @@ const WhitelistAddresses = ({ colonyAddress, users }: Props) => {
         appearance={{ margin: 'small', theme: 'dark', size: 'normal' }}
       />
       <MembersList
-        colonyAddress={colonyAddress}
+        colony={colony}
         domainId={ROOT_DOMAIN_ID}
         users={users}
         showUserReputation={false}
@@ -39,7 +39,7 @@ const WhitelistAddresses = ({ colonyAddress, users }: Props) => {
           return (
             <WhitelistMembersListExtraContent
               userAddress={props.id}
-              colonyAddress={colonyAddress}
+              colonyAddress={colony.colonyAddress}
             />
           );
         }}

--- a/src/modules/users/components/UserInfo/UserInfo.tsx
+++ b/src/modules/users/components/UserInfo/UserInfo.tsx
@@ -52,7 +52,7 @@ interface Props {
   renderAvatar?: (
     address: Address,
     user?: AnyUser,
-    colonyAddress?: Colony,
+    colony?: Colony,
     domainId?: number,
   ) => ReactNode;
   domainId?: number;

--- a/src/modules/users/components/UserInfo/UserInfo.tsx
+++ b/src/modules/users/components/UserInfo/UserInfo.tsx
@@ -6,7 +6,7 @@ import {
 } from 'react-intl';
 
 import { Address } from '~types/index';
-import { AnyUser } from '~data/index';
+import { AnyUser, Colony } from '~data/index';
 import Icon from '~core/Icon';
 import MaskedAddress from '~core/MaskedAddress';
 import HookedUserAvatar from '~users/HookedUserAvatar';
@@ -29,12 +29,12 @@ const UserAvatar = HookedUserAvatar({ fetchUser: false });
 const defaultRenderAvatar = (
   address: Address,
   user?: AnyUser,
-  colonyAddress?: Address,
+  colony?: Colony,
   domainId?: number,
 ) => (
   <UserAvatar
     address={address}
-    colonyAddress={colonyAddress}
+    colony={colony}
     domainId={domainId}
     user={user}
     showInfo
@@ -45,14 +45,14 @@ const defaultRenderAvatar = (
 
 interface Props {
   children?: ReactNode;
-  colonyAddress: Address;
+  colony: Colony;
   placeholder?: MessageDescriptor;
   user?: AnyUser;
   userAddress?: Address;
   renderAvatar?: (
     address: Address,
     user?: AnyUser,
-    colonyAddress?: Address,
+    colonyAddress?: Colony,
     domainId?: number,
   ) => ReactNode;
   domainId?: number;
@@ -60,7 +60,7 @@ interface Props {
 
 const UserInfo = ({
   children,
-  colonyAddress,
+  colony,
   placeholder = MSG.placeholder,
   user,
   userAddress,
@@ -80,7 +80,7 @@ const UserInfo = ({
     <div className={styles.main}>
       {userAddress ? (
         <div className={styles.avatarContainer}>
-          {renderAvatar(userAddress, user, colonyAddress, domainId)}
+          {renderAvatar(userAddress, user, colony, domainId)}
         </div>
       ) : (
         <Icon


### PR DESCRIPTION
Add user permissions section to MembersInfoPopover. If the user doesn't have any permissions, then the section shouldn't appear

![FireShot Capture 429 - Colony - localhost](https://user-images.githubusercontent.com/18473896/131725755-f7c0d9aa-3e52-4992-9258-87e93e5e5f0b.png)


Resolves #2658 
