### PR TITLE
Update BuyTokens validation

### DIFF
--- a/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
+++ b/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
@@ -5,6 +5,7 @@ import * as yup from 'yup';
 import { FormikProps } from 'formik';
 import { AddressZero } from 'ethers/constants';
 import { bigNumberify } from 'ethers/utils';
+import isNil from 'lodash/isNil';
 
 import Heading from '~core/Heading';
 import QuestionMarkTooltip from '~core/QuestionMarkTooltip';
@@ -109,10 +110,23 @@ interface FormValues {
 
 const displayName = 'dashboard.CoinMachine.BuyTokens';
 
-const validationSchema = (userBalance: number) =>
-  yup.object().shape({
-    amount: yup.number().moreThan(0).max(userBalance),
+const validationSchema = (userBalance: string, tokenDecimals: number) => {
+  let amountFieldValidation = yup
+    .number()
+    .moreThan(0)
+    .max(
+      parseFloat(userBalance),
+      `The amount must be less or equal to ${userBalance}`,
+    );
+
+  if (tokenDecimals === 0) {
+    amountFieldValidation = amountFieldValidation.integer();
+  }
+
+  return yup.object().shape({
+    amount: amountFieldValidation,
   });
+};
 
 const BuyTokens = ({
   colony: { colonyAddress, colonyName },
@@ -286,6 +300,10 @@ const BuyTokens = ({
     );
   }
 
+  const sellableTokenDecimals = !isNil(sellableToken)
+    ? sellableToken.decimals
+    : 18;
+
   return (
     <div
       className={getMainClasses({}, styles, {
@@ -319,12 +337,8 @@ const BuyTokens = ({
               amount: '0',
             }}
             validationSchema={validationSchema(
-              parseFloat(
-                getFormattedTokenValue(
-                  maxUserPurchase,
-                  sellableToken?.decimals || 18,
-                ),
-              ),
+              getFormattedTokenValue(maxUserPurchase, sellableTokenDecimals),
+              sellableTokenDecimals,
             )}
             submit={ActionTypes.COIN_MACHINE_BUY_TOKENS}
             error={ActionTypes.COIN_MACHINE_BUY_TOKENS_ERROR}

--- a/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
+++ b/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
@@ -5,7 +5,6 @@ import * as yup from 'yup';
 import { FormikProps } from 'formik';
 import { AddressZero } from 'ethers/constants';
 import { bigNumberify } from 'ethers/utils';
-import isNil from 'lodash/isNil';
 
 import Heading from '~core/Heading';
 import QuestionMarkTooltip from '~core/QuestionMarkTooltip';
@@ -33,6 +32,7 @@ import {
 } from '~utils/tokens';
 import { getMainClasses } from '~utils/css';
 import { mapPayload, withMeta, pipe } from '~utils/actions';
+import { DEFAULT_TOKEN_DECIMALS } from '~constants';
 
 import GetWhitelisted from '../GetWhitelisted';
 
@@ -300,9 +300,9 @@ const BuyTokens = ({
     );
   }
 
-  const sellableTokenDecimals = !isNil(sellableToken)
+  const sellableTokenDecimals = sellableToken
     ? sellableToken.decimals
-    : 18;
+    : DEFAULT_TOKEN_DECIMALS;
 
   return (
     <div


### PR DESCRIPTION
Basically:

- Replaced parseInt for parseFloat in order to accurately get the max value.
- Updated validationSchema to pass the balance as it's returned from `getFormattedTokenValue` instead of passing it first through parseFloat as otherwise values like `0.00000...` (for low values), will not be displayed on the error message correctly.
- Took into account that the amount must be an integer if the decimals of the sold token is `0` 

Resolves #2724 
