### PR TITLE
Add unwrap and claim tokens routes

### DIFF
--- a/src/modules/dashboard/components/ClaimTokensPage/ClaimTokensPage.tsx
+++ b/src/modules/dashboard/components/ClaimTokensPage/ClaimTokensPage.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const displayName = 'dashboard.ClaimTokensPage';
+
+const ClaimTokensPage = () => {
+  // @TODO: Add actual content for the claim tokens page
+  return <span>Claim tokens now!! Limited time offer</span>;
+};
+
+ClaimTokensPage.displayName = displayName;
+
+export default ClaimTokensPage;

--- a/src/modules/dashboard/components/ClaimTokensPage/index.ts
+++ b/src/modules/dashboard/components/ClaimTokensPage/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ClaimTokensPage';

--- a/src/modules/dashboard/components/CreateUserWizard/StepConfirmTransaction.tsx
+++ b/src/modules/dashboard/components/CreateUserWizard/StepConfirmTransaction.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { defineMessages } from 'react-intl';
 import { Redirect, useHistory } from 'react-router-dom';
 
-import { LANDING_PAGE_ROUTE } from '~routes/index';
 import { useSelector } from '~utils/hooks';
 import { useLoggedInUser } from '~data/index';
 
@@ -28,14 +27,26 @@ const displayName = 'dashboard.CreateUserWizard.StepConfirmTransaction';
 const StepConfirmTransaction = () => {
   const { username } = useLoggedInUser();
   const transactionGroups = useSelector(groupedTransactions);
-  const { location } = useHistory<{ colonyURL?: string }>();
+  const { location } = useHistory<{
+    colonyURL?: string;
+    redirectTo?: string;
+  }>();
 
   if (username) {
     if (location?.state?.colonyURL) {
       return <Redirect to={location.state.colonyURL} />;
     }
 
-    return <Redirect to={LANDING_PAGE_ROUTE} />;
+    return (
+      <Redirect
+        to={{
+          pathname: location.state.redirectTo,
+          state: {
+            ...location.state,
+          },
+        }}
+      />
+    );
   }
 
   const colonyTransaction = findTransactionGroupByKey(

--- a/src/modules/dashboard/components/CreateUserWizard/StepConfirmTransaction.tsx
+++ b/src/modules/dashboard/components/CreateUserWizard/StepConfirmTransaction.tsx
@@ -12,6 +12,8 @@ import {
 } from '~users/GasStation/transactionGroup';
 import Heading from '~core/Heading';
 import GasStationContent from '~users/GasStation/GasStationContent';
+import { LANDING_PAGE_ROUTE } from '~routes/routeConstants';
+
 import styles from './StepConfirmTransaction.css';
 
 const MSG = defineMessages({
@@ -40,7 +42,7 @@ const StepConfirmTransaction = () => {
     return (
       <Redirect
         to={{
-          pathname: location.state.redirectTo,
+          pathname: location.state.redirectTo || LANDING_PAGE_ROUTE,
           state: {
             ...location.state,
           },

--- a/src/modules/dashboard/components/UnwrapTokensPage/UnwrapTokensPage.tsx
+++ b/src/modules/dashboard/components/UnwrapTokensPage/UnwrapTokensPage.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const displayName = 'dashboard.UnwrapTokensPage';
+
+const UnwrapTokensPage = () => {
+  // @TODO: Add actual content for the unwrap tokens page
+  return <span>Unwrap tokens now!! Limited time offer</span>;
+};
+
+UnwrapTokensPage.displayName = displayName;
+
+export default UnwrapTokensPage;

--- a/src/modules/dashboard/components/UnwrapTokensPage/index.ts
+++ b/src/modules/dashboard/components/UnwrapTokensPage/index.ts
@@ -1,0 +1,1 @@
+export { default } from './UnwrapTokensPage';

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -19,11 +19,14 @@ import { ColonyBackText } from '~pages/BackTexts';
 import LoadingTemplate from '~pages/LoadingTemplate';
 import LadingPage from '~pages/LandingPage';
 import ActionsPage from '~dashboard/ActionsPage';
+import ClaimTokensPage from '~dashboard/ClaimTokensPage';
+import UnwrapTokensPage from '~dashboard/UnwrapTokensPage';
 
 import appLoadingContext from '~context/appLoadingState';
 import ColonyFunding from '~dashboard/ColonyFunding';
 import { useLoggedInUser } from '~data/index';
 import { ActionTypes } from '~redux/index';
+import { METACOLONY_ENS } from '~constants';
 
 import {
   COLONY_EVENTS_ROUTE,
@@ -44,6 +47,8 @@ import {
   MEMBERS_ROUTE,
   ACTIONS_PAGE_ROUTE,
   COIN_MACHINE_ROUTE,
+  UNWRAP_TOKEN_ROUTE,
+  CLAIM_TOKEN_ROUTE,
 } from './routeConstants';
 
 import AlwaysAccesibleRoute from './AlwaysAccesibleRoute';
@@ -57,6 +62,10 @@ const MSG = defineMessages({
   loadingAppMessage: {
     id: 'routes.Routes.loadingAppMessage',
     defaultMessage: 'Loading App',
+  },
+  backToMetacolony: {
+    id: 'routes.Routes.backToMetacolony',
+    defaultMessage: 'Back to The Metacolony',
   },
 });
 
@@ -143,6 +152,28 @@ const Routes = () => {
           layout={SimpleNav}
           routeProps={{
             hasBackLink: false,
+          }}
+        />
+        <WalletRequiredRoute
+          isConnected={isConnected}
+          didClaimProfile={didClaimProfile}
+          path={UNWRAP_TOKEN_ROUTE}
+          component={UnwrapTokensPage}
+          layout={NavBar}
+          routeProps={{
+            backText: MSG.backToMetacolony,
+            backRoute: `/colony/${METACOLONY_ENS}`,
+          }}
+        />
+        <WalletRequiredRoute
+          isConnected={isConnected}
+          didClaimProfile={didClaimProfile}
+          path={CLAIM_TOKEN_ROUTE}
+          component={ClaimTokensPage}
+          layout={NavBar}
+          routeProps={{
+            backText: MSG.backToMetacolony,
+            backRoute: `/colony/${METACOLONY_ENS}`,
           }}
         />
 

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -62,10 +62,6 @@ const MSG = defineMessages({
     id: 'routes.Routes.loadingAppMessage',
     defaultMessage: 'Loading App',
   },
-  backToMetacolony: {
-    id: 'routes.Routes.backToMetacolony',
-    defaultMessage: 'Back to The Metacolony',
-  },
 });
 
 const Routes = () => {

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -26,7 +26,6 @@ import appLoadingContext from '~context/appLoadingState';
 import ColonyFunding from '~dashboard/ColonyFunding';
 import { useLoggedInUser } from '~data/index';
 import { ActionTypes } from '~redux/index';
-import { METACOLONY_ENS } from '~constants';
 
 import {
   COLONY_EVENTS_ROUTE,
@@ -154,28 +153,6 @@ const Routes = () => {
             hasBackLink: false,
           }}
         />
-        <WalletRequiredRoute
-          isConnected={isConnected}
-          didClaimProfile={didClaimProfile}
-          path={UNWRAP_TOKEN_ROUTE}
-          component={UnwrapTokensPage}
-          layout={NavBar}
-          routeProps={{
-            backText: MSG.backToMetacolony,
-            backRoute: `/colony/${METACOLONY_ENS}`,
-          }}
-        />
-        <WalletRequiredRoute
-          isConnected={isConnected}
-          didClaimProfile={didClaimProfile}
-          path={CLAIM_TOKEN_ROUTE}
-          component={ClaimTokensPage}
-          layout={NavBar}
-          routeProps={{
-            backText: MSG.backToMetacolony,
-            backRoute: `/colony/${METACOLONY_ENS}`,
-          }}
-        />
 
         <AlwaysAccesibleRoute
           path={LANDING_PAGE_ROUTE}
@@ -253,6 +230,24 @@ const Routes = () => {
           component={ColonyHome}
           layout={Default}
           routeProps={{ hasBackLink: false }}
+        />
+        <AlwaysAccesibleRoute
+          path={UNWRAP_TOKEN_ROUTE}
+          component={UnwrapTokensPage}
+          layout={NavBar}
+          routeProps={({ colonyName }) => ({
+            backText: ColonyBackText,
+            backRoute: `/colony/${colonyName}`,
+          })}
+        />
+        <AlwaysAccesibleRoute
+          path={CLAIM_TOKEN_ROUTE}
+          component={ClaimTokensPage}
+          layout={NavBar}
+          routeProps={({ colonyName }) => ({
+            backText: ColonyBackText,
+            backRoute: `/colony/${colonyName}`,
+          })}
         />
 
         {/*

--- a/src/routes/WalletRequiredRoute.tsx
+++ b/src/routes/WalletRequiredRoute.tsx
@@ -10,16 +10,13 @@ import { StaticContext } from 'react-router';
 import BetaCautionAlert from '~core/BetaCautionAlert';
 import FeedbackWidget from '~core/FeedbackWidget';
 import { RouteComponentProps } from '~pages/RouteLayouts';
-import { METACOLONY_ENS } from '~constants';
 
 import {
   CREATE_USER_ROUTE,
   LANDING_PAGE_ROUTE,
   CONNECT_ROUTE,
   CREATE_COLONY_ROUTE,
-  NOT_FOUND_ROUTE,
 } from './routeConstants';
-import { CLAIM_TOKEN_ROUTE, UNWRAP_TOKEN_ROUTE } from '.';
 
 interface ComponentProps extends RouteProps {
   routeProps?: RouteComponentProps;
@@ -56,19 +53,14 @@ const WalletRequiredRoute = ({
       path={path}
       render={(
         props: ReactRouterComponentProps<
-          { colonyName?: string },
+          {},
           StaticContext,
           {
             redirectTo?: string;
             colonyURL?: string;
-            isMetaColonyExclusive?: boolean;
           }
         >,
       ) => {
-        const isMetaColonyExclusive =
-          props.match.path === CLAIM_TOKEN_ROUTE ||
-          props.match.path === UNWRAP_TOKEN_ROUTE;
-
         /**
          * Connected
          */
@@ -92,7 +84,6 @@ const WalletRequiredRoute = ({
                     pathname: redirectTo,
                     state: {
                       colonyURL,
-                      isMetaColonyExclusive,
                     },
                   }}
                 />
@@ -191,23 +182,10 @@ const WalletRequiredRoute = ({
                 state: {
                   ...location?.state,
                   redirectTo: locationPath,
-                  isMetaColonyExclusive,
                 },
               }}
             />
           );
-        }
-
-        /*
-         * Redirect user to the 404 page if the page is exclusive to the meta colony
-         * and the colony used in the URL isn't it.
-         */
-        if (
-          (isMetaColonyExclusive ||
-            props.location.state.isMetaColonyExclusive) &&
-          props.match.params.colonyName !== METACOLONY_ENS
-        ) {
-          return <Redirect to={NOT_FOUND_ROUTE} />;
         }
 
         /**

--- a/src/routes/routeConstants.ts
+++ b/src/routes/routeConstants.ts
@@ -16,3 +16,5 @@ export const NOT_FOUND_ROUTE = '/404';
 export const LANDING_PAGE_ROUTE = '/landing';
 export const ACTIONS_PAGE_ROUTE = `${COLONY_HOME_ROUTE}/tx/:transactionHash`;
 export const COIN_MACHINE_ROUTE = `${COLONY_HOME_ROUTE}/buy-tokens/:transactionHash?`;
+export const UNWRAP_TOKEN_ROUTE = `${COLONY_HOME_ROUTE}/unwrap-tokens`;
+export const CLAIM_TOKEN_ROUTE = `${COLONY_HOME_ROUTE}/claim-tokens`;


### PR DESCRIPTION
Added `/:colonyName/unwrap-tokens` and `/:colonyName/claim-tokens` routes to the metacolony. 

**What to test:**
1. You shouldn't be able to go to those routes if the colony from which we are trying to access it is not the meta colony. If you try it, you should be redirected to a 404 page.
2. You shouldn't be able to access the pages if you don't have a wallet connected and username assigned.

In order to test the page with a normal non-meta colony you can just change line `208` inside `WalletProtectedRoute` to `props.match.params.colonyName === METACOLONY_ENS`

Resolves #2976 
