### PR TITLE
Fixes funding link alignment

### DIFF
--- a/src/data/resolvers/events.ts
+++ b/src/data/resolvers/events.ts
@@ -1,4 +1,4 @@
-import { ClientType, ColonyClientV6, getLogs } from '@colony/colony-js';
+import { ClientType, ColonyClientV6 } from '@colony/colony-js';
 import { AddressZero } from 'ethers/constants';
 import { Resolvers } from '@apollo/client';
 
@@ -58,12 +58,10 @@ export const eventsResolvers = ({
         )) as ColonyClientV6;
 
         const colonyInRecoveryMode = await colonyClient.isInRecoveryMode();
+        const enterRecoveryEvents =
+          recoveryStartedEvents?.data?.recoveryAllEnteredEvents || [];
 
-        const enterRecoveryEvents = await getLogs(
-          colonyClient,
-          colonyClient.filters.RecoveryModeEntered(null),
-        );
-        const [mostRecentRecoveryStarted] = enterRecoveryEvents.reverse();
+        const [mostRecentRecoveryStarted] = [...enterRecoveryEvents].reverse();
 
         const recoveryApprovalsForCurrentSession = await apolloClient.query<
           RecoveryRolesAndApprovalsForSessionQuery,
@@ -91,6 +89,7 @@ export const eventsResolvers = ({
         const {
           recoveryRolesAndApprovalsForSession: approvalsForSession,
         } = recoveryApprovalsForCurrentSession.data;
+
         const currentUserNeedsToApprove = approvalsForSession.find(
           ({ id: userWalletAddress, approvedRecoveryExit }) =>
             !approvedRecoveryExit &&

--- a/src/modules/dashboard/components/ColonyTotalFunds/ColonyTotalFunds.css
+++ b/src/modules/dashboard/components/ColonyTotalFunds/ColonyTotalFunds.css
@@ -52,7 +52,7 @@
 
 .rightArrowDisplay {
   display: inline-block;
-  margin: -11px 3px 0 15px;
+  margin: -11px 3px -6px 15px;
   vertical-align: middle;
   font-size: var(--size-medium);
   font-weight: var(--weight-bold);

--- a/src/modules/dashboard/components/ColonyTotalFunds/ColonyTotalFunds.css
+++ b/src/modules/dashboard/components/ColonyTotalFunds/ColonyTotalFunds.css
@@ -52,11 +52,19 @@
 
 .rightArrowDisplay {
   display: inline-block;
-  margin: -11px 3px -6px 15px;
+  margin: -11px 3px -3px 15px;
   vertical-align: middle;
   font-size: var(--size-medium);
   font-weight: var(--weight-bold);
   color: var(--colony-blue);
+}
+
+@media only screen and (-webkit-min-device-pixel-ratio: 2),
+  only screen and (min-resolution: 192dpi),
+only screen and (min-resolution: 2dppx) {
+  .rightArrowDisplay {
+    margin: -11px 3px -6px 15px;
+  }
 }
 
 .caretIcon {

--- a/src/modules/dashboard/components/ColonyTotalFunds/ColonyTotalFunds.css
+++ b/src/modules/dashboard/components/ColonyTotalFunds/ColonyTotalFunds.css
@@ -36,10 +36,13 @@
 }
 
 .totalBalanceCopy {
+  display: flex;
+  align-items: center;
   margin-top: 12px;
   font-size: var(--size-small);
   font-weight: var(--weight-bold);
   color: var(--temp-grey-blue-7);
+  gap: 15px;
 }
 
 .totalBalanceCopy button {
@@ -51,20 +54,14 @@
 }
 
 .rightArrowDisplay {
-  display: inline-block;
-  margin: -11px 3px -3px 15px;
-  vertical-align: middle;
+  display: contents;
+
+  /* // margin: -11px 3px -3px 15px; */
+
+  /* vertical-align: middle; */
   font-size: var(--size-medium);
   font-weight: var(--weight-bold);
   color: var(--colony-blue);
-}
-
-@media only screen and (-webkit-min-device-pixel-ratio: 2),
-  only screen and (min-resolution: 192dpi),
-  only screen and (min-resolution: 2dppx) {
-  .rightArrowDisplay {
-    margin: -11px 3px -6px 15px;
-  }
 }
 
 .caretIcon {

--- a/src/modules/dashboard/components/ColonyTotalFunds/ColonyTotalFunds.css
+++ b/src/modules/dashboard/components/ColonyTotalFunds/ColonyTotalFunds.css
@@ -55,10 +55,6 @@
 
 .rightArrowDisplay {
   display: contents;
-
-  /* // margin: -11px 3px -3px 15px; */
-
-  /* vertical-align: middle; */
   font-size: var(--size-medium);
   font-weight: var(--weight-bold);
   color: var(--colony-blue);

--- a/src/modules/dashboard/components/ColonyTotalFunds/ColonyTotalFunds.css
+++ b/src/modules/dashboard/components/ColonyTotalFunds/ColonyTotalFunds.css
@@ -61,7 +61,7 @@
 
 @media only screen and (-webkit-min-device-pixel-ratio: 2),
   only screen and (min-resolution: 192dpi),
-only screen and (min-resolution: 2dppx) {
+  only screen and (min-resolution: 2dppx) {
   .rightArrowDisplay {
     margin: -11px 3px -6px 15px;
   }

--- a/src/modules/pages/components/WizardTemplateColony/WizardTemplateColony.css
+++ b/src/modules/pages/components/WizardTemplateColony/WizardTemplateColony.css
@@ -29,9 +29,7 @@
 }
 
 .address {
-  display: flex;
-  justify-content: space-between;
-  width: 185px;
+  composes: flexContainerRow flexAlignStart from '~styles/layout.css';
   position: relative;
   font-weight: var(--weight-bold);
 }
@@ -54,7 +52,7 @@
   height: 8px;
   width: 8px;
   position: relative;
-  top: 5px;
+  top: 6px;
   border-radius: 50%;
   background-color: var(--danger);
   content: '';
@@ -71,11 +69,10 @@
 }
 
 .hello {
-  margin-top: -3px;
   font-weight: var(--weight-normal);
+  line-height: 17px;
 }
 
 .copy {
-  margin-left: 40px;
-  position: absolute;
+  margin-left: 8px;
 }


### PR DESCRIPTION
## Description
- [x] Fix the alignment of the funding link

**New stuff** ✨
Added a gap: 15px to separate each button on itself Colony total balance / Manage funds

**Changes** 🏗
Moved from margin to flex based align-items: center; for alignment of items.
**Removed** 
Margin for the rightarrowicon

## TODO

- [ x]  Fixes the alignment of the funding link


## Screenshots **Updated**
![image](https://user-images.githubusercontent.com/6601142/140768617-2735f7d0-4909-47e6-99c1-0f48103cefa6.png)
![image](https://user-images.githubusercontent.com/6601142/140768715-8229b5d1-f0af-44f7-89fa-3df245598385.png)
![image](https://user-images.githubusercontent.com/6601142/140768787-e7d2acbf-8148-420d-9134-4a9edb9a478e.png)

Resolves #2814 
