### PR TITLE
Fix aside element covering up other elements

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyHomeLayout.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHomeLayout.tsx
@@ -93,7 +93,7 @@ const ColonyHomeLayout = ({
           )}
           {children}
         </div>
-        {showSidebar ? (
+        {showSidebar && (
           <aside className={styles.rightAside}>
             <ColonyDomainDescription
               colony={colony}
@@ -103,8 +103,6 @@ const ColonyHomeLayout = ({
             <ColonyMembers colony={colony} currentDomainId={filteredDomainId} />
             <ColonyExtensions colony={colony} />
           </aside>
-        ) : (
-          <aside />
         )}
       </div>
       <ColonyUpgrade colony={colony} />


### PR DESCRIPTION
Removed empty aside element which appeared when the page displayed by `ColonyHomeLayout` didn't have a sidebar like the action list or event list did. With this change, the extension (extension list, details, setup, and enabling) and coin machine page should be affected.

From what I've tested, the removal of the `aside` doesn't negatively impact the UI of the pages that were using it and gets rid of the bug, but that could just be from my side of things.

We will find out if it's working as expected once you guys test it on your env :)

Resolves #2869 