### PR TITLE
Members List Poor Man's Pagination

### DIFF
--- a/src/modules/dashboard/components/CreateUserWizard/StepConfirmTransaction.tsx
+++ b/src/modules/dashboard/components/CreateUserWizard/StepConfirmTransaction.tsx
@@ -31,9 +31,8 @@ const StepConfirmTransaction = () => {
   const { location } = useHistory<{ colonyURL?: string }>();
 
   if (username) {
-    const { colonyURL } = location.state;
-    if (colonyURL) {
-      return <Redirect to={colonyURL} />;
+    if (location?.state?.colonyURL) {
+      return <Redirect to={location.state.colonyURL} />;
     }
 
     return <Redirect to={LANDING_PAGE_ROUTE} />;

--- a/src/modules/pages/components/RouteLayouts/UserNavigation.tsx
+++ b/src/modules/pages/components/RouteLayouts/UserNavigation.tsx
@@ -19,6 +19,7 @@ import {
   useLoggedInUser,
   useUserBalanceWithLockQuery,
   useColonyFromNameQuery,
+  Colony,
 } from '~data/index';
 import { useSelector } from '~utils/hooks';
 import { useAutoLogin, getLastWallet } from '~utils/autoLogin';
@@ -209,7 +210,7 @@ const UserNavigation = () => {
       )}
       <AvatarDropdown
         onlyLogout={!isNetworkAllowed}
-        colony={colonyData?.processedColony}
+        colony={colonyData?.processedColony as Colony}
       />
     </div>
   );

--- a/src/modules/pages/components/RouteLayouts/UserNavigation.tsx
+++ b/src/modules/pages/components/RouteLayouts/UserNavigation.tsx
@@ -207,7 +207,10 @@ const UserNavigation = () => {
           )}
         </InboxPopover>
       )}
-      <AvatarDropdown onlyLogout={!isNetworkAllowed} />
+      <AvatarDropdown
+        onlyLogout={!isNetworkAllowed}
+        colony={colonyData?.processedColony}
+      />
     </div>
   );
 };

--- a/src/modules/users/components/AvatarDropdown/AvatarDropdown.tsx
+++ b/src/modules/users/components/AvatarDropdown/AvatarDropdown.tsx
@@ -3,7 +3,7 @@ import classnames from 'classnames';
 
 import Popover from '~core/Popover';
 import HookedUserAvatar from '~users/HookedUserAvatar';
-import { useLoggedInUser } from '~data/index';
+import { useLoggedInUser, Colony } from '~data/index';
 import { removeValueUnits } from '~utils/css';
 
 import AvatarDropdownPopover from './AvatarDropdownPopover';
@@ -18,11 +18,12 @@ const UserAvatar = HookedUserAvatar();
 
 interface Props {
   onlyLogout?: boolean;
+  colony: Colony;
 }
 
 const displayName = 'users.AvatarDropdown';
 
