### PR TITLE
Prevent user seeing their ban status from other colonies

### DIFF
--- a/src/modules/core/components/Comment/Actions/CommentActions.tsx
+++ b/src/modules/core/components/Comment/Actions/CommentActions.tsx
@@ -81,7 +81,7 @@ const CommentActions = ({
           id={id}
           ref={ref}
           className={classnames(styles.actionsButton, {
-            [styles.activeDropdown]: false,
+            [styles.activeDropdown]: isOpen,
           })}
           onClick={() => setOpen(true)}
           type="button"

--- a/src/modules/core/components/Comment/Actions/CommentActions.tsx
+++ b/src/modules/core/components/Comment/Actions/CommentActions.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { defineMessages } from 'react-intl';
 
 import classnames from 'classnames';
@@ -32,6 +32,7 @@ const CommentActions = ({
   fullComment,
   onHoverActiveState = () => null,
 }: Props) => {
+  const [isOpen, setOpen] = useState(false);
   /*
    * @NOTE Offset Calculations
    * This is dependant on the number of actions, may need to be adjusted
@@ -41,6 +42,14 @@ const CommentActions = ({
   if (permission === COMMENT_MODERATION.CAN_EDIT) {
     popoverOffset = [0, 8];
   }
+
+  useEffect(() => {
+    if (isOpen) {
+      onHoverActiveState(true);
+    } else {
+      onHoverActiveState(false);
+    }
+  }, [isOpen, onHoverActiveState]);
 
   return (
     <Popover
@@ -54,6 +63,8 @@ const CommentActions = ({
       trigger="click"
       showArrow={false}
       placement="left"
+      isOpen={isOpen}
+      onClose={() => setOpen(false)}
       popperProps={{
         modifiers: [
           {
@@ -65,31 +76,23 @@ const CommentActions = ({
         ],
       }}
     >
-      {({ isOpen, toggle, ref, id }) => {
-        if (isOpen) {
-          onHoverActiveState(true);
-        } else {
-          onHoverActiveState(false);
-        }
-        return (
-          <button
-            id={id}
-            ref={ref}
-            className={classnames(styles.actionsButton, {
-              [styles.activeDropdown]: isOpen,
-            })}
-            onClick={toggle}
-            type="button"
-            data-test="commentActions"
-          >
-            <Icon
-              className={styles.actionsIcon}
-              name="three-dots-row"
-              title={MSG.commentActionsTitle}
-            />
-          </button>
-        );
-      }}
+      {({ ref, id }) => (
+        <button
+          id={id}
+          ref={ref}
+          className={classnames(styles.actionsButton, {
+            [styles.activeDropdown]: false,
+          })}
+          onClick={() => setOpen(true)}
+          type="button"
+        >
+          <Icon
+            className={styles.actionsIcon}
+            name="three-dots-row"
+            title={MSG.commentActionsTitle}
+          />
+        </button>
+      )}
     </Popover>
   );
 };


### PR DESCRIPTION
This fixes a problem where a user who was banned in one colony would have go and create a new colony (where he had permissions), and he would be able to see their banned status _(but not remove it)_

This happened because the mongodb query on the server would only filter by the user's wallet address, not also by the colony in which the comment took place.

This fixes the problem by updating the query on the server to also filter by the colony address: https://github.com/JoinColony/colonyServer/commit/b2f449b6ecbb375f50150db6e5f025b63105d5db

While I was at it, I also fixed a issue introduced in the `CommentActions` component, which would trigger a state update in the render method of `Popover`, which made React go crazy:

![Screenshot from 2021-11-18 22-49-16](https://user-images.githubusercontent.com/1193222/142494492-2da1689d-df1e-447f-922d-16b1ca00f060.png)


Resolves #2918 