### PR TITLE
Add annotations to the Unlock Token modal

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -116,8 +116,10 @@
     "transaction.ColonyClient.exitRecoveryMode.title": "Exit Recovery Mode",
     "transaction.ColonyClient.exitRecoveryMode.description": "Exit Recovery Mode",
 
-    "transaction.ColonyClient.unlockToken.title": "Unlock Token",
-    "transaction.ColonyClient.unlockToken.description": "Unlock Token",
+    "transaction.group.tokenUnlockAction.title": "Unlock Token",
+    "transaction.group.tokenUnlockAction.description": "Unlocking native Token",
+    "transaction.ColonyClient.unlockToken.title": "Unlocking Token",
+    "transaction.ColonyClient.unlockToken.description": "Unlocking Token",
 
     "transaction.group.paymentAction.title": "Expenditure Payment",
     "transaction.group.paymentAction.description": "Expenditure Payment",

--- a/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenDialog.tsx
+++ b/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenDialog.tsx
@@ -5,7 +5,13 @@ import { useHistory } from 'react-router-dom';
 import Dialog, { DialogProps } from '~core/Dialog';
 import { ActionForm } from '~core/Fields';
 import { ActionTypes } from '~redux/index';
-import { pipe, mergePayload, withMeta } from '~utils/actions';
+import {
+  pipe,
+  mergePayload,
+  withMeta,
+  withKey,
+  mapPayload,
+} from '~utils/actions';
 import { Colony } from '~data/index';
 import { WizardDialogType } from '~utils/hooks';
 
