### PR TITLE
Fix comments subscription using wrong data

### DIFF
--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeed.tsx
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeed.tsx
@@ -9,7 +9,6 @@ import { MiniSpinnerLoader } from '~core/Preloaders';
 import { getEventsForActions } from '~utils/events';
 
 import {
-  useCommentsSubscription,
   AnyUser,
   OneDomain,
   ColonyAction,
@@ -21,6 +20,7 @@ import {
 import { ActionUserRoles, ColonyActions, Address } from '~types/index';
 import { MotionVote } from '~utils/colonyMotions';
 import { useTransformer } from '~utils/hooks';
+import { useCurrentComments } from '~utils/hooks/useCurrentComments';
 import { commentTransformer } from '../../transformers';
 import { getAllUserRoles } from '../../../transformers';
 import { hasRoot, canAdminister } from '../../../users/checks';
@@ -131,12 +131,10 @@ const ActionsPageFeed = ({
     (hasRoot(allUserRoles) || canAdminister(allUserRoles));
 
   const {
-    data: serverComments,
-    loading: loadingServerComments,
+    currentComments,
+    loading: loadingCurrentComments,
     error,
-  } = useCommentsSubscription({
-    variables: { transactionHash },
-  });
+  } = useCurrentComments(transactionHash);
 
   const filteredEvents = useMemo(() => {
     if (networkEvents) {
@@ -146,9 +144,8 @@ const ActionsPageFeed = ({
   }, [actionType, networkEvents]);
 
   const filteredComments = useMemo(() => {
-    const comments = serverComments?.transactionMessages?.messages || [];
-    return commentTransformer(comments, walletAddress, canAdministerComments);
-  }, [canAdministerComments, serverComments, walletAddress]);
+    return commentTransformer(currentComments, walletAddress, canAdministerComments);
+  }, [canAdministerComments, currentComments, walletAddress]);
 
   const sortedFeed = useMemo(() => {
     const feedItems: FeedItems = [
@@ -312,7 +309,7 @@ const ActionsPageFeed = ({
   return (
     <>
       <ul className={styles.main}>{customRenderWithFallback()}</ul>
-      {(loadingServerComments || extenalLoadingState) && (
+      {(loadingCurrentComments || extenalLoadingState) && (
         <MiniSpinnerLoader
           className={styles.loading}
           loadingTextClassName={styles.loaderMessage}

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeed.tsx
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeed.tsx
@@ -144,7 +144,11 @@ const ActionsPageFeed = ({
   }, [actionType, networkEvents]);
 
   const filteredComments = useMemo(() => {
-    return commentTransformer(currentComments, walletAddress, canAdministerComments);
+    return commentTransformer(
+      currentComments,
+      walletAddress,
+      canAdministerComments,
+    );
   }, [canAdministerComments, currentComments, walletAddress]);
 
   const sortedFeed = useMemo(() => {

--- a/src/modules/dashboard/components/CoinMachine/Chat/Chat.tsx
+++ b/src/modules/dashboard/components/CoinMachine/Chat/Chat.tsx
@@ -5,11 +5,11 @@ import Comment, { CommentInput } from '~core/Comment';
 import { MiniSpinnerLoader } from '~core/Preloaders';
 import {
   Colony,
-  useCommentsSubscription,
   useLoggedInUser,
   useCoinMachineHasWhitelistQuery,
   useUserWhitelistStatusQuery,
 } from '~data/index';
+import { useCurrentComments } from '~utils/hooks/useCurrentComments';
 import { useTransformer } from '~utils/hooks';
 import { commentTransformer } from '../../../transformers';
 import { getAllUserRoles } from '../../../../transformers';
@@ -107,9 +107,7 @@ const Chat = ({
     setTimeout(scrollComments, 0);
   }, [scrollComments]);
 
-  const { data, loading } = useCommentsSubscription({
-    variables: { transactionHash },
-  });
+  const { currentComments, loading } = useCurrentComments(transactionHash);
 
   /*
    * This triggers after every new comment was made
@@ -117,9 +115,8 @@ const Chat = ({
   useLayoutEffect(scrollComments, [scrollComments]);
 
   const filteredComments = useMemo(() => {
-    const comments = data?.transactionMessages?.messages || [];
-    return commentTransformer(comments, walletAddress, canAdministerComments);
-  }, [canAdministerComments, data, walletAddress]);
+    return commentTransformer(currentComments, walletAddress, canAdministerComments);
+  }, [canAdministerComments, currentComments, walletAddress]);
 
   if (loading || loadingCoinMachineWhitelistState || userStatusLoading) {
     return (

--- a/src/modules/dashboard/components/CoinMachine/Chat/Chat.tsx
+++ b/src/modules/dashboard/components/CoinMachine/Chat/Chat.tsx
@@ -115,7 +115,11 @@ const Chat = ({
   useLayoutEffect(scrollComments, [scrollComments]);
 
   const filteredComments = useMemo(() => {
-    return commentTransformer(currentComments, walletAddress, canAdministerComments);
+    return commentTransformer(
+      currentComments,
+      walletAddress,
+      canAdministerComments,
+    );
   }, [canAdministerComments, currentComments, walletAddress]);
 
   if (loading || loadingCoinMachineWhitelistState || userStatusLoading) {

--- a/src/utils/hooks/useCurrentComments.ts
+++ b/src/utils/hooks/useCurrentComments.ts
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+import {
+  useCommentsSubscription,
+  TransactionMessageFragment,
+} from '~data/index';
+
+export const useCurrentComments = (transactionHash: string) => {
+  const [currentComments, setCurrentComments] = useState<
+    TransactionMessageFragment[]
+  >([]);
+
+  const { loading, error } = useCommentsSubscription({
+    variables: { transactionHash },
+    onSubscriptionData: ({ subscriptionData }) => {
+      const transactionMessages = subscriptionData.data?.transactionMessages;
+
+      if (transactionMessages) {
+        if (transactionMessages.transactionHash === transactionHash) {
+          setCurrentComments(transactionMessages.messages);
+        }
+      }
+    },
+  });
+
+  return {
+    currentComments,
+    loading,
+    error,
+  };
+};


### PR DESCRIPTION
Fixes comment subscription overriding data if you have 2 tabs open with different chats going on.

**What to test?**

First case: Open an action/motion page, and a different action/motion page in another tab. Test if chatting in one changes the other one.

Second case: Open a coin machine, and a different coin machine in another tab. Test if chatting in one changes the other one. 

Resolves #2896
Resolves #2861 
