### PR TITLE
Add total sold vs available widget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "react-router-dom": "^5.1.2",
         "react-tabs": "^3.1.0",
         "react-textarea-autosize": "^8.3.3",
+        "react-textfit": "^1.1.1",
         "recompose": "^0.30.0",
         "redux": "^4.0.1",
         "redux-immutable": "^4.0.0",
@@ -49242,6 +49243,27 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/react-textfit": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/react-textfit/-/react-textfit-1.1.1.tgz",
+      "integrity": "sha512-UDSQRo5yBEGueLTE5SgNV9fSmr5CWJkE0E0R0YbcbCO69iuJGfcT6wspKhX2sIwdsDyT9qXOwMC80cnRolir7Q==",
+      "dependencies": {
+        "process": "^0.11.10",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/react-textfit/node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -98098,6 +98120,22 @@
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
+        }
+      }
+    },
+    "react-textfit": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/react-textfit/-/react-textfit-1.1.1.tgz",
+      "integrity": "sha512-UDSQRo5yBEGueLTE5SgNV9fSmr5CWJkE0E0R0YbcbCO69iuJGfcT6wspKhX2sIwdsDyT9qXOwMC80cnRolir7Q==",
+      "requires": {
+        "process": "^0.11.10",
+        "prop-types": "^15.7.2"
+      },
+      "dependencies": {
+        "process": {
+          "version": "0.11.10",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+          "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -193,6 +193,7 @@
     "react-router-dom": "^5.1.2",
     "react-tabs": "^3.1.0",
     "react-textarea-autosize": "^8.3.3",
+    "react-textfit": "^1.1.1",
     "recompose": "^0.30.0",
     "redux": "^4.0.1",
     "redux-immutable": "^4.0.0",

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -238,6 +238,7 @@ export type Query = {
   coinMachineSalePeriods: SalePeriod;
   coinMachineSaleTokens: SaleTokens;
   coinMachineTokenBalance: Scalars['String'];
+  coinMachineTotalTokens: TotalTokens;
   coinMachineTransactionAmount: TrannsactionAmount;
   colonies: Array<SubgraphColony>;
   colony: SubgraphColony;
@@ -359,6 +360,11 @@ export type QueryCoinMachineSaleTokensArgs = {
 
 
 export type QueryCoinMachineTokenBalanceArgs = {
+  colonyAddress: Scalars['String'];
+};
+
+
+export type QueryCoinMachineTotalTokensArgs = {
   colonyAddress: Scalars['String'];
 };
 
@@ -1291,6 +1297,11 @@ export type SalePeriod = {
   price: Scalars['String'];
 };
 
+export type TotalTokens = {
+  totalAvailableTokens: Scalars['String'];
+  totalSoldTokens: Scalars['String'];
+};
+
 export type ColonyExtension = {
   address: Scalars['String'];
   id: Scalars['String'];
@@ -2186,6 +2197,13 @@ export type CoinMachineTokenBalanceQueryVariables = Exact<{
 
 
 export type CoinMachineTokenBalanceQuery = Pick<Query, 'coinMachineTokenBalance'>;
+
+export type CoinMachineTotalTokensQueryVariables = Exact<{
+  colonyAddress: Scalars['String'];
+}>;
+
+
+export type CoinMachineTotalTokensQuery = { coinMachineTotalTokens: Pick<TotalTokens, 'totalAvailableTokens' | 'totalSoldTokens'> };
 
 export type CoinMachineHasWhitelistQueryVariables = Exact<{
   colonyAddress: Scalars['String'];
@@ -6067,6 +6085,40 @@ export function useCoinMachineTokenBalanceLazyQuery(baseOptions?: Apollo.LazyQue
 export type CoinMachineTokenBalanceQueryHookResult = ReturnType<typeof useCoinMachineTokenBalanceQuery>;
 export type CoinMachineTokenBalanceLazyQueryHookResult = ReturnType<typeof useCoinMachineTokenBalanceLazyQuery>;
 export type CoinMachineTokenBalanceQueryResult = Apollo.QueryResult<CoinMachineTokenBalanceQuery, CoinMachineTokenBalanceQueryVariables>;
+export const CoinMachineTotalTokensDocument = gql`
+    query CoinMachineTotalTokens($colonyAddress: String!) {
+  coinMachineTotalTokens(colonyAddress: $colonyAddress) @client {
+    totalAvailableTokens
+    totalSoldTokens
+  }
+}
+    `;
+
+/**
+ * __useCoinMachineTotalTokensQuery__
+ *
+ * To run a query within a React component, call `useCoinMachineTotalTokensQuery` and pass it any options that fit your needs.
+ * When your component renders, `useCoinMachineTotalTokensQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useCoinMachineTotalTokensQuery({
+ *   variables: {
+ *      colonyAddress: // value for 'colonyAddress'
+ *   },
+ * });
+ */
+export function useCoinMachineTotalTokensQuery(baseOptions?: Apollo.QueryHookOptions<CoinMachineTotalTokensQuery, CoinMachineTotalTokensQueryVariables>) {
+        return Apollo.useQuery<CoinMachineTotalTokensQuery, CoinMachineTotalTokensQueryVariables>(CoinMachineTotalTokensDocument, baseOptions);
+      }
+export function useCoinMachineTotalTokensLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CoinMachineTotalTokensQuery, CoinMachineTotalTokensQueryVariables>) {
+          return Apollo.useLazyQuery<CoinMachineTotalTokensQuery, CoinMachineTotalTokensQueryVariables>(CoinMachineTotalTokensDocument, baseOptions);
+        }
+export type CoinMachineTotalTokensQueryHookResult = ReturnType<typeof useCoinMachineTotalTokensQuery>;
+export type CoinMachineTotalTokensLazyQueryHookResult = ReturnType<typeof useCoinMachineTotalTokensLazyQuery>;
+export type CoinMachineTotalTokensQueryResult = Apollo.QueryResult<CoinMachineTotalTokensQuery, CoinMachineTotalTokensQueryVariables>;
 export const CoinMachineHasWhitelistDocument = gql`
     query CoinMachineHasWhitelist($colonyAddress: String!) {
   coinMachineHasWhitelist(colonyAddress: $colonyAddress) @client

--- a/src/data/graphql/queries/coinMachine.graphql
+++ b/src/data/graphql/queries/coinMachine.graphql
@@ -60,6 +60,13 @@ query CoinMachineTokenBalance($colonyAddress: String!) {
   coinMachineTokenBalance(colonyAddress: $colonyAddress) @client
 }
 
+query CoinMachineTotalTokens($colonyAddress: String!) {
+  coinMachineTotalTokens(colonyAddress: $colonyAddress) @client {
+    totalAvailableTokens
+    totalSoldTokens
+  }
+}
+
 query CoinMachineHasWhitelist($colonyAddress: String!) {
   coinMachineHasWhitelist(colonyAddress: $colonyAddress) @client
 }

--- a/src/data/graphql/typeDefs/coinMachine.ts
+++ b/src/data/graphql/typeDefs/coinMachine.ts
@@ -44,6 +44,11 @@ export default gql`
     colonyAddress: String!
   }
 
+  type TotalTokens {
+    totalAvailableTokens: String!
+    totalSoldTokens: String!
+  }
+
   extend type Query {
     coinMachineSaleTokens(colonyAddress: String!): SaleTokens!
     coinMachineCurrentPeriodPrice(colonyAddress: String!): String!
@@ -62,6 +67,7 @@ export default gql`
     coinMachineCurrentSalePeriod(colonyAddress: String!): CurrentSalePeriod!
     currentPeriodTokens(colonyAddress: String!): CurrentPeriodTokens!
     coinMachineTokenBalance(colonyAddress: String!): String!
+    coinMachineTotalTokens(colonyAddress: String!): TotalTokens!
     coinMachinePeriods(
       skip: Int!
       first: Int!

--- a/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
+++ b/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
@@ -201,7 +201,7 @@ const BuyTokens = ({
   const getFormattedCost = useCallback(
     (amount) => {
       const decimalCost = new Decimal(amount)
-        .times(salePriceData.coinMachineCurrentPeriodPrice)
+        .times(salePriceData?.coinMachineCurrentPeriodPrice || '0')
         .toFixed(0, Decimal.ROUND_HALF_UP);
 
       return getFormattedTokenValue(

--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.css
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.css
@@ -24,7 +24,7 @@
   min-height: 600px;
   width: 1030px;
   grid-template-columns: [buy] 340px [remaining] 220px [comments] auto;
-  grid-template-rows: [time] 180px [tokens] 180px [sales] 315px;
+  grid-template-rows: [time] 113px [tokens] 113px [totals] 113px [sales] 315px;
   column-gap: 20px;
   row-gap: 20px;
 }
@@ -55,7 +55,14 @@
   composes: container;
   padding: 0;
   grid-column: remaining / comments;
-  grid-row: tokens / sales;
+  grid-row: tokens / totals;
+}
+
+.tokensTotals {
+  composes: container;
+  padding: 0;
+  grid-column: remaining / comments;
+  grid-row: totals / sales;
 }
 
 .sales {

--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.css.d.ts
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.css.d.ts
@@ -6,6 +6,7 @@ export const container: string;
 export const buy: string;
 export const timeRemaining: string;
 export const tokensRemaining: string;
+export const tokensTotals: string;
 export const sales: string;
 export const comments: string;
 export const saleStarted: string;

--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -346,6 +346,7 @@ const CoinMachine = ({
             }}
             sellableToken={sellableToken}
             purchaseToken={purchaseToken}
+            periodTokens={periodTokens}
           />
         </div>
         <div className={styles.comments}>

--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -295,7 +295,13 @@ const CoinMachine = ({
               />
             </div>
             <div className={styles.tokensRemaining}>
-              <RemainingTokens periodTokens={periodTokens} />
+              <RemainingTokens
+                periodTokens={periodTokens}
+                isTotalSale={false}
+              />
+            </div>
+            <div className={styles.tokensTotals}>
+              <RemainingTokens periodTokens={periodTokens} isTotalSale />
             </div>
           </>
         )}

--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -168,10 +168,17 @@ const CoinMachine = ({
     if (!saleTokensData || !periodTokensData || !hasSaleStarted) {
       return undefined;
     }
+    const maxPerPeriodTokens = bigNumberify(maxPerPeriod);
+    const leftAvailableTokens = bigNumberify(
+      coinMachineTokenBalanceData?.coinMachineTokenBalance || '0',
+    );
+
     return {
       decimals: saleTokensData.coinMachineSaleTokens.sellableToken.decimals,
       soldPeriodTokens: bigNumberify(activeSold),
-      maxPeriodTokens: bigNumberify(maxPerPeriod),
+      maxPeriodTokens: maxPerPeriodTokens.gt(leftAvailableTokens)
+        ? leftAvailableTokens
+        : bigNumberify(maxPerPeriod),
       targetPeriodTokens: bigNumberify(targetPerPeriod),
     };
   }, [
@@ -181,6 +188,7 @@ const CoinMachine = ({
     activeSold,
     maxPerPeriod,
     targetPerPeriod,
+    coinMachineTokenBalanceData,
   ]);
 
   const totalTokens = useMemo(() => {

--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingDisplayWidget.css
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingDisplayWidget.css
@@ -1,7 +1,7 @@
 .main {
   display: flex;
   flex-direction: column;
-  padding: 15px;
+  padding: 10px 15px;
   height: 100%;
   border-radius: var(--radius-large);
 }
@@ -48,26 +48,13 @@
   color: var(--danger);
 }
 
-.footer {
-  display: flex;
-  align-items: center;
-  height: 20px;
-}
-
-.footerText {
-  margin-right: 8px;
-  font-size: var(--size-smallish);
-  font-weight: var(--weight-bold);
-  color: var(--temp-grey-blue-7);
-}
-
 .themeDanger .footerText {
   color: var(--colony-white);
 }
 
 .tooltipIcon {
   position: relative;
-  top: -5px;
+  top: 2px;
   right: -5px;
 }
 

--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingDisplayWidget.css
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingDisplayWidget.css
@@ -33,7 +33,12 @@
   height: 100%;
   font-size: var(--size-medium-l);
   font-weight: var(--weight-bold);
+  text-align: center;
   color: var(--temp-grey-blue-7);
+}
+
+.value div {
+  width: 190px;
 }
 
 .themeDanger .main {

--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingDisplayWidget.css
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingDisplayWidget.css
@@ -41,6 +41,10 @@
   width: 190px;
 }
 
+.value span {
+  font-size: unset;
+}
+
 .themeDanger .main {
   color: var(--colony-white);
 }

--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingDisplayWidget.css.d.ts
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingDisplayWidget.css.d.ts
@@ -4,7 +4,6 @@ export const themeDanger: string;
 export const header: string;
 export const value: string;
 export const valueWarning: string;
-export const footer: string;
 export const footerText: string;
 export const tooltipIcon: string;
 export const tooltip: string;

--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingDisplayWidget.tsx
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingDisplayWidget.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { FormattedMessage, MessageDescriptor } from 'react-intl';
+import { MessageDescriptor } from 'react-intl';
 import classnames from 'classnames';
 
 import Heading from '~core/Heading';
@@ -7,10 +7,6 @@ import QuestionMarkTooltip from '~core/QuestionMarkTooltip';
 
 import { getMainClasses } from '~utils/css';
 import { ComplexMessageValues } from '~types/index';
-
-import TokenPriceStatusIcon, {
-  TokenPriceStatuses,
-} from '../TokenPriceStatusIcon';
 
 import styles from './RemainingDisplayWidget.css';
 
@@ -31,7 +27,7 @@ type Props = {
   widgetText: WidgetText;
   isWarning: boolean;
   displayedValue: string | ReactElement;
-  priceStatus?: TokenPriceStatuses;
+  isTotalSale?: boolean;
 };
 
 const displayName = 'dashboard.CoinMachine.RemainingDisplayWidget';
@@ -41,13 +37,14 @@ const RemainingDisplayWidget = ({
   appearance = { theme: 'white' },
   isWarning,
   displayedValue,
-  priceStatus,
+  isTotalSale,
 }: Props) => {
   return (
     <div className={getMainClasses(appearance, styles)}>
       <div className={styles.header}>
         <Heading
           text={widgetText.title}
+          textValues={{ isTotalSale }}
           appearance={{
             size: 'small',
             theme: appearance.theme === 'danger' ? 'invert' : 'dark',
@@ -58,6 +55,7 @@ const RemainingDisplayWidget = ({
           tooltipText={widgetText.tooltipText}
           invertedIcon={appearance.theme === 'danger'}
           tooltipClassName={styles.tooltip}
+          tooltipTextValues={{ isTotalSale }}
         />
       </div>
       <div
@@ -67,14 +65,14 @@ const RemainingDisplayWidget = ({
       >
         {displayedValue}
       </div>
-      {widgetText.footerText && (
+      {/* {widgetText.footerText && (
         <div className={styles.footer}>
           <p className={styles.footerText}>
             <FormattedMessage {...widgetText.footerText} />
           </p>
           {priceStatus && <TokenPriceStatusIcon status={priceStatus} />}
         </div>
-      )}
+      )} */}
     </div>
   );
 };

--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingDisplayWidget.tsx
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingDisplayWidget.tsx
@@ -65,14 +65,6 @@ const RemainingDisplayWidget = ({
       >
         {displayedValue}
       </div>
-      {/* {widgetText.footerText && (
-        <div className={styles.footer}>
-          <p className={styles.footerText}>
-            <FormattedMessage {...widgetText.footerText} />
-          </p>
-          {priceStatus && <TokenPriceStatusIcon status={priceStatus} />}
-        </div>
-      )} */}
     </div>
   );
 };

--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingDisplayWidget.tsx
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingDisplayWidget.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { MessageDescriptor } from 'react-intl';
 import classnames from 'classnames';
+import { Textfit } from 'react-textfit';
 
 import Heading from '~core/Heading';
 import QuestionMarkTooltip from '~core/QuestionMarkTooltip';
@@ -28,6 +29,7 @@ type Props = {
   isWarning: boolean;
   displayedValue: string | ReactElement;
   isTotalSale?: boolean;
+  isTokens?: boolean;
 };
 
 const displayName = 'dashboard.CoinMachine.RemainingDisplayWidget';
@@ -38,6 +40,7 @@ const RemainingDisplayWidget = ({
   isWarning,
   displayedValue,
   isTotalSale,
+  isTokens = false,
 }: Props) => {
   return (
     <div className={getMainClasses(appearance, styles)}>
@@ -63,7 +66,14 @@ const RemainingDisplayWidget = ({
           [styles.valueWarning]: isWarning,
         })}
       >
-        {displayedValue}
+        {/* This is to avoid unnecessary calculaitons from Textfit for the timer */}
+        {isTokens ? (
+          <Textfit min={10} max={18} perfectFit={false} mode="single">
+            {displayedValue}
+          </Textfit>
+        ) : (
+          displayedValue
+        )}
       </div>
     </div>
   );

--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingDisplayWidget.tsx
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingDisplayWidget.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement } from 'react';
 import { MessageDescriptor } from 'react-intl';
 import classnames from 'classnames';
-import { Textfit } from 'react-textfit';
 
 import Heading from '~core/Heading';
 import QuestionMarkTooltip from '~core/QuestionMarkTooltip';
@@ -29,7 +28,6 @@ type Props = {
   isWarning: boolean;
   displayedValue: string | ReactElement;
   isTotalSale?: boolean;
-  isTokens?: boolean;
 };
 
 const displayName = 'dashboard.CoinMachine.RemainingDisplayWidget';
@@ -40,7 +38,6 @@ const RemainingDisplayWidget = ({
   isWarning,
   displayedValue,
   isTotalSale,
-  isTokens = false,
 }: Props) => {
   return (
     <div className={getMainClasses(appearance, styles)}>
@@ -66,14 +63,7 @@ const RemainingDisplayWidget = ({
           [styles.valueWarning]: isWarning,
         })}
       >
-        {/* This is to avoid unnecessary calculaitons from Textfit for the timer */}
-        {isTokens ? (
-          <Textfit min={10} max={18} mode="single">
-            {displayedValue}
-          </Textfit>
-        ) : (
-          displayedValue
-        )}
+        {displayedValue}
       </div>
     </div>
   );

--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingDisplayWidget.tsx
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingDisplayWidget.tsx
@@ -68,7 +68,7 @@ const RemainingDisplayWidget = ({
       >
         {/* This is to avoid unnecessary calculaitons from Textfit for the timer */}
         {isTokens ? (
-          <Textfit min={10} max={18} perfectFit={false} mode="single">
+          <Textfit min={10} max={18} mode="single">
             {displayedValue}
           </Textfit>
         ) : (

--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTokens.tsx
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTokens.tsx
@@ -94,6 +94,7 @@ const RemainingTokens = ({
       isWarning={showValueWarning}
       displayedValue={displayedValue}
       isTotalSale={isTotalSale}
+      isTokens
     />
   );
 };

--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTokens.tsx
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTokens.tsx
@@ -2,8 +2,6 @@ import React, { useMemo } from 'react';
 import { FormattedMessage, defineMessages } from 'react-intl';
 import { BigNumber } from 'ethers/utils';
 
-import { getPriceStatus } from '../utils';
-
 import RemainingTokensValue from './RemainingTokensValue';
 import RemainingWidget from './RemainingDisplayWidget';
 
@@ -19,6 +17,7 @@ export interface PeriodTokensType {
 }
 
 interface Props {
+  isTotalSale: boolean;
   appearance?: Appearance;
   periodTokens?: PeriodTokensType;
 }
@@ -29,19 +28,21 @@ const displayName =
 const MSG = defineMessages({
   tokensRemainingTitle: {
     id: 'dashboard.CoinMachine.RemainingDisplayWidgets.RemainingTokens.title',
-    defaultMessage: 'Tokens remaining',
+    defaultMessage: `{isTotalSale, select,
+      true {Total}
+      false {Batch}
+    } sold vs available`,
   },
   tokensRemainingTooltip: {
     id: 'dashboard.CoinMachine.RemainingDisplayWidgets.RemainingTokens.tooltip',
-    defaultMessage: `This is the number of tokens remaining in the current batch.`,
+    // eslint-disable-next-line max-len
+    defaultMessage: `This is the number of tokens remaining in the {isTotalSale, select,
+      true {sale.}
+      false {current batch.}}`,
   },
   tokensTypePlaceholder: {
     id: 'dashboard.CoinMachine.RemainingDisplayWidgets.RemainingTokens.title',
     defaultMessage: '0',
-  },
-  tokensTypeFooterText: {
-    id: `dashboard.CoinMachine.RemainingDisplayWidgets.RemainingTokens.footerText`,
-    defaultMessage: 'Price next sale',
   },
   soldOut: {
     id: 'dashboard.CoinMachine.RemainingDisplayWidgets.RemainingTokens.soldOut',
@@ -50,25 +51,17 @@ const MSG = defineMessages({
 });
 
 const RemainingTokens = ({
+  isTotalSale,
   appearance = { theme: 'white' },
   periodTokens,
 }: Props) => {
-  const priceStatus = useMemo(() => {
-    if (!periodTokens) {
-      return undefined;
-    }
-
-    return getPriceStatus(periodTokens, periodTokens.soldPeriodTokens, true);
-  }, [periodTokens]);
-
   const widgetText = useMemo(() => {
     return {
       title: MSG.tokensRemainingTitle,
       placeholder: MSG.tokensTypePlaceholder,
       tooltipText: MSG.tokensRemainingTooltip,
-      footerText: priceStatus && MSG.tokensTypeFooterText,
     };
-  }, [priceStatus]);
+  }, []);
 
   const displayedValue = useMemo(() => {
     if (periodTokens) {
@@ -97,7 +90,7 @@ const RemainingTokens = ({
       appearance={appearance}
       isWarning={showValueWarning}
       displayedValue={displayedValue}
-      priceStatus={periodTokens && priceStatus}
+      isTotalSale={isTotalSale}
     />
   );
 };

--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTokens.tsx
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTokens.tsx
@@ -13,13 +13,13 @@ export interface PeriodTokensType {
   decimals: number;
   soldPeriodTokens: BigNumber;
   maxPeriodTokens: BigNumber;
-  targetPeriodTokens: BigNumber;
+  targetPeriodTokens?: BigNumber;
 }
 
 interface Props {
   isTotalSale: boolean;
   appearance?: Appearance;
-  periodTokens?: PeriodTokensType;
+  tokenAmounts?: PeriodTokensType;
 }
 
 const displayName =
@@ -53,7 +53,7 @@ const MSG = defineMessages({
 const RemainingTokens = ({
   isTotalSale,
   appearance = { theme: 'white' },
-  periodTokens,
+  tokenAmounts,
 }: Props) => {
   const widgetText = useMemo(() => {
     return {
@@ -64,25 +64,28 @@ const RemainingTokens = ({
   }, []);
 
   const displayedValue = useMemo(() => {
-    if (periodTokens) {
+    if (tokenAmounts) {
       return (
         <RemainingTokensValue
-          periodTokens={periodTokens}
-          tokensBought={periodTokens.soldPeriodTokens}
+          tokenAmounts={tokenAmounts}
+          tokensBought={tokenAmounts.soldPeriodTokens}
         />
       );
     }
 
     return <FormattedMessage {...widgetText.placeholder} />;
-  }, [widgetText, periodTokens]);
+  }, [widgetText, tokenAmounts]);
 
   const showValueWarning = useMemo(() => {
-    if (periodTokens?.soldPeriodTokens.gte(periodTokens?.maxPeriodTokens)) {
+    if (
+      !isTotalSale ||
+      tokenAmounts?.soldPeriodTokens.gte(tokenAmounts?.maxPeriodTokens)
+    ) {
       return true;
     }
 
     return false;
-  }, [periodTokens]);
+  }, [tokenAmounts, isTotalSale]);
 
   return (
     <RemainingWidget

--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTokens.tsx
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTokens.tsx
@@ -94,7 +94,6 @@ const RemainingTokens = ({
       isWarning={showValueWarning}
       displayedValue={displayedValue}
       isTotalSale={isTotalSale}
-      isTokens
     />
   );
 };

--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTokensValue.tsx
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTokensValue.tsx
@@ -1,8 +1,8 @@
-import { FormattedMessage, defineMessages, FormattedNumber } from 'react-intl';
-import React, { useCallback, useMemo } from 'react';
+import { FormattedMessage, defineMessages } from 'react-intl';
+import React from 'react';
 import { bigNumberify, BigNumberish } from 'ethers/utils';
-import Decimal from 'decimal.js';
 
+import Numeral from '~core/Numeral';
 import { PeriodTokensType } from '~dashboard/CoinMachine/RemainingDisplayWidgets';
 import { getFormattedTokenValue } from '~utils/tokens';
 
@@ -23,42 +23,14 @@ const displayedName = `dashboard.CoinMachine.RemainingDisplayWidgets.RemainingTo
 const RemainingTokensValue = ({ tokenAmounts, tokensBought }: Props) => {
   const { maxPeriodTokens, decimals } = tokenAmounts;
 
-  const defineIfFiveFiguresOrLarger = useCallback(
-    (value) => value.split('.')[0].length >= 5,
-    [],
-  );
-
-  const boughtTokens = useMemo(
-    () => getFormattedTokenValue(tokensBought, decimals),
-    [tokensBought, decimals],
-  );
-  const availableTokens = useMemo(
-    () => getFormattedTokenValue(maxPeriodTokens, decimals),
-    [maxPeriodTokens, decimals],
-  );
-
-  const displayValue = useCallback(
-    (tokens: string) => {
-      const tokensDecimalValue = new Decimal(tokens);
-      if (defineIfFiveFiguresOrLarger(tokens)) {
-        return tokensDecimalValue.toDP(0).toString().split('.')[0];
-      }
-
-      return tokensDecimalValue.toDP(2).toString();
-    },
-    [defineIfFiveFiguresOrLarger],
-  );
-
   if (bigNumberify(tokensBought).gte(maxPeriodTokens)) {
     return <FormattedMessage {...MSG.soldOut} />;
   }
 
   return (
     <>
-      {/* @ts-ignore */}
-      <FormattedNumber value={displayValue(boughtTokens)} /> /{' '}
-      {/* @ts-ignore */}
-      <FormattedNumber value={displayValue(availableTokens)} />
+      <Numeral value={getFormattedTokenValue(tokensBought, decimals)} /> /{' '}
+      <Numeral value={getFormattedTokenValue(maxPeriodTokens, decimals)} />
     </>
   );
 };

--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTokensValue.tsx
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTokensValue.tsx
@@ -13,14 +13,14 @@ const MSG = defineMessages({
 });
 
 interface Props {
-  periodTokens: PeriodTokensType;
+  tokenAmounts: PeriodTokensType;
   tokensBought: BigNumberish;
 }
 
 const displayedName = `dashboard.CoinMachine.RemainingDisplayWidgets.RemainingTokensValue`;
 
-const RemainingTokensValue = ({ periodTokens, tokensBought }: Props) => {
-  const { maxPeriodTokens, decimals } = periodTokens;
+const RemainingTokensValue = ({ tokenAmounts, tokensBought }: Props) => {
+  const { maxPeriodTokens, decimals } = tokenAmounts;
 
   if (bigNumberify(tokensBought).gte(maxPeriodTokens)) {
     return <FormattedMessage {...MSG.soldOut} />;
@@ -28,7 +28,7 @@ const RemainingTokensValue = ({ periodTokens, tokensBought }: Props) => {
 
   return (
     <>
-      {getFormattedTokenValue(maxPeriodTokens.sub(tokensBought), decimals)}/
+      {getFormattedTokenValue(tokensBought, decimals)} /{' '}
       {getFormattedTokenValue(maxPeriodTokens, decimals)}
     </>
   );

--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTokensValue.tsx
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTokensValue.tsx
@@ -1,6 +1,7 @@
+import React, { useMemo } from 'react';
 import { FormattedMessage, defineMessages } from 'react-intl';
-import React from 'react';
 import { bigNumberify, BigNumberish } from 'ethers/utils';
+import { Textfit } from 'react-textfit';
 
 import Numeral from '~core/Numeral';
 import { PeriodTokensType } from '~dashboard/CoinMachine/RemainingDisplayWidgets';
@@ -23,15 +24,33 @@ const displayedName = `dashboard.CoinMachine.RemainingDisplayWidgets.RemainingTo
 const RemainingTokensValue = ({ tokenAmounts, tokensBought }: Props) => {
   const { maxPeriodTokens, decimals } = tokenAmounts;
 
+  const boughtTokens = useMemo(
+    () => getFormattedTokenValue(tokensBought, decimals),
+    [tokensBought, decimals],
+  );
+
+  const totalTokens = useMemo(
+    () => getFormattedTokenValue(maxPeriodTokens, decimals),
+    [maxPeriodTokens, decimals],
+  );
+
+  const isMultiLine = useMemo(() => {
+    const maxCharactersOnOneLine = 25;
+    const combinedStringLength = totalTokens
+      .split('.')[0]
+      .concat(boughtTokens.split('.')[0]);
+
+    return combinedStringLength.length > maxCharactersOnOneLine;
+  }, [totalTokens, boughtTokens]);
+
   if (bigNumberify(tokensBought).gte(maxPeriodTokens)) {
     return <FormattedMessage {...MSG.soldOut} />;
   }
 
   return (
-    <>
-      <Numeral value={getFormattedTokenValue(tokensBought, decimals)} /> /{' '}
-      <Numeral value={getFormattedTokenValue(maxPeriodTokens, decimals)} />
-    </>
+    <Textfit min={10} max={18} mode={isMultiLine ? 'multi' : 'single'}>
+      <Numeral value={boughtTokens} /> / <Numeral value={totalTokens} />
+    </Textfit>
   );
 };
 

--- a/src/modules/dashboard/components/CoinMachine/TokenSalesTable/TokenSalesTable.css
+++ b/src/modules/dashboard/components/CoinMachine/TokenSalesTable/TokenSalesTable.css
@@ -4,7 +4,7 @@
   height: 100%;
 }
 
-.container > h5 {
+.container h5 {
   margin-bottom: 34px;
   font-size: var(--size-smallish);
 }
@@ -90,6 +90,13 @@
    * In order to better align the spinner with the text
    */
   margin-top: -9px;
+}
+
+.headingContainer {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-right: 25px;
 }
 
 .priceStatusHeading {

--- a/src/modules/dashboard/components/CoinMachine/TokenSalesTable/TokenSalesTable.css
+++ b/src/modules/dashboard/components/CoinMachine/TokenSalesTable/TokenSalesTable.css
@@ -91,3 +91,16 @@
    */
   margin-top: -9px;
 }
+
+.priceStatusHeading {
+  display: flex;
+  align-items: center;
+  height: 20px;
+}
+
+.priceStatusHeadingText {
+  margin-right: 8px;
+  font-size: var(--size-smallish);
+  font-weight: var(--weight-bold);
+  color: var(--temp-grey-blue-7);
+}

--- a/src/modules/dashboard/components/CoinMachine/TokenSalesTable/TokenSalesTable.css.d.ts
+++ b/src/modules/dashboard/components/CoinMachine/TokenSalesTable/TokenSalesTable.css.d.ts
@@ -10,5 +10,6 @@ export const tokenSymbol: string;
 export const noDataMessage: string;
 export const hiddenDataMessage: string;
 export const loading: string;
+export const headingContainer: string;
 export const priceStatusHeading: string;
 export const priceStatusHeadingText: string;

--- a/src/modules/dashboard/components/CoinMachine/TokenSalesTable/TokenSalesTable.css.d.ts
+++ b/src/modules/dashboard/components/CoinMachine/TokenSalesTable/TokenSalesTable.css.d.ts
@@ -10,3 +10,5 @@ export const tokenSymbol: string;
 export const noDataMessage: string;
 export const hiddenDataMessage: string;
 export const loading: string;
+export const priceStatusHeading: string;
+export const priceStatusHeadingText: string;

--- a/src/modules/dashboard/components/CoinMachine/TokenSalesTable/TokenSalesTable.tsx
+++ b/src/modules/dashboard/components/CoinMachine/TokenSalesTable/TokenSalesTable.tsx
@@ -65,6 +65,10 @@ const MSG = defineMessages({
     id: 'dashboard.CoinMachine.TokenSalesTable.loading',
     defaultMessage: 'Loading previous sales table entries...',
   },
+  priceNextSale: {
+    id: `dashboard.CoinMachine.TokenSalesTable.priceNextSale`,
+    defaultMessage: 'Price next batch',
+  },
 });
 
 interface PeriodInfo {
@@ -98,6 +102,14 @@ const TokenSalesTable = ({
 }: Props) => {
   const PREV_PERIODS_LIMIT = 100;
   const salePeriodQueryVariables = { colonyAddress, limit: PREV_PERIODS_LIMIT };
+
+  const priceStatusHeading = useMemo(() => {
+    if (!periodTokens) {
+      return undefined;
+    }
+
+    return getPriceStatus(periodTokens, periodTokens.soldPeriodTokens, true);
+  }, [periodTokens]);
 
   const {
     data: salePeriodsData,
@@ -187,13 +199,25 @@ const TokenSalesTable = ({
 
   return (
     <div className={styles.container}>
-      <Heading
-        text={MSG.tableTitle}
-        appearance={{
-          size: 'small',
-          theme: 'dark',
-        }}
-      />
+      <div>
+        <Heading
+          text={MSG.tableTitle}
+          appearance={{
+            size: 'small',
+            theme: 'dark',
+          }}
+        />
+        {priceStatusHeading && (
+          <div className={styles.priceStatusHeading}>
+            <p className={styles.priceStatusHeadingText}>
+              <FormattedMessage {...MSG.priceNextSale} />
+            </p>
+            {priceStatusHeading && (
+              <TokenPriceStatusIcon status={priceStatusHeading} />
+            )}
+          </div>
+        )}
+      </div>
       <div className={styles.tableContainer}>
         <Table className={styles.table} appearance={{ separators: 'none' }}>
           <TableHeader className={styles.tableHeader}>

--- a/src/modules/dashboard/components/CoinMachine/TokenSalesTable/TokenSalesTable.tsx
+++ b/src/modules/dashboard/components/CoinMachine/TokenSalesTable/TokenSalesTable.tsx
@@ -79,6 +79,7 @@ interface PeriodInfo {
 }
 
 interface Props {
+  periodTokens?: Required<PeriodTokensType>;
   colonyAddress: Address;
   extensionAddress?: Address;
   sellableToken?: TokenInfoQuery['tokenInfo'];
@@ -89,6 +90,7 @@ interface Props {
 const displayName = 'dashboard.CoinMachine.TokenSalesTable';
 
 const TokenSalesTable = ({
+  periodTokens,
   colonyAddress,
   extensionAddress,
   sellableToken,
@@ -163,7 +165,7 @@ const TokenSalesTable = ({
             {
               targetPeriodTokens: bigNumberify(targetPerPeriod),
               maxPeriodTokens: bigNumberify(maxPerPeriod),
-            } as PeriodTokensType,
+            } as Required<PeriodTokensType>,
             tokensBought,
           ),
         };
@@ -199,7 +201,7 @@ const TokenSalesTable = ({
 
   return (
     <div className={styles.container}>
-      <div>
+      <div className={styles.headingContainer}>
         <Heading
           text={MSG.tableTitle}
           appearance={{

--- a/src/modules/dashboard/components/CoinMachine/utils.ts
+++ b/src/modules/dashboard/components/CoinMachine/utils.ts
@@ -4,7 +4,7 @@ import { PeriodTokensType } from './RemainingDisplayWidgets';
 import { TokenPriceStatuses } from './TokenPriceStatusIcon';
 
 export const getPriceStatus = (
-  periodTokens: PeriodTokensType,
+  periodTokens: Required<PeriodTokensType>,
   tokensBought: BigNumberish,
   isOnlyHigherNeeded = false,
 ) => {


### PR DESCRIPTION
## Description

This PR adds total sold vs. available widget and adds some updates to tokens display in the remaining widget.

**New stuff** ✨

- add new widget & corresponding queries
- add react-textfit package
- add updated numbers formatting

## TODO

- the numbers in sold vs. available widgets should go into 2 lines when they hit 10px - this is now done! :)

<img width="596" alt="Screenshot 2021-11-23 at 14 12 18" src="https://user-images.githubusercontent.com/34057551/143030218-2f8d12d0-0739-4ad4-81a2-e31618978bb3.png">

Resolves #2868 