### PR TITLE
Update font weight of BuyTokens info tooltip

### DIFF
--- a/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.css
+++ b/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.css
@@ -35,6 +35,7 @@
 .tooltip {
   padding: 4px;
   width: 250px;
+  font-weight: var(--weight-bold);
 }
 
 .form {


### PR DESCRIPTION
BuyTokens's info tooltip styling should now be consistent with the rest of the tooltips in the coin machine

Resolves #2950 
