### PR TITLE
Fix being able to see mint tokens modal for non native tokens

### DIFF
--- a/src/modules/dashboard/components/ManageFundsDialog/ManageFundsDialog.tsx
+++ b/src/modules/dashboard/components/ManageFundsDialog/ManageFundsDialog.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
 import { DialogProps, ActionDialogProps } from '~core/Dialog';
@@ -188,12 +188,20 @@ const ManageFundsDialog = ({
       },
     },
   ];
+  const filteredItems = useMemo(() => {
+    return colony.canMintNativeToken
+      ? items
+      : items.filter(
+          ({ icon }) =>
+            icon !== 'emoji-padlock' && icon !== 'emoji-seed-sprout',
+        );
+  }, [colony, items]);
   return (
     <IndexModal
       cancel={cancel}
       close={close}
       title={MSG.dialogHeader}
-      items={items}
+      items={filteredItems}
       back={() => callStep(prevStep)}
     />
   );


### PR DESCRIPTION
## Description

This PR fixes the issue described in https://github.com/JoinColony/colonyDapp/issues/2681 . 

**Updates** 🏗
After chat with product team we decided to remove those options from manage funds dialog

**Changes** 🏗

* Updated checks in ManageFundsDialog 

**Cases to test** ⚰️
1. Colony have native token, voting extension is disabled - we can go to mint tokens and unlock tokens modals
2. Colony have native token, voting extension is enabled - we can go to mint tokens and unlock tokens modals
3. Colony have non native token, voting extension is disabled - we CANNOT go to mint tokens and unlock tokens modals
4. Colony have non native token, voting extension is enabled - we CANNOT go to mint tokens and unlock tokens modals

<img width="506" alt="Screenshot 2021-10-29 at 15 07 31" src="https://user-images.githubusercontent.com/13069555/139441722-b52ad096-cfdc-457f-87ac-ae063401f1c3.png">
<img width="497" alt="Screenshot 2021-10-29 at 15 07 23" src="https://user-images.githubusercontent.com/13069555/139441731-22164618-7667-46fe-b7b6-3216f411477a.png">


Resolves #2681 
