### PR TITLE
Fix alignment of the wallet text in wizard

### DIFF
--- a/src/modules/pages/components/WizardTemplateColony/WizardTemplateColony.css
+++ b/src/modules/pages/components/WizardTemplateColony/WizardTemplateColony.css
@@ -29,9 +29,7 @@
 }
 
 .address {
-  display: flex;
-  justify-content: space-between;
-  width: 185px;
+  composes: flexContainerRow flexAlignStart from '~styles/layout.css';
   position: relative;
   font-weight: var(--weight-bold);
 }
@@ -54,7 +52,7 @@
   height: 8px;
   width: 8px;
   position: relative;
-  top: 5px;
+  top: 6px;
   border-radius: 50%;
   background-color: var(--danger);
   content: '';
@@ -71,11 +69,10 @@
 }
 
 .hello {
-  margin-top: -3px;
   font-weight: var(--weight-normal);
+  line-height: 17px;
 }
 
 .copy {
-  margin-left: 40px;
-  position: absolute;
+  margin-left: 8px;
 }


### PR DESCRIPTION
## Description

Improve the alignment of the text in the wizard.

**Changes** 🏗

* Removed absolute positioning and utilised CSS Flexbox for improved alignment

![update-header-text-in-wizard](https://user-images.githubusercontent.com/33682027/140731724-e86a42a0-12ec-4983-b74a-e96c710efe4e.png)

Resolves #2836