@@ -34,6 +40,10 @@ const UnlockTokenDialog = ({
 
   const transform = useCallback(
     pipe(
+      withKey(colonyAddress),
+      mapPayload(({ annotationMessage }) => ({
+        annotationMessage,
+      })),
       mergePayload({
         colonyAddress,
       }),
@@ -44,7 +54,9 @@ const UnlockTokenDialog = ({
 
   return (
     <ActionForm
-      initialValues={{}}
+      initialValues={{
+        annotationMessage: undefined,
+      }}
       submit={ActionTypes.COLONY_ACTION_UNLOCK_TOKEN}
       error={ActionTypes.COLONY_ACTION_UNLOCK_TOKEN_ERROR}
       success={ActionTypes.COLONY_ACTION_UNLOCK_TOKEN_SUCCESS}

--- a/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenForm.tsx
+++ b/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenForm.tsx
@@ -17,6 +17,7 @@ import { getAllUserRoles } from '../../../transformers';
 import { hasRoot } from '../../../users/checks';
 
 import styles from './UnlockTokenForm.css';
+import { Annotations } from '~core/Fields';
 
 const MSG = defineMessages({
   title: {
@@ -38,6 +39,10 @@ const MSG = defineMessages({
     id: 'dashboard.UnlockTokenDialog.UnlockTokenForm.noPermission',
     defaultMessage: `You do not have the {roleRequired} permission required
       to take this action.`,
+  },
+  annotation: {
+    id: `dashboard.UnlockTokenDialog.UnlockTokenForm.annotation`,
+    defaultMessage: 'Explain why you’re making these changes (optional)',
   },
 });
 
@@ -92,6 +97,11 @@ const UnlockTokenForm = ({
             href={LEARN_MORE_URL}
           />
         </div>
+        <Annotations
+          label={MSG.annotation}
+          name="annotationMessage"
+          disabled={!userHasPermissions}
+        />
       </DialogSection>
       {!hasRootPermission && (
         <DialogSection appearance={{ theme: 'sidePadding' }}>

--- a/src/modules/dashboard/sagas/actions/unlockToken.ts
+++ b/src/modules/dashboard/sagas/actions/unlockToken.ts
@@ -9,29 +9,133 @@ import {
 } from '~data/index';
 import { Action, ActionTypes } from '~redux/index';
 import { putError, takeFrom } from '~utils/saga/effects';
-import { createTransaction, getTxChannel } from '../../../core/sagas';
+import {
+  createTransaction,
+  createTransactionChannels,
+  getTxChannel,
+} from '../../../core/sagas';
+import { ipfsUpload } from '../../../core/sagas/ipfs';
+import {
+  transactionReady,
+  transactionPending,
+  transactionAddParams,
+} from '../../../core/actionCreators';
 
-function* colonyTokenUnlock({
+function* tokenUnlockAction({
   meta,
-  payload: { colonyAddress },
+  meta: { id: metaId },
+  payload: { colonyAddress, annotationMessage },
 }: Action<ActionTypes.COLONY_ACTION_UNLOCK_TOKEN>) {
-  const txChannel = yield call(getTxChannel, meta.id);
+  let txChannel;
 
   try {
-    yield fork(createTransaction, meta.id, {
+    const apolloClient = TEMP_getContext(ContextModule.ApolloClient);
+
+    txChannel = yield call(getTxChannel, metaId);
+
+    const batchKey = 'tokenUnlockAction';
+    const {
+      tokenUnlockAction: tokenUnlock,
+      annotateTokenUnlockAction: annotateTokenUnlock,
+    } = yield createTransactionChannels(metaId, [
+      'tokenUnlockAction',
+      'annotateTokenUnlockAction',
+    ]);
+
+    /*
+     * Create a grouped transaction
+     */
+    const createGroupTransaction = ({ id, index }, config) =>
+      fork(createTransaction, id, {
+        ...config,
+        group: {
+          key: batchKey,
+          id: metaId,
+          index,
+        },
+      });
+
+    /*
+     * Add the tokenUnlock transaction to the group
+     */
+
+    yield createGroupTransaction(tokenUnlock, {
       context: ClientType.ColonyClient,
       methodName: 'unlockToken',
       identifier: colonyAddress,
+      params: [],
+      ready: false,
     });
 
-    yield takeFrom(txChannel, ActionTypes.TRANSACTION_SUCCEEDED);
+    /*
+     * If annotation message exists add the transaction to the group
+     */
 
-    yield put({
-      type: ActionTypes.COLONY_ACTION_UNLOCK_TOKEN_SUCCESS,
-      meta,
-    });
+    if (annotationMessage) {
+      yield createGroupTransaction(annotateTokenUnlock, {
+        context: ClientType.ColonyClient,
+        methodName: 'annotateTransaction',
+        identifier: colonyAddress,
+        params: [],
+        ready: false,
+      });
+    }
 
-    const apolloClient = TEMP_getContext(ContextModule.ApolloClient);
+    /*
+     * Wait for transactions to be created
+     */
+
+    yield takeFrom(tokenUnlock.channel, ActionTypes.TRANSACTION_CREATED);
+
+    if (annotationMessage) {
+      yield takeFrom(
+        annotateTokenUnlock.channel,
+        ActionTypes.TRANSACTION_CREATED,
+      );
+    }
+
+    /*
+     * Check for transaction and wait for response
+     */
+
+    yield put(transactionReady(tokenUnlock.id));
+
+    const {
+      payload: { hash: txHash },
+    } = yield takeFrom(
+      tokenUnlock.channel,
+      ActionTypes.TRANSACTION_HASH_RECEIVED,
+    );
+    yield takeFrom(tokenUnlock.channel, ActionTypes.TRANSACTION_SUCCEEDED);
+
+    if (annotationMessage) {
+      yield put(transactionPending(annotateTokenUnlock.id));
+
+      /*
+       * Upload annotation metadata to IPFS
+       */
+      let annotationMessageIpfsHash = null;
+      annotationMessageIpfsHash = yield call(
+        ipfsUpload,
+        JSON.stringify({
+          annotationMessage,
+        }),
+      );
+
+      yield put(
+        transactionAddParams(annotateTokenUnlock.id, [
+          txHash,
+          annotationMessageIpfsHash,
+        ]),
+      );
+
+      yield put(transactionReady(annotateTokenUnlock.id));
+
+      yield takeFrom(
+        annotateTokenUnlock.channel,
+        ActionTypes.TRANSACTION_SUCCEEDED,
+      );
+    }
 
     yield apolloClient.query<
       ProcessedColonyQuery,
@@ -42,6 +146,11 @@ function* colonyTokenUnlock({
         address: colonyAddress,
       },
       fetchPolicy: 'network-only',
+    });
+
+    yield put({
+      type: ActionTypes.COLONY_ACTION_UNLOCK_TOKEN_SUCCESS,
+      meta,
     });
   } catch (error) {
     return yield putError(
@@ -56,5 +165,5 @@ function* colonyTokenUnlock({
 }
 
 export default function* unlockTokenActionSaga() {
-  yield takeEvery(ActionTypes.COLONY_ACTION_UNLOCK_TOKEN, colonyTokenUnlock);
+  yield takeEvery(ActionTypes.COLONY_ACTION_UNLOCK_TOKEN, tokenUnlockAction);
 }

--- a/src/redux/types/actions/colonyActions.ts
+++ b/src/redux/types/actions/colonyActions.ts
@@ -171,6 +171,7 @@ export type ColonyActionsActionTypes =
       ActionTypes.COLONY_ACTION_UNLOCK_TOKEN,
       {
         colonyAddress: Address;
+        annotationMessage?: string;
       },
       MetaWithHistory<object>
     >


### PR DESCRIPTION
## Description

This PR adds an annotation input field to the Unlock Token modal. 

It includes:
- Utilising the existing Annotations component.
- Handling of the annotation transaction in the, now renamed for consistency, tokenUnlockAction saga.
- Updated COLONY_ACTION_UNLOCK_TOKEN redux action type.
- New language definitions.

![UnlockTokenAnnotation](https://user-images.githubusercontent.com/33682027/144265699-14bdbf9d-9489-4a7b-9b9a-ffe2f80e54ec.gif)

## Testing:
- Navigate to New Action > Manage Funds > Unlock Token
- Enter in some text into the annotation field
- Click the "Confirm" button


Resolves #2815
