### PR TITLE
Fix alignment of the wallet text in wizard

### DIFF
--- a/src/modules/pages/components/RouteLayouts/UserNavigation.css
+++ b/src/modules/pages/components/RouteLayouts/UserNavigation.css
@@ -115,7 +115,6 @@
   border: none;
   border-radius: var(--radius-normal);
   background-color: color-mod(var(--temp-grey-blue-7) alpha(10%));
-  line-height: 1;
   color: var(--temp-grey-blue-7);
   cursor: pointer;
 }

--- a/src/modules/pages/components/RouteLayouts/UserNavigation.css
+++ b/src/modules/pages/components/RouteLayouts/UserNavigation.css
@@ -99,20 +99,9 @@
 .walletAddress {
   margin: 0;
   padding: 0 9px;
-
-  /*
-   * @NOTE We need to do border sizing shenanigans due to how the border color
-   * is required by spec to have opacity.
-   *
-   * Otherwise, the two colors will overlap and it will lead to an unexpected border color.
-   *
-   * For this, we remove the border (and compensate the size with padding), while in the
-   * active class (the one that has a different colored border), we remove the extra padding
-   * and set the border
-   */
   height: 100%;
   position: relative;
-  border: none;
+  border: 1px solid transparent;
   border-radius: var(--radius-normal);
   background-color: color-mod(var(--temp-grey-blue-7) alpha(10%));
   color: var(--temp-grey-blue-7);
@@ -121,7 +110,7 @@
 
 .walletAddress > span {
   position: relative;
-  top: -0.5px;
+  line-height: 24px;
 }
 
 .walletAddress:hover {
@@ -131,7 +120,6 @@
 
 .walletAddressActive {
   composes: walletAddress;
-  padding: 1px 8px 2px;
   border: 1px solid var(--colony-blue);
   color: var(--colony-blue);
 }

--- a/src/modules/pages/components/RouteLayouts/UserNavigation.css
+++ b/src/modules/pages/components/RouteLayouts/UserNavigation.css
@@ -115,6 +115,7 @@
   border: none;
   border-radius: var(--radius-normal);
   background-color: color-mod(var(--temp-grey-blue-7) alpha(10%));
+  line-height: 1;
   color: var(--temp-grey-blue-7);
   cursor: pointer;
 }

--- a/src/modules/pages/components/RouteLayouts/UserNavigation.css
+++ b/src/modules/pages/components/RouteLayouts/UserNavigation.css
@@ -97,7 +97,7 @@
 }
 
 .walletAddress {
-  margin: 0 2px;
+  margin: 0;
   padding: 0 9px;
 
   /*
@@ -110,12 +110,12 @@
    * active class (the one that has a different colored border), we remove the extra padding
    * and set the border
    */
-  height: 22px;
+  height: 100%;
   position: relative;
-  top: -0.1px;
   border: none;
   border-radius: var(--radius-normal);
   background-color: color-mod(var(--temp-grey-blue-7) alpha(10%));
+  line-height: 1;
   color: var(--temp-grey-blue-7);
   cursor: pointer;
 }
