### PR TITLE
Remove whitelist address field when whitelist extension is not installed

### DIFF
--- a/src/modules/dashboard/components/Extensions/ExtensionSetup.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionSetup.tsx
@@ -201,7 +201,7 @@ const ExtensionSetup = ({
     whitelistAddress,
   ]);
 
-  const showWhitelistAddressField = useCallback(
+  const showInputField = useCallback(
     (paramName) => {
       return (
         paramName !== 'whitelistAddress' ||
@@ -265,41 +265,40 @@ const ExtensionSetup = ({
           key={paramName}
           className={isExtraParams ? styles.extraParams : ''}
         >
-          {type === ExtensionParamType.Input &&
-            showWhitelistAddressField(paramName) && (
-              <div
-                className={`${styles.input} ${
-                  paramName.endsWith('Address') ? styles.addressInput : ''
-                }`}
-              >
-                <Input
-                  appearance={{ size: 'medium', theme: 'minimal' }}
-                  label={title}
-                  name={paramName}
+          {type === ExtensionParamType.Input && showInputField(paramName) && (
+            <div
+              className={`${styles.input} ${
+                paramName.endsWith('Address') ? styles.addressInput : ''
+              }`}
+            >
+              <Input
+                appearance={{ size: 'medium', theme: 'minimal' }}
+                label={title}
+                name={paramName}
+              />
+              <p className={styles.inputsDescription}>
+                <FormattedMessage
+                  {...description}
+                  values={{
+                    span: (chunks) => (
+                      <span className={styles.descriptionExample}>
+                        {chunks}
+                      </span>
+                    ),
+                  }}
                 />
-                <p className={styles.inputsDescription}>
-                  <FormattedMessage
-                    {...description}
-                    values={{
-                      span: (chunks) => (
-                        <span className={styles.descriptionExample}>
-                          {chunks}
-                        </span>
-                      ),
-                    }}
-                  />
-                </p>
-                {(complementaryLabel || tokenLabel) && (
-                  <span className={styles.complementaryLabel}>
-                    {complementaryLabel ? (
-                      <FormattedMessage {...MSG[complementaryLabel]} />
-                    ) : (
-                      getToken(values[tokenLabel])?.symbol
-                    )}
-                  </span>
-                )}
-              </div>
-            )}
+              </p>
+              {(complementaryLabel || tokenLabel) && (
+                <span className={styles.complementaryLabel}>
+                  {complementaryLabel ? (
+                    <FormattedMessage {...MSG[complementaryLabel]} />
+                  ) : (
+                    getToken(values[tokenLabel])?.symbol
+                  )}
+                </span>
+              )}
+            </div>
+          )}
           {type === ExtensionParamType.Textarea && (
             <div className={styles.textArea}>
               <Textarea

--- a/src/modules/dashboard/components/Extensions/ExtensionSetup.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionSetup.tsx
@@ -1,5 +1,5 @@
-import { FormikProps } from 'formik';
 import React, { useCallback, useMemo } from 'react';
+import { FormikProps } from 'formik';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { useHistory, useParams, Redirect } from 'react-router';
 import moveDecimal from 'move-decimal-point';
@@ -201,6 +201,17 @@ const ExtensionSetup = ({
     whitelistAddress,
   ]);
 
+  const showWhitelistAddressField = useCallback(
+    (paramName) => {
+      return (
+        paramName !== 'whitelistAddress' ||
+        // @ts-ignore
+        initialValues?.whitelistAddress !== AddressZero
+      );
+    },
+    [initialValues],
+  );
+
   if (
     installedExtension.details.deprecated ||
     (installedExtension.details.initialized &&
@@ -254,40 +265,41 @@ const ExtensionSetup = ({
           key={paramName}
           className={isExtraParams ? styles.extraParams : ''}
         >
-          {type === ExtensionParamType.Input && (
-            <div
-              className={`${styles.input} ${
-                paramName.endsWith('Address') ? styles.addressInput : ''
-              }`}
-            >
-              <Input
-                appearance={{ size: 'medium', theme: 'minimal' }}
-                label={title}
-                name={paramName}
-              />
-              <p className={styles.inputsDescription}>
-                <FormattedMessage
-                  {...description}
-                  values={{
-                    span: (chunks) => (
-                      <span className={styles.descriptionExample}>
-                        {chunks}
-                      </span>
-                    ),
-                  }}
+          {type === ExtensionParamType.Input &&
+            showWhitelistAddressField(paramName) && (
+              <div
+                className={`${styles.input} ${
+                  paramName.endsWith('Address') ? styles.addressInput : ''
+                }`}
+              >
+                <Input
+                  appearance={{ size: 'medium', theme: 'minimal' }}
+                  label={title}
+                  name={paramName}
                 />
-              </p>
-              {(complementaryLabel || tokenLabel) && (
-                <span className={styles.complementaryLabel}>
-                  {complementaryLabel ? (
-                    <FormattedMessage {...MSG[complementaryLabel]} />
-                  ) : (
-                    getToken(values[tokenLabel])?.symbol
-                  )}
-                </span>
-              )}
-            </div>
-          )}
+                <p className={styles.inputsDescription}>
+                  <FormattedMessage
+                    {...description}
+                    values={{
+                      span: (chunks) => (
+                        <span className={styles.descriptionExample}>
+                          {chunks}
+                        </span>
+                      ),
+                    }}
+                  />
+                </p>
+                {(complementaryLabel || tokenLabel) && (
+                  <span className={styles.complementaryLabel}>
+                    {complementaryLabel ? (
+                      <FormattedMessage {...MSG[complementaryLabel]} />
+                    ) : (
+                      getToken(values[tokenLabel])?.symbol
+                    )}
+                  </span>
+                )}
+              </div>
+            )}
           {type === ExtensionParamType.Textarea && (
             <div className={styles.textArea}>
               <Textarea


### PR DESCRIPTION
## Description

This PR removes the whitelists address field from Coin Machine extension setup if the whitelist extension is not enabled. This is agreed with Jack and Chad in the product-private channel. In this case the address zero is submitted as whitelist address so that there is no error during transaction.

**Changes** 🏗

- update `ExtensionSetup` component.

resolves #2743 
