### PR TITLE
Add autofocus to comment box input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33354,12 +33354,23 @@
       }
     },
     "react-textarea-autosize": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-7.1.2.tgz",
-      "integrity": "sha512-uH3ORCsCa3C6LHxExExhF4jHoXYCQwE5oECmrRsunlspaDAbS4mGKNlWZqjLfInWtFQcf0o1n1jC/NGXFdUBCg==",
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.3.tgz",
+      "integrity": "sha512-2XlHXK2TDxS6vbQaoPbMOfQ8GK7+irc2fVK6QFIcC8GOnH3zI/v481n+j1L0WaPVvKxwesnY93fEfH++sus2rQ==",
       "requires": {
-        "@babel/runtime": "^7.1.2",
-        "prop-types": "^15.6.0"
+        "@babel/runtime": "^7.10.2",
+        "use-composed-ref": "^1.0.0",
+        "use-latest": "^1.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
+          "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
       }
     },
     "read-cache": {
@@ -37592,6 +37603,11 @@
       "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
       "dev": true
     },
+    "ts-essentials": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-2.0.12.tgz",
+      "integrity": "sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w=="
+    },
     "ts-invariant": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
@@ -38456,6 +38472,27 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "use-composed-ref": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.1.0.tgz",
+      "integrity": "sha512-my1lNHGWsSDAhhVAT4MKs6IjBUtG6ZG11uUqexPH9PptiIZDQOzaF4f5tEbJ2+7qvNbtXNBbU3SfmN+fXlWDhg==",
+      "requires": {
+        "ts-essentials": "^2.0.3"
+      }
+    },
+    "use-isomorphic-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ=="
+    },
+    "use-latest": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.2.0.tgz",
+      "integrity": "sha512-d2TEuG6nSLKQLAfW3By8mKr8HurOlTkul0sOpxbClIv4SQ4iOd7BYr7VIzdbktUCnv7dua/60xzd8igMU6jmyw==",
+      "requires": {
+        "use-isomorphic-layout-effect": "^1.0.0"
+      }
     },
     "use-memo-one": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "react-redux-promise-listener": "^1.0.0",
     "react-router-dom": "^5.1.2",
     "react-tabs": "^3.1.0",
-    "react-textarea-autosize": "^7.1.2",
+    "react-textarea-autosize": "^8.3.3",
     "recompose": "^0.30.0",
     "redux": "^4.0.1",
     "redux-immutable": "^4.0.0",

--- a/src/modules/core/components/Fields/Textarea/TextareaAutoresize.tsx
+++ b/src/modules/core/components/Fields/Textarea/TextareaAutoresize.tsx
@@ -1,5 +1,5 @@
-import React, { ReactNode, HTMLAttributes } from 'react';
-import Textarea from 'react-textarea-autosize';
+import React, { ReactNode } from 'react';
+import Textarea, { TextareaAutosizeProps } from 'react-textarea-autosize';
 import { useField } from 'formik';
 import { MessageDescriptor, useIntl } from 'react-intl';
 
@@ -21,16 +21,9 @@ type Appearance = {
   size?: 'small';
 };
 
