### PR TITLE
Update chat keyboard functionality

### DIFF
--- a/src/modules/core/components/CommentInput/CommentInput.tsx
+++ b/src/modules/core/components/CommentInput/CommentInput.tsx
@@ -1,6 +1,6 @@
 import React, {
   useCallback,
-  KeyboardEvent,
+  KeyboardEvent as KeyboardEventType,
   SyntheticEvent,
   useRef,
 } from 'react';
@@ -31,15 +31,12 @@ const MSG = defineMessages({
     id: 'CommentInput.commentInstuctions',
     defaultMessage: `{sendCombo} to send {newLineCombo} for a new line`,
   },
-  sendCombo: {
-    id: 'CommentInput.sendCombo',
-    defaultMessage: `{isMac, select,
-      true {⌘}
-      other {Ctrl}
-    }+Return`,
-  },
   newLineCombo: {
     id: 'CommentInput.newLineCombo',
+    defaultMessage: 'Shift+Return',
+  },
+  sendCombo: {
+    id: 'CommentInput.sendCombo',
     defaultMessage: 'Return',
   },
 });
@@ -68,18 +65,19 @@ interface Props {
 }
 
 const handleKeyboardSubmit = (
-  capturedEvent: KeyboardEvent<any>,
+  capturedEvent: KeyboardEventType<any>,
   callback: (e: SyntheticEvent<any>) => any,
 ) => {
-  const { key, ctrlKey, metaKey } = capturedEvent;
+  const { key, shiftKey } = capturedEvent;
 
   /*
    * The meta key is interpreted on MacOS as the command ⌘ key
    */
-  if ((ctrlKey || metaKey) && key === ENTER) {
+  if (!shiftKey && key === ENTER) {
     capturedEvent.preventDefault();
     return callback(capturedEvent);
   }
+
   return false;
 };
 
@@ -173,12 +171,15 @@ const CommentInput = ({
                 values={{
                   sendCombo: (
                     <b>
-                      <FormattedMessage {...MSG.sendCombo} values={{ isMac }} />
+                      <FormattedMessage {...MSG.sendCombo} />
                     </b>
                   ),
                   newLineCombo: (
                     <b>
-                      <FormattedMessage {...MSG.newLineCombo} />
+                      <FormattedMessage
+                        {...MSG.newLineCombo}
+                        values={{ isMac }}
+                      />
                     </b>
                   ),
                 }}

--- a/src/modules/core/components/CommentInput/CommentInput.tsx
+++ b/src/modules/core/components/CommentInput/CommentInput.tsx
@@ -41,13 +41,6 @@ const MSG = defineMessages({
   },
 });
 
-/*
- * This a poor man's way of detecting the Mac os platform (even though
- * it has a bit of future proofing baked in), but it's a good alternative for
- * now, until we have time to come back and make a proper detector.
- */
-const isMac: boolean = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
-
 const validationSchema = yup.object().shape({
   message: yup.string().trim().min(3).required(),
 });
@@ -176,10 +169,7 @@ const CommentInput = ({
                   ),
                   newLineCombo: (
                     <b>
-                      <FormattedMessage
-                        {...MSG.newLineCombo}
-                        values={{ isMac }}
-                      />
+                      <FormattedMessage {...MSG.newLineCombo} />
                     </b>
                   ),
                 }}

--- a/src/modules/core/components/CommentInput/CommentInput.tsx
+++ b/src/modules/core/components/CommentInput/CommentInput.tsx
@@ -1,6 +1,6 @@
 import React, {
   useCallback,
-  KeyboardEvent as KeyboardEventType,
+  KeyboardEvent,
   SyntheticEvent,
   useRef,
 } from 'react';
@@ -65,7 +65,7 @@ interface Props {
 }
 
 const handleKeyboardSubmit = (
-  capturedEvent: KeyboardEventType<any>,
+  capturedEvent: KeyboardEvent<any>,
   callback: (e: SyntheticEvent<any>) => any,
 ) => {
   const { key, shiftKey } = capturedEvent;


### PR DESCRIPTION
## Description

This PR changes the chat functionality to use `enter` to send/submit a message & to use `shift + enter` for a new line - similar to all messaging apps on the web.

**Changes** 🏗

- update `CommentInput` component

resolves #2713 
