### PR TITLE
Use transaction token instead of colony token

### DIFF
--- a/src/modules/dashboard/transformers.ts
+++ b/src/modules/dashboard/transformers.ts
@@ -158,6 +158,7 @@ export const getActionsListData = (
             motionState: undefined,
             motionId: undefined,
             timeoutPeriods: undefined,
+            transactionTokenAddress: undefined,
             blockNumber: 0,
             totalNayStake: '0',
             requiredStake: '0',
@@ -208,6 +209,7 @@ export const getActionsListData = (
                   },
                 },
               } = unformattedAction;
+
               formatedAction.actionType = ColonyActions.Payment;
               formatedAction.recipient = recipient;
               formatedAction.fromDomain = ethDomainId;
@@ -217,6 +219,9 @@ export const getActionsListData = (
               formatedAction.decimals = decimals;
               if (unformattedAction?.agent) {
                 formatedAction.initiator = unformattedAction.agent;
+              }
+              if (tokenAddress === AddressZero) {
+                formatedAction.transactionTokenAddress = tokenAddress;
               }
             } catch (error) {
               log.verbose(

--- a/src/types/colonyActions.ts
+++ b/src/types/colonyActions.ts
@@ -126,6 +126,7 @@ export interface FormattedAction {
   recipient: Address;
   amount: string;
   tokenAddress: Address;
+  transactionTokenAddress?: Address;
   symbol: string;
   decimals: string;
   fromDomain: string;

--- a/src/utils/colonyActions.ts
+++ b/src/utils/colonyActions.ts
@@ -79,6 +79,7 @@ export const getValuesForActionType = (
           fromDomain: values.fromDomain,
           toDomain: values.toDomain,
           initiator: values.agent,
+          transactionTokenAddress: values.token,
         };
       }
       case ColonyActions.EditDomain: {


### PR DESCRIPTION
## Description

This PR fixes wrongly displayed token symbol when transferring funds 


**Changes** 🏗

* Updated ActionsListItem to use correct token
* Updated colonyActions for MoveFunds action to pass transactionToken

Resolves #2707 
