### PR TITLE
Fix permission label not being centered

### DIFF
--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.css
@@ -30,8 +30,11 @@
 
 .value i {
   display: inline-block;
-  margin: -3px 6px 0 0;
-  vertical-align: middle;
+}
+
+.text {
+  display: inline-block;
+  margin-left: 8px;
 }
 
 .transactionHashLink {

--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.css.d.ts
@@ -2,6 +2,7 @@ export const item: string;
 export const value: string;
 export const label: string;
 export const descriptionValue: string;
+export const text: string;
 export const transactionHashLink: string;
 export const domainDescriptionItem: string;
 export const domainDescription: string;

--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.tsx
@@ -117,16 +117,18 @@ const DetailsWidget = ({
             appearance={{ size: 'small' }}
             name={ACTION_TYPES_ICONS_MAP[actionType]}
           />
-          <FormattedMessage
-            id={messageId}
-            /*
-             * @NOTE We need to use the action type value that was converted to
-             * camelCase since ReactIntl doesn't like keys that are composed
-             * of two separate strings (apparently you can't pass it just a plain
-             * string with spaces...)
-             */
-            values={{ actionType: values?.actionType }}
-          />
+          <div className={styles.text}>
+            <FormattedMessage
+              id={messageId}
+              /*
+               * @NOTE We need to use the action type value that was converted to
+               * camelCase since ReactIntl doesn't like keys that are composed
+               * of two separate strings (apparently you can't pass it just a plain
+               * string with spaces...)
+               */
+              values={{ actionType: values?.actionType }}
+            />
+          </div>
         </div>
       </div>
       {values?.motionDomain && (


### PR DESCRIPTION
## Description

This pr fixes permission labels not being properly centered (on motion page)

**Changes** 🏗

* Updated Details Widget

<img width="426" alt="Screenshot 2021-11-12 at 14 23 46" src="https://user-images.githubusercontent.com/13069555/141479838-212f4ce3-7542-438a-9d52-56b475d2386f.png">

Resolves #2876 
