### PR TITLE
Refresh sales data period query after extension install

### DIFF
--- a/src/modules/dashboard/components/CoinMachine/TokenSalesTable/TokenSalesTable.tsx
+++ b/src/modules/dashboard/components/CoinMachine/TokenSalesTable/TokenSalesTable.tsx
@@ -88,6 +88,7 @@ interface Props {
 }
 
 const displayName = 'dashboard.CoinMachine.TokenSalesTable';
+export const PREV_PERIODS_LIMIT = 100;
 
 const TokenSalesTable = ({
   periodTokens,
@@ -102,7 +103,6 @@ const TokenSalesTable = ({
     maxPerPeriod,
   },
 }: Props) => {
-  const PREV_PERIODS_LIMIT = 100;
   const salePeriodQueryVariables = { colonyAddress, limit: PREV_PERIODS_LIMIT };
 
   const priceStatusHeading = useMemo(() => {

--- a/src/modules/dashboard/sagas/utils/refreshExtension.ts
+++ b/src/modules/dashboard/sagas/utils/refreshExtension.ts
@@ -23,8 +23,12 @@ import {
   UserWhitelistStatusQuery,
   UserWhitelistStatusQueryVariables,
   UserWhitelistStatusDocument,
+  CoinMachineSalePeriodsQuery,
+  CoinMachineSalePeriodsQueryVariables,
+  CoinMachineSalePeriodsDocument,
 } from '~data/index';
 import { ContextModule, TEMP_getContext } from '~context/index';
+import { PREV_PERIODS_LIMIT } from '~dashboard/CoinMachine/TokenSalesTable/TokenSalesTable';
 
 export function* refreshExtension(
   colonyAddress: string,
@@ -64,6 +68,20 @@ export function* refreshExtension(
       variables: {
         colonyAddress,
         userAddress: walletAddress,
+      },
+      fetchPolicy: 'network-only',
+    });
+  }
+
+  if (extensionId === Extension.CoinMachine) {
+    yield apolloClient.query<
+      CoinMachineSalePeriodsQuery,
+      CoinMachineSalePeriodsQueryVariables
+    >({
+      query: CoinMachineSalePeriodsDocument,
+      variables: {
+        colonyAddress,
+        limit: PREV_PERIODS_LIMIT,
       },
       fetchPolicy: 'network-only',
     });


### PR DESCRIPTION
## Description

This PR fixes PreviousSalesTable widget caching issue. It was showing data from previous sales (but from last coin extension address) after coin machine extension reinstall

**Changes** 🏗

* Updated refreshExtension to update SalesPeriodData after coin machine extension install

Resolves #2970 
