### PR TITLE
Fix staking slider no more rep error

### DIFF
--- a/src/modules/core/components/Slider/Slider.tsx
+++ b/src/modules/core/components/Slider/Slider.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import ReactSlider from 'rc-slider';
 import { useField } from 'formik';
+import Decimal from 'decimal.js';
 
 import 'rc-slider/assets/index.css';
 
@@ -15,7 +16,7 @@ interface Props {
   value: number;
   max?: number;
   min?: number;
-  limit?: number;
+  limit?: Decimal;
   appearance?: Appearance;
   onChange?: (val: any) => void;
   name: string;
@@ -53,18 +54,18 @@ const Slider = ({
   }, [sliderValue, value, setSliderValue]);
 
   const limitValue = useMemo(() => {
-    return limit ? limit * 100 : 0;
+    return limit ? limit.times(100) : new Decimal(0);
   }, [limit]);
 
   const gradientPercentage = useMemo(
-    () => (limitValue >= 100 ? 100 : limitValue),
+    () => (limitValue.gte(100) ? new Decimal(100) : limitValue),
     [limitValue],
   );
 
   const onSliderChange = useCallback(
     (val): void => {
       if (
-        (limit !== undefined && sliderValue < limitValue) ||
+        (limit !== undefined && limitValue.gt(sliderValue)) ||
         val < sliderValue ||
         !limitValue
       ) {
@@ -79,13 +80,13 @@ const Slider = ({
       }
       if (
         limit !== undefined &&
-        (sliderValue > limitValue || val > limitValue)
+        (limitValue.lt(sliderValue) || val > limitValue)
       ) {
-        setSliderValue(limitValue);
-        setValue(limitValue);
+        setSliderValue(limitValue.toNumber());
+        setValue(limitValue.toString());
 
         if (onChange) {
-          onChange(limitValue);
+          onChange(limitValue.toString());
         }
         if (handleLimitExceeded) {
           handleLimitExceeded(true);
@@ -98,8 +99,8 @@ const Slider = ({
 
   const marks = {};
 
-  if (limit && limit < max) {
-    marks[limit] = {};
+  if (limit && limit.lt(max)) {
+    marks[limit.toNumber()] = {};
   }
 
   const SliderColorsObject = {
@@ -155,7 +156,9 @@ const Slider = ({
         }}
         dotStyle={{
           display:
-            gradientPercentage === 100 || gradientPercentage <= 0 ? 'none' : '',
+            gradientPercentage.eq(100) || gradientPercentage.lte(0)
+              ? 'none'
+              : '',
           height: sizes.markHeight,
           width: sizes.markWidth,
           backgroundColor: '#76748B',

--- a/src/modules/dashboard/components/ActionsPage/StakingValidationError/StakingValidationError.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingValidationError/StakingValidationError.tsx
@@ -26,11 +26,11 @@ const stakeValidationMSG = defineMessage({
   },
   stakeMoreTokens: {
     id: 'dashboard.ActionsPage.StakingValidationError.stakeMore',
-    defaultMessage: 'You do not have enough active tokens to stake more.',
+    defaultMessage: `Oops! You don't have enough active tokens. To stake more than this, please activate more tokens.`,
   },
   stakeMoreReputation: {
     id: 'dashboard.ActionsPage.StakingValidationError.reputation',
-    defaultMessage: 'You do not have enough reputation to stake more.',
+    defaultMessage: `Oops! Your ability to stake is limited by the amount of Reputation you have. To be able to stake more, you'll need to earn more Reputation.`,
   },
   cantStakeMore: {
     id: 'dashboard.ActionsPage.StakingValidationError.stakeMore',

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
@@ -120,7 +120,7 @@ const StakingSlider = ({
         return 'cantStakeMore';
       }
 
-      if (userActivatedTokens.gt(maxStake)) {
+      if (userActivatedTokens.gt(maxStake) && maxStake.lt(remainingToStake)) {
         return 'stakeMoreReputation';
       }
 

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
@@ -84,7 +84,7 @@ const StakingSlider = ({
   const maxStake = new Decimal(maxUserStake);
 
   const userStakeLimitPercentage = remainingToStake.lte(minUserStake)
-    ? 0
+    ? new Decimal(0)
     : (maxStake.gte(userActivatedTokens) ? userActivatedTokens : maxStake)
         .minus(minUserStake)
         .div(remainingToStake.minus(minUserStake));
@@ -160,7 +160,7 @@ const StakingSlider = ({
         <Slider
           name="amount"
           value={values.amount}
-          limit={parseFloat(userStakeLimitPercentage.toFixed(5))}
+          limit={userStakeLimitPercentage}
           step={0.01}
           min={0}
           max={100}

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
@@ -250,7 +250,7 @@ const StakingWidget = ({
                 type="submit"
                 disabled={
                   !canBeStaked ||
-                  userActivatedTokens.lte(getDecimalStake(values.amount))
+                  userActivatedTokens.lt(getDecimalStake(values.amount))
                 }
                 text={MSG.stakeButton}
               />

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/ChangeTokenStateForm.tsx
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/ChangeTokenStateForm.tsx
@@ -4,6 +4,7 @@ import { BigNumber, bigNumberify } from 'ethers/utils';
 import { FormikProps } from 'formik';
 import moveDecimal from 'move-decimal-point';
 import * as yup from 'yup';
+import Decimal from 'decimal.js';
 
 import Button from '~core/Button';
 import { ActionForm, Input } from '~core/Fields';
@@ -241,7 +242,7 @@ const ChangeTokenStateForm = ({
               disabled={
                 !isValid ||
                 values.amount === undefined ||
-                values.amount > unformattedTokenBalance
+                new Decimal(unformattedTokenBalance).lt(values.amount || 0)
               }
             />
           </div>


### PR DESCRIPTION
- Fixed token activation popover not validating correctly some token amounts due to Javascript being weird with type coercion
- Fixed staking slider error showing up in cases where the user had more active tokens than reputation points, but had enough reputation to stake the entire remaining stake, and therefore the error making no sense.
- FIxed staking slider sometimes having a wrong limit due to the precision of the numbers used to calculate it

Resolves #2768 
