### PR TITLE
Improve Coin Machine period timer

### DIFF
--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -1292,8 +1292,8 @@ export type SaleTokens = {
 };
 
 export type CurrentSalePeriod = {
-  periodLength: Scalars['String'];
-  timeRemaining: Scalars['String'];
+  periodLength: Scalars['Int'];
+  timeRemaining: Scalars['Int'];
 };
 
 export type CurrentPeriodTokens = {

--- a/src/data/graphql/typeDefs/coinMachine.ts
+++ b/src/data/graphql/typeDefs/coinMachine.ts
@@ -14,8 +14,8 @@ export default gql`
   }
 
   type CurrentSalePeriod {
-    periodLength: String!
-    timeRemaining: String!
+    periodLength: Int!
+    timeRemaining: Int!
   }
   type CurrentPeriodTokens {
     maxPerPeriodTokens: String!

--- a/src/data/resolvers/coinMachine.ts
+++ b/src/data/resolvers/coinMachine.ts
@@ -201,8 +201,8 @@ export const coinMachineResolvers = ({
           bigNumberify(blockTime).mod(periodLengthInMs),
         );
         return {
-          periodLength: periodLength.toString(),
-          timeRemaining: timeRemaining.toString(),
+          periodLength: periodLengthInMs.toNumber(),
+          timeRemaining: timeRemaining.toNumber(),
         };
       } catch (error) {
         console.error(error);

--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -110,6 +110,10 @@ const CoinMachine = ({
     loading: currentSalePeriodLoading,
   } = useCoinMachineCurrentSalePeriodQuery({
     variables: { colonyAddress },
+    /*
+     * Refetch every minute to try and keep the timers in sync with the chain
+     */
+    pollInterval: 60 * 1000,
     fetchPolicy: 'network-only',
   });
 
@@ -183,15 +187,8 @@ const CoinMachine = ({
     [periodTokens],
   );
 
-  const timeRemaining = parseInt(
-    currentSalePeriodData?.coinMachineCurrentSalePeriod?.timeRemaining || '0',
-    10,
-  );
-
-  const periodLength = parseInt(
-    currentSalePeriodData?.coinMachineCurrentSalePeriod?.periodLength || '0',
-    10,
-  );
+  const { timeRemaining = 0, periodLength = 0 } =
+    currentSalePeriodData?.coinMachineCurrentSalePeriod || {};
 
   useEffect(() => {
     const tokenBoughtEventsLength =
@@ -213,19 +210,19 @@ const CoinMachine = ({
   ]);
 
   useEffect(() => {
-    if (timeRemaining > 1000 && timeRemaining < periodLength * 1000) {
+    if (timeRemaining > 1000 && timeRemaining < periodLength) {
       setTimeout(() => {
         refetchCurrentPeriodTokensData({ colonyAddress });
-        startPollingCurrentPeriodTokensData(periodLength * 1000);
+        startPollingCurrentPeriodTokensData(periodLength);
         refetchCurrentPeriodPrice();
-        startPollingCurrentPeriodPrice(periodLength * 1000);
+        startPollingCurrentPeriodPrice(periodLength);
         refetchCurrentPeriodMaxUserPurchase();
-        startPollingCurrentPeriodMaxUserPurchase(periodLength * 1000);
+        startPollingCurrentPeriodMaxUserPurchase(periodLength);
       }, timeRemaining);
     } else {
-      startPollingCurrentPeriodTokensData(periodLength * 1000);
-      startPollingCurrentPeriodPrice(periodLength * 1000);
-      startPollingCurrentPeriodMaxUserPurchase(periodLength * 1000);
+      startPollingCurrentPeriodTokensData(periodLength);
+      startPollingCurrentPeriodPrice(periodLength);
+      startPollingCurrentPeriodMaxUserPurchase(periodLength);
     }
     return () => {
       stopPollingCurrentPeriodPrice();
@@ -333,6 +330,7 @@ const CoinMachine = ({
                 value={hasSaleStarted ? timeRemaining : null}
                 periodLength={periodLength}
                 colonyAddress={colonyAddress}
+                syncing={currentSalePeriodLoading}
               />
             </div>
             <div className={styles.tokensRemaining}>

--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -108,6 +108,7 @@ const CoinMachine = ({
   const {
     data: currentSalePeriodData,
     loading: currentSalePeriodLoading,
+    stopPolling: stopcurrentSalePeriodPolling,
   } = useCoinMachineCurrentSalePeriodQuery({
     variables: { colonyAddress },
     /*
@@ -243,6 +244,16 @@ const CoinMachine = ({
     startPollingCurrentPeriodMaxUserPurchase,
     stopPollingCurrentPeriodMaxUserPurchase,
   ]);
+
+  /*
+   * Cleanup on component unmount
+   */
+  useEffect(
+    () => () => {
+      stopcurrentSalePeriodPolling();
+    },
+    [stopcurrentSalePeriodPolling],
+  );
 
   if (
     loadingExtensionsData ||

--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingDisplayWidget.tsx
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingDisplayWidget.tsx
@@ -6,6 +6,7 @@ import Heading from '~core/Heading';
 import QuestionMarkTooltip from '~core/QuestionMarkTooltip';
 
 import { getMainClasses } from '~utils/css';
+import { ComplexMessageValues } from '~types/index';
 
 import TokenPriceStatusIcon, {
   TokenPriceStatuses,
@@ -17,14 +18,17 @@ type Appearance = {
   theme?: 'white' | 'danger';
 };
 
+interface WidgetText {
+  title: MessageDescriptor;
+  titleValues?: ComplexMessageValues;
+  placeholder: MessageDescriptor;
+  tooltipText: MessageDescriptor;
+  footerText?: MessageDescriptor;
+}
+
 type Props = {
   appearance?: Appearance;
-  widgetText: {
-    title: MessageDescriptor;
-    placeholder: MessageDescriptor;
-    tooltipText: MessageDescriptor;
-    footerText?: MessageDescriptor;
-  };
+  widgetText: WidgetText;
   isWarning: boolean;
   displayedValue: string | ReactElement;
   priceStatus?: TokenPriceStatuses;

--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTime.tsx
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTime.tsx
@@ -3,6 +3,7 @@ import { FormattedMessage, defineMessages } from 'react-intl';
 import { useDispatch } from 'redux-react-hook';
 
 import TimerValue from '~core/TimerValue';
+import { SpinnerLoader } from '~core/Preloaders';
 
 import { ActionTypes } from '~redux/index';
 import { Address } from '~types/index';
@@ -19,6 +20,7 @@ type Props = {
   value: number | null;
   appearance?: Appearance;
   periodLength: number;
+  syncing?: boolean;
 };
 
 const displayName =
@@ -48,6 +50,7 @@ const RemainingTime = ({
   value,
   periodLength,
   colonyAddress,
+  syncing = false,
 }: Props) => {
   const dispatch = useDispatch();
 
@@ -70,11 +73,16 @@ const RemainingTime = ({
 
   const displayedValue = useMemo(() => {
     if (splitTime) {
-      return <TimerValue splitTime={splitTime} />;
+      return (
+        <div>
+          {syncing && <SpinnerLoader appearance={{ size: 'small' }} />}
+          <TimerValue splitTime={splitTime} />
+        </div>
+      );
     }
 
     return <FormattedMessage {...widgetText.placeholder} />;
-  }, [splitTime, widgetText]);
+  }, [splitTime, syncing, widgetText]);
 
   const showValueWarning =
     appearance.theme !== 'danger' &&


### PR DESCRIPTION
Basically this PR adds a 1 minute poll interval to the salePeriod query _(the one that fetches the period remaining time, and the period length)_, so that it will keep (mostly) in sync with the values on the chain. This will help us achieve a (somewhat) accurate timer. _(it cannot be trully 100% accurate since times in the client, and on the chain deviate)_

While I was at it, I also did some improvements to the query and to the `RemainingDisplayWidget` _(to actually display when it's syncing)_

Resolves #2912 
