### PR TITLE
Add fetch policy - network only to colony funding

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.tsx
@@ -56,6 +56,7 @@ const ColonyFunding = ({ colony, currentDomainId }: Props) => {
       domainIds: [currentDomainId],
       tokenAddresses: colonyTokens.map(({ address }) => address),
     },
+    fetchPolicy: 'network-only',
   });
 
   return (


### PR DESCRIPTION
## Description

This PR fixes not correctly updated colony funds for sub teams

**Changes** 🏗

* Updated fetch-policy to netowrk-only in ColonyFunding component

**How to test** 🏗
1. Create new team
2. Send tokens to the team
3. Create payment from this sub team
4. Check if value in colony funding is correctly updated

<img width="214" alt="Screenshot 2021-11-15 at 11 56 00" src="https://user-images.githubusercontent.com/13069555/141769964-a36a7c41-a923-461d-b314-a7e56fa22519.png">

Resolves  #2880 
