### PR TITLE
Fix Coin Machine whitelist status check if not enabled

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -161,6 +161,8 @@
 
     "transaction.group.enableExtension.title": "Enable Colony Extension",
     "transaction.group.enableExtension.description": "Enable Colony Extension",
+    "transaction.group.unistallExtensions.title": "Uninstall Colony Extension",
+    "transaction.group.unistallExtensions.description": "Uninstall Colony Extension",
     "transaction.CoinMachineClient.initialise.title": "Initialize CoinMachine Extension",
     "transaction.VotingReputationClient.initialise.title": "Initialize Voting Reputation Extension",
     "transaction.WhitelistClient.initialise.title": "Initialize Whitelist Extension",
@@ -170,6 +172,8 @@
     "transaction.ColonyClient.deprecateExtension.description": "Deprecate Colony Extension",
     "transaction.ColonyClient.upgradeExtension.title": "Upgrade Colony Extension",
     "transaction.ColonyClient.upgradeExtension.description": "Upgrade Colony Extension",
+    "transaction.CoinMachineClient.setWhitelist.title": "Update Coin Machine Whitelist Address",
+    "transaction.CoinMachineClient.setWhitelist.description": "Update Coin Machine Whitelist Address",
 
     "transaction.WhitelistClient.approveUsers.title": "Update whitelist users",
     "transaction.group.approveUsers.title": "Update whitelist users",

