### PR TITLE
Better handling of unsupported Contract Versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4348,9 +4348,9 @@
       }
     },
     "@colony/colony-js": {
-      "version": "4.1.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-4.1.0-beta.2.tgz",
-      "integrity": "sha512-s0MiS0kR/J0AFud9LqaiS+YUHgMCRYhitTAQJr122S2lfzCpMuthUUpkwObKdCMRaWV09npUIjb17p2HW9rW+g==",
+      "version": "4.1.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-4.1.0-beta.4.tgz",
+      "integrity": "sha512-gEyqeeav5btApcAHd2r1Nf1uE+DSNfQjXXrB8ZcJ262ptA/xNF1ldH2j0CrrUrNRQQr3oZc1BpRb3AiAvPXG3Q==",
       "requires": {
         "isomorphic-fetch": "^2.2.1",
         "lodash.isequal": "^4.5.0"

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.0.2",
-    "@colony/colony-js": "^4.1.0-beta.2",
+    "@colony/colony-js": "^4.1.0-beta.4",
     "@colony/redux-promise-listener": "^1.2.0",
     "@formatjs/intl-pluralrules": "^1.5.7",
     "@formatjs/intl-relativetimeformat": "^4.5.14",

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -194,7 +194,6 @@ export type Mutation = {
   removeUpvoteFromSuggestion?: Maybe<Suggestion>;
   sendTransactionMessage: Scalars['Boolean'];
   setLoggedInUser: LoggedInUser;
-  setNetworkContracts: NetworkContracts;
   setSuggestionStatus?: Maybe<Suggestion>;
   setUserTokens?: Maybe<User>;
   subscribeToColony?: Maybe<User>;
@@ -240,11 +239,6 @@ export type MutationSendTransactionMessageArgs = {
 
 export type MutationSetLoggedInUserArgs = {
   input?: Maybe<LoggedInUserInput>;
-};
-
-
-export type MutationSetNetworkContractsArgs = {
-  input?: Maybe<NetworkContractsInput>;
 };
 
 
@@ -1357,13 +1351,6 @@ export type SendTransactionMessageMutationVariables = Exact<{
 
 
 export type SendTransactionMessageMutation = Pick<Mutation, 'sendTransactionMessage'>;
-
-export type SetNetworkContractsMutationVariables = Exact<{
-  input: NetworkContractsInput;
-}>;
-
-
-export type SetNetworkContractsMutation = { setNetworkContracts: Pick<NetworkContracts, 'version' | 'feeInverse'> };
 
 export type UpdateNetworkContractsMutationVariables = Exact<{ [key: string]: never; }>;
 
@@ -2575,39 +2562,6 @@ export function useSendTransactionMessageMutation(baseOptions?: Apollo.MutationH
 export type SendTransactionMessageMutationHookResult = ReturnType<typeof useSendTransactionMessageMutation>;
 export type SendTransactionMessageMutationResult = Apollo.MutationResult<SendTransactionMessageMutation>;
 export type SendTransactionMessageMutationOptions = Apollo.BaseMutationOptions<SendTransactionMessageMutation, SendTransactionMessageMutationVariables>;
-export const SetNetworkContractsDocument = gql`
-    mutation SetNetworkContracts($input: NetworkContractsInput!) {
-  setNetworkContracts(input: $input) @client {
-    version
-    feeInverse
-  }
-}
-    `;
-export type SetNetworkContractsMutationFn = Apollo.MutationFunction<SetNetworkContractsMutation, SetNetworkContractsMutationVariables>;
-
-/**
- * __useSetNetworkContractsMutation__
- *
- * To run a mutation, you first call `useSetNetworkContractsMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useSetNetworkContractsMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [setNetworkContractsMutation, { data, loading, error }] = useSetNetworkContractsMutation({
- *   variables: {
- *      input: // value for 'input'
- *   },
- * });
- */
-export function useSetNetworkContractsMutation(baseOptions?: Apollo.MutationHookOptions<SetNetworkContractsMutation, SetNetworkContractsMutationVariables>) {
-        return Apollo.useMutation<SetNetworkContractsMutation, SetNetworkContractsMutationVariables>(SetNetworkContractsDocument, baseOptions);
-      }
-export type SetNetworkContractsMutationHookResult = ReturnType<typeof useSetNetworkContractsMutation>;
-export type SetNetworkContractsMutationResult = Apollo.MutationResult<SetNetworkContractsMutation>;
-export type SetNetworkContractsMutationOptions = Apollo.BaseMutationOptions<SetNetworkContractsMutation, SetNetworkContractsMutationVariables>;
 export const UpdateNetworkContractsDocument = gql`
     mutation UpdateNetworkContracts {
   updateNetworkContracts @client {

--- a/src/data/graphql/mutations.graphql
+++ b/src/data/graphql/mutations.graphql
@@ -76,13 +76,6 @@ mutation SendTransactionMessage($input: SendTransactionMessageInput!) {
 
 # Network Contracts
 
-mutation SetNetworkContracts($input: NetworkContractsInput!) {
-  setNetworkContracts(input: $input) @client {
-    version
-    feeInverse
-  }
-}
-
 mutation UpdateNetworkContracts {
   updateNetworkContracts @client {
     version

--- a/src/data/graphql/typeDefs.ts
+++ b/src/data/graphql/typeDefs.ts
@@ -389,7 +389,6 @@ export default gql`
   extend type Mutation {
     setLoggedInUser(input: LoggedInUserInput): LoggedInUser!
     clearLoggedInUser: LoggedInUser!
-    setNetworkContracts(input: NetworkContractsInput): NetworkContracts!
     updateNetworkContracts: NetworkContracts!
   }
 

--- a/src/data/helpers.ts
+++ b/src/data/helpers.ts
@@ -17,15 +17,11 @@ import {
   useNetworkContractsQuery,
   NetworkContractsQuery,
   NetworkContractsQueryVariables,
-  NetworkContractsInput,
   NetworkContractsDocument,
-  SetNetworkContractsMutation,
-  SetNetworkContractsMutationVariables,
   UpdateNetworkContractsMutation,
   UpdateNetworkContractsMutationVariables,
   UpdateNetworkContractsDocument,
 } from './index';
-import { SetNetworkContractsDocument } from './generated';
 
 export const getMinimalUser = (address: string): UserQuery['user'] => ({
   id: address,
@@ -123,25 +119,6 @@ export const useNetworkContracts = () => {
 /*
  * Network Contracts saga helpers, to be used when initializing the app
  */
-export function* setNetworkContracts(input: NetworkContractsInput) {
-  const apolloClient = TEMP_getContext(ContextModule.ApolloClient);
-  const result = yield apolloClient.mutate<
-    SetNetworkContractsMutation,
-    SetNetworkContractsMutationVariables
-  >({
-    mutation: SetNetworkContractsDocument,
-    variables: { input },
-  });
-  const {
-    data: { setNetworkContracts: networkContracts },
-  } = result as {
-    data: {
-      setNetworkContracts: SetNetworkContractsMutation['setNetworkContracts'];
-    };
-  };
-  return networkContracts;
-}
-
 export function* getNetworkContracts() {
   const apolloClient = TEMP_getContext(ContextModule.ApolloClient);
   const result = yield apolloClient.query<

--- a/src/data/resolvers/extensions.ts
+++ b/src/data/resolvers/extensions.ts
@@ -8,7 +8,9 @@ import {
   getLogs,
   getBlockTime,
   ROOT_DOMAIN_ID,
+  Extension,
 } from '@colony/colony-js';
+import * as colonyJSVersionExports from '@colony/colony-js/lib/versions';
 
 import { Context } from '~context/index';
 import { getMinimalUser } from '~data/index';
@@ -20,7 +22,10 @@ export const extensionsResolvers = ({
   colonyManager,
 }: Required<Context>): Resolvers => ({
   Query: {
-    async networkExtensionVersion(_, { extensionId }) {
+    async networkExtensionVersion(
+      _,
+      { extensionId }: { extensionId: Extension },
+    ) {
       /*
        * Prettier is being stupid again
        */
@@ -42,8 +47,12 @@ export const extensionsResolvers = ({
             ) => firstVersion.toNumber() - secondVersion.toNumber(),
           )
           .pop();
-        const version = latestEvent?.values?.version;
-        return version.toNumber();
+        const version = latestEvent?.values?.version?.toNumber();
+        const latestSupportedVersion =
+          colonyJSVersionExports[`Current${extensionId}Version`];
+        return version <= latestSupportedVersion
+          ? version
+          : latestSupportedVersion;
       }
       return 0;
     },

--- a/src/data/resolvers/networkContracts.ts
+++ b/src/data/resolvers/networkContracts.ts
@@ -1,4 +1,5 @@
 import { Resolvers } from '@apollo/client';
+import { CurrentColonyVersion } from '@colony/colony-js';
 
 import { Context } from '~context/index';
 import { NetworkContractsDocument } from '../generated';
@@ -24,7 +25,18 @@ export const networkContractsResolvers = ({
       const changedData = {
         networkContracts: {
           ...networkContracts,
-          version: version.toString(),
+          version:
+            /*
+             * @NOTE Always return the version of the colony contracts that is
+             * supported by colonyJS (otherwise the app breaks)
+             *
+             * So if the version from the network resolver is greater than the
+             * current colonyJS supported version, limit it to the version
+             * returned by colonyJS
+             */
+            version.toNumber() <= CurrentColonyVersion
+              ? version.toString()
+              : String(CurrentColonyVersion),
           /*
            * Network fee inverse as defined by the ColonyNetwork contract.
            * If the current fee is 1%, this will be `100`.

--- a/src/data/resolvers/networkContracts.ts
+++ b/src/data/resolvers/networkContracts.ts
@@ -15,16 +15,6 @@ export const networkContractsResolvers = ({
   colonyManager: { networkClient },
 }: Required<Context>): Resolvers => ({
   Mutation: {
-    async setNetworkContracts(_root, { input }, { cache }) {
-      const { networkContracts } = cache.readQuery({
-        query: NetworkContractsDocument,
-      });
-      const changedData = {
-        networkContracts: { ...networkContracts, ...input },
-      };
-      cache.writeQuery({ query: NetworkContractsDocument, data: changedData });
-      return changedData.networkContracts;
-    },
     async updateNetworkContracts(_root, _, { cache }) {
       const { networkContracts } = cache.readQuery({
         query: NetworkContractsDocument,

--- a/src/modules/dashboard/components/ColonyHome/ColonyUpgrade/ColonyUpgrade.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyUpgrade/ColonyUpgrade.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
-import { ColonyVersion } from '@colony/colony-js';
 
 import { useDialog } from '~core/Dialog';
 import NetworkContractUpgradeDialog from '~dashboard/NetworkContractUpgradeDialog';
@@ -64,13 +63,11 @@ const ColonyUpgrade = ({ colony }: Props) => {
   const hasRegisteredProfile = !!username && !ethereal;
   const canUpgradeColony = hasRegisteredProfile && hasRoot(allUserRoles);
 
-  const networkVersionIsSupported = !!ColonyVersion[networkVersion as string];
-  const mustUpgrade =
-    networkVersionIsSupported &&
-    colonyMustBeUpgraded(colony, networkVersion as string);
-  const shouldUpdgrade =
-    networkVersionIsSupported &&
-    colonyShouldBeUpgraded(colony, networkVersion as string);
+  const mustUpgrade = colonyMustBeUpgraded(colony, networkVersion as string);
+  const shouldUpdgrade = colonyShouldBeUpgraded(
+    colony,
+    networkVersion as string,
+  );
 
   if (mustUpgrade) {
     return (

--- a/src/modules/dashboard/components/NetworkContractUpgradeDialog/NetworkContractUpgradeDialogForm.tsx
+++ b/src/modules/dashboard/components/NetworkContractUpgradeDialog/NetworkContractUpgradeDialogForm.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FormattedMessage, defineMessages } from 'react-intl';
 import { FormikProps } from 'formik';
-import { ColonyRole, ColonyVersion } from '@colony/colony-js';
+import { ColonyRole } from '@colony/colony-js';
 
 import Button from '~core/Button';
 import { ActionDialogProps } from '~core/Dialog';
@@ -57,10 +57,6 @@ const MSG = defineMessages({
     id: `dashboard.NetworkContractUpgradeDialog.NetworkContractUpgradeDialogForm.legacyPermissionsWarningTitle`,
     defaultMessage: `Upgrade to the next colony version is prevented while more than one colony member has the {recoveryRole} role.`,
   },
-  upgradeVersionNotSupported: {
-    id: `dashboard.NetworkContractUpgradeDialog.NetworkContractUpgradeDialogForm.upgradeVersionNotSupported`,
-    defaultMessage: `The newly deployed version of the contract is not yet supported by the Dapp`,
-  },
   legacyPermissionsWarningDescription: {
     id: `dashboard.NetworkContractUpgradeDialog.NetworkContractUpgradeDialogForm.legacyPermissionsWarningDescription`,
     defaultMessage: `
@@ -109,7 +105,6 @@ const NetworkContractUpgradeDialogForm = ({
 
   const { version: newVersion } = useNetworkContracts();
 
-  const networkVersionIsSupported = !!ColonyVersion[newVersion as string];
   const currentVersion = parseInt(version, 10);
   const nextVersion = currentVersion + 1;
   const networkVersion = parseInt(newVersion || '1', 10);
@@ -123,9 +118,7 @@ const NetworkContractUpgradeDialogForm = ({
     values.forceAction,
   );
   const canUpgradeVersion =
-    networkVersionIsSupported &&
-    userHasPermission &&
-    !!colonyCanBeUpgraded(colony, newVersion as string);
+    userHasPermission && !!colonyCanBeUpgraded(colony, newVersion as string);
 
   const inputDisabled = !canUpgradeVersion || onlyForceAction;
 
@@ -256,13 +249,6 @@ const NetworkContractUpgradeDialogForm = ({
                 ),
               }}
             />
-          </div>
-        </DialogSection>
-      )}
-      {networkVersion > currentVersion && !networkVersionIsSupported && (
-        <DialogSection appearance={{ theme: 'sidePadding' }}>
-          <div className={styles.noPermissionMessage}>
-            <FormattedMessage {...MSG.upgradeVersionNotSupported} />
           </div>
         </DialogSection>
       )}

--- a/src/modules/dashboard/sagas/colonyCreate.ts
+++ b/src/modules/dashboard/sagas/colonyCreate.ts
@@ -24,6 +24,7 @@ import {
   NetworkExtensionVersionQuery,
   NetworkExtensionVersionQueryVariables,
   NetworkExtensionVersionDocument,
+  getNetworkContracts,
 } from '~data/index';
 import ENS from '~lib/ENS';
 import { ActionTypes, Action, AllActions } from '~redux/index';
@@ -311,7 +312,7 @@ function* colonyCreate({
         );
       }
 
-      const latestVersion = yield networkClient.getCurrentColonyVersion();
+      const { version: latestVersion } = yield getNetworkContracts();
 
       yield put(
         transactionAddParams(createColony.id, [

--- a/src/modules/dashboard/sagas/colonyFinishDeployment.ts
+++ b/src/modules/dashboard/sagas/colonyFinishDeployment.ts
@@ -22,6 +22,9 @@ import {
   SubscribeToColonyMutation,
   SubscribeToColonyMutationVariables,
   SubscribeToColonyDocument,
+  NetworkExtensionVersionQuery,
+  NetworkExtensionVersionQueryVariables,
+  NetworkExtensionVersionDocument,
   cacheUpdates,
 } from '~data/index';
 import { ActionTypes, Action, AllActions } from '~redux/index';
@@ -297,14 +300,27 @@ function* colonyRestartDeployment({
       yield takeFrom(setOwner.channel, ActionTypes.TRANSACTION_SUCCEEDED);
     }
 
+    /*
+     * Deploy OneTx
+     */
     if (deployOneTx) {
-      /*
-       * Deploy OneTx
-       */
+      const {
+        data: { networkExtensionVersion },
+      } = yield apolloClient.query<
+        NetworkExtensionVersionQuery,
+        NetworkExtensionVersionQueryVariables
+      >({
+        query: NetworkExtensionVersionDocument,
+        variables: {
+          extensionId: Extension.OneTxPayment,
+        },
+        fetchPolicy: 'network-only',
+      });
+
       yield put(
         transactionAddParams(deployOneTx.id, [
           getExtensionHash(Extension.OneTxPayment),
-          1,
+          networkExtensionVersion,
         ]),
       );
       yield put(transactionReady(deployOneTx.id));

--- a/src/modules/dashboard/sagas/extensions/colonyExtensionInstall.ts
+++ b/src/modules/dashboard/sagas/extensions/colonyExtensionInstall.ts
@@ -27,7 +27,7 @@ export function* colonyExtensionInstall({
 
   try {
     /*
-     * Get the latest extension version that's deployed to the network
+     * Get the latest extension version that's supported by colonyJS
      */
     const {
       data: { networkExtensionVersion },


### PR DESCRIPTION
## Description

This PR completes the partial work done #2651 by fixing some of the contract version paths that were overlooked when initially attempting a fix for this:
- Creating a new colony
- Installing a new extension
- Upgrading an existing extension

This is being accomplished by routing all network version calls _(for the colonies at least)_ through the `getNetworkContracts` helper, which will be refactored to take into account the `CurrentColonyVersion` from `colonyJS`

**Changes** 

- [x] updated `colonyNetwork` submodule branch
- [x] updated `colonyJS` to the latest beta release
- [x] Refactored `updateNetworkContracts` resolver
- [x] Removed unused `setNetworkContracts` resolver
- [x] Fix `colonyCreate` saga to use `getNetworkContracts` to fetch correct colony version
- [x] Remove `NetworkContractUpgrade` and `ColonyUpgrade` redundant logic
- [x] Refactored `networkExtensionVersion` resolver
- [x] Fixed `colonyFinishDeployed` to use the proper `OneTxPayment` extension version
