### PR TITLE
Fix ETH to USD conversion

### DIFF
--- a/src/modules/core/components/EthUsd/EthUsd.tsx
+++ b/src/modules/core/components/EthUsd/EthUsd.tsx
@@ -17,7 +17,7 @@ const MSG = defineMessages({
 
 interface Appearance {
   theme: 'primary' | 'grey' | 'dark';
-  size: 'medium' | 'large' | 'small';
+  size?: 'medium' | 'large' | 'small';
 }
 
 interface Props extends NumeralProps {

--- a/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialogForm.css
+++ b/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialogForm.css
@@ -22,7 +22,6 @@
   font-size: 11px !important;
   font-weight: 700;
   text-align: right;
-  justify-self: right;
 }
 
 .domainPotBalance {

--- a/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialogForm.css
+++ b/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialogForm.css
@@ -9,7 +9,19 @@
   margin-left: 20px;
 }
 
+.tokenAmountContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-top: 20px;
+  gap: 20px;
+}
+
 .tokenAmountUsd {
+  width: 100%;
+  font-size: 11px !important;
+  font-weight: 700;
+  text-align: right;
   justify-self: right;
 }
 

--- a/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialogForm.css
+++ b/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialogForm.css
@@ -19,7 +19,7 @@
 
 .tokenAmountUsd {
   width: 100%;
-  font-size: 11px !important;
+  font-size: 11px;
   font-weight: 700;
   text-align: right;
 }

--- a/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialogForm.css.d.ts
+++ b/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialogForm.css.d.ts
@@ -1,6 +1,7 @@
 export const wideButton: string;
 export const tokenAmount: string;
 export const tokenAmountSelect: string;
+export const tokenAmountContainer: string;
 export const tokenAmountUsd: string;
 export const domainPotBalance: string;
 export const domainSelects: string;

--- a/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialogForm.tsx
+++ b/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialogForm.tsx
@@ -431,31 +431,33 @@ const CreatePaymentDialogForm = ({
               forcedFieldError={customAmountError}
             />
           </div>
-          <div className={styles.tokenAmountSelect}>
-            <TokenSymbolSelector
-              label={MSG.token}
-              tokens={tokens}
-              name="tokenAddress"
-              elementOnly
-              appearance={{ alignOptions: 'right', theme: 'grey' }}
-              disabled={inputDisabled}
-            />
-          </div>
-          {values.tokenAddress === AddressZero && (
-            <div className={styles.tokenAmountUsd}>
-              <EthUsd
-                appearance={{ theme: 'grey', size: 'small' }}
-                value={
-                  /*
-                   * @NOTE Set value to 0 if amount is only the decimal point
-                   * Just entering the decimal point will pass it through to EthUsd
-                   * and that will try to fetch the balance for, which, obviously, will fail
-                   */
-                  values.amount && values.amount !== '.' ? values.amount : '0'
-                }
+          <div className={styles.tokenAmountContainer}>
+            <div className={styles.tokenAmountSelect}>
+              <TokenSymbolSelector
+                label={MSG.token}
+                tokens={tokens}
+                name="tokenAddress"
+                elementOnly
+                appearance={{ alignOptions: 'right', theme: 'grey' }}
+                disabled={inputDisabled}
               />
             </div>
-          )}
+            {values.tokenAddress === AddressZero && (
+              <div className={styles.tokenAmountUsd}>
+                <EthUsd
+                  appearance={{ theme: 'grey' }}
+                  value={
+                    /*
+                     * @NOTE Set value to 0 if amount is only the decimal point
+                     * Just entering the decimal point will pass it through to EthUsd
+                     * and that will try to fetch the balance for, which, obviously, will fail
+                     */
+                    values.amount && values.amount !== '.' ? values.amount : '0'
+                  }
+                />
+              </div>
+            )}
+          </div>
         </div>
       </DialogSection>
       <DialogSection>

--- a/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialogForm.css
+++ b/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialogForm.css
@@ -24,7 +24,7 @@
 
 .tokenAmountUsd {
   width: 100%;
-  font-size: 11px !important;
+  font-size: 11px;
   font-weight: 700;
   text-align: right;
 }

--- a/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialogForm.css
+++ b/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialogForm.css
@@ -14,8 +14,19 @@
   margin-left: 20px;
 }
 
+.tokenAmountContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-top: 20px;
+  gap: 20px;
+}
+
 .tokenAmountUsd {
-  justify-self: right;
+  width: 100%;
+  font-size: 11px !important;
+  font-weight: 700;
+  text-align: right;
 }
 
 .domainPotBalance {

--- a/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialogForm.css.d.ts
+++ b/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialogForm.css.d.ts
@@ -2,6 +2,7 @@ export const wideButton: string;
 export const tokenAmount: string;
 export const amountContainer: string;
 export const tokenAmountSelect: string;
+export const tokenAmountContainer: string;
 export const tokenAmountUsd: string;
 export const domainPotBalance: string;
 export const domainSelects: string;

--- a/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialogForm.tsx
+++ b/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialogForm.tsx
@@ -370,31 +370,33 @@ const TransferFundsDialogForm = ({
               onChange={() => validateForm()}
             />
           </div>
-          <div className={styles.tokenAmountSelect}>
-            <TokenSymbolSelector
-              label={MSG.token}
-              tokens={tokens}
-              name="tokenAddress"
-              elementOnly
-              appearance={{ alignOptions: 'right', theme: 'grey' }}
-              disabled={inputDisabled}
-            />
-          </div>
-          {values.tokenAddress === AddressZero && (
-            <div className={styles.tokenAmountUsd}>
-              <EthUsd
-                appearance={{ theme: 'grey', size: 'small' }}
-                value={
-                  /*
-                   * @NOTE Set value to 0 if amount is only the decimal point
-                   * Just entering the decimal point will pass it through to EthUsd
-                   * and that will try to fetch the balance for, which, obviously, will fail
-                   */
-                  values.amount && values.amount !== '.' ? values.amount : '0'
-                }
+          <div className={styles.tokenAmountContainer}>
+            <div className={styles.tokenAmountSelect}>
+              <TokenSymbolSelector
+                label={MSG.token}
+                tokens={tokens}
+                name="tokenAddress"
+                elementOnly
+                appearance={{ alignOptions: 'right', theme: 'grey' }}
+                disabled={inputDisabled}
               />
             </div>
-          )}
+            {values.tokenAddress === AddressZero && (
+              <div className={styles.tokenAmountUsd}>
+                <EthUsd
+                  appearance={{ theme: 'grey' }}
+                  value={
+                    /*
+                     * @NOTE Set value to 0 if amount is only the decimal point
+                     * Just entering the decimal point will pass it through to EthUsd
+                     * and that will try to fetch the balance for, which, obviously, will fail
+                     */
+                    values.amount && values.amount !== '.' ? values.amount : '0'
+                  }
+                />
+              </div>
+            )}
+          </div>
         </div>
       </DialogSection>
       <DialogSection>


### PR DESCRIPTION
## Description
Fixes the position of the converted amount in usd to be at the bottom of the selector input.
And makes it use the same styling than available funds further up it.
**New stuff** ✨
Added a new container tokenAmountContainer css class.
Which we wrap-in with a div our current EthUsd and Select Input form in each dialog in both form tsx files

**Changes** 🏗
* EthUsd > Appearance > size? making size optional. so it respects the parents if not given in order to make it be 11px and not 12px.
* for both CreatePaymentDialogForm.css and TransferFundsDialogForm.css, add the font size and weight to tokenAmountUsd class.

**Deletions** ⚰️
* Size small Appearance props on EthUsd component in the dialog forms.


## Screenshots
![image](https://user-images.githubusercontent.com/6601142/140935019-febd535e-b9bd-4159-a485-a11018fc15a6.png)
![image](https://user-images.githubusercontent.com/6601142/140935126-0491bafe-7529-442d-a3ca-c971762a8b9d.png)


## TODO

- [x] Fix ETH to USD conversion placement in create payment dialog
- [x] Fix ETH to USD conversion placement in transfer funds dialog
- [x] It needs to also have the same font styles and colors than available funds too

Resolves #2813