@@ -139,6 +139,7 @@
 
 .buttonsWrapper {
   margin-right: 12px;
+  padding: 1px;
   height: 26px;
   position: relative;
   border-radius: var(--radius-normal);

--- a/src/modules/pages/components/RouteLayouts/UserNavigation.css
+++ b/src/modules/pages/components/RouteLayouts/UserNavigation.css
@@ -138,6 +138,10 @@
 }
 
 .buttonsWrapper {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
   margin-right: 12px;
   padding: 1px;
   height: 26px;

--- a/src/modules/pages/components/RouteLayouts/UserNavigation.tsx
+++ b/src/modules/pages/components/RouteLayouts/UserNavigation.tsx
@@ -149,9 +149,7 @@ const UserNavigation = () => {
           <MiniSpinnerLoader title={MSG.walletAutologin} />
         </div>
       ) : (
-        <div
-          className={styles.buttonsWrapper}
-        >
+        <div className={styles.buttonsWrapper}>
           {userCanNavigate && nativeToken && userLock && (
             <UserTokenActivationButton
               nativeToken={nativeToken}

--- a/src/modules/pages/components/RouteLayouts/UserNavigation.tsx
+++ b/src/modules/pages/components/RouteLayouts/UserNavigation.tsx
@@ -28,7 +28,6 @@ import { SUPPORTED_NETWORKS } from '~constants';
 import { groupedTransactionsAndMessages } from '../../../core/selectors';
 
 import styles from './UserNavigation.css';
-import stylesLayout from '../../../../styles/shared/layout.css';
 
 const MSG = defineMessages({
   inboxTitle: {
@@ -151,12 +150,7 @@ const UserNavigation = () => {
         </div>
       ) : (
         <div
-          className={`
-            ${styles.buttonsWrapper}
-            ${stylesLayout.flexContainerRow}
-            ${stylesLayout.flexJustifyCenter}
-            ${stylesLayout.flexAlignCenter}
-          `}
+          className={styles.buttonsWrapper}
         >
           {userCanNavigate && nativeToken && userLock && (
             <UserTokenActivationButton

--- a/src/modules/pages/components/RouteLayouts/UserNavigation.tsx
+++ b/src/modules/pages/components/RouteLayouts/UserNavigation.tsx
@@ -28,6 +28,7 @@ import { SUPPORTED_NETWORKS } from '~constants';
 import { groupedTransactionsAndMessages } from '../../../core/selectors';
 
 import styles from './UserNavigation.css';
+import stylesLayout from '../../../../styles/shared/layout.css';
 
 const MSG = defineMessages({
   inboxTitle: {
@@ -149,7 +150,14 @@ const UserNavigation = () => {
           <MiniSpinnerLoader title={MSG.walletAutologin} />
         </div>
       ) : (
-        <div className={styles.buttonsWrapper}>
+        <div
+          className={`
+            ${styles.buttonsWrapper}
+            ${stylesLayout.flexContainerRow}
+            ${stylesLayout.flexJustifyCenter}
+            ${stylesLayout.flexAlignCenter}
+          `}
+        >
           {userCanNavigate && nativeToken && userLock && (
             <UserTokenActivationButton
               nativeToken={nativeToken}

--- a/src/modules/pages/components/WizardTemplateColony/WizardTemplateColony.css
+++ b/src/modules/pages/components/WizardTemplateColony/WizardTemplateColony.css
@@ -74,5 +74,5 @@
 }
 
 .copy {
-  margin-left:8px;
+  margin-left: 8px;
 }

--- a/src/modules/pages/components/WizardTemplateColony/WizardTemplateColony.css
+++ b/src/modules/pages/components/WizardTemplateColony/WizardTemplateColony.css
@@ -29,9 +29,7 @@
 }
 
 .address {
-  display: flex;
-  justify-content: space-between;
-  width: 185px;
+  composes: flexContainerRow flexAlignStart from '~styles/layout.css';
   position: relative;
   font-weight: var(--weight-bold);
 }
@@ -54,7 +52,7 @@
   height: 8px;
   width: 8px;
   position: relative;
-  top: 5px;
+  top: 6px;
   border-radius: 50%;
   background-color: var(--danger);
   content: '';
@@ -71,11 +69,10 @@
 }
 
 .hello {
-  margin-top: -3px;
   font-weight: var(--weight-normal);
+  line-height: 17px;
 }
 
 .copy {
-  margin-left: 40px;
-  position: absolute;
+  margin-left:8px;
 }


### PR DESCRIPTION
## Description

Improve the alignment of the text in the wizard.

**Changes** 🏗

* Removed absolute positioning and utilised CSS Flexbox for improved alignment

![update-header-text-in-wizard](https://user-images.githubusercontent.com/33682027/140731724-e86a42a0-12ec-4983-b74a-e96c710efe4e.png)

Resolves #2836
