### PR TITLE
Modifies SaleFailed state to be more versatile

### DIFF
--- a/src/modules/dashboard/components/CoinMachine/SaleStateWidget/SaleStateWidget.tsx
+++ b/src/modules/dashboard/components/CoinMachine/SaleStateWidget/SaleStateWidget.tsx
@@ -66,7 +66,7 @@ const MSG = defineMessages({
   },
   saleFailedTitle: {
     id: 'dashboard.CoinMachine.SaleStateWidget.saleFailedTitle',
-    defaultMessage: `You didn't get any CLNY this time`,
+    defaultMessage: `You didn't get any {token} this time`,
   },
   saleFailedAmountLabel: {
     id: 'dashboard.CoinMachine.SaleStateWidget.saleFailedAmountLabel',
@@ -78,7 +78,7 @@ const MSG = defineMessages({
   },
   saleFailedSubtext: {
     id: 'dashboard.CoinMachine.SaleStateWidget.saleFailedSubtext',
-    defaultMessage: 'Don’t worry, you can try again in...',
+    defaultMessage: 'Please try again, if there is still time and tokens left.',
   },
   loadingTitle: {
     id: 'dashboard.CoinMachine.SaleStateWidget.loadingTitle',
@@ -197,7 +197,11 @@ const SaleStateWidget = ({
     switch (state) {
       case SaleState.PartialSuccess:
       case SaleState.SaleFailed:
-        return <TimerValue splitTime={splitTime} />;
+        if (showTimeCountdown && timeLeftToNextSale > 0) {
+          return <TimerValue splitTime={splitTime} />;
+        }
+        return <FormattedMessage {...MSG.tryAgain} />;
+
       case SaleState.TransactionFailed:
         return <FormattedMessage {...MSG.tryAgain} />;
       case SaleState.Success:
@@ -275,6 +279,9 @@ const SaleStateWidget = ({
         <Heading
           appearance={{ size: 'medium', theme: 'dark', margin: 'none' }}
           text={MSG[`${state}Title`]}
+          textValues={{
+            token: sellableToken?.symbol || '???',
+          }}
         />
         <TransactionLink
           className={styles.blockExplorer}
@@ -321,7 +328,7 @@ const SaleStateWidget = ({
         />
       </div>
       <div className={styles.footer}>
-        {showTimeCountdown ? (
+        {showTimeCountdown && timeLeftToNextSale > 0 ? (
           <div className={styles.nextSale}>
             <FormattedMessage {...MSG.nextSale} />
           </div>

--- a/src/modules/dashboard/components/CoinMachine/SaleStateWidget/SaleStateWidget.tsx
+++ b/src/modules/dashboard/components/CoinMachine/SaleStateWidget/SaleStateWidget.tsx
@@ -280,7 +280,7 @@ const SaleStateWidget = ({
           appearance={{ size: 'medium', theme: 'dark', margin: 'none' }}
           text={MSG[`${state}Title`]}
           textValues={{
-            token: sellableToken?.symbol || '???',
+            token: sellableToken?.symbol || '',
           }}
         />
         <TransactionLink


### PR DESCRIPTION
## Description

Modifies the SaleFailed state to be more versatile and avoids a blank button when there is no time left on the timer.

![salefailed-state](https://user-images.githubusercontent.com/33682027/145091709-91eb770c-b869-48d3-b760-1ef8ff76fe39.png)

![salefailed-state-timer](https://user-images.githubusercontent.com/33682027/145091848-0a4e5e29-9ae0-4486-9465-8c6317754490.png)


**Testing** 

- You need to have coinMachine enabled and have it funded.
- You need to initiate a token buy.
- You may like to make the following temporary  modification to more reliably get the SaleFailed state. `setState(SaleState.SaleFailed); return;`

![sample-code-2](https://user-images.githubusercontent.com/33682027/145091178-856ac84a-cd11-4339-ab64-340b91a57e7c.jpg)

- You may like to make the following temporary modification to more reliably get nil time value. `timeLeftToNextSale = 0;`

![sample-code-1](https://user-images.githubusercontent.com/33682027/145091265-4ebc70a5-99b2-4656-bd0c-94d996e7c8ef.jpg)

Resolves #3003
