### PR TITLE
Fix initial coin machine timer

### DIFF
--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -52,7 +52,8 @@ type Props = {
 
 const displayName = 'dashboard.CoinMachine';
 
-const LEARN_MORE_LINK = '';
+const LEARN_MORE_LINK =
+  'https://colony.gitbook.io/colony/extensions/coin-machine';
 
 const CoinMachine = ({
   colony: { colonyAddress, colonyName },

--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTime.tsx
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTime.tsx
@@ -51,7 +51,7 @@ const RemainingTime = ({
   const dispatch = useDispatch();
 
   const { splitTime, timeLeft } = useSplitTime(
-    typeof value === 'number' ? value : 0,
+    typeof value === 'number' ? value : -1,
     true,
     periodLength,
   );

--- a/src/utils/hooks/useSplitTime.ts
+++ b/src/utils/hooks/useSplitTime.ts
@@ -12,9 +12,12 @@ const useSplitTime = (
   useEffect(() => {
     let timer: NodeJS.Timeout;
     if (activeTimer) {
-      timer = setInterval(() => {
-        setTimeLeft(timeLeft - 1);
-      }, 1000);
+      if (timeLeft > 0) {
+        timer = setInterval(() => {
+          setTimeLeft(timeLeft - 1);
+        }, 1000);
+      }
+
       if (timeLeft === 0 && periodLength) {
         setTimeLeft(periodLength);
       }


### PR DESCRIPTION
- Fixed coin machine timer showing up when the sale is "paused" instead of showing the `N/A` state
- Added link to Learn More of the coin machine page


Resolves #2737 
