### PR TITLE
Fixes permissions bug on unlock modal when token already unlocked

### DIFF
--- a/src/modules/dashboard/components/ManageFundsDialog/ManageFundsDialog.tsx
+++ b/src/modules/dashboard/components/ManageFundsDialog/ManageFundsDialog.tsx
@@ -117,7 +117,7 @@ const ManageFundsDialog = ({
     ? colony.canMintNativeToken
     : colony.canMintNativeToken && hasRoot(allUserRoles);
   const canUnlockToken = isVotingExtensionEnabled
-    ? colony.isNativeTokenLocked && colony.canUnlockNativeToken
+    ? colony.canUnlockNativeToken
     : colony.canUnlockNativeToken && hasRoot(allUserRoles);
 
   const canManageTokens = hasRegisteredProfile && hasRoot(allUserRoles);

--- a/src/modules/dashboard/components/ManageFundsDialog/ManageFundsDialog.tsx
+++ b/src/modules/dashboard/components/ManageFundsDialog/ManageFundsDialog.tsx
@@ -118,9 +118,7 @@ const ManageFundsDialog = ({
     : colony.canMintNativeToken && hasRoot(allUserRoles);
   const canUnlockToken = isVotingExtensionEnabled
     ? colony.isNativeTokenLocked && colony.canUnlockNativeToken
-    : colony.isNativeTokenLocked &&
-      colony.canUnlockNativeToken &&
-      hasRoot(allUserRoles);
+    : colony.canUnlockNativeToken && hasRoot(allUserRoles);
 
   const canManageTokens = hasRegisteredProfile && hasRoot(allUserRoles);
 

--- a/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenForm.css
+++ b/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenForm.css
@@ -27,6 +27,10 @@
   color: color-mod(var(--sky-blue) alpha(90%));
 }
 
+.unlocked {
+  margin-bottom: 20px;
+}
+
 .wrapper {
   margin-bottom: 20px;
 }

--- a/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenForm.css.d.ts
+++ b/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenForm.css.d.ts
@@ -1,4 +1,5 @@
 export const noPermissionMessage: string;
 export const note: string;
 export const learnMoreLink: string;
+export const unlocked: string;
 export const wrapper: string;

--- a/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenForm.tsx
+++ b/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenForm.tsx
@@ -40,8 +40,8 @@ const MSG = defineMessages({
       to take this action.`,
   },
   unlockedTitle: {
-    id: 'dashboard.UnlockTokenDialog.UnlockTokenForm.dialogunlockedTitle',
-    defaultMessage: 'Token  Unlocked',
+    id: 'dashboard.UnlockTokenDialog.UnlockTokenForm.unlockedTitle',
+    defaultMessage: 'Token Unlocked',
   },
   unlockedDescription: {
     id: 'dashboard.UnlockTokenDialog.UnlockTokenForm.unlockedDescription',

--- a/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenForm.tsx
+++ b/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenForm.tsx
@@ -26,8 +26,8 @@ const MSG = defineMessages({
   description: {
     id: 'dashboard.UnlockTokenDialog.UnlockTokenForm.description',
     defaultMessage: `Your colony’s native token is locked and non-transferrable
-    by default. This action allows you to unlock it so that it may be
-    freely transferred between accounts.`,
+     by default. This action allows you to unlock it so that it may be
+     freely transferred between accounts.`,
   },
   note: {
     id: 'dashboard.UnlockTokenDialog.UnlockTokenForm.note',

--- a/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenForm.tsx
+++ b/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenForm.tsx
@@ -91,19 +91,23 @@ const UnlockTokenForm = ({
         {colony.isNativeTokenLocked ? (
           <FormattedMessage {...MSG.description} />
         ) : (
-          <FormattedMessage {...MSG.unlockedDescription} />
+          <div className={styles.unlocked}>
+            <FormattedMessage {...MSG.unlockedDescription} />
+          </div>
         )}
       </DialogSection>
-      <DialogSection appearance={{ theme: 'sidePadding' }}>
-        <div className={styles.note}>
-          <FormattedMessage {...MSG.note} />
-          <ExternalLink
-            className={styles.learnMoreLink}
-            text={{ id: 'text.learnMore' }}
-            href={LEARN_MORE_URL}
-          />
-        </div>
-      </DialogSection>
+      {colony.isNativeTokenLocked && (
+        <DialogSection appearance={{ theme: 'sidePadding' }}>
+          <div className={styles.note}>
+            <FormattedMessage {...MSG.note} />
+            <ExternalLink
+              className={styles.learnMoreLink}
+              text={{ id: 'text.learnMore' }}
+              href={LEARN_MORE_URL}
+            />
+          </div>
+        </DialogSection>
+      )}
       {!hasRootPermission && (
         <DialogSection appearance={{ theme: 'sidePadding' }}>
           <div className={styles.noPermissionMessage}>

--- a/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenForm.tsx
+++ b/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenForm.tsx
@@ -26,8 +26,8 @@ const MSG = defineMessages({
   description: {
     id: 'dashboard.UnlockTokenDialog.UnlockTokenForm.description',
     defaultMessage: `Your colony’s native token is locked and non-transferrable
-     by default. This action allows you to unlock it so that it may be
-     freely transferred between accounts.`,
+    by default. This action allows you to unlock it so that it may be
+    freely transferred between accounts.`,
   },
   note: {
     id: 'dashboard.UnlockTokenDialog.UnlockTokenForm.note',
@@ -38,6 +38,14 @@ const MSG = defineMessages({
     id: 'dashboard.UnlockTokenDialog.UnlockTokenForm.noPermission',
     defaultMessage: `You do not have the {roleRequired} permission required
       to take this action.`,
+  },
+  unlockedTitle: {
+    id: 'dashboard.UnlockTokenDialog.UnlockTokenForm.dialogunlockedTitle',
+    defaultMessage: 'Token  Unlocked',
+  },
+  unlockedDescription: {
+    id: 'dashboard.UnlockTokenDialog.UnlockTokenForm.unlockedDescription',
+    defaultMessage: `Your colony’s native token has already been unlocked.`,
   },
 });
 
@@ -57,7 +65,6 @@ const UnlockTokenForm = ({
   handleSubmit,
 }: Props & FormikProps<any>) => {
   const { walletAddress } = useLoggedInUser();
-
   const allUserRoles = useTransformer(getAllUserRoles, [colony, walletAddress]);
 
   const hasRootPermission = hasRoot(allUserRoles);
@@ -70,7 +77,7 @@ const UnlockTokenForm = ({
       <DialogSection appearance={{ theme: 'heading' }}>
         <Heading
           appearance={{ size: 'medium', margin: 'none', theme: 'dark' }}
-          text={MSG.title}
+          text={colony.isNativeTokenLocked ? MSG.title : MSG.unlockedTitle}
         />
       </DialogSection>
       {!hasRootPermission && (
@@ -81,7 +88,11 @@ const UnlockTokenForm = ({
         </DialogSection>
       )}
       <DialogSection appearance={{ theme: 'sidePadding' }}>
-        <FormattedMessage {...MSG.description} />
+        {colony.isNativeTokenLocked ? (
+          <FormattedMessage {...MSG.description} />
+        ) : (
+          <FormattedMessage {...MSG.unlockedDescription} />
+        )}
       </DialogSection>
       <DialogSection appearance={{ theme: 'sidePadding' }}>
         <div className={styles.note}>


### PR DESCRIPTION
## Description

- [x] allow you to access the modal, but tell you that the token is already unlocked and there's nothing for you to do (with the controls disabled of course)

**New stuff** ✨

* Added new unlockedTitle, and unlockedDescription, which are conditionally showed instead of the regular title & description when the NativeToken is Not Locked anymore.


**Changes** 🏗


* Where title and description are called, we check for colony.nativeTokenIsLocked, and if true we show the regular one, if false the unlocked one variants.

**Deletions** ⚰️

* Removed condition check colony.isNativeTokenLocked from canUnlockNativeToken (So permission error doesn't show when it's already Unlocked)

## TODO

- [x] Add new unlocked title and description messages
- [x] Remove permissions check if token unlocked
- [x] Show different versions of text if token alrady unlocked

Resolves #2989 