-const AvatarDropdown = ({ onlyLogout = false }: Props) => {
+const AvatarDropdown = ({ onlyLogout = false, colony }: Props) => {
   const { username, walletAddress, ethereal } = useLoggedInUser();
 
   /*
@@ -52,6 +53,7 @@ const AvatarDropdown = ({ onlyLogout = false }: Props) => {
           username={username}
           walletConnected={!!walletAddress && !ethereal}
           onlyLogout={onlyLogout}
+          colony={colony}
         />
       )}
       trigger="click"

--- a/src/modules/users/components/AvatarDropdown/AvatarDropdownPopover.tsx
+++ b/src/modules/users/components/AvatarDropdown/AvatarDropdownPopover.tsx
@@ -2,18 +2,21 @@ import React, { useCallback } from 'react';
 import { defineMessages } from 'react-intl';
 
 import { ActionButton } from '~core/Button';
+import NavLink from '~core/NavLink';
+import ExternalLink from '~core/ExternalLink';
+
+import { Colony } from '~data/index';
+import DropdownMenu, {
+  DropdownMenuSection,
+  DropdownMenuItem,
+} from '~core/DropdownMenu';
 import { ActionTypes } from '~redux/index';
 import {
   USER_EDIT_ROUTE,
   CREATE_COLONY_ROUTE,
   CREATE_USER_ROUTE,
 } from '~routes/index';
-import DropdownMenu, {
-  DropdownMenuSection,
-  DropdownMenuItem,
-} from '~core/DropdownMenu';
-import NavLink from '~core/NavLink';
-import ExternalLink from '~core/ExternalLink';
+
 import styles from './AvatarDropdownPopover.css';
 
 const MSG = defineMessages({
@@ -56,6 +59,7 @@ interface Props {
   username?: string | null;
   walletConnected?: boolean;
   onlyLogout?: boolean;
+  colony: Colony;
 }
 
 const displayName = 'users.AvatarDropdown.AvatarDropdownPopover';
@@ -65,13 +69,20 @@ const AvatarDropdownPopover = ({
   username,
   walletConnected = false,
   onlyLogout = false,
+  colony,
 }: Props) => {
   const renderUserSection = useCallback(() => {
     return (
       <DropdownMenuSection separator>
         {!username && (
           <DropdownMenuItem>
-            <NavLink to={CREATE_USER_ROUTE} text={MSG.buttonGetStarted} />
+            <NavLink
+              to={{
+                pathname: CREATE_USER_ROUTE,
+                state: { colonyURL: `/colony/${colony.colonyName}` },
+              }}
+              text={MSG.buttonGetStarted}
+            />
           </DropdownMenuItem>
         )}
         {username && (
@@ -94,7 +105,7 @@ const AvatarDropdownPopover = ({
         )}
       </DropdownMenuSection>
     );
-  }, [username]);
+  }, [colony, username]);
 
   const renderColonySection = () => (
     <DropdownMenuSection separator>


### PR DESCRIPTION
This PR adds a _"pagination"_ implementation to the `Members` list for the colony. This is **not a proper** implementation of pagination as the metadata server where we fetch this data from does not have this capability. As I've mentioned in my [comment](https://github.com/JoinColony/colonyDapp/blob/34371d0229b41ea312522fc0ae4a59d7117b69f6/src/modules/dashboard/components/Members/Members.tsx#L256-L266), the only good way to implement this, would be to add this logic to the server, then just fetch the chunks of users data we need.

But due to time constraints we have to do the next best thing. Just split the users list into chunks, and then render just render specific chunks. While the data fetching cost still remains high, it will alleviate some memory problems that React will incur trying to render a huge list.

While I was at it, I also fixed a problem when the user wasn't being redirected properly back to the colony, when first registering their account.

## Testing

### 1. Members list 

Just replace the `skelethonUsers` array with one that duplicates your existent data a stupid amount of times_(ignore React duplicate keys error)_

```js
 const skelethonUsers = useMemo(() => {
    let displayMembers =
      allMembers?.subscribedUsers.map(
        ({ profile: { walletAddress } }) => walletAddress,
      ) || [];
    if (currentDomainId !== COLONY_TOTAL_BALANCE_DOMAIN_ID) {
      displayMembers = membersWithReputation?.colonyMembersWithReputation || [];
    }

    return [
      ...displayMembers,
      ...displayMembers,
      ...displayMembers,
      ...displayMembers,
      ...displayMembers,
      ...displayMembers,
      ...displayMembers,
      ...displayMembers,
      ...displayMembers,
      ...displayMembers,
    ].map((walletAddress) => ({
      id: walletAddress,
      profile: { walletAddress },
    }));
  }, [allMembers, membersWithReputation, currentDomainId]);
```

### 2. Redirect after account creation

- Go to an existing colony with a fresh address _(one that doesn't have a profile already registered)_
- Click the top-right avatar dropdown "Get Started" menu entry
- Create your profile
- At the end, after the transaction is confirmed, you should be redirected back to the original colony you started from