-interface Props
-  extends Omit<HTMLAttributes<HTMLTextAreaElement>, 'placeholder'> {
+interface Props extends Omit<TextareaAutosizeProps, 'placeholder'> {
   /** Appearance object */
   appearance?: Appearance;
-
-  /** If set, it will allow the element to be focused when mounted */
-  autoFocus?: boolean;
-
-  /** Is the input disabled */
-  disabled?: boolean;
 
   /** Should the element render with its label or not */
   elementOnly?: boolean;
@@ -44,9 +37,6 @@ interface Props
   /** Help text values for intl interpolation  */
   helpValues?: SimpleMessageValues;
 
-  /** Input id */
-  id?: string;
-
   /** Pass a ref to the `<textarea>` element */
   innerRef?: (ref: HTMLElement | null) => void;
 
@@ -55,12 +45,6 @@ interface Props
 
   /** Label text values for intl interpolation  */
   labelValues?: SimpleMessageValues;
-
-  /** The maximum number of rows to resize to, before the scrollbar shows up */
-  maxRows?: number;
-
-  /** The minimum number of rows to show (css height can interfere with this) */
-  minRows?: number;
 
   /** Html input `name` attribute */
   name: string;
@@ -103,14 +87,16 @@ const TextareaAutoresize = ({
       ? formatMessage(placeholderProp)
       : placeholderProp;
 
-  const inputProps = {
-    'aria-invalid': error ? true : null,
+  const inputProps: TextareaAutosizeProps & {
+    ref: ((ref: HTMLElement | null) => void) | undefined;
+  } = {
+    'aria-invalid': error ? 'true' : undefined,
     className: getMainClasses(appearance, styles),
     id,
     maxRows,
     minRows,
     placeholder,
-    inputRef: innerRef,
+    ref: innerRef,
     title:
       typeof label === 'object' ? formatMessage(label, labelValues) : label,
     ...rest,

--- a/src/modules/core/components/Fields/Textarea/TextareaAutoresize.tsx
+++ b/src/modules/core/components/Fields/Textarea/TextareaAutoresize.tsx
@@ -110,7 +110,7 @@ const TextareaAutoresize = ({
     maxRows,
     minRows,
     placeholder,
-    ref: innerRef,
+    inputRef: innerRef,
     title:
       typeof label === 'object' ? formatMessage(label, labelValues) : label,
     ...rest,

--- a/src/modules/dashboard/components/ActionsPage/InputStorageWidget/InputStorageWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/InputStorageWidget/InputStorageWidget.tsx
@@ -83,97 +83,78 @@ const InputStorageWidget = ({
   }, [storageSlot, colonyAddress, fetchStorageSlotValue]);
 
   /*
-   * We need to handle these manually using a ref, since the TextAreaAutoresize
-   * component doesn't give us access to the native React ones :(
+   * Prevent entering a new line
+   *
+   * Based on specs we need to **fake** a multi-line input, but one
+   * you can't actually create a new line manully, just if the text
+   * overflows...
+   *
+   * While we're at it we also disable the space bar, since no value
+   * that can be entered requires a space (it's just a litte nice-to-have)
    */
-  const handleStorageSlotLocationBlur = useCallback(
-    (
-      autoResizeTextarea: HTMLElement | null,
-      currentValue,
-      fieldError,
-      updateValues,
-    ) => {
-      if (autoResizeTextarea) {
-        /*
-         * Add 0x prefix on blur and set the storage slot in state
-         */
-        const handleOnBlur = () => {
-          if (!fieldError && currentValue) {
-            const normalizedStorageSlot = ensureHexPrefix(currentValue);
-            updateValues('storageSlotLocation', normalizedStorageSlot);
-            setStorageSlot(normalizedStorageSlot);
-          }
-          if (!currentValue) {
-            setStorageSlot('');
-          }
-        };
-        autoResizeTextarea.addEventListener('blur', handleOnBlur);
-        /*
-         * Prevent entering a new line
-         *
-         * Based on specs we need to **fake** a multi-line input, but one
-         * you can't actually create a new line manully, just if the text
-         * overflows...
-         *
-         * While we're at it we also disable the space bar, since no value
-         * that can be entered requires a space (it's just a litte nice-to-have)
-         */
-        const handleOnKeyDown = (event) => {
-          if (event.key === ENTER || event.code === SPACE) {
-            event.preventDefault();
-          }
-        };
-        autoResizeTextarea.addEventListener('keydown', handleOnKeyDown);
-      }
-    },
-    [],
-  );
+  const handleOnKeyDown = useCallback((event) => {
+    if (event.key === ENTER || event.code === SPACE) {
+      event.preventDefault();
+    }
+  }, []);
 
   /*
    * We need to handle these manually using a ref, since the TextAreaAutoresize
    * component doesn't give us access to the native React ones :(
    */
-  const handleNewStorageSlotValueBlur = useCallback(
-    (
-      autoResizeTextarea: HTMLElement | null,
-      currentValue,
-      fieldError,
-      updateValues,
-    ) => {
-      if (autoResizeTextarea) {
-        /*
-         * Add 0x prefix on blur and set the storage slot in state
-         */
-        const handleOnBlur = () => {
-          if (!fieldError && currentValue) {
-            const noPrefixValue = currentValue.startsWith('0x')
-              ? currentValue.slice(2)
-              : currentValue;
-            const paddedValue = noPrefixValue.padStart(64, '0');
-            updateValues('newStorageSlotValue', ensureHexPrefix(paddedValue));
-          }
-        };
-        autoResizeTextarea.addEventListener('blur', handleOnBlur);
-        /*
-         * Prevent entering a new line
-         *
-         * Based on specs we need to **fake** a multi-line input, but one
-         * you can't actually create a new line manully, just if the text
-         * overflows...
-         *
-         * While we're at it we also disable the space bar, since no value
-         * that can be entered requires a space (it's just a litte nice-to-have)
-         */
-        const handleOnKeyDown = (event) => {
-          if (event.key === ENTER || event.code === SPACE) {
-            event.preventDefault();
-          }
-        };
-        autoResizeTextarea.addEventListener('keydown', handleOnKeyDown);
-      }
-    },
-    [],
-  );
+  const handleStorageSlotLocationBlur = (
+    autoResizeTextarea: HTMLElement | null,
+    currentValue,
+    fieldError,
+    updateValues,
+  ) => {
+    if (autoResizeTextarea) {
+      /*
+       * Add 0x prefix on blur and set the storage slot in state
+       */
+      // eslint-disable-next-line no-param-reassign
+      autoResizeTextarea.onblur = () => {
+        if (!fieldError && currentValue) {
+          const normalizedStorageSlot = ensureHexPrefix(currentValue);
+          updateValues('storageSlotLocation', normalizedStorageSlot);
+          setStorageSlot(normalizedStorageSlot);
+        }
+        if (!currentValue) {
+          setStorageSlot('');
+        }
+      };
+
+      autoResizeTextarea.addEventListener('keydown', handleOnKeyDown);
+    }
+  };
+  /*
+   * We need to handle these manually using a ref, since the TextAreaAutoresize
+   * component doesn't give us access to the native React ones :(
+   */
+  const handleNewStorageSlotValueBlur = (
+    autoResizeTextarea: HTMLElement | null,
+    currentValue,
+    fieldError,
+    updateValues,
+  ) => {
+    if (autoResizeTextarea) {
+      /*
+       * Add 0x prefix on blur and set the storage slot in state
+       */
+      // eslint-disable-next-line no-param-reassign
+      autoResizeTextarea.onblur = () => {
+        if (!fieldError && currentValue) {
+          const noPrefixValue = currentValue.startsWith('0x')
+            ? currentValue.slice(2)
+            : currentValue;
+          const paddedValue = noPrefixValue.padStart(64, '0');
+          updateValues('newStorageSlotValue', ensureHexPrefix(paddedValue));
+        }
+      };
+
+      autoResizeTextarea.addEventListener('keydown', handleOnKeyDown);
+    }
+  };
 
   const handleSubmitSuccess = useCallback(
     (_, { resetForm }) => {

--- a/src/modules/dashboard/components/ActionsPage/InputStorageWidget/InputStorageWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/InputStorageWidget/InputStorageWidget.tsx
@@ -87,14 +87,17 @@ const InputStorageWidget = ({
    * component doesn't give us access to the native React ones :(
    */
   const handleStorageSlotLocationBlur = useCallback(
-    (textarea, currentValue, fieldError, updateValues) => {
-      if (textarea?._ref) {
-        // eslint-disable-next-line no-param-reassign, no-underscore-dangle
-        const autoResizeTextareaComponent = textarea?._ref;
+    (
+      autoResizeTextarea: HTMLElement | null,
+      currentValue,
+      fieldError,
+      updateValues,
+    ) => {
+      if (autoResizeTextarea) {
         /*
          * Add 0x prefix on blur and set the storage slot in state
          */
-        autoResizeTextareaComponent.onblur = () => {
+        const handleOnBlur = () => {
           if (!fieldError && currentValue) {
             const normalizedStorageSlot = ensureHexPrefix(currentValue);
             updateValues('storageSlotLocation', normalizedStorageSlot);
@@ -104,6 +107,7 @@ const InputStorageWidget = ({
             setStorageSlot('');
           }
         };
+        autoResizeTextarea.addEventListener('blur', handleOnBlur);
         /*
          * Prevent entering a new line
          *
@@ -114,11 +118,12 @@ const InputStorageWidget = ({
          * While we're at it we also disable the space bar, since no value
          * that can be entered requires a space (it's just a litte nice-to-have)
          */
-        autoResizeTextareaComponent.onkeypress = (event) => {
+        const handleOnKeyDown = (event) => {
           if (event.key === ENTER || event.code === SPACE) {
             event.preventDefault();
           }
         };
+        autoResizeTextarea.addEventListener('keydown', handleOnKeyDown);
       }
     },
     [],
@@ -129,14 +134,17 @@ const InputStorageWidget = ({
    * component doesn't give us access to the native React ones :(
    */
   const handleNewStorageSlotValueBlur = useCallback(
-    (textarea, currentValue, fieldError, updateValues) => {
-      if (textarea?._ref) {
-        // eslint-disable-next-line no-param-reassign, no-underscore-dangle
-        const autoResizeTextareaComponent = textarea?._ref;
+    (
+      autoResizeTextarea: HTMLElement | null,
+      currentValue,
+      fieldError,
+      updateValues,
+    ) => {
+      if (autoResizeTextarea) {
         /*
          * Add 0x prefix on blur and set the storage slot in state
          */
-        autoResizeTextareaComponent.onblur = () => {
+        const handleOnBlur = () => {
           if (!fieldError && currentValue) {
             const noPrefixValue = currentValue.startsWith('0x')
               ? currentValue.slice(2)
@@ -145,6 +153,7 @@ const InputStorageWidget = ({
             updateValues('newStorageSlotValue', ensureHexPrefix(paddedValue));
           }
         };
+        autoResizeTextarea.addEventListener('blur', handleOnBlur);
         /*
          * Prevent entering a new line
          *
@@ -155,11 +164,12 @@ const InputStorageWidget = ({
          * While we're at it we also disable the space bar, since no value
          * that can be entered requires a space (it's just a litte nice-to-have)
          */
-        autoResizeTextareaComponent.onkeypress = (event) => {
+        const handleOnKeyDown = (event) => {
           if (event.key === ENTER || event.code === SPACE) {
             event.preventDefault();
           }
         };
+        autoResizeTextarea.addEventListener('keydown', handleOnKeyDown);
       }
     },
     [],

--- a/src/modules/dashboard/components/ActionsPageComment/ActionsPageComment.tsx
+++ b/src/modules/dashboard/components/ActionsPageComment/ActionsPageComment.tsx
@@ -3,6 +3,7 @@ import React, {
   KeyboardEvent,
   SyntheticEvent,
   useRef,
+  useState,
 } from 'react';
 import * as yup from 'yup';
 import { FormikProps, FormikBag } from 'formik';
@@ -82,6 +83,10 @@ const handleKeyboardSubmit = (
 
 const ActionsPageComment = ({ transactionHash, colonyAddress }: Props) => {
   const commentBoxRef = useRef<HTMLInputElement>(null);
+  const [
+    commentBoxInputRef,
+    setCommentBoxInputRef,
+  ] = useState<HTMLElement | null>(null);
 
   const [sendTransactionMessage] = useSendTransactionMessageMutation();
 
@@ -116,9 +121,15 @@ const ActionsPageComment = ({ transactionHash, colonyAddress }: Props) => {
          */
         resetForm({});
         setFieldError('messsage', '');
+        commentBoxInputRef?.focus();
         commentBoxRef?.current?.scrollIntoView({ behavior: 'smooth' });
       }),
-    [transactionHash, colonyAddress, sendTransactionMessage],
+    [
+      transactionHash,
+      colonyAddress,
+      sendTransactionMessage,
+      commentBoxInputRef,
+    ],
   );
 
   return (
@@ -141,6 +152,7 @@ const ActionsPageComment = ({ transactionHash, colonyAddress }: Props) => {
               maxRows={6}
               onKeyDown={(event) => handleKeyboardSubmit(event, handleSubmit)}
               disabled={isSubmitting}
+              innerRef={(ref) => setCommentBoxInputRef(ref)}
             />
             {isSubmitting && (
               <div className={styles.submitting}>


### PR DESCRIPTION
The TextareaAutosize is only used on 2 components, the comment box or chat, and on the storage inputs of the recovery mode actions page. So to kill 2 birds with 1 stone while testing I would just enter recovery mode, all the instances where the component is used are there (Apart from CoinMachine's chat of course).

- Added autofocus to comment box input after you submit a message
- Changed how to comment box input ref is used on the `InputStorageWidget` to accommodate the changes made to `TextareaAutosize`
- Changed the ref returned by `TextareaAutosize` from the ref of the react component to specifically the ref to the HTML element
- Updated `react-textarea-autosize` lib in order to solve some weird `ref` issues I encountered while working on this. Also to get that sweet TS support

Resolves #2719 
