### PR TITLE
Contain the scroll on dialogs

### DIFF
--- a/src/modules/core/components/Dialog/Dialog.css
+++ b/src/modules/core/components/Dialog/Dialog.css
@@ -2,12 +2,14 @@
   max-height: calc(100vh - 28px);
   position: relative;
   z-index: var(--z-index-dialog);
-  overflow-y: auto;
+  overflow: hidden;
   outline: none;
 }
 
 .main {
+  max-height: 85vh;
   width: 500px;
+  overflow-y: auto;
   border-radius: var(--radius-normal);
   background-color: var(--colony-white);
 }


### PR DESCRIPTION
## Description

- Fixes scroll on dialog boxes to be within the dialog container.
- Also sets a max height of dialog boxes.

![fixes-scroll](https://user-images.githubusercontent.com/33682027/143495738-442cc099-91f5-44a9-b747-01ddffd55a69.png)


Resolves #2942
