### PR TITLE
Update actionThatNeedAtension resolver to not use logs

### DIFF
--- a/src/data/resolvers/events.ts
+++ b/src/data/resolvers/events.ts
@@ -1,4 +1,4 @@
-import { ClientType, ColonyClientV6, getLogs } from '@colony/colony-js';
+import { ClientType, ColonyClientV6 } from '@colony/colony-js';
 import { AddressZero } from 'ethers/constants';
 import { Resolvers } from '@apollo/client';
 
@@ -58,12 +58,10 @@ export const eventsResolvers = ({
         )) as ColonyClientV6;
 
         const colonyInRecoveryMode = await colonyClient.isInRecoveryMode();
+        const enterRecoveryEvents =
+          recoveryStartedEvents?.data?.recoveryAllEnteredEvents || [];
 
-        const enterRecoveryEvents = await getLogs(
-          colonyClient,
-          colonyClient.filters.RecoveryModeEntered(null),
-        );
-        const [mostRecentRecoveryStarted] = enterRecoveryEvents.reverse();
+        const [mostRecentRecoveryStarted] = [...enterRecoveryEvents].reverse();
 
         const recoveryApprovalsForCurrentSession = await apolloClient.query<
           RecoveryRolesAndApprovalsForSessionQuery,
@@ -91,6 +89,7 @@ export const eventsResolvers = ({
         const {
           recoveryRolesAndApprovalsForSession: approvalsForSession,
         } = recoveryApprovalsForCurrentSession.data;
+
         const currentUserNeedsToApprove = approvalsForSession.find(
           ({ id: userWalletAddress, approvedRecoveryExit }) =>
             !approvedRecoveryExit &&


### PR DESCRIPTION
## Description

This PR updates actionsThatNeedAttention resolver to use subgraph events

**Changes** 🏗

* Refactored actionsThatNeedAttention resolver

<img width="750" alt="Screenshot 2021-11-05 at 15 59 35" src="https://user-images.githubusercontent.com/13069555/140532026-4ceaa814-8d39-42f5-8b67-e55a2467171a.png">

Resolves #2796 
