### PR TITLE
Hide `userLimitFraction` during coin machine installation when there is no whitelist

### DIFF
--- a/src/modules/dashboard/components/Extensions/ExtensionSetup.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionSetup.tsx
@@ -301,7 +301,8 @@ const ExtensionSetup = ({
   const showInputField = useCallback(
     (paramName) => {
       return (
-        paramName !== 'whitelistAddress' ||
+        (paramName !== 'whitelistAddress' &&
+          paramName !== 'userLimitFraction') ||
         // @ts-ignore
         initialValues?.whitelistAddress !== AddressZero
       );


### PR DESCRIPTION
## Description

This PR hides per person limit field when there is no whitelist. This limit is not enforced when there is no whitelist (you can see the explanation in the thread of the corresponding issue) so Jack said to hide it (like we do with the whitelist address field).

To test - try enabling coin machine with whitelist & without.

resolves #2934 