### PR TITLE
Fix edit domain dialog 

### DIFF
--- a/src/modules/dashboard/components/EditDomainDialog/EditDomainDialog.tsx
+++ b/src/modules/dashboard/components/EditDomainDialog/EditDomainDialog.tsx
@@ -74,7 +74,7 @@ const EditDomainDialog = ({
     domainName: yup.string().max(20).required(),
     domainId: yup.number().required(),
     domainColor: yup.string(),
-    domainPurpose: yup.string().max(90),
+    domainPurpose: yup.string().nullable().max(90),
     annotationMessage: yup.string().max(4000),
     motionDomainId: yup.number(),
   });


### PR DESCRIPTION
Fixed `domainPurpose` validation on the edit domain.

The dialog was overflowing because the error message (that was hidden) below the domain purpose input was really long, due to `domainPurpose` being initially `null/undefined`.

Resolves #2988 
