### PR TITLE
Add error message for finalize motion widget

### DIFF
--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -3229,130 +3229,6 @@ export function useTokenBalancesForDomainsLazyQuery(baseOptions?: Apollo.LazyQue
 export type TokenBalancesForDomainsQueryHookResult = ReturnType<typeof useTokenBalancesForDomainsQuery>;
 export type TokenBalancesForDomainsLazyQueryHookResult = ReturnType<typeof useTokenBalancesForDomainsLazyQuery>;
 export type TokenBalancesForDomainsQueryResult = Apollo.QueryResult<TokenBalancesForDomainsQuery, TokenBalancesForDomainsQueryVariables>;
-export const UserColoniesDocument = gql`
-    query UserColonies($address: String!) {
-  user(address: $address) {
-    id
-    processedColonies @client {
-      id
-      avatarHash
-      avatarURL
-      colonyAddress
-      colonyName
-      displayName
-    }
-    colonyAddresses
-  }
-}
-    `;
-
-/**
- * __useUserColoniesQuery__
- *
-<<<<<<< HEAD
-=======
- * To run a query within a React component, call `useNetworkExtensionVersionQuery` and pass it any options that fit your needs.
- * When your component renders, `useNetworkExtensionVersionQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useNetworkExtensionVersionQuery({
- *   variables: {
- *      extensionId: // value for 'extensionId'
- *   },
- * });
- */
-export function useNetworkExtensionVersionQuery(baseOptions?: Apollo.QueryHookOptions<NetworkExtensionVersionQuery, NetworkExtensionVersionQueryVariables>) {
-        return Apollo.useQuery<NetworkExtensionVersionQuery, NetworkExtensionVersionQueryVariables>(NetworkExtensionVersionDocument, baseOptions);
-      }
-export function useNetworkExtensionVersionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<NetworkExtensionVersionQuery, NetworkExtensionVersionQueryVariables>) {
-          return Apollo.useLazyQuery<NetworkExtensionVersionQuery, NetworkExtensionVersionQueryVariables>(NetworkExtensionVersionDocument, baseOptions);
-        }
-export type NetworkExtensionVersionQueryHookResult = ReturnType<typeof useNetworkExtensionVersionQuery>;
-export type NetworkExtensionVersionLazyQueryHookResult = ReturnType<typeof useNetworkExtensionVersionLazyQuery>;
-export type NetworkExtensionVersionQueryResult = Apollo.QueryResult<NetworkExtensionVersionQuery, NetworkExtensionVersionQueryVariables>;
-export const WhitelistedUsersDocument = gql`
-    query WhitelistedUsers($colonyAddress: String!) {
-  whitelistedUsers(colonyAddress: $colonyAddress) @client {
-    id
-    profile {
-      walletAddress
-    }
-  }
-}
-    `;
-
-/**
- * __useWhitelistedUsersQuery__
- *
- * To run a query within a React component, call `useWhitelistedUsersQuery` and pass it any options that fit your needs.
- * When your component renders, `useWhitelistedUsersQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useWhitelistedUsersQuery({
- *   variables: {
- *      colonyAddress: // value for 'colonyAddress'
- *   },
- * });
- */
-export function useWhitelistedUsersQuery(baseOptions?: Apollo.QueryHookOptions<WhitelistedUsersQuery, WhitelistedUsersQueryVariables>) {
-        return Apollo.useQuery<WhitelistedUsersQuery, WhitelistedUsersQueryVariables>(WhitelistedUsersDocument, baseOptions);
-      }
-export function useWhitelistedUsersLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<WhitelistedUsersQuery, WhitelistedUsersQueryVariables>) {
-          return Apollo.useLazyQuery<WhitelistedUsersQuery, WhitelistedUsersQueryVariables>(WhitelistedUsersDocument, baseOptions);
-        }
-export type WhitelistedUsersQueryHookResult = ReturnType<typeof useWhitelistedUsersQuery>;
-export type WhitelistedUsersLazyQueryHookResult = ReturnType<typeof useWhitelistedUsersLazyQuery>;
-export type WhitelistedUsersQueryResult = Apollo.QueryResult<WhitelistedUsersQuery, WhitelistedUsersQueryVariables>;
-export const TokenBalancesForDomainsDocument = gql`
-    query TokenBalancesForDomains($colonyAddress: String!, $tokenAddresses: [String!]!, $domainIds: [Int!]) {
-  tokens(addresses: $tokenAddresses) @client {
-    id
-    address
-    iconHash
-    decimals
-    name
-    symbol
-    balances(colonyAddress: $colonyAddress, domainIds: $domainIds) {
-      domainId
-      amount
-    }
-  }
-}
-    `;
-
-/**
- * __useTokenBalancesForDomainsQuery__
- *
- * To run a query within a React component, call `useTokenBalancesForDomainsQuery` and pass it any options that fit your needs.
- * When your component renders, `useTokenBalancesForDomainsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useTokenBalancesForDomainsQuery({
- *   variables: {
- *      colonyAddress: // value for 'colonyAddress'
- *      tokenAddresses: // value for 'tokenAddresses'
- *      domainIds: // value for 'domainIds'
- *   },
- * });
- */
-export function useTokenBalancesForDomainsQuery(baseOptions?: Apollo.QueryHookOptions<TokenBalancesForDomainsQuery, TokenBalancesForDomainsQueryVariables>) {
-        return Apollo.useQuery<TokenBalancesForDomainsQuery, TokenBalancesForDomainsQueryVariables>(TokenBalancesForDomainsDocument, baseOptions);
-      }
-export function useTokenBalancesForDomainsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<TokenBalancesForDomainsQuery, TokenBalancesForDomainsQueryVariables>) {
-          return Apollo.useLazyQuery<TokenBalancesForDomainsQuery, TokenBalancesForDomainsQueryVariables>(TokenBalancesForDomainsDocument, baseOptions);
-        }
-export type TokenBalancesForDomainsQueryHookResult = ReturnType<typeof useTokenBalancesForDomainsQuery>;
-export type TokenBalancesForDomainsLazyQueryHookResult = ReturnType<typeof useTokenBalancesForDomainsLazyQuery>;
-export type TokenBalancesForDomainsQueryResult = Apollo.QueryResult<TokenBalancesForDomainsQuery, TokenBalancesForDomainsQueryVariables>;
 export const DomainBalanceDocument = gql`
     query DomainBalance($colonyAddress: String!, $tokenAddress: String!, $domainId: Int!) {
   domainBalance(colonyAddress: $colonyAddress, tokenAddress: $tokenAddress, domainId: $domainId) @client
@@ -3406,7 +3282,6 @@ export const UserColoniesDocument = gql`
 /**
  * __useUserColoniesQuery__
  *
->>>>>>> Feat: add `DomainBalance` query, types & resolver
  * To run a query within a React component, call `useUserColoniesQuery` and pass it any options that fit your needs.
  * When your component renders, `useUserColoniesQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -272,6 +272,7 @@ export type Query = {
   colonyMembersWithReputation?: Maybe<Array<Scalars['String']>>;
   colonyName: Scalars['String'];
   colonyReputation?: Maybe<Scalars['String']>;
+  domainBalance: Scalars['String'];
   domains: Array<SubgraphDomain>;
   events: Array<SubgraphEvent>;
   eventsForMotion: Array<ParsedEvent>;
@@ -376,6 +377,13 @@ export type QueryColonyNameArgs = {
 export type QueryColonyReputationArgs = {
   address: Scalars['String'];
   domainId?: Maybe<Scalars['Int']>;
+};
+
+
+export type QueryDomainBalanceArgs = {
+  colonyAddress: Scalars['String'];
+  tokenAddress: Scalars['String'];
+  domainId: Scalars['Int'];
 };
 
 
@@ -1491,6 +1499,15 @@ export type TokenBalancesForDomainsQuery = { tokens: Array<(
     Pick<Token, 'id' | 'address' | 'iconHash' | 'decimals' | 'name' | 'symbol'>
     & { balances: Array<Pick<DomainBalance, 'domainId' | 'amount'>> }
   )> };
+
+export type DomainBalanceQueryVariables = Exact<{
+  colonyAddress: Scalars['String'];
+  tokenAddress: Scalars['String'];
+  domainId: Scalars['Int'];
+}>;
+
+
+export type DomainBalanceQuery = Pick<Query, 'domainBalance'>;
 
 export type UserColoniesQueryVariables = Exact<{
   address: Scalars['String'];
@@ -3232,6 +3249,164 @@ export const UserColoniesDocument = gql`
 /**
  * __useUserColoniesQuery__
  *
+<<<<<<< HEAD
+=======
+ * To run a query within a React component, call `useNetworkExtensionVersionQuery` and pass it any options that fit your needs.
+ * When your component renders, `useNetworkExtensionVersionQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useNetworkExtensionVersionQuery({
+ *   variables: {
+ *      extensionId: // value for 'extensionId'
+ *   },
+ * });
+ */
+export function useNetworkExtensionVersionQuery(baseOptions?: Apollo.QueryHookOptions<NetworkExtensionVersionQuery, NetworkExtensionVersionQueryVariables>) {
+        return Apollo.useQuery<NetworkExtensionVersionQuery, NetworkExtensionVersionQueryVariables>(NetworkExtensionVersionDocument, baseOptions);
+      }
+export function useNetworkExtensionVersionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<NetworkExtensionVersionQuery, NetworkExtensionVersionQueryVariables>) {
+          return Apollo.useLazyQuery<NetworkExtensionVersionQuery, NetworkExtensionVersionQueryVariables>(NetworkExtensionVersionDocument, baseOptions);
+        }
+export type NetworkExtensionVersionQueryHookResult = ReturnType<typeof useNetworkExtensionVersionQuery>;
+export type NetworkExtensionVersionLazyQueryHookResult = ReturnType<typeof useNetworkExtensionVersionLazyQuery>;
+export type NetworkExtensionVersionQueryResult = Apollo.QueryResult<NetworkExtensionVersionQuery, NetworkExtensionVersionQueryVariables>;
+export const WhitelistedUsersDocument = gql`
+    query WhitelistedUsers($colonyAddress: String!) {
+  whitelistedUsers(colonyAddress: $colonyAddress) @client {
+    id
+    profile {
+      walletAddress
+    }
+  }
+}
+    `;
+
+/**
+ * __useWhitelistedUsersQuery__
+ *
+ * To run a query within a React component, call `useWhitelistedUsersQuery` and pass it any options that fit your needs.
+ * When your component renders, `useWhitelistedUsersQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useWhitelistedUsersQuery({
+ *   variables: {
+ *      colonyAddress: // value for 'colonyAddress'
+ *   },
+ * });
+ */
+export function useWhitelistedUsersQuery(baseOptions?: Apollo.QueryHookOptions<WhitelistedUsersQuery, WhitelistedUsersQueryVariables>) {
+        return Apollo.useQuery<WhitelistedUsersQuery, WhitelistedUsersQueryVariables>(WhitelistedUsersDocument, baseOptions);
+      }
+export function useWhitelistedUsersLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<WhitelistedUsersQuery, WhitelistedUsersQueryVariables>) {
+          return Apollo.useLazyQuery<WhitelistedUsersQuery, WhitelistedUsersQueryVariables>(WhitelistedUsersDocument, baseOptions);
+        }
+export type WhitelistedUsersQueryHookResult = ReturnType<typeof useWhitelistedUsersQuery>;
+export type WhitelistedUsersLazyQueryHookResult = ReturnType<typeof useWhitelistedUsersLazyQuery>;
+export type WhitelistedUsersQueryResult = Apollo.QueryResult<WhitelistedUsersQuery, WhitelistedUsersQueryVariables>;
+export const TokenBalancesForDomainsDocument = gql`
+    query TokenBalancesForDomains($colonyAddress: String!, $tokenAddresses: [String!]!, $domainIds: [Int!]) {
+  tokens(addresses: $tokenAddresses) @client {
+    id
+    address
+    iconHash
+    decimals
+    name
+    symbol
+    balances(colonyAddress: $colonyAddress, domainIds: $domainIds) {
+      domainId
+      amount
+    }
+  }
+}
+    `;
+
+/**
+ * __useTokenBalancesForDomainsQuery__
+ *
+ * To run a query within a React component, call `useTokenBalancesForDomainsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useTokenBalancesForDomainsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useTokenBalancesForDomainsQuery({
+ *   variables: {
+ *      colonyAddress: // value for 'colonyAddress'
+ *      tokenAddresses: // value for 'tokenAddresses'
+ *      domainIds: // value for 'domainIds'
+ *   },
+ * });
+ */
+export function useTokenBalancesForDomainsQuery(baseOptions?: Apollo.QueryHookOptions<TokenBalancesForDomainsQuery, TokenBalancesForDomainsQueryVariables>) {
+        return Apollo.useQuery<TokenBalancesForDomainsQuery, TokenBalancesForDomainsQueryVariables>(TokenBalancesForDomainsDocument, baseOptions);
+      }
+export function useTokenBalancesForDomainsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<TokenBalancesForDomainsQuery, TokenBalancesForDomainsQueryVariables>) {
+          return Apollo.useLazyQuery<TokenBalancesForDomainsQuery, TokenBalancesForDomainsQueryVariables>(TokenBalancesForDomainsDocument, baseOptions);
+        }
+export type TokenBalancesForDomainsQueryHookResult = ReturnType<typeof useTokenBalancesForDomainsQuery>;
+export type TokenBalancesForDomainsLazyQueryHookResult = ReturnType<typeof useTokenBalancesForDomainsLazyQuery>;
+export type TokenBalancesForDomainsQueryResult = Apollo.QueryResult<TokenBalancesForDomainsQuery, TokenBalancesForDomainsQueryVariables>;
+export const DomainBalanceDocument = gql`
+    query DomainBalance($colonyAddress: String!, $tokenAddress: String!, $domainId: Int!) {
+  domainBalance(colonyAddress: $colonyAddress, tokenAddress: $tokenAddress, domainId: $domainId) @client
+}
+    `;
+
+/**
+ * __useDomainBalanceQuery__
+ *
+ * To run a query within a React component, call `useDomainBalanceQuery` and pass it any options that fit your needs.
+ * When your component renders, `useDomainBalanceQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useDomainBalanceQuery({
+ *   variables: {
+ *      colonyAddress: // value for 'colonyAddress'
+ *      tokenAddress: // value for 'tokenAddress'
+ *      domainId: // value for 'domainId'
+ *   },
+ * });
+ */
+export function useDomainBalanceQuery(baseOptions?: Apollo.QueryHookOptions<DomainBalanceQuery, DomainBalanceQueryVariables>) {
+        return Apollo.useQuery<DomainBalanceQuery, DomainBalanceQueryVariables>(DomainBalanceDocument, baseOptions);
+      }
+export function useDomainBalanceLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<DomainBalanceQuery, DomainBalanceQueryVariables>) {
+          return Apollo.useLazyQuery<DomainBalanceQuery, DomainBalanceQueryVariables>(DomainBalanceDocument, baseOptions);
+        }
+export type DomainBalanceQueryHookResult = ReturnType<typeof useDomainBalanceQuery>;
+export type DomainBalanceLazyQueryHookResult = ReturnType<typeof useDomainBalanceLazyQuery>;
+export type DomainBalanceQueryResult = Apollo.QueryResult<DomainBalanceQuery, DomainBalanceQueryVariables>;
+export const UserColoniesDocument = gql`
+    query UserColonies($address: String!) {
+  user(address: $address) {
+    id
+    processedColonies @client {
+      id
+      avatarHash
+      avatarURL
+      colonyAddress
+      colonyName
+      displayName
+    }
+    colonyAddresses
+  }
+}
+    `;
+
+/**
+ * __useUserColoniesQuery__
+ *
+>>>>>>> Feat: add `DomainBalance` query, types & resolver
  * To run a query within a React component, call `useUserColoniesQuery` and pass it any options that fit your needs.
  * When your component renders, `useUserColoniesQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.

--- a/src/data/graphql/queries.graphql
+++ b/src/data/graphql/queries.graphql
@@ -126,6 +126,10 @@ query TokenBalancesForDomains($colonyAddress: String!, $tokenAddresses: [String!
   }
 }
 
+query DomainBalance($colonyAddress: String!, $tokenAddress: String!, $domainId: Int!) {
+  domainBalance(colonyAddress: $colonyAddress, tokenAddress: $tokenAddress, domainId: $domainId) @client
+}
+
 query UserColonies($address: String!) {
   user(address: $address) {
     id

--- a/src/data/graphql/typeDefs.ts
+++ b/src/data/graphql/typeDefs.ts
@@ -411,6 +411,11 @@ export default gql`
     whitelistAgreement(agreementHash: String!): String!
     whitelistAgreementHash(colonyAddress: String!): String
     hasKycPolicy(colonyAddress: String!): Boolean!
+    domainBalance(
+      colonyAddress: String!
+      tokenAddress: String!
+      domainId: Int!
+    ): String!
   }
 
   extend type Mutation {

--- a/src/data/resolvers/token.ts
+++ b/src/data/resolvers/token.ts
@@ -171,6 +171,20 @@ export const tokenResolvers = ({
       );
       return tokens.filter((token) => !!token);
     },
+    async domainBalance(_, { colonyAddress, tokenAddress, domainId }) {
+      const colonyClient = await colonyManager.getClient(
+        ClientType.ColonyClient,
+        colonyAddress,
+      );
+
+      const balance = await getBalanceForTokenAndDomain(
+        colonyClient,
+        tokenAddress,
+        domainId,
+      );
+
+      return balance.toString();
+    },
   },
   Token: {
     async balances(

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
@@ -109,6 +109,7 @@ const DefaultMotion = ({
     toDomain,
     blockNumber,
     newVersion,
+    tokenAddress,
   },
   colonyAction,
   token: { decimals, symbol },
@@ -519,6 +520,9 @@ const DefaultMotion = ({
               motionId={motionId}
               scrollToRef={bottomElementRef}
               motionState={motionState}
+              fromDomain={fromDomain}
+              motionAmount={amount}
+              tokenAddress={tokenAddress}
             />
           )}
           <DetailsWidget

--- a/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.css
@@ -82,3 +82,10 @@
 .loading {
   padding-top: 20px;
 }
+
+.finalizeError {
+  margin-top: 6px;
+  font-size: var(--size-tiny);
+  font-weight: var(--weight-bold);
+  color: var(--pink);
+}

--- a/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.css.d.ts
@@ -10,3 +10,4 @@ export const tooltip: string;
 export const voteResults: string;
 export const outcome: string;
 export const loading: string;
+export const finalizeError: string;


### PR DESCRIPTION
## Description

This PR disables the `Finalize` (motion) button & adds an error message when there is insufficient funds to finalize the motion.

It's applicable for Create payment & Transfer Funds motions.

**New stuff** ✨

- add `domainBalance` query, types & resolver
- disable the button & add error message to `FinalizeMotionAndClaimWidget`

resolves #2762 

<img width="1028" alt="Screenshot 2021-10-14 at 16 39 46" src="https://user-images.githubusercontent.com/34057551/137343053-4d699282-749a-4f37-8e56-3e782d5047fc.png">
<img width="1065" alt="Screenshot 2021-10-14 at 16 39 37" src="https://user-images.githubusercontent.com/34057551/137343056-a808e65d-3865-4246-94c9-5cb9bc24a52b.png">


