### PR TITLE
Add polling logic to CoinMachine

### DIFF
--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useMemo } from 'react';
 import { Redirect, useParams } from 'react-router-dom';
 import { defineMessages, FormattedMessage } from 'react-intl';
-import { Extension } from '@colony/colony-js';
+import { Extension, Network } from '@colony/colony-js';
 import { bigNumberify } from 'ethers/utils';
 
+import { DEFAULT_NETWORK } from '~constants';
 import ExternalLink from '~core/ExternalLink';
 import { SpinnerLoader } from '~core/Preloaders';
 import BreadCrumb, { Crumb } from '~core/BreadCrumb';
@@ -78,6 +79,7 @@ const CoinMachine = ({
     variables: { address: colonyAddress },
   });
 
+  const pollInterval = DEFAULT_NETWORK === Network.Mainnet ? 20000 : 5000;
   const { installedExtensions = [] } = extensionsData?.processedColony || {};
   const coinMachineExtension = installedExtensions?.find(
     ({ extensionId }) => extensionId === Extension.CoinMachine,
@@ -110,7 +112,7 @@ const CoinMachine = ({
   } = useCurrentPeriodTokensQuery({
     variables: { colonyAddress },
     fetchPolicy: 'network-only',
-    pollInterval: 1000,
+    pollInterval,
   });
 
   const {
@@ -128,7 +130,7 @@ const CoinMachine = ({
   } = useCoinMachineCurrentPeriodPriceQuery({
     variables: { colonyAddress },
     fetchPolicy: 'network-only',
-    pollInterval: 1000,
+    pollInterval,
   });
 
   const {
@@ -138,7 +140,7 @@ const CoinMachine = ({
   } = useCoinMachineCurrentPeriodMaxUserPurchaseQuery({
     variables: { colonyAddress, userAddress: walletAddress },
     fetchPolicy: 'network-only',
-    pollInterval: 1000,
+    pollInterval,
   });
 
   const hasSaleStarted = !bigNumberify(

--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -1,10 +1,9 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { Redirect, useParams } from 'react-router-dom';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { Extension } from '@colony/colony-js';
 import { bigNumberify } from 'ethers/utils';
 
-import { AddressZero } from 'ethers/constants';
 import ExternalLink from '~core/ExternalLink';
 import { SpinnerLoader } from '~core/Preloaders';
 import BreadCrumb, { Crumb } from '~core/BreadCrumb';
@@ -16,7 +15,6 @@ import {
   Colony,
   useCoinMachineCurrentSalePeriodQuery,
   useCoinMachineTokenBalanceQuery,
-  useSubgraphTokenBoughtEventsSubscription,
   useCoinMachineCurrentPeriodPriceQuery,
   useCoinMachineCurrentPeriodMaxUserPurchaseQuery,
   useLoggedInUser,
@@ -71,8 +69,6 @@ const CoinMachine = ({
   const { transactionHash } = useParams<{
     transactionHash: string;
   }>();
-  const [tokenBoughtEventsCounter, setTokenBoughtEventsCounter] = useState(0);
-
   const { walletAddress } = useLoggedInUser();
 
   const {
@@ -86,17 +82,6 @@ const CoinMachine = ({
   const coinMachineExtension = installedExtensions?.find(
     ({ extensionId }) => extensionId === Extension.CoinMachine,
   );
-
-  const {
-    data: tokenBoughtEventsData,
-    loading: loadingTokenBoughtEventsData,
-  } = useSubgraphTokenBoughtEventsSubscription({
-    variables: {
-      colonyAddress,
-      extensionAddress:
-        coinMachineExtension?.address.toLowerCase() || AddressZero,
-    },
-  });
 
   const {
     data: saleTokensData,
@@ -120,13 +105,12 @@ const CoinMachine = ({
 
   const {
     data: periodTokensData,
-    refetch: refetchCurrentPeriodTokensData,
-    startPolling: startPollingCurrentPeriodTokensData,
     stopPolling: stopPollingCurrentPeriodTokensData,
     loading: periodTokensLoading,
   } = useCurrentPeriodTokensQuery({
     variables: { colonyAddress },
     fetchPolicy: 'network-only',
+    pollInterval: 1000,
   });
 
   const {
@@ -140,23 +124,21 @@ const CoinMachine = ({
   const {
     data: salePriceData,
     loading: loadingSalePrice,
-    refetch: refetchCurrentPeriodPrice,
-    startPolling: startPollingCurrentPeriodPrice,
     stopPolling: stopPollingCurrentPeriodPrice,
   } = useCoinMachineCurrentPeriodPriceQuery({
     variables: { colonyAddress },
     fetchPolicy: 'network-only',
+    pollInterval: 1000,
   });
 
   const {
     data: maxUserPurchaseData,
     loading: loadingMaxUserPurchase,
-    refetch: refetchCurrentPeriodMaxUserPurchase,
-    startPolling: startPollingCurrentPeriodMaxUserPurchase,
     stopPolling: stopPollingCurrentPeriodMaxUserPurchase,
   } = useCoinMachineCurrentPeriodMaxUserPurchaseQuery({
     variables: { colonyAddress, userAddress: walletAddress },
     fetchPolicy: 'network-only',
+    pollInterval: 1000,
   });
 
   const hasSaleStarted = !bigNumberify(
@@ -191,59 +173,18 @@ const CoinMachine = ({
   const { timeRemaining = 0, periodLength = 0 } =
     currentSalePeriodData?.coinMachineCurrentSalePeriod || {};
 
-  useEffect(() => {
-    const tokenBoughtEventsLength =
-      tokenBoughtEventsData?.tokenBoughtEvents.length || 0;
-    if (tokenBoughtEventsCounter < tokenBoughtEventsLength) {
-      refetchCurrentPeriodTokensData({ colonyAddress });
-      setTokenBoughtEventsCounter(tokenBoughtEventsLength);
-      refetchCurrentPeriodPrice();
-      refetchCurrentPeriodMaxUserPurchase();
-    }
-  }, [
-    colonyAddress,
-    tokenBoughtEventsData,
-    tokenBoughtEventsCounter,
-    setTokenBoughtEventsCounter,
-    refetchCurrentPeriodTokensData,
-    refetchCurrentPeriodPrice,
-    refetchCurrentPeriodMaxUserPurchase,
-  ]);
-
-  useEffect(() => {
-    if (timeRemaining > 1000 && timeRemaining < periodLength) {
-      setTimeout(() => {
-        refetchCurrentPeriodTokensData({ colonyAddress });
-        startPollingCurrentPeriodTokensData(periodLength);
-        refetchCurrentPeriodPrice();
-        startPollingCurrentPeriodPrice(periodLength);
-        refetchCurrentPeriodMaxUserPurchase();
-        startPollingCurrentPeriodMaxUserPurchase(periodLength);
-      }, timeRemaining);
-    } else {
-      startPollingCurrentPeriodTokensData(periodLength);
-      startPollingCurrentPeriodPrice(periodLength);
-      startPollingCurrentPeriodMaxUserPurchase(periodLength);
-    }
-    return () => {
+  useEffect(
+    () => () => {
       stopPollingCurrentPeriodPrice();
       stopPollingCurrentPeriodTokensData();
       stopPollingCurrentPeriodMaxUserPurchase();
-    };
-  }, [
-    colonyAddress,
-    periodLength,
-    timeRemaining,
-    refetchCurrentPeriodTokensData,
-    startPollingCurrentPeriodTokensData,
-    stopPollingCurrentPeriodTokensData,
-    stopPollingCurrentPeriodPrice,
-    refetchCurrentPeriodPrice,
-    startPollingCurrentPeriodPrice,
-    refetchCurrentPeriodMaxUserPurchase,
-    startPollingCurrentPeriodMaxUserPurchase,
-    stopPollingCurrentPeriodMaxUserPurchase,
-  ]);
+    },
+    [
+      stopPollingCurrentPeriodTokensData,
+      stopPollingCurrentPeriodPrice,
+      stopPollingCurrentPeriodMaxUserPurchase,
+    ],
+  );
 
   /*
    * Cleanup on component unmount
@@ -261,8 +202,7 @@ const CoinMachine = ({
     currentSalePeriodLoading ||
     !extensionsData?.processedColony?.installedExtensions ||
     periodTokensLoading ||
-    coinMachineTokenBalanceLoading ||
-    loadingTokenBoughtEventsData
+    coinMachineTokenBalanceLoading
   ) {
     return (
       <div className={styles.loadingSpinner}>


### PR DESCRIPTION
Replaced `refetch` logic in `CoinMachine` with `polling` logic.

Affected queries: `CurrentPeriodMaxUserPurchase`, `CurrentPeriodTokens` and `CurrentPeriodMaxUserPurchase`

Resolves #2916 
