### PR TITLE
Fix `canUserStake` logic in `StakingWidget`

### DIFF
--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
@@ -205,9 +205,9 @@ const StakingWidget = ({
    * Motion can be still staked (ie: amount left to stake)
    */
   const canUserStakeYay =
-    canUserStake && new Decimal(remainingToFullyYayStaked).gt(1);
+    canUserStake && new Decimal(remainingToFullyYayStaked).gt(0);
   const canUserStakeNay =
-    canUserStake && new Decimal(remainingToFullyNayStaked).gt(1);
+    canUserStake && new Decimal(remainingToFullyNayStaked).gt(0);
 
   const canBeStaked = isObjection ? canUserStakeNay : canUserStakeYay;
 


### PR DESCRIPTION
## Description

This PR fixes the logic of `canUserStake` in `StakingWidget`.

I wasn't able to reproduce the bug in development but I looked for possible reasons it happens & ways to solve and I think that's the best guess for now. I think that the problem is in rounding when submitting the stake. This change will hopefully allow to stake the last minimal bit that's there.

resolves #2733 