### PR TITLE
Improve token displays of SaleStateWidget and BuyTokens

### DIFF
--- a/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
+++ b/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
@@ -6,6 +6,7 @@ import { FormikProps } from 'formik';
 import { AddressZero } from 'ethers/constants';
 import { bigNumberify } from 'ethers/utils';
 
+import Decimal from 'decimal.js';
 import Heading from '~core/Heading';
 import QuestionMarkTooltip from '~core/QuestionMarkTooltip';
 import ExternalLink from '~core/ExternalLink';
@@ -187,6 +188,19 @@ const BuyTokens = ({
   const currentSalePrice = getFormattedTokenValue(
     salePriceData?.coinMachineCurrentPeriodPrice || '0',
     purchaseToken?.decimals || 18,
+  );
+
+  const getFormattedCost = useCallback(
+    (amount) => {
+      const decimalCost = new Decimal(amount).times(
+        salePriceData.coinMachineCurrentPeriodPrice,
+      );
+      return getFormattedTokenValue(
+        decimalCost.toString(),
+        purchaseToken?.decimals,
+      );
+    },
+    [salePriceData],
   );
 
   const globalDisable =
@@ -462,12 +476,7 @@ const BuyTokens = ({
                     <div className={styles.amountsValues}>
                       {!isSoldOut ? (
                         <div>
-                          {values.amount
-                            ? (
-                                parseInt(values.amount, 10) *
-                                parseFloat(currentSalePrice)
-                              ).toFixed(2)
-                            : ''}
+                          {values.amount ? getFormattedCost(values.amount) : ''}
                         </div>
                       ) : (
                         <div>N/A</div>

--- a/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
+++ b/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
@@ -200,9 +200,10 @@ const BuyTokens = ({
 
   const getFormattedCost = useCallback(
     (amount) => {
-      const decimalCost = new Decimal(amount).times(
-        salePriceData.coinMachineCurrentPeriodPrice,
-      );
+      const decimalCost = new Decimal(amount)
+        .times(salePriceData.coinMachineCurrentPeriodPrice)
+        .toFixed(0, Decimal.ROUND_HALF_UP);
+
       return getFormattedTokenValue(
         decimalCost.toString(),
         purchaseToken?.decimals,

--- a/src/modules/dashboard/components/CoinMachine/SaleStateWidget/SaleStateWidget.tsx
+++ b/src/modules/dashboard/components/CoinMachine/SaleStateWidget/SaleStateWidget.tsx
@@ -218,7 +218,8 @@ const SaleStateWidget = ({
           new Decimal(10).pow(
             getTokenDecimalsWithFallback(purchaseToken?.decimals),
           ),
-        );
+        )
+        .toFixed(0, Decimal.ROUND_HALF_UP);
 
       let formattedAmount = getFormattedTokenValue(
         transactionAmount,

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -62,8 +62,5 @@ export const getFormattedTokenValue = (
   if (decimalValue.lt(0.00001) && decimalValue.gt(0)) {
     return SMALL_TOKEN_AMOUNT_FORMAT;
   }
-  return new Decimal(bigNumberify(value).toString())
-    .div(safeDecimals)
-    .toDP(5, Decimal.ROUND_DOWN)
-    .toString();
+  return decimalValue.toDP(5, Decimal.ROUND_DOWN).toString();
 };


### PR DESCRIPTION
- Improved formatting of tokens in the SaleStateWidget and BuyTokens `Cost` field.
- Also, while working with the above changes, I noticed that the "max buy amount" validation could be improved. As it was before, the validation could've been problematic when trying to buy a really small amount (0.00000...) or sums with really detailed decimals (12.18429...). Please make sure to test it.
- Improved `getFormattedTokenValue` code, should be a bit easier to read now.

Resolves #2910 
