### PR TITLE
Fixes coin machine footer padding issue

### DIFF
--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.css
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.css
@@ -1,5 +1,14 @@
 .main {
   display: block;
+  margin: 0 0 20px 20px;
+  height: 100%;
+  width: calc(100% + 360px);
+}
+
+@media (max-height: 1024px) {
+  .main {
+    margin-bottom: 20%;
+  }
 }
 
 .loadingSpinner {

--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.css
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.css
@@ -5,7 +5,7 @@
   width: calc(100% + 360px);
 }
 
-@media (max-height: 1024px) {
+@media (max-height: 960px) {
   .main {
     margin-bottom: 20%;
   }


### PR DESCRIPTION
## Description

- [x] Fixes padding in the bottom of the coin machine, So 'We love feedback' doesn't get on top of it.

**New stuff** ✨

* Adds bottom padding value to mainContent class in ColonyHomeLayout.css


<img width="872" alt="Screenshot 2021-11-24 at 01 50 23" src="https://user-images.githubusercontent.com/6601142/143152552-249f168d-dcd5-4f9f-9142-276d05572b25.png">


Resolves #2902 
