### PR TITLE
Fixes assigning motionId properly when team is pre-selected

### DIFF
--- a/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialog.tsx
+++ b/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialog.tsx
@@ -143,7 +143,10 @@ const CreatePaymentDialog = ({
         amount: undefined,
         tokenAddress: nativeTokenAddress,
         annotation: undefined,
-        motionDomainId: ROOT_DOMAIN_ID,
+        motionDomainId: (ethDomainId === 0 || ethDomainId === undefined
+          ? ROOT_DOMAIN_ID
+          : ethDomainId
+        ).toString(),
       }}
       validationSchema={validationSchema}
       submit={getFormAction('SUBMIT')}


### PR DESCRIPTION
## Description

- [ ] In order to reproduce the bug, you need to choose the team before creating the expenditure (see screenshots below), which gets it attached/pre-selected to the UI when creating a new payment/motion

**Changes** 🏗

* As per @rdig suggestions, I copied the implementation from domainId for motionDomainId.
```before
      initialValues={{
        forceAction: false,
        domainId: (ethDomainId === 0 || ethDomainId === undefined
          ? ROOT_DOMAIN_ID
          : ethDomainId
        ).toString(),
...
        motionDomainId: ROOT_DOMAIN_ID,
      }}
```
```after
      initialValues={{
        forceAction: false,
        domainId: (ethDomainId === 0 || ethDomainId === undefined
          ? ROOT_DOMAIN_ID
          : ethDomainId
        ).toString(),
...
        motionDomainId: (ethDomainId === 0 || ethDomainId === undefined
          ? ROOT_DOMAIN_ID
          : ethDomainId
        ).toString(),
      }}
```

Screenshots
1. Choose a team before creating payment
![image](https://user-images.githubusercontent.com/6601142/144124732-17cb9af8-bb0d-406a-b1f0-1233715826fe.png)


2. Create a payment / motion
![image](https://user-images.githubusercontent.com/6601142/144124581-3cb14a9a-a97b-442c-a790-2dd9beb2c304.png)

3. Your motion will be created at the correct domainId of your chosen team
4. 
![image](https://user-images.githubusercontent.com/6601142/144124424-2540cf48-6801-442b-aaca-f3df5b370e6f.png)


Resolves #2980
