### PR TITLE
Add ban wallet address dialog

### DIFF
--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css
@@ -16,9 +16,16 @@
 
 .rightAside {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: flex-start;
   padding: 200px 0 20px 50px;
   width: 26.5%;
+}
+
+.actionButtons {
+  margin-bottom: 10px;
+  margin-left: 30px;
+  width: fit-content;
 }
 
 .loadingWrapper {

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css
@@ -16,16 +16,8 @@
 
 .rightAside {
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
   padding: 200px 0 20px 50px;
   width: 26.5%;
-}
-
-.actionButtons {
-  margin-bottom: 10px;
-  margin-left: 30px;
-  width: fit-content;
 }
 
 .loadingWrapper {

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css.d.ts
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css.d.ts
@@ -2,5 +2,6 @@ export const main: string;
 export const mainContentGrid: string;
 export const mainContent: string;
 export const rightAside: string;
+export const actionButtons: string;
 export const loadingWrapper: string;
 export const controls: string;

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css.d.ts
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css.d.ts
@@ -2,6 +2,5 @@ export const main: string;
 export const mainContentGrid: string;
 export const mainContent: string;
 export const rightAside: string;
-export const actionButtons: string;
 export const loadingWrapper: string;
 export const controls: string;

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -10,6 +10,7 @@ import LoadingTemplate from '~pages/LoadingTemplate';
 import Members from '~dashboard/Members';
 import PermissionManagementDialog from '~dashboard/PermissionManagementDialog';
 import WrongNetworkDialog from '~dashboard/ColonyHome/WrongNetworkDialog';
+import ToggleBanningAddressDialog from '~dashboard/ToggleBanningAddressDialog';
 
 import {
   useColonyFromNameQuery,
@@ -18,10 +19,10 @@ import {
   useBannedUsersQuery,
   useLoggedInUser,
 } from '~data/index';
+import { useTransformer } from '~utils/hooks';
 import { useEnabledExtensions } from '~utils/hooks/useEnabledExtensions';
 import { NOT_FOUND_ROUTE } from '~routes/index';
 import { checkIfNetworkIsAllowed } from '~utils/networks';
-import { useTransformer } from '~utils/hooks';
 import { getAllUserRoles } from '../../../transformers';
 import { hasRoot, canAdminister } from '../../../users/checks';
 import { oneTxMustBeUpgraded } from '../../../dashboard/checks';
@@ -35,12 +36,12 @@ const MSG = defineMessages({
     id: 'dashboard.ColonyMembers.editPermissions',
     defaultMessage: 'Edit permissions',
   },
-  banUser: {
-    id: 'dashboard.ColonyMembers.banUser',
+  banAddress: {
+    id: 'dashboard.ColonyMembers.banAddress',
     defaultMessage: 'Ban address',
   },
-  unbanUser: {
-    id: 'dashboard.ColonyMembers.unbanUser',
+  unbanAddress: {
+    id: 'dashboard.ColonyMembers.unbanAddress',
     defaultMessage: 'Unban address',
   },
   loadingText: {
@@ -60,6 +61,7 @@ const ColonyMembers = () => {
   const hasRegisteredProfile = !!username && !ethereal;
 
   const openWrongNetworkDialog = useDialog(WrongNetworkDialog);
+  const openToggleBanningDialog = useDialog(ToggleBanningAddressDialog);
 
   const { colonyName } = useParams<{
     colonyName: string;
@@ -169,7 +171,6 @@ const ColonyMembers = () => {
           )}
         </div>
         <aside className={styles.rightAside}>
-          {}
           {!controlsDisabled && (
             <ul className={styles.controls}>
               <li>
@@ -188,21 +189,29 @@ const ColonyMembers = () => {
               </li>
               {canAdministerComments && (
                 <>
-                  {/*
-                   * @TODO Add proper modals
-                   */}
                   <li>
                     <Button
                       appearance={{ theme: 'blue' }}
-                      text={MSG.banUser}
-                      onClick={handlePermissionManagementDialog}
+                      text={MSG.banAddress}
+                      onClick={() =>
+                        openToggleBanningDialog({
+                          colonyAddress:
+                            colonyData?.processedColony?.colonyAddress,
+                        })
+                      }
                     />
                   </li>
                   <li>
                     <Button
                       appearance={{ theme: 'blue' }}
-                      text={MSG.unbanUser}
-                      onClick={handlePermissionManagementDialog}
+                      text={MSG.unbanAddress}
+                      onClick={() =>
+                        openToggleBanningDialog({
+                          isBanning: false,
+                          colonyAddress:
+                            colonyData?.processedColony?.colonyAddress,
+                        })
+                      }
                     />
                   </li>
                 </>

--- a/src/modules/dashboard/components/ToggleBanningAddressDialog/ToggleBanningAddressDialog.css
+++ b/src/modules/dashboard/components/ToggleBanningAddressDialog/ToggleBanningAddressDialog.css
@@ -1,0 +1,15 @@
+.userPickerContainer {
+  margin-top: 20px;
+  margin-left: 30px;
+}
+
+.divider {
+  margin-top: 50px;
+}
+
+.infoNote {
+  margin-bottom: 15px;
+  font-size: var(--size-tiny);
+  font-weight: var(--weight-bold);
+  color: var(--temp-grey-blue-7);
+}

--- a/src/modules/dashboard/components/ToggleBanningAddressDialog/ToggleBanningAddressDialog.css
+++ b/src/modules/dashboard/components/ToggleBanningAddressDialog/ToggleBanningAddressDialog.css
@@ -13,3 +13,8 @@
   font-weight: var(--weight-bold);
   color: var(--temp-grey-blue-7);
 }
+
+.footer button:first-of-type {
+  margin-right: 20px;
+  padding: 9px 0px;
+}

--- a/src/modules/dashboard/components/ToggleBanningAddressDialog/ToggleBanningAddressDialog.css.d.ts
+++ b/src/modules/dashboard/components/ToggleBanningAddressDialog/ToggleBanningAddressDialog.css.d.ts
@@ -1,0 +1,3 @@
+export const userPickerContainer: string;
+export const divider: string;
+export const infoNote: string;

--- a/src/modules/dashboard/components/ToggleBanningAddressDialog/ToggleBanningAddressDialog.css.d.ts
+++ b/src/modules/dashboard/components/ToggleBanningAddressDialog/ToggleBanningAddressDialog.css.d.ts
@@ -1,3 +1,4 @@
 export const userPickerContainer: string;
 export const divider: string;
 export const infoNote: string;
+export const footer: string;

--- a/src/modules/dashboard/components/ToggleBanningAddressDialog/ToggleBanningAddressDialog.tsx
+++ b/src/modules/dashboard/components/ToggleBanningAddressDialog/ToggleBanningAddressDialog.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import { FormikProps } from 'formik';
+import * as yup from 'yup';
+
+import Dialog, { DialogProps, DialogSection } from '~core/Dialog';
+import { Form } from '~core/Fields';
+import Heading from '~core/Heading';
+import { ItemDataType } from '~core/OmniPicker';
+import SingleUserPicker, { filterUserSelection } from '~core/SingleUserPicker';
+import HookedUserAvatar from '~users/HookedUserAvatar';
+
+import { useMembersSubscription, AnyUser } from '~data/index';
+import { Address } from '~types/index';
+
+import styles from './ToggleBanningAddressDialog.css';
+import Button from '~core/Button';
+
+const MSG = defineMessages({
+  title: {
+    id: 'dashboard.ToggleBanningAddressDialog.ToggleBanningAddressDialog.title',
+    defaultMessage: `{isBanning, select,
+    true {Ban}
+    false {Unban}
+    } a wallet address from chat`,
+  },
+  selectUser: {
+    id: `dashboard.ToggleBanningAddressDialog.ToggleBanningAddressDialog.selectUser`,
+    defaultMessage: 'Select user or paste wallet address',
+  },
+  infoNote: {
+    id: `dashboard.ToggleBanningAddressDialog.ToggleBanningAddressDialog.infoNote`,
+    defaultMessage: `Please note: this only prevents this user from chats in this colony. They will still be able to interact with any smart contracts they have permission to use.`,
+  },
+  banish: {
+    id: `dashboard.ToggleBanningAddressDialog.ToggleBanningAddressDialog.banish`,
+    defaultMessage: 'Banish them',
+  },
+  deactivateBan: {
+    id: `dashboard.ToggleBanningAddressDialog.ToggleBanningAddressDialog.deactivateBan`,
+    defaultMessage: 'Deactivate ban',
+  },
+  lastChance: {
+    id: `dashboard.ToggleBanningAddressDialog.ToggleBanningAddressDialog.lastChance`,
+    defaultMessage: 'Let’s give them one last chance...',
+  },
+  damnedSouls: {
+    id: `dashboard.ToggleBanningAddressDialog.ToggleBanningAddressDialog.damnedSouls`,
+    defaultMessage: 'Leave it on the list of damned souls',
+  },
+});
+
+export interface FormValues {
+  userAddress: Address;
+}
+
+const displayName = 'dashboard.ToggleBanningAddressDialog';
+
+interface Props extends DialogProps {
+  colonyAddress: Address;
+  isBanning?: boolean;
+}
+
+const UserAvatar = HookedUserAvatar({ fetchUser: false });
+
+const supRenderAvatar = (address: Address, item: ItemDataType<AnyUser>) => (
+  <UserAvatar address={address} user={item} size="xs" notSet={false} />
+);
+
+const validationSchema = yup.object().shape({
+  userAddress: yup.object().shape({
+    profile: yup.object().shape({
+      walletAddress: yup.string().address().required(),
+    }),
+  }),
+});
+
+const ToggleBanningAddressDialog = ({
+  colonyAddress,
+  cancel,
+  close,
+  isBanning = true,
+}: Props) => {
+  const { data: colonyMembers } = useMembersSubscription({
+    variables: { colonyAddress },
+  });
+
+  return (
+    <Form
+      initialValues={{ userAddress: '' }}
+      validationSchema={validationSchema}
+      validateOnMount
+      /* temporary to avoid ts error */
+      onSubmit={close}
+    >
+      {({ isValid }: FormikProps<FormValues>) => (
+        <Dialog cancel={cancel}>
+          <DialogSection>
+            <Heading
+              appearance={{ size: 'medium', margin: 'none', theme: 'dark' }}
+              text={MSG.title}
+              textValues={{ isBanning }}
+            />
+          </DialogSection>
+          <DialogSection>
+            <div className={styles.userPickerContainer}>
+              <SingleUserPicker
+                appearance={{ width: 'wide' }}
+                data={colonyMembers?.subscribedUsers || []}
+                label={MSG.selectUser}
+                name="userAddress"
+                filter={filterUserSelection}
+                renderAvatar={supRenderAvatar}
+              />
+            </div>
+          </DialogSection>
+          <DialogSection>
+            <hr className={styles.divider} />
+            <div className={styles.infoNote}>
+              <FormattedMessage {...MSG.infoNote} />
+            </div>
+          </DialogSection>
+          <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
+            <Button
+              appearance={{ theme: 'secondary' }}
+              text={isBanning ? MSG.lastChance : MSG.damnedSouls}
+              style={{ fontWeight: 'bold' }}
+              onClick={close}
+            />
+            <Button
+              appearance={{
+                theme: isBanning ? 'pink' : 'primary',
+                size: 'large',
+              }}
+              text={isBanning ? MSG.banish : MSG.deactivateBan}
+              disabled={!isValid}
+            />
+          </DialogSection>
+        </Dialog>
+      )}
+    </Form>
+  );
+};
+
+ToggleBanningAddressDialog.displayName = displayName;
+
+export default ToggleBanningAddressDialog;

--- a/src/modules/dashboard/components/ToggleBanningAddressDialog/ToggleBanningAddressDialog.tsx
+++ b/src/modules/dashboard/components/ToggleBanningAddressDialog/ToggleBanningAddressDialog.tsx
@@ -18,34 +18,34 @@ import Button from '~core/Button';
 
 const MSG = defineMessages({
   title: {
-    id: 'dashboard.ToggleBanningAddressDialog.ToggleBanningAddressDialog.title',
+    id: 'dashboard.ToggleBanningAddressDialog.title',
     defaultMessage: `{isBanning, select,
     true {Ban}
     false {Unban}
     } a wallet address from chat`,
   },
   selectUser: {
-    id: `dashboard.ToggleBanningAddressDialog.ToggleBanningAddressDialog.selectUser`,
+    id: 'dashboard.ToggleBanningAddressDialog.selectUser',
     defaultMessage: 'Select user or paste wallet address',
   },
   infoNote: {
-    id: `dashboard.ToggleBanningAddressDialog.ToggleBanningAddressDialog.infoNote`,
-    defaultMessage: `Please note: this only prevents this user from chats in this colony. They will still be able to interact with any smart contracts they have permission to use.`,
+    id: 'dashboard.ToggleBanningAddressDialog.infoNote',
+    defaultMessage: `Please note: this only prevents the user from chatting in this colony. They will still be able to interact with any smart contracts they have permission to use.`,
   },
   banish: {
-    id: `dashboard.ToggleBanningAddressDialog.ToggleBanningAddressDialog.banish`,
+    id: 'dashboard.ToggleBanningAddressDialog.banish',
     defaultMessage: 'Banish them',
   },
   deactivateBan: {
-    id: `dashboard.ToggleBanningAddressDialog.ToggleBanningAddressDialog.deactivateBan`,
+    id: 'dashboard.ToggleBanningAddressDialog.deactivateBan',
     defaultMessage: 'Deactivate ban',
   },
   lastChance: {
-    id: `dashboard.ToggleBanningAddressDialog.ToggleBanningAddressDialog.lastChance`,
+    id: `dashboard.ToggleBanningAddressDialog.lastChance`,
     defaultMessage: 'Let’s give them one last chance...',
   },
   damnedSouls: {
-    id: `dashboard.ToggleBanningAddressDialog.ToggleBanningAddressDialog.damnedSouls`,
+    id: 'dashboard.ToggleBanningAddressDialog.damnedSouls',
     defaultMessage: 'Leave it on the list of damned souls',
   },
 });
@@ -121,20 +121,21 @@ const ToggleBanningAddressDialog = ({
             </div>
           </DialogSection>
           <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
-            <Button
-              appearance={{ theme: 'secondary' }}
-              text={isBanning ? MSG.lastChance : MSG.damnedSouls}
-              style={{ fontWeight: 'bold' }}
-              onClick={close}
-            />
-            <Button
-              appearance={{
-                theme: isBanning ? 'pink' : 'primary',
-                size: 'large',
-              }}
-              text={isBanning ? MSG.banish : MSG.deactivateBan}
-              disabled={!isValid}
-            />
+            <div className={styles.footer}>
+              <Button
+                appearance={{ theme: 'secondary', size: 'large' }}
+                text={isBanning ? MSG.lastChance : MSG.damnedSouls}
+                onClick={close}
+              />
+              <Button
+                appearance={{
+                  theme: isBanning ? 'pink' : 'primary',
+                  size: 'large',
+                }}
+                text={isBanning ? MSG.banish : MSG.deactivateBan}
+                disabled={!isValid}
+              />
+            </div>
           </DialogSection>
         </Dialog>
       )}

--- a/src/modules/dashboard/components/ToggleBanningAddressDialog/index.ts
+++ b/src/modules/dashboard/components/ToggleBanningAddressDialog/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ToggleBanningAddressDialog';

--- a/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialog.tsx
+++ b/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialog.tsx
@@ -24,7 +24,7 @@ const MSG = defineMessages({
     defaultMessage: 'Amount must be greater than zero',
   },
   noBalance: {
-    id: 'dashboard.CreatePaymentDialog.TransferFundsDialog.noBalance',
+    id: 'dashboard.TransferFundsDialog.noBalance',
     defaultMessage: 'Insufficient balance in from domain pot',
   },
 });


### PR DESCRIPTION
## Description

This PR adds buttons & a dialog to ban/unban users - from the Members page.

**New stuff** ✨

- add `ToggleBanningAddressDialog`
- add buttons to `ColonyMembers`

**Changes** 🏗

- update `ColonyMembers` with permissions around new buttons

resolves #2854  
<img width="1002" alt="Screenshot 2021-11-11 at 19 00 01" src="https://user-images.githubusercontent.com/34057551/141346625-e3a34954-e844-45e9-801e-ee0d5d7f2644.png">


<img width="592" alt="Screenshot 2021-11-11 at 19 00 23" src="https://user-images.githubusercontent.com/34057551/141346669-66004a75-17e3-4085-87fa-788b365d0924.png">

