### PR TITLE
Add default user to user picker in `Smite` dialog

### DIFF
--- a/src/modules/dashboard/components/SmiteDialog/SmiteDialog.tsx
+++ b/src/modules/dashboard/components/SmiteDialog/SmiteDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { FormikProps } from 'formik';
 import * as yup from 'yup';
 import { ROOT_DOMAIN_ID } from '@colony/colony-js';
@@ -12,9 +12,10 @@ import { ActionForm } from '~core/Fields';
 import { DEFAULT_TOKEN_DECIMALS } from '~constants';
 import { Address } from '~types/index';
 import { ActionTypes } from '~redux/index';
-import { useMembersSubscription, useLoggedInUser } from '~data/index';
+import { useMembersSubscription } from '~data/index';
 import { pipe, withMeta, mapPayload } from '~utils/actions';
 import { WizardDialogType } from '~utils/hooks';
+import { useSelectedUser } from '~utils/hooks/useSelectedUser';
 
 import DialogForm from './SmiteDialogForm';
 
@@ -126,23 +127,7 @@ const SmiteDialog = ({
     [totalReputationData],
   );
 
-  const { walletAddress: loggedInUserWalletAddress } = useLoggedInUser();
-
-  const selectedUser = useMemo(() => {
-    if (!colonyMembers) {
-      return undefined;
-    }
-
-    const [firstSubscriber, secondSubscriber] = colonyMembers?.subscribedUsers;
-
-    if (!secondSubscriber) {
-      return firstSubscriber;
-    }
-
-    return firstSubscriber.profile.walletAddress === loggedInUserWalletAddress
-      ? secondSubscriber
-      : firstSubscriber;
-  }, [colonyMembers, loggedInUserWalletAddress]);
+  const selectedUser = useSelectedUser(colonyMembers);
 
   return (
     <ActionForm

--- a/src/modules/dashboard/components/SmiteDialog/SmiteDialog.tsx
+++ b/src/modules/dashboard/components/SmiteDialog/SmiteDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { FormikProps } from 'formik';
 import * as yup from 'yup';
 import { ROOT_DOMAIN_ID } from '@colony/colony-js';
@@ -12,7 +12,7 @@ import { ActionForm } from '~core/Fields';
 import { DEFAULT_TOKEN_DECIMALS } from '~constants';
 import { Address } from '~types/index';
 import { ActionTypes } from '~redux/index';
-import { useMembersSubscription } from '~data/index';
+import { useMembersSubscription, useLoggedInUser } from '~data/index';
 import { pipe, withMeta, mapPayload } from '~utils/actions';
 import { WizardDialogType } from '~utils/hooks';
 
@@ -126,6 +126,22 @@ const SmiteDialog = ({
     [totalReputationData],
   );
 
+  const { walletAddress: loggedInUserWalletAddress } = useLoggedInUser();
+
+  const selectedUser = useMemo(() => {
+    if (!colonyMembers) {
+      return undefined;
+    }
+
+    if (colonyMembers.subscribedUsers.length === 1) {
+      return colonyMembers.subscribedUsers[0];
+    }
+
+    return colonyMembers.subscribedUsers[0].id === loggedInUserWalletAddress
+      ? colonyMembers.subscribedUsers[1]
+      : colonyMembers.subscribedUsers[0];
+  }, [colonyMembers, loggedInUserWalletAddress]);
+
   return (
     <ActionForm
       initialValues={{
@@ -134,11 +150,12 @@ const SmiteDialog = ({
           ? ROOT_DOMAIN_ID
           : ethDomainId
         ).toString(),
-        user: undefined,
+        user: selectedUser,
         amount: undefined,
         annotation: undefined,
         motionDomainId: ROOT_DOMAIN_ID,
       }}
+      enableReinitialize
       submit={getFormAction('SUBMIT')}
       error={getFormAction('ERROR')}
       success={getFormAction('SUCCESS')}

--- a/src/modules/dashboard/components/SmiteDialog/SmiteDialog.tsx
+++ b/src/modules/dashboard/components/SmiteDialog/SmiteDialog.tsx
@@ -133,13 +133,15 @@ const SmiteDialog = ({
       return undefined;
     }
 
-    if (colonyMembers.subscribedUsers.length === 1) {
-      return colonyMembers.subscribedUsers[0];
+    const [firstSubscriber, secondSubscriber] = colonyMembers?.subscribedUsers;
+
+    if (!secondSubscriber) {
+      return firstSubscriber;
     }
 
-    return colonyMembers.subscribedUsers[0].id === loggedInUserWalletAddress
-      ? colonyMembers.subscribedUsers[1]
-      : colonyMembers.subscribedUsers[0];
+    return firstSubscriber.profile.walletAddress === loggedInUserWalletAddress
+      ? secondSubscriber
+      : firstSubscriber;
   }, [colonyMembers, loggedInUserWalletAddress]);
 
   return (

--- a/src/modules/dashboard/components/SmiteDialog/SmiteDialogForm.tsx
+++ b/src/modules/dashboard/components/SmiteDialog/SmiteDialogForm.tsx
@@ -129,7 +129,7 @@ const SmiteDialogForm = ({
     hasRegisteredProfile && userHasRole(domainRoles, ColonyRole.Arbitration);
 
   const [userHasPermission, onlyForceAction] = useDialogActionPermissions(
-    colony.colonyAddress,
+    colonyAddress,
     hasRoles,
     isVotingExtensionEnabled,
     values.forceAction,
@@ -201,7 +201,7 @@ const SmiteDialogForm = ({
   >(
     (option) => {
       const value = option ? option.value : undefined;
-      const domain = colony.domains.find(
+      const domain = domains.find(
         ({ ethDomainId }) => Number(value) === ethDomainId,
       ) as OneDomain;
       return (
@@ -214,7 +214,7 @@ const SmiteDialogForm = ({
         </div>
       );
     },
-    [values, colonyAddress, colony.domains],
+    [values, colonyAddress, domains],
   );
 
   useEffect(() => {

--- a/src/utils/hooks/useSelectedUser.ts
+++ b/src/utils/hooks/useSelectedUser.ts
@@ -10,7 +10,8 @@ export const useSelectedUser = (colonyMembers) => {
       return undefined;
     }
 
-    const [firstSubscriber, secondSubscriber] = colonyMembers?.subscribedUsers;
+    const [firstSubscriber, secondSubscriber] =
+      colonyMembers?.subscribedUsers || [];
 
     if (!secondSubscriber) {
       return firstSubscriber;

--- a/src/utils/hooks/useSelectedUser.ts
+++ b/src/utils/hooks/useSelectedUser.ts
@@ -1,0 +1,23 @@
+import { useMemo } from 'react';
+
+import { useLoggedInUser } from '~data/index';
+
+export const useSelectedUser = (colonyMembers) => {
+  const { walletAddress: loggedInUserWalletAddress } = useLoggedInUser();
+
+  return useMemo(() => {
+    if (!colonyMembers) {
+      return undefined;
+    }
+
+    const [firstSubscriber, secondSubscriber] = colonyMembers?.subscribedUsers;
+
+    if (!secondSubscriber) {
+      return firstSubscriber;
+    }
+
+    return firstSubscriber.profile.walletAddress === loggedInUserWalletAddress
+      ? secondSubscriber
+      : firstSubscriber;
+  }, [colonyMembers, loggedInUserWalletAddress]);
+};


### PR DESCRIPTION
## Description

This PR adds a default user to the user picker field in `SmiteDialog`. If there is just one user in the dropdown, this user will be selected. If it's more than 1 user, then we pick the first user that's not a logged in user (assuming that the logged in user doesn't want to smite himself)

**Changes** 🏗

- update `SmiteDialog` & `SmiteDialogForm` components

resolves #2829 

![smite-dialog](https://user-images.githubusercontent.com/34057551/140179060-1ac04596-d961-4785-82ec-a916aecfd7c7.gif)