--- a/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
+++ b/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
@@ -190,7 +190,9 @@ const BuyTokens = ({
   );
 
   const globalDisable =
-    !isCurrentlyOnSale || !userHasProfile || !isUserWhitelisted;
+    !isCurrentlyOnSale ||
+    !userHasProfile ||
+    (isWhitelistExtensionEnabled && !isUserWhitelisted);
 
   const handleInputFocus = useCallback(
     ({ amount }, setFieldValue) => {

--- a/src/modules/dashboard/sagas/extensions/colonyExtensionUninstall.ts
+++ b/src/modules/dashboard/sagas/extensions/colonyExtensionUninstall.ts
@@ -1,40 +1,126 @@
 import { call, fork, put, takeEvery } from 'redux-saga/effects';
-import { ClientType, getExtensionHash } from '@colony/colony-js';
+import { ClientType, getExtensionHash, Extension } from '@colony/colony-js';
+import { AddressZero } from 'ethers/constants';
 
-import { Action, ActionTypes, AllActions } from '~redux/index';
+import {
+  CoinMachineHasWhitelistQuery,
+  CoinMachineHasWhitelistQueryVariables,
+  CoinMachineHasWhitelistDocument,
+} from '~data/index';
+import { Action, ActionTypes } from '~redux/index';
 import { putError, takeFrom } from '~utils/saga/effects';
 
+import { ContextModule, TEMP_getContext } from '~context/index';
 import {
   createTransaction,
   getTxChannel,
-  waitForTxResult,
+  createTransactionChannels,
 } from '../../../core/sagas';
+import { transactionReady } from '../../../core/actionCreators';
 
 import { refreshExtension } from '../utils';
 
 export function* colonyExtensionUninstall({
+  meta: { id: metaId },
   meta,
   payload: { colonyAddress, extensionId },
 }: Action<ActionTypes.COLONY_EXTENSION_UNINSTALL>) {
-  const txChannel = yield call(getTxChannel, meta.id);
-
+  let txChannel;
   try {
-    yield fork(createTransaction, meta.id, {
+    const colonyManager = TEMP_getContext(ContextModule.ColonyManager);
+    const apolloClient = TEMP_getContext(ContextModule.ApolloClient);
+    txChannel = yield call(getTxChannel, metaId);
+
+    let coinMachineClient;
+    let coinMachineDeprecated;
+    try {
+      coinMachineClient = yield colonyManager.getClient(
+        ClientType.CoinMachineClient,
+        colonyAddress,
+      );
+      coinMachineDeprecated = yield coinMachineClient.getDeprecated();
+    } catch (error) {
+      /*
+       * Silent error since we don't really care about it, but it means
+       * that the coin machine client is not installed in the colony
+       */
+    }
+    const haveToUpdateCoinMachineWhitelist =
+      extensionId === Extension.Whitelist &&
+      !!coinMachineClient &&
+      !coinMachineDeprecated;
+
+    const batchKey = 'unistallExtensions';
+    const {
+      uninstallExtensionTx: uninstallExtension,
+      updateCoinMachineWhitelistTx: updateCoinMachineWhitelist,
+    } = yield createTransactionChannels(metaId, [
+      'uninstallExtensionTx',
+      'updateCoinMachineWhitelistTx',
+    ]);
+
+    const createGroupTransaction = ({ id, index }, config) =>
+      fork(createTransaction, id, {
+        ...config,
+        group: {
+          key: batchKey,
+          id: metaId,
+          index,
+        },
+      });
+
+    yield createGroupTransaction(uninstallExtension, {
       context: ClientType.ColonyClient,
       methodName: 'uninstallExtension',
       identifier: colonyAddress,
       params: [getExtensionHash(extensionId)],
+      ready: false,
     });
 
-    yield takeFrom(txChannel, ActionTypes.TRANSACTION_CREATED);
+    if (haveToUpdateCoinMachineWhitelist) {
+      yield createGroupTransaction(updateCoinMachineWhitelist, {
+        context: ClientType.CoinMachineClient,
+        methodName: 'setWhitelist',
+        identifier: colonyAddress,
+        params: [AddressZero],
+        ready: false,
+      });
+    }
 
-    yield put<AllActions>({
-      type: ActionTypes.COLONY_EXTENSION_UNINSTALL_SUCCESS,
-      payload: {},
-      meta,
+    yield takeFrom(uninstallExtension.channel, ActionTypes.TRANSACTION_CREATED);
+    if (haveToUpdateCoinMachineWhitelist) {
+      yield takeFrom(
+        updateCoinMachineWhitelist.channel,
+        ActionTypes.TRANSACTION_CREATED,
+      );
+    }
+
+    yield put(transactionReady(uninstallExtension.id));
+    yield takeFrom(
+      uninstallExtension.channel,
+      ActionTypes.TRANSACTION_SUCCEEDED,
+    );
+
+    if (haveToUpdateCoinMachineWhitelist) {
+      yield put(transactionReady(updateCoinMachineWhitelist.id));
+      yield takeFrom(
+        updateCoinMachineWhitelist.channel,
+        ActionTypes.TRANSACTION_SUCCEEDED,
+      );
+    }
+
+    yield call(refreshExtension, colonyAddress, extensionId);
+
+    yield apolloClient.query<
+      CoinMachineHasWhitelistQuery,
+      CoinMachineHasWhitelistQueryVariables
+    >({
+      query: CoinMachineHasWhitelistDocument,
+      variables: {
+        colonyAddress,
+      },
+      fetchPolicy: 'network-only',
     });
-
-    yield waitForTxResult(txChannel);
   } catch (error) {
     return yield putError(
       ActionTypes.COLONY_EXTENSION_UNINSTALL_ERROR,
@@ -42,8 +128,6 @@ export function* colonyExtensionUninstall({
       meta,
     );
   } finally {
-    yield call(refreshExtension, colonyAddress, extensionId);
-
     txChannel.close();
   }
   return null;


### PR DESCRIPTION
This PR fixes a issue where the coin machine would check if the user is whitelisted even if the whitelist extension wasn't installed and added to the coin machine. Based on that information it would prevent the user from buying, commenting, etc

While I was at it, I found another bug _(that no one noticed so far)_. If you install Whitelist, then Coin Machine, then uninstall Whitelist while Coin Machine was running, trying to access it would break the dapp. This happened because it would still check for the old whitelist contract address and would try to instantiate it. 

To fix this, we have to send an extra transaction when uninstalling whitelist to update the coin machine whitelist address internally to `AddressZero` _(the initial value)_. This way Coin Machine would know the whitelist was removed and can now function properly.

Resolves #2915 