### PR TITLE
Coin Machine Previous Batches (Sales) Table Multiple Fixes

### DIFF
--- a/src/data/resolvers/coinMachine.ts
+++ b/src/data/resolvers/coinMachine.ts
@@ -531,6 +531,17 @@ export const coinMachineResolvers = ({
                 return period;
               }
 
+              /*
+               * If there are no more tokens in the coin machine, the price doesn't
+               * evolve anymore
+               */
+              if (bigNumberify(period.tokensAvailable).isZero()) {
+                return {
+                  ...period,
+                  price: previousPrice.toString(),
+                };
+              }
+
               const previousPeriodTokensBought = periodArray[periodIndex - 1]
                 ?.tokensBought
                 ? bigNumberify(periodArray[periodIndex - 1]?.tokensBought)

--- a/src/data/resolvers/coinMachine.ts
+++ b/src/data/resolvers/coinMachine.ts
@@ -30,6 +30,10 @@ import { getToken } from './token';
 /*
  * Small helper to replay TokensBought / Transfer events over a reversed
  * period array in order to generate a historic available tokens total
+ *
+ * Since we are going in reverse:
+ * - if tokens were bought we add to to the count
+ * - if tokens were transfered into the coin machine we subtract from the count
  */
 const replayBalanceEvents = (
   {
@@ -383,13 +387,13 @@ export const coinMachineResolvers = ({
         );
         historicAvailableTokensEvents
           /*
-           * Only use events that outside of the latest sale period
+           * Only use events that are outside of the latest sale period.
            * Earlier events, basically everything that happened in the current
            * "active" sale period
            */
           .filter(
             ({ timestamp: eventTimestamp = 0 }) =>
-              eventTimestamp > stalePeriods[0].saleEndedAt,
+              eventTimestamp >= stalePeriods[0].saleEndedAt,
           )
           .map((event) => {
             lastPeriodAvailableTokens = replayBalanceEvents(
@@ -435,9 +439,6 @@ export const coinMachineResolvers = ({
                 /*
                  * Find all the events that happened within this period and
                  * replay them onto the current available tokens.
-                 * Since we are going in reverse:
-                 * - if tokens were bought we add to to the count
-                 * - if tokens were transfered into the coin machine we subtract from the count
                  */
                 historicAvailableTokensEvents
                   .filter(
@@ -457,10 +458,12 @@ export const coinMachineResolvers = ({
                   ({ saleEndedAt: activeSaleEndedAt }) =>
                     activeSaleEndedAt === String(staleSaleEndedAt),
                 );
-                const tokensAvailable = lastPeriodAvailableTokens.lt(0)
+                const tokensAvailable = lastPeriodAvailableTokens.lte(0)
                   ? bigNumberify(0)
                   : lastPeriodAvailableTokens;
 
+                const periodTokensBought =
+                  existingActiveSale?.tokensBought || tokensBought.toString();
                 /*
                  * If there's a sale in the same period as there was the first
                  * token transfer into Coin Machine, make sure to fetch that
@@ -470,24 +473,21 @@ export const coinMachineResolvers = ({
                  * as tokens coming, to prevent showing something like 1000/0 tokens bought
                  */
                 const tokensAvailableWithFallback =
-                  tokensAvailable.lte(0) &&
-                  lastPeriodAvailableTokens.lte(0) &&
-                  firstTokenTransfer &&
-                  firstTokenTransfer.timestamp &&
-                  firstTokenTransfer.timestamp <= staleSaleEndedAt
-                    ? firstTokenTransfer.values.wad
+                  bigNumberify(periodTokensBought).gt(tokensAvailable) &&
+                  tokensAvailable.lte(0)
+                    ? firstTokenTransfer?.values?.wad || bigNumberify(0)
                     : tokensAvailable;
 
                 return existingActiveSale
                   ? {
                       saleEndedAt: existingActiveSale.saleEndedAt,
-                      tokensBought: existingActiveSale.tokensBought,
+                      tokensBought: periodTokensBought,
                       price: existingActiveSale.price,
                       tokensAvailable: tokensAvailableWithFallback.toString(),
                     }
                   : {
                       saleEndedAt: String(staleSaleEndedAt),
-                      tokensBought: tokensBought.toString(),
+                      tokensBought: periodTokensBought,
                       price: stalePrice.toString(),
                       tokensAvailable: tokensAvailableWithFallback.toString(),
                     };

--- a/src/data/resolvers/coinMachine.ts
+++ b/src/data/resolvers/coinMachine.ts
@@ -495,15 +495,17 @@ export const coinMachineResolvers = ({
             )
             /*
              * Filter out
+             * - periods with 0 available tokens (coin machine is out of tokens)
              * - sale periods that end in the future
              * - sale periods generated for timestamps starting before
              *  the extension was installed
              */
             .filter(
-              ({ saleEndedAt }) =>
+              ({ saleEndedAt, tokensAvailable }) =>
                 parseInt(saleEndedAt, 10) <= currentBlockTime &&
                 parseInt(saleEndedAt, 10) >=
-                  (extensionInitialised.timestamp || 0),
+                  (extensionInitialised.timestamp || 0) &&
+                bigNumberify(tokensAvailable).gt(0),
             )
             /*
              * Price evolution calculations require us to go for oldest sale period
@@ -530,7 +532,6 @@ export const coinMachineResolvers = ({
                 previousPrice = currentPrice;
                 return period;
               }
-
               /*
                * If there are no more tokens in the coin machine, the price doesn't
                * evolve anymore

--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -147,23 +147,30 @@ const CoinMachine = ({
     coinMachineTokenBalanceData?.coinMachineTokenBalance || 0,
   ).isZero();
 
+  const {
+    activeSoldTokens: activeSold = '0',
+    maxPerPeriodTokens: maxPerPeriod = '0',
+    targetPerPeriodTokens: targetPerPeriod = '0',
+  } = periodTokensData?.currentPeriodTokens || {};
+
   const periodTokens = useMemo(() => {
     if (!saleTokensData || !periodTokensData || !hasSaleStarted) {
       return undefined;
     }
     return {
       decimals: saleTokensData.coinMachineSaleTokens.sellableToken.decimals,
-      soldPeriodTokens: bigNumberify(
-        periodTokensData.currentPeriodTokens.activeSoldTokens,
-      ),
-      maxPeriodTokens: bigNumberify(
-        periodTokensData.currentPeriodTokens.maxPerPeriodTokens,
-      ),
-      targetPeriodTokens: bigNumberify(
-        periodTokensData.currentPeriodTokens.targetPerPeriodTokens,
-      ),
+      soldPeriodTokens: bigNumberify(activeSold),
+      maxPeriodTokens: bigNumberify(maxPerPeriod),
+      targetPeriodTokens: bigNumberify(targetPerPeriod),
     };
-  }, [periodTokensData, saleTokensData, hasSaleStarted]);
+  }, [
+    saleTokensData,
+    periodTokensData,
+    hasSaleStarted,
+    activeSold,
+    maxPerPeriod,
+    targetPerPeriod,
+  ]);
 
   const isSoldOut = useMemo(
     () =>
@@ -295,12 +302,15 @@ const CoinMachine = ({
         <div className={styles.sales}>
           <TokenSalesTable
             colonyAddress={colonyAddress}
-            periodLength={periodLength}
-            periodRemainingTime={timeRemaining}
+            extensionAddress={coinMachineExtension?.address}
+            periodInfo={{
+              periodLengthMS: periodLength,
+              periodRemainingMS: timeRemaining,
+              targetPerPeriod,
+              maxPerPeriod,
+            }}
             sellableToken={sellableToken}
             purchaseToken={purchaseToken}
-            periodTokens={periodTokens}
-            extensionAddress={coinMachineExtension?.address}
           />
         </div>
         <div className={styles.comments}>

--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -230,14 +230,15 @@ const CoinMachine = ({
     return <Redirect to={`/colony/${colonyName}`} />;
   }
 
-  const saleToken = saleTokensData?.coinMachineSaleTokens?.sellableToken;
+  const { sellableToken, purchaseToken } =
+    saleTokensData?.coinMachineSaleTokens || {};
 
   const breadCrumbs: Crumb[] = [
     MSG.title,
     <div>
       <FormattedMessage
         {...MSG.buyTokens}
-        values={{ symbol: saleToken?.symbol }}
+        values={{ symbol: sellableToken?.symbol }}
       />
       <ExternalLink
         className={styles.learnMore}
@@ -256,7 +257,7 @@ const CoinMachine = ({
           <div className={styles.saleStarted}>
             <SaleStateWidget
               colony={colony}
-              sellableToken={saleToken}
+              sellableToken={sellableToken}
               timeLeftToNextSale={timeRemaining}
               transactionHash={transactionHash}
               purchaseToken={
@@ -296,7 +297,8 @@ const CoinMachine = ({
             colonyAddress={colonyAddress}
             periodLength={periodLength}
             periodRemainingTime={timeRemaining}
-            sellableToken={saleToken}
+            sellableToken={sellableToken}
+            purchaseToken={purchaseToken}
             periodTokens={periodTokens}
             extensionAddress={coinMachineExtension?.address}
           />

--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingDisplayWidget.tsx
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingDisplayWidget.tsx
@@ -60,13 +60,13 @@ const RemainingDisplayWidget = ({
           tooltipClassName={styles.tooltip}
         />
       </div>
-      <p
+      <div
         className={classnames(styles.value, {
           [styles.valueWarning]: isWarning,
         })}
       >
         {displayedValue}
-      </p>
+      </div>
       {widgetText.footerText && (
         <div className={styles.footer}>
           <p className={styles.footerText}>

--- a/src/modules/dashboard/components/CoinMachine/TokenSalesTable/SoldTokensWidget.css
+++ b/src/modules/dashboard/components/CoinMachine/TokenSalesTable/SoldTokensWidget.css
@@ -1,0 +1,3 @@
+.soldOut {
+  color: var(--danger);
+}

--- a/src/modules/dashboard/components/CoinMachine/TokenSalesTable/SoldTokensWidget.css.d.ts
+++ b/src/modules/dashboard/components/CoinMachine/TokenSalesTable/SoldTokensWidget.css.d.ts
@@ -1,0 +1,1 @@
+export const soldOut: string;

--- a/src/modules/dashboard/components/CoinMachine/TokenSalesTable/SoldTokensWidget.tsx
+++ b/src/modules/dashboard/components/CoinMachine/TokenSalesTable/SoldTokensWidget.tsx
@@ -1,45 +1,58 @@
 import { FormattedMessage, defineMessages } from 'react-intl';
 import React from 'react';
-import { bigNumberify, BigNumberish } from 'ethers/utils';
+import { bigNumberify } from 'ethers/utils';
 
-import { PeriodTokensType } from '~dashboard/CoinMachine/RemainingDisplayWidgets';
+import { AnyToken } from '~data/index';
 import { getFormattedTokenValue } from '~utils/tokens';
+
+import styles from './SoldTokensWidget.css';
 
 const MSG = defineMessages({
   soldOut: {
     id: `dashboard.CoinMachine.TokenSalesTable.SoldTokensWidget.soldOut`,
     defaultMessage: 'SOLD OUT',
   },
+  periodTokens: {
+    id: `dashboard.CoinMachine.TokenSalesTable.SoldTokensWidget.periodTokens`,
+    defaultMessage: '{tokensBought}/{tokensAvailable}',
+  },
 });
 
 interface Props {
-  periodTokens: PeriodTokensType;
-  tokensBought: BigNumberish;
-  tokensAvailable: BigNumberish;
+  tokensBought: string;
+  tokensAvailable: string;
+  sellableToken: AnyToken;
 }
 
 const displayedName = `dashboard.CoinMachine.TokenSalesTable.SoldTokensWidget`;
 
 const SoldTokensWidget = ({
-  periodTokens,
   tokensBought,
-  tokensAvailable = 0,
+  tokensAvailable,
+  sellableToken: { decimals = 18 },
 }: Props) => {
-  const { maxPeriodTokens, decimals } = periodTokens;
-
-  const upperLimit = bigNumberify(tokensAvailable).lte(maxPeriodTokens)
-    ? bigNumberify(tokensAvailable)
-    : maxPeriodTokens;
-
-  if (bigNumberify(tokensBought).gte(upperLimit) && upperLimit.gt(0)) {
-    return <FormattedMessage {...MSG.soldOut} />;
+  if (bigNumberify(tokensBought).gte(tokensAvailable)) {
+    return (
+      <span className={styles.soldOut}>
+        <FormattedMessage {...MSG.soldOut} />
+      </span>
+    );
   }
 
   return (
-    <>
-      {getFormattedTokenValue(bigNumberify(tokensBought), decimals)}/
-      {getFormattedTokenValue(upperLimit, decimals)}
-    </>
+    <FormattedMessage
+      {...MSG.periodTokens}
+      values={{
+        tokensBought: getFormattedTokenValue(
+          bigNumberify(tokensBought),
+          decimals,
+        ),
+        tokensAvailable: getFormattedTokenValue(
+          bigNumberify(tokensAvailable),
+          decimals,
+        ),
+      }}
+    />
   );
 };
 

--- a/src/modules/dashboard/components/CoinMachine/TokenSalesTable/SoldTokensWidget.tsx
+++ b/src/modules/dashboard/components/CoinMachine/TokenSalesTable/SoldTokensWidget.tsx
@@ -21,6 +21,7 @@ const MSG = defineMessages({
 interface Props {
   tokensBought: string;
   tokensAvailable: string;
+  maxPerPeriod: string;
   sellableToken: AnyToken;
 }
 
@@ -29,9 +30,19 @@ const displayedName = `dashboard.CoinMachine.TokenSalesTable.SoldTokensWidget`;
 const SoldTokensWidget = ({
   tokensBought,
   tokensAvailable,
+  maxPerPeriod,
   sellableToken: { decimals = 18 },
 }: Props) => {
-  if (bigNumberify(tokensBought).gte(tokensAvailable)) {
+  const totalAvailable = bigNumberify(tokensAvailable);
+  const maximumPerPeriod = bigNumberify(maxPerPeriod);
+  const lowestUpperLimit = totalAvailable.gt(maximumPerPeriod)
+    ? maximumPerPeriod
+    : totalAvailable;
+
+  if (
+    bigNumberify(tokensBought).gte(lowestUpperLimit) &&
+    lowestUpperLimit.eq(maximumPerPeriod)
+  ) {
     return (
       <span className={styles.soldOut}>
         <FormattedMessage {...MSG.soldOut} />
@@ -47,10 +58,7 @@ const SoldTokensWidget = ({
           bigNumberify(tokensBought),
           decimals,
         ),
-        tokensAvailable: getFormattedTokenValue(
-          bigNumberify(tokensAvailable),
-          decimals,
-        ),
+        tokensAvailable: getFormattedTokenValue(lowestUpperLimit, decimals),
       }}
     />
   );

--- a/src/modules/dashboard/components/CoinMachine/TokenSalesTable/TokenSalesTable.css
+++ b/src/modules/dashboard/components/CoinMachine/TokenSalesTable/TokenSalesTable.css
@@ -58,10 +58,6 @@
   margin-left: 8px;
 }
 
-.cellDataDanger {
-  color: var(--danger);
-}
-
 .tokenSymbol {
   color: var(--temp-grey-blue-7);
 }

--- a/src/modules/dashboard/components/CoinMachine/TokenSalesTable/TokenSalesTable.css.d.ts
+++ b/src/modules/dashboard/components/CoinMachine/TokenSalesTable/TokenSalesTable.css.d.ts
@@ -6,7 +6,6 @@ export const tableHeader: string;
 export const tableHeaderCell: string;
 export const tableRow: string;
 export const cellData: string;
-export const cellDataDanger: string;
 export const tokenSymbol: string;
 export const noDataMessage: string;
 export const hiddenDataMessage: string;

--- a/src/modules/dashboard/components/CoinMachine/TokenSalesTable/TokenSalesTable.tsx
+++ b/src/modules/dashboard/components/CoinMachine/TokenSalesTable/TokenSalesTable.tsx
@@ -37,7 +37,7 @@ import styles from './TokenSalesTable.css';
 const MSG = defineMessages({
   tableTitle: {
     id: 'dashboard.CoinMachine.TokenSalesTable.tableTitle',
-    defaultMessage: `Previous Sales`,
+    defaultMessage: `Previous batches`,
   },
   saleColumnTitle: {
     id: `dashboard.CoinMachine.TokenSalesTable.saleColumnTitle`,

--- a/src/modules/dashboard/components/CoinMachine/TokenSalesTable/TokenSalesTable.tsx
+++ b/src/modules/dashboard/components/CoinMachine/TokenSalesTable/TokenSalesTable.tsx
@@ -142,6 +142,7 @@ const TokenSalesTable = ({
             <SoldTokensWidget
               tokensBought={tokensBought}
               tokensAvailable={tokensAvailable}
+              maxPerPeriod={maxPerPeriod}
               sellableToken={sellableToken as AnyToken}
             />
           ),

--- a/src/modules/dashboard/components/CoinMachine/TokenSalesTable/TokenSalesTable.tsx
+++ b/src/modules/dashboard/components/CoinMachine/TokenSalesTable/TokenSalesTable.tsx
@@ -44,11 +44,11 @@ const MSG = defineMessages({
   },
   amountColumnTitle: {
     id: `dashboard.CoinMachine.TokenSalesTable.amountColumnTitle`,
-    defaultMessage: 'Amount {nativeTokenSymbol}',
+    defaultMessage: 'Amount {sellableTokenSymbol}',
   },
   priceColumnTitle: {
     id: `dashboard.CoinMachine.TokenSalesTable.priceColumnTitle`,
-    defaultMessage: 'Price ETH',
+    defaultMessage: 'Price {purchaseTokenSymbol}',
   },
   noTableData: {
     id: 'dashboard.CoinMachine.TokenSalesTable.noTableData',
@@ -69,6 +69,7 @@ const MSG = defineMessages({
 interface Props {
   periodTokens?: PeriodTokensType;
   sellableToken?: TokenInfoQuery['tokenInfo'];
+  purchaseToken?: TokenInfoQuery['tokenInfo'];
   colonyAddress: Address;
   periodLength: number;
   periodRemainingTime: number;
@@ -80,6 +81,7 @@ const displayName = 'dashboard.CoinMachine.TokenSalesTable';
 const TokenSalesTable = ({
   periodTokens,
   sellableToken,
+  purchaseToken,
   colonyAddress,
   periodLength,
   periodRemainingTime,
@@ -105,13 +107,14 @@ const TokenSalesTable = ({
     {
       text: MSG.amountColumnTitle,
       textValues: {
-        nativeTokenSymbol: sellableToken?.symbol,
+        sellableTokenSymbol: sellableToken?.symbol,
         span: (chunks) => <span className={styles.tokenSymbol}>{chunks}</span>,
       },
     },
     {
       text: MSG.priceColumnTitle,
       textValues: {
+        purchaseTokenSymbol: purchaseToken?.symbol,
         span: (chunks) => <span className={styles.tokenSymbol}>{chunks}</span>,
       },
     },


### PR DESCRIPTION
This PR does so minor, but important, fixes to the Coin Machine Previous Sales _(which was renamed to "Previous Batches")_

- [x] Fix the sales display when the coin machine is out of tokens (it would have show 0 for all periods even though you had sales)
- [x] Show correct purchase token symbol
- [x] Change table title
- [x] Stop price evolution if there are no more tokens available in the coin machine
- [x] Hide sale periods in which there are no tokens available in the coin machine

Resolves #2906 
Resolves #2931 
Resolves #2935
Resolves #2936
Resolves #2933
