### PR TITLE
"I agree" button disabled, changing zoom makes button enabled

### DIFF
--- a/src/modules/dashboard/components/Whitelist/AgreementDialog/AgreementDialog.tsx
+++ b/src/modules/dashboard/components/Whitelist/AgreementDialog/AgreementDialog.tsx
@@ -68,7 +68,7 @@ const AgreementDialog = ({
 
   const handleScroll = (e) => {
     const bottom =
-      e.target.scrollHeight - e.target.scrollTop <= e.target.clientHeight;
+      e.target.scrollHeight - 1 - e.target.scrollTop <= e.target.clientHeight;
 
     if (bottom) {
       setHasBeenScrolled(true);


### PR DESCRIPTION
## Description

Fixes the agreement 'Got it' / 'I agree' button not working in some cases on scroll.

NOTE: The only way I was able to replicate the issue was to zoom in within the browser window.

### Before fix:

![Colony-agreement-scroll](https://user-images.githubusercontent.com/33682027/143829769-73f33e57-2103-46f7-b52a-bd77c79f4b76.gif)


### After fix:

![Colony-agreement-scroll-fix](https://user-images.githubusercontent.com/33682027/143829783-67cec378-279f-4076-82fa-be7e6441cc26.gif)


Resolves #2965
