### PR TITLE
Filter out duplicated forced events for motions

### DIFF
--- a/src/modules/dashboard/components/ColonyActions/ColonyActions.tsx
+++ b/src/modules/dashboard/components/ColonyActions/ColonyActions.tsx
@@ -9,6 +9,7 @@ import ActionsList, {
 import { Select, Form } from '~core/Fields';
 import LoadMoreButton from '~core/LoadMoreButton';
 import { SpinnerLoader } from '~core/Preloaders';
+import { useEnabledExtensions } from '~utils/hooks/useEnabledExtensions';
 
 import {
   Colony,
@@ -86,6 +87,10 @@ const ColonyActions = ({
 
   const history = useHistory();
 
+  const { installedExtensionsAddresses } = useEnabledExtensions({
+    colonyAddress,
+  });
+
   const {
     data: oneTxActions,
     loading: oneTxActionsLoading,
@@ -147,6 +152,7 @@ const ColonyActions = ({
   });
 
   const actions = useTransformer(getActionsListData, [
+    installedExtensionsAddresses,
     { ...oneTxActions, ...eventsActions, ...motions },
     commentCount?.transactionMessagesCount,
     {

--- a/src/modules/dashboard/transformers.ts
+++ b/src/modules/dashboard/transformers.ts
@@ -41,6 +41,7 @@ interface ActionsTransformerMetadata {
 }
 
 export const getActionsListData = (
+  installedExtensionsAddresses: Address[],
   unformattedActions?: {
     oneTxPayments?: SubgraphOneTxSubscription['oneTxPayments'];
     events?: SubgraphEventsThatAreActionsSubscription['events'];
@@ -64,7 +65,17 @@ export const getActionsListData = (
    */
 
   const filteredUnformattedActions = {
-    oneTxPayments: unformattedActions?.oneTxPayments || [],
+    oneTxPayments:
+      unformattedActions?.oneTxPayments?.reduce((acc, action) => {
+        if (
+          installedExtensionsAddresses?.find(
+            (extensionAddress) => extensionAddress === action?.agent,
+          )
+        ) {
+          return acc;
+        }
+        return [...acc, action];
+      }, []) || [],
     events:
       unformattedActions?.events?.reduce((acc, event) => {
         if (

--- a/src/utils/hooks/useEnabledExtensions.tsx
+++ b/src/utils/hooks/useEnabledExtensions.tsx
@@ -30,8 +30,13 @@ export const useEnabledExtensions = ({ colonyAddress }: Props) => {
     !installedOneTxPaymentExtension.details.deprecated
   );
 
+  const installedExtensionsAddresses = installedExtensions.map((extension) =>
+    extension.address?.toLowerCase(),
+  );
+
   return {
     isVotingExtensionEnabled,
     isOneTxPaymentExtensionEnabled,
+    installedExtensionsAddresses,
   };
 };


### PR DESCRIPTION
## Description

This PR updates action list on home page

**Changes** 🏗

* Filtered out forced events emitted by contract when motion extension is enabled

Resolves #2703 
