### PR TITLE
Add redirection to colony after connecting user

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonySubscription/ColonySubscription.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonySubscription/ColonySubscription.tsx
@@ -37,7 +37,10 @@ interface Props {
   colony: Colony;
 }
 
-const ColonySubscription = ({ colony: { colonyAddress }, colony }: Props) => {
+const ColonySubscription = ({
+  colony: { colonyAddress, colonyName },
+  colony,
+}: Props) => {
   const { username, walletAddress, networkId } = useLoggedInUser();
 
   const { data } = useUserColonyAddressesQuery({
@@ -84,7 +87,10 @@ const ColonySubscription = ({ colony: { colonyAddress }, colony }: Props) => {
       {!isSubscribed && !username && (
         <Link
           className={styles.createUserRedirect}
-          to={CREATE_USER_ROUTE}
+          to={{
+            pathname: CREATE_USER_ROUTE,
+            state: { colonyURL: `/colony/${colonyName}` },
+          }}
           text={MSG.joinColony}
         />
       )}

--- a/src/modules/dashboard/components/CreateUserWizard/StepConfirmTransaction.tsx
+++ b/src/modules/dashboard/components/CreateUserWizard/StepConfirmTransaction.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { defineMessages } from 'react-intl';
-import { Redirect } from 'react-router-dom';
+import { Redirect, useHistory } from 'react-router-dom';
 
 import { LANDING_PAGE_ROUTE } from '~routes/index';
 import { useSelector } from '~utils/hooks';
@@ -28,8 +28,14 @@ const displayName = 'dashboard.CreateUserWizard.StepConfirmTransaction';
 const StepConfirmTransaction = () => {
   const { username } = useLoggedInUser();
   const transactionGroups = useSelector(groupedTransactions);
+  const { location } = useHistory<{ colonyURL?: string }>();
 
   if (username) {
+    const { colonyURL } = location.state;
+    if (colonyURL) {
+      return <Redirect to={colonyURL} />;
+    }
+
     return <Redirect to={LANDING_PAGE_ROUTE} />;
   }
 

--- a/src/routes/WalletRequiredRoute.tsx
+++ b/src/routes/WalletRequiredRoute.tsx
@@ -5,7 +5,6 @@ import {
   RouteProps,
   RouteComponentProps as ReactRouterComponentProps,
 } from 'react-router-dom';
-import { Location } from 'history';
 import { StaticContext } from 'react-router';
 
 import BetaCautionAlert from '~core/BetaCautionAlert';
@@ -55,7 +54,7 @@ const WalletRequiredRoute = ({
         props: ReactRouterComponentProps<
           {},
           StaticContext,
-          { redirectTo?: Location | string }
+          { redirectTo?: string; colonyURL?: string }
         >,
       ) => {
         /**
@@ -64,6 +63,8 @@ const WalletRequiredRoute = ({
         if (isConnected) {
           const redirectTo =
             props.location.state && props.location.state.redirectTo;
+          const colonyURL =
+            props.location.state && props.location.state.colonyURL;
           /**
            * Has username
            */
@@ -73,7 +74,16 @@ const WalletRequiredRoute = ({
              * connecting the wallet, then redirect back to it
              */
             if (redirectTo) {
-              return <Redirect to={redirectTo} />;
+              return (
+                <Redirect
+                  to={{
+                    pathname: redirectTo,
+                    state: {
+                      colonyURL,
+                    },
+                  }}
+                />
+              );
             }
             /**
              * We've connected, but already have a profile, just redirect to
@@ -165,6 +175,7 @@ const WalletRequiredRoute = ({
               to={{
                 pathname: CONNECT_ROUTE,
                 state: {
+                  ...location?.state,
                   redirectTo: locationPath,
                 },
               }}

--- a/src/routes/WalletRequiredRoute.tsx
+++ b/src/routes/WalletRequiredRoute.tsx
@@ -153,7 +153,7 @@ const WalletRequiredRoute = ({
                 to={{
                   pathname: CREATE_USER_ROUTE,
                   state: {
-                    redirectTo: locationPath,
+                    redirectTo: colonyURL || locationPath,
                   },
                 }}
               />


### PR DESCRIPTION
Added redirection back to the colony for 3 cases:

1. User is not connected, clicks join, connects wallet, has a username already.
2. User is connected, clicks join, doesn't have a username.
3. User is not connected, clicks join, doesn't have a username.

Resolves #2940 
