### PR TITLE
Fix alignment on friendly name and masked address in events list

### DIFF
--- a/src/modules/core/components/FriendlyName/FriendlyName.css
+++ b/src/modules/core/components/FriendlyName/FriendlyName.css
@@ -1,6 +1,5 @@
 .main {
   composes: inlineEllipsis from '~styles/text.css';
-  display: inline-block;
+  display: contents;
   max-width: 150px;
-  vertical-align: text-bottom;
 }

--- a/src/modules/core/components/Popover/Tooltip.css
+++ b/src/modules/core/components/Popover/Tooltip.css
@@ -1,6 +1,6 @@
 .container {
   padding: 5px 10px;
   font-size: var(--size-tiny);
-  line-height: 18px;
+  line-height: 16px;
   letter-spacing: 0.5px;
 }

--- a/src/modules/dashboard/components/ColonyEvents/ColonyEventsListItem.css
+++ b/src/modules/dashboard/components/ColonyEvents/ColonyEventsListItem.css
@@ -110,7 +110,6 @@
 }
 
 .tooltip span {
-  vertical-align: text-top;
   font-size: var(--size-tiny);
 }
 


### PR DESCRIPTION
## Description

- [x] fix alignment issues  for masked address
- [x]  fix alignment issues for friendly name
- [x]  fix alignment issues inside tooltip

**Fixes**  alignment of both FriendlyName and MaskedAddress both in the events list item and in the tooltip hover.

## Screenshot
![image](https://user-images.githubusercontent.com/6601142/139853656-54a38e4e-49a6-4ae9-8320-3a801ce1b08f.png)
![image](https://user-images.githubusercontent.com/6601142/139909348-e3943057-c929-4bfb-9df1-9d55e4bec67d.png)

Supersedes #2828
```Notice: This PR is a redo of https://github.com/JoinColony/colonyDapp/pull/2828  in order to fix the bad rebasing of master branch```

Resolves #2824 