### PR TITLE
Updated button size, copy and removed microcopy

### DIFF
--- a/src/modules/core/components/Comment/Dialogs/BanComment/BanComment.css
+++ b/src/modules/core/components/Comment/Dialogs/BanComment/BanComment.css
@@ -68,6 +68,6 @@
   color: color-mod(var(--dark) alpha(65%));
 }
 
-.confirmButtonContainer > button {
-  width: 160px;
+.confirmButtonContainer {
+  max-width: 100%;
 }

--- a/src/modules/core/components/Comment/Dialogs/BanComment/BanComment.tsx
+++ b/src/modules/core/components/Comment/Dialogs/BanComment/BanComment.tsx
@@ -55,7 +55,7 @@ const MSG = defineMessages({
   confirmButtonText: {
     id: 'core.Comment.BanComment.confirmButtonText',
     defaultMessage: `{unban, select,
-      true {Unban the user}
+      true {Remove ban}
       other {Ban the troll}
     }`,
   },
@@ -131,9 +131,11 @@ const BanComment = ({
                 />
               </div>
             </div>
-            <p className={styles.note}>
-              <FormattedMessage {...MSG.note} values={{ unban }} />
-            </p>
+            {!unban && (
+              <p className={styles.note}>
+                <FormattedMessage {...MSG.note} values={{ unban }} />
+              </p>
+            )}
           </div>
           {!unban && (
             <div className={styles.modalContent}>

--- a/src/modules/core/components/Comment/Dialogs/BanComment/BanComment.tsx
+++ b/src/modules/core/components/Comment/Dialogs/BanComment/BanComment.tsx
@@ -35,10 +35,7 @@ const MSG = defineMessages({
   note: {
     id: 'core.Comment.BanComment.note',
     /* eslint-disable max-len */
-    defaultMessage: `Please note: {unban, select,
-      true {this only allows this user chatting in this colony. They will still be able to interact with any smart contracts they have permission to use.}
-      other {this only prevents this user from chatting in this colony. They will still be able to interact with any smart contracts they have permission to use.}
-    }`,
+    defaultMessage: `Please note: this only prevents this user from chatting in this colony. They will still be able to interact with any smart contracts they have permission to use.`,
     /* eslint-enable max-len */
   },
   commentLabel: {
@@ -133,7 +130,7 @@ const BanComment = ({
             </div>
             {!unban && (
               <p className={styles.note}>
-                <FormattedMessage {...MSG.note} values={{ unban }} />
+                <FormattedMessage {...MSG.note} />
               </p>
             )}
           </div>


### PR DESCRIPTION
## Description

- Fixes center alignment of 'Unban the user' button.
- Updates the button copy to 'Remove ban'
- Removes the irrelevant microcopy note text under the referenced user.

![unban-user](https://user-images.githubusercontent.com/33682027/143468758-0fabbee6-4fff-44bf-84a6-01bd46103041.png)

Resolves #2932
