### PR TITLE
Makes caret in single user picker open omni picker

### DIFF
--- a/src/modules/core/components/SingleUserPicker/SingleUserPicker.tsx
+++ b/src/modules/core/components/SingleUserPicker/SingleUserPicker.tsx
@@ -230,6 +230,7 @@ const SingleUserPicker = ({
             </div>
             {(!value || (value && !isResettable)) && (
               <Icon
+                onClick={openOmniPicker}
                 className={classnames(styles.arrowIcon, {
                   [styles.arrowIconActive]: omniPickerIsOpen,
                 })}


### PR DESCRIPTION
## Description

How to test:
1. Create a colony
2. Go to members page.
3. Click Ban a user
4. Click on the caret-down icon to open omni-picker for user select

## TODO
- [x] Fixes caret-down not opening the omni picker when clicked

**Changes** 🏗

* added a prop onClick={openOmnipicker} in Icon inside SinglePickerUser
```ts
<Icon
  onClick={openOmniPicker}
  ...
/>
```
## Screenshot 📷 
![Kapture 2021-12-06 at 16 29 18](https://user-images.githubusercontent.com/6601142/144874684-379bf4d2-2345-4bf3-92f3-cc0306d2bf3f.gif)


Resolves #2889
