### PR TITLE
Fix/2726 update remaining tokens price status icon

### DIFF
--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTokens.tsx
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTokens.tsx
@@ -53,14 +53,22 @@ const RemainingTokens = ({
   appearance = { theme: 'white' },
   periodTokens,
 }: Props) => {
+  const priceStatus = useMemo(() => {
+    if (!periodTokens) {
+      return undefined;
+    }
+
+    return getPriceStatus(periodTokens, periodTokens.soldPeriodTokens, true);
+  }, [periodTokens]);
+
   const widgetText = useMemo(() => {
     return {
       title: MSG.tokensRemainingTitle,
       placeholder: MSG.tokensTypePlaceholder,
       tooltipText: MSG.tokensRemainingTooltip,
-      footerText: MSG.tokensTypeFooterText,
+      footerText: priceStatus && MSG.tokensTypeFooterText,
     };
-  }, []);
+  }, [priceStatus]);
 
   const displayedValue = useMemo(() => {
     if (periodTokens) {
@@ -74,14 +82,6 @@ const RemainingTokens = ({
 
     return <FormattedMessage {...widgetText.placeholder} />;
   }, [widgetText, periodTokens]);
-
-  const priceStatus = useMemo(() => {
-    if (!periodTokens) {
-      return undefined;
-    }
-
-    return getPriceStatus(periodTokens, periodTokens.soldPeriodTokens, true);
-  }, [periodTokens]);
 
   const showValueWarning = useMemo(() => {
     if (periodTokens?.soldPeriodTokens.gte(periodTokens?.maxPeriodTokens)) {

--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTokens.tsx
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTokens.tsx
@@ -80,7 +80,7 @@ const RemainingTokens = ({
       return undefined;
     }
 
-    return getPriceStatus(periodTokens, periodTokens.soldPeriodTokens);
+    return getPriceStatus(periodTokens, periodTokens.soldPeriodTokens, true);
   }, [periodTokens]);
 
   const showValueWarning = useMemo(() => {

--- a/src/utils/colonyCoinMachine.ts
+++ b/src/utils/colonyCoinMachine.ts
@@ -19,7 +19,7 @@ export const getPriceStatus = (
   }
 
   if (
-    !isOnlyHigherNeeded &&
+    isOnlyHigherNeeded &&
     (bigNumberify(tokensBought).eq(targetPeriodTokens) ||
       bigNumberify(tokensBought).lt(targetPeriodTokens))
   ) {

--- a/src/utils/colonyCoinMachine.ts
+++ b/src/utils/colonyCoinMachine.ts
@@ -6,11 +6,24 @@ import { TokenPriceStatuses } from '~dashboard/CoinMachine/TokenPriceStatusIcon'
 export const getPriceStatus = (
   periodTokens: PeriodTokensType,
   tokensBought: BigNumberish,
+  isOnlyHigherNeeded = false,
 ) => {
   const { maxPeriodTokens, targetPeriodTokens } = periodTokens;
 
   if (bigNumberify(tokensBought).gte(maxPeriodTokens)) {
     return TokenPriceStatuses.PRICE_SOLD_OUT;
+  }
+
+  if (bigNumberify(tokensBought).gt(targetPeriodTokens)) {
+    return TokenPriceStatuses.PRICE_UP;
+  }
+
+  if (
+    !isOnlyHigherNeeded &&
+    (bigNumberify(tokensBought).eq(targetPeriodTokens) ||
+      bigNumberify(tokensBought).lt(targetPeriodTokens))
+  ) {
+    return undefined;
   }
 
   if (bigNumberify(tokensBought).eq(targetPeriodTokens)) {
@@ -19,10 +32,6 @@ export const getPriceStatus = (
 
   if (bigNumberify(tokensBought).lt(targetPeriodTokens)) {
     return TokenPriceStatuses.PRICE_DOWN;
-  }
-
-  if (bigNumberify(tokensBought).gt(targetPeriodTokens)) {
-    return TokenPriceStatuses.PRICE_UP;
   }
 
   return undefined;


### PR DESCRIPTION
## Description

This PR removes the footer fo the `RemainingTokens` widget when the price is projected to stay the same or decrease.

**New stuff** ✨

* New stuff goes here

**Changes** 🏗

- update `getPriceStatus` util function
- update `RemainingTokens` component

resolves #2726 
