### PR TITLE
Fix prices for Coinmachine periods with no sales

### DIFF
--- a/jest.conf.json
+++ b/jest.conf.json
@@ -14,6 +14,7 @@
     "rootDir": "src",
     "moduleNameMapper": {
         "^\\~constants$": "<rootDir>/modules/constants.ts",
+        "^\\~externalUrls$": "<rootDir>/modules/externalUrls.ts",
         "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.ts",
         "\\.(css|less)$": "<rootDir>/__mocks__/styleMock.ts",
         "^\\~context(.*)$": "<rootDir>/context$1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "react-tabs": "^3.1.0",
         "react-textarea-autosize": "^8.3.3",
         "react-textfit": "^1.1.1",
+        "react-twitter-widgets": "^1.10.0",
         "recompose": "^0.30.0",
         "redux": "^4.0.1",
         "redux-immutable": "^4.0.0",
@@ -42482,6 +42483,11 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/loadjs": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/loadjs/-/loadjs-4.2.0.tgz",
+      "integrity": "sha512-AgQGZisAlTPbTEzrHPb6q+NYBMD+DP9uvGSIjSUM5uG+0jG15cb8axWpxuOIqrmQjn6scaaH8JwloiP27b2KXA=="
+    },
     "node_modules/localforage": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.7.3.tgz",
@@ -49197,6 +49203,17 @@
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "engines": {
         "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/react-twitter-widgets": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/react-twitter-widgets/-/react-twitter-widgets-1.10.0.tgz",
+      "integrity": "sha512-K7MAREhkKJxrhoiNWricKs1O++NyElnVpcplLzZ67gDrmeIsD3E4TUzlt0/nTZAHPOPPc86V4kEd4KIg4de7cQ==",
+      "dependencies": {
+        "loadjs": "^4.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17"
       }
     },
     "node_modules/read-cache": {
@@ -92521,6 +92538,11 @@
         "json5": "^1.0.1"
       }
     },
+    "loadjs": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/loadjs/-/loadjs-4.2.0.tgz",
+      "integrity": "sha512-AgQGZisAlTPbTEzrHPb6q+NYBMD+DP9uvGSIjSUM5uG+0jG15cb8axWpxuOIqrmQjn6scaaH8JwloiP27b2KXA=="
+    },
     "localforage": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.7.3.tgz",
@@ -98011,6 +98033,14 @@
           "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
           "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
         }
+      }
+    },
+    "react-twitter-widgets": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/react-twitter-widgets/-/react-twitter-widgets-1.10.0.tgz",
+      "integrity": "sha512-K7MAREhkKJxrhoiNWricKs1O++NyElnVpcplLzZ67gDrmeIsD3E4TUzlt0/nTZAHPOPPc86V4kEd4KIg4de7cQ==",
+      "requires": {
+        "loadjs": "^4.2.0"
       }
     },
     "read-cache": {

--- a/package.json
+++ b/package.json
@@ -194,6 +194,7 @@
     "react-tabs": "^3.1.0",
     "react-textarea-autosize": "^8.3.3",
     "react-textfit": "^1.1.1",
+    "react-twitter-widgets": "^1.10.0",
     "recompose": "^0.30.0",
     "redux": "^4.0.1",
     "redux-immutable": "^4.0.0",

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -2031,15 +2031,13 @@ export type CoinMachineHasWhitelistQueryVariables = Exact<{
 
 export type CoinMachineHasWhitelistQuery = Pick<Query, 'coinMachineHasWhitelist'>;
 
-export type SubgraphCoinMachinePeriodsQueryVariables = Exact<{
-  colonyAddress: Scalars['String'];
-  extensionAddress: Scalars['String'];
-  limit: Scalars['Int'];
+export type SubgraphCoinMachineExtensionInstalledQueryVariables = Exact<{
+  argumentsFilter: Scalars['String'];
   sortDirection?: Maybe<Scalars['String']>;
 }>;
 
 
-export type SubgraphCoinMachinePeriodsQuery = { coinMachinePeriods: Array<Pick<SalePeriod, 'saleEndedAt' | 'tokensBought' | 'price'>>, extensionInitialisedEvents: Array<(
+export type SubgraphCoinMachineExtensionInstalledQuery = { extensionInstalledEvents: Array<(
     Pick<SubgraphEvent, 'id' | 'address' | 'name' | 'args' | 'timestamp'>
     & { transaction: (
       Pick<SubgraphTransaction, 'id'>
@@ -2049,7 +2047,18 @@ export type SubgraphCoinMachinePeriodsQuery = { coinMachinePeriods: Array<Pick<S
         & { number: SubgraphBlock['id'] }
       ) }
     ) }
-  )>, tokenBoughtEvents: Array<(
+  )> };
+
+export type SubgraphCoinMachinePeriodsQueryVariables = Exact<{
+  colonyAddress: Scalars['String'];
+  extensionAddress: Scalars['String'];
+  limit: Scalars['Int'];
+  periodsCreatedAfter: Scalars['String'];
+  sortDirection?: Maybe<Scalars['String']>;
+}>;
+
+
+export type SubgraphCoinMachinePeriodsQuery = { coinMachinePeriods: Array<Pick<SalePeriod, 'saleEndedAt' | 'tokensBought' | 'price'>>, tokenBoughtEvents: Array<(
     Pick<SubgraphEvent, 'id' | 'address' | 'name' | 'args' | 'timestamp'>
     & { transaction: (
       Pick<SubgraphTransaction, 'id'>
@@ -5377,14 +5386,9 @@ export function useCoinMachineHasWhitelistLazyQuery(baseOptions?: Apollo.LazyQue
 export type CoinMachineHasWhitelistQueryHookResult = ReturnType<typeof useCoinMachineHasWhitelistQuery>;
 export type CoinMachineHasWhitelistLazyQueryHookResult = ReturnType<typeof useCoinMachineHasWhitelistLazyQuery>;
 export type CoinMachineHasWhitelistQueryResult = Apollo.QueryResult<CoinMachineHasWhitelistQuery, CoinMachineHasWhitelistQueryVariables>;
-export const SubgraphCoinMachinePeriodsDocument = gql`
-    query SubgraphCoinMachinePeriods($colonyAddress: String!, $extensionAddress: String!, $limit: Int!, $sortDirection: String = asc) {
-  coinMachinePeriods(where: {colonyAddress: $colonyAddress}, skip: 0, first: $limit, orderBy: "saleEndedAt", orderDirection: "desc") {
-    saleEndedAt
-    tokensBought
-    price
-  }
-  extensionInitialisedEvents: events(orderBy: "timestamp", orderDirection: $sortDirection, where: {name_contains: "ExtensionInitialised", address: $extensionAddress}) {
+export const SubgraphCoinMachineExtensionInstalledDocument = gql`
+    query SubgraphCoinMachineExtensionInstalled($argumentsFilter: String!, $sortDirection: String = desc) {
+  extensionInstalledEvents: events(orderBy: "timestamp", orderDirection: $sortDirection, where: {name_contains: "ExtensionInstalled", args_contains: $argumentsFilter}) {
     id
     transaction {
       id
@@ -5399,6 +5403,42 @@ export const SubgraphCoinMachinePeriodsDocument = gql`
     name
     args
     timestamp
+  }
+}
+    `;
+
+/**
+ * __useSubgraphCoinMachineExtensionInstalledQuery__
+ *
+ * To run a query within a React component, call `useSubgraphCoinMachineExtensionInstalledQuery` and pass it any options that fit your needs.
+ * When your component renders, `useSubgraphCoinMachineExtensionInstalledQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useSubgraphCoinMachineExtensionInstalledQuery({
+ *   variables: {
+ *      argumentsFilter: // value for 'argumentsFilter'
+ *      sortDirection: // value for 'sortDirection'
+ *   },
+ * });
+ */
+export function useSubgraphCoinMachineExtensionInstalledQuery(baseOptions?: Apollo.QueryHookOptions<SubgraphCoinMachineExtensionInstalledQuery, SubgraphCoinMachineExtensionInstalledQueryVariables>) {
+        return Apollo.useQuery<SubgraphCoinMachineExtensionInstalledQuery, SubgraphCoinMachineExtensionInstalledQueryVariables>(SubgraphCoinMachineExtensionInstalledDocument, baseOptions);
+      }
+export function useSubgraphCoinMachineExtensionInstalledLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SubgraphCoinMachineExtensionInstalledQuery, SubgraphCoinMachineExtensionInstalledQueryVariables>) {
+          return Apollo.useLazyQuery<SubgraphCoinMachineExtensionInstalledQuery, SubgraphCoinMachineExtensionInstalledQueryVariables>(SubgraphCoinMachineExtensionInstalledDocument, baseOptions);
+        }
+export type SubgraphCoinMachineExtensionInstalledQueryHookResult = ReturnType<typeof useSubgraphCoinMachineExtensionInstalledQuery>;
+export type SubgraphCoinMachineExtensionInstalledLazyQueryHookResult = ReturnType<typeof useSubgraphCoinMachineExtensionInstalledLazyQuery>;
+export type SubgraphCoinMachineExtensionInstalledQueryResult = Apollo.QueryResult<SubgraphCoinMachineExtensionInstalledQuery, SubgraphCoinMachineExtensionInstalledQueryVariables>;
+export const SubgraphCoinMachinePeriodsDocument = gql`
+    query SubgraphCoinMachinePeriods($colonyAddress: String!, $extensionAddress: String!, $limit: Int!, $periodsCreatedAfter: String!, $sortDirection: String = asc) {
+  coinMachinePeriods(where: {colonyAddress: $colonyAddress, saleEndedAt_gte: $periodsCreatedAfter}, skip: 0, first: $limit, orderBy: "saleEndedAt", orderDirection: "desc") {
+    saleEndedAt
+    tokensBought
+    price
   }
   tokenBoughtEvents: events(orderBy: "timestamp", orderDirection: $sortDirection, where: {name_contains: "TokensBought", address: $extensionAddress}) {
     id
@@ -5434,6 +5474,7 @@ export const SubgraphCoinMachinePeriodsDocument = gql`
  *      colonyAddress: // value for 'colonyAddress'
  *      extensionAddress: // value for 'extensionAddress'
  *      limit: // value for 'limit'
+ *      periodsCreatedAfter: // value for 'periodsCreatedAfter'
  *      sortDirection: // value for 'sortDirection'
  *   },
  * });

--- a/src/data/graphql/queries/coinMachine.graphql
+++ b/src/data/graphql/queries/coinMachine.graphql
@@ -71,24 +71,13 @@ query CoinMachineHasWhitelist($colonyAddress: String!) {
   coinMachineHasWhitelist(colonyAddress: $colonyAddress) @client
 }
 
-query SubgraphCoinMachinePeriods($colonyAddress: String!, $extensionAddress: String!, $limit: Int!, $sortDirection: String = asc) {
-  coinMachinePeriods(
-    where: { colonyAddress: $colonyAddress },
-    skip: 0,
-    first: $limit
-    orderBy: "saleEndedAt",
-    orderDirection: "desc"
-  ) {
-    saleEndedAt
-    tokensBought
-    price
-  }
-  extensionInitialisedEvents: events(
+query SubgraphCoinMachineExtensionInstalled($argumentsFilter: String!, $sortDirection: String = desc) {
+  extensionInstalledEvents: events(
     orderBy: "timestamp",
     orderDirection: $sortDirection,
     where: {
-      name_contains: "ExtensionInitialised",
-      address: $extensionAddress
+      name_contains: "ExtensionInstalled",
+      args_contains: $argumentsFilter
     }
   ) {
     id
@@ -105,6 +94,23 @@ query SubgraphCoinMachinePeriods($colonyAddress: String!, $extensionAddress: Str
     name
     args
     timestamp
+  }
+}
+
+query SubgraphCoinMachinePeriods($colonyAddress: String!, $extensionAddress: String!, $limit: Int!, $periodsCreatedAfter: String!, $sortDirection: String = asc) {
+  coinMachinePeriods(
+    where: {
+      colonyAddress: $colonyAddress
+      saleEndedAt_gte: $periodsCreatedAfter
+    },
+    skip: 0,
+    first: $limit
+    orderBy: "saleEndedAt",
+    orderDirection: "desc"
+  ) {
+    saleEndedAt
+    tokensBought
+    price
   }
   tokenBoughtEvents: events(
     orderBy: "timestamp",

--- a/src/data/resolvers/coinMachine.ts
+++ b/src/data/resolvers/coinMachine.ts
@@ -387,6 +387,7 @@ export const coinMachineResolvers = ({
         const availableTokens = await coinMachineClient.getTokenBalance();
         const targetPerPeriod = await coinMachineClient.getTargetPerPeriod();
         const windowSize = await coinMachineClient.getWindowSize();
+        const currentPeriodPrice = await coinMachineClient.getCurrentPrice();
         const currentBlock = await networkClient.provider.getBlock('latest');
         const currentBlockTime = currentBlock.timestamp * 1000;
 
@@ -653,13 +654,17 @@ export const coinMachineResolvers = ({
             .map((period) => {
               // Skip periods with known price
               let currentPrice = bigNumberify(period.price);
-              // currentprice === 0 then {
-              // nextPrice = current price of coin machine;
-              // return {
-              //   ...period,
-              //   price: nextPrice.toString(),
-              // };
-              // }
+              /*
+               * @TODO While this works, we need the initial price that Coin Machine started with,
+               * and not the current coin machine prioce
+               */
+              if (currentPrice.isZero()) {
+                nextPrice = currentPeriodPrice;
+                return {
+                  ...period,
+                  price: nextPrice.toString(),
+                };
+              }
               if (currentPrice.gt(0)) {
                 nextPrice = currentPrice;
                 return period;

--- a/src/data/resolvers/coinMachine.ts
+++ b/src/data/resolvers/coinMachine.ts
@@ -3,7 +3,6 @@ import {
   getLogs,
   getBlockTime,
   CoinMachineClientV2,
-  TokenClient,
 } from '@colony/colony-js';
 import { Resolvers } from '@apollo/client';
 import { BigNumber, bigNumberify, BigNumberish } from 'ethers/utils';
@@ -266,10 +265,8 @@ export const coinMachineResolvers = ({
           ClientType.CoinMachineClient,
           colonyAddress,
         );
-        const tokenClient = (await colonyManager.getClient(
-          ClientType.TokenClient,
-          colonyAddress,
-        )) as TokenClient;
+        const tokenAddress = await coinMachineClient.getToken();
+        const tokenClient = await colonyManager.getTokenClient(tokenAddress);
 
         const currentTokenBalance = await coinMachineClient.getTokenBalance();
 
@@ -339,10 +336,8 @@ export const coinMachineResolvers = ({
           ClientType.CoinMachineClient,
           colonyAddress,
         )) as CoinMachineClientV2;
-        const tokenClient = (await colonyManager.getClient(
-          ClientType.TokenClient,
-          colonyAddress,
-        )) as TokenClient;
+        const tokenAddress = await coinMachineClient.getToken();
+        const tokenClient = await colonyManager.getTokenClient(tokenAddress);
 
         const subgraphData = await apolloClient.query<
           SubgraphCoinMachinePeriodsQuery,
@@ -639,6 +634,13 @@ export const coinMachineResolvers = ({
             .map((period) => {
               // Skip periods with known price
               let currentPrice = bigNumberify(period.price);
+              // currentprice === 0 then {
+              // nextPrice = current price of coin machine;
+              // return {
+              //   ...period,
+              //   price: nextPrice.toString(),
+              // };
+              // }
               if (currentPrice.gt(0)) {
                 nextPrice = currentPrice;
                 return period;

--- a/src/data/staticData/extensionData.tsx
+++ b/src/data/staticData/extensionData.tsx
@@ -15,6 +15,7 @@ import { Colony } from '~data/index';
 import { getBlockExplorerLink } from '~utils/external';
 import { DEFAULT_NETWORK_INFO } from '~constants';
 import { Address, WhitelistPolicy } from '~types/index';
+import { CM_BLOG_POST, CM_GOOGLE_SHEET, CM_DESCRIPTION } from '~externalUrls';
 
 export interface ExtensionBodyProps {
   colony: Colony;
@@ -88,11 +89,6 @@ const oneTransactionPaymentMessages = {
     defaultMessage: 'Pay a single account one type of token.',
   },
 };
-
-const COIN_MACHINE_BLOG_POST_LINK = `https://blog.colony.io/introducing-coin-machine/`;
-const COIN_MACHINE_GOOGLE_SHEET_LINK = `https://docs.google.com/spreadsheets/d/1ZCuFcwqI4S6ZK5OwTl1yN7AK8mjv5d_V3g-_kMen01Y/edit#gid=2013814210`;
-// to add a more detailed link
-const COIN_MACHINE_DESCRIPTION_LINK = 'https://colony.gitbook.io/colony/';
 
 const coinMachineMessages = {
   coinMachineName: {
@@ -386,15 +382,15 @@ const extensions: { [key: string]: ExtensionData } = {
     descriptionLinks: [
       <ExternalLink
         text={MSG.coinMachineDescriptionBlogPostLink}
-        href={COIN_MACHINE_BLOG_POST_LINK}
+        href={CM_BLOG_POST}
       />,
       <ExternalLink
         text={MSG.coinMachineDescriptionGoogleSheetLink}
-        href={COIN_MACHINE_GOOGLE_SHEET_LINK}
+        href={CM_GOOGLE_SHEET}
       />,
       <ExternalLink
         text={MSG.coinMachineDescriptionHereLink}
-        href={COIN_MACHINE_DESCRIPTION_LINK}
+        href={CM_DESCRIPTION}
       />,
     ],
     currentVersion: 1,

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -47,6 +47,8 @@
     "label.password": "Password",
     "label.force": "Force",
     "label.banned": "Banned",
+    "label.loading": "Loading",
+    "label.waiting": "Waiting",
     "placeholder.email": "handle@domain.com",
     "placeholder.password": "Password",
 

--- a/src/modules/constants.ts
+++ b/src/modules/constants.ts
@@ -160,11 +160,4 @@ export const ALLDOMAINS_DOMAIN_SELECTION = {
   description: '',
 };
 
-export const TOKEN_LOGOS_REPO_URL = `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains`;
-
-export const NETWORK_RELEASES_URL = `https://github.com/JoinColony/colonyNetwork/releases/tag`;
-
 export const SMALL_TOKEN_AMOUNT_FORMAT = '0.00000...';
-
-export const FEEDBACK_LINK =
-  'https://portal.productboard.com/colony/1-colony-portal/tabs/4-bugs';

--- a/src/modules/core/components/BetaCautionAlert/BetaCautionAlert.tsx
+++ b/src/modules/core/components/BetaCautionAlert/BetaCautionAlert.tsx
@@ -3,6 +3,8 @@ import { FormattedMessage } from 'react-intl';
 
 import ExternalLink from '~core/ExternalLink';
 
+import { BETA_DISCLAIMER } from '~externalUrls';
+
 import styles from './BetaCautionAlert.css';
 
 const MSG = {
@@ -15,8 +17,6 @@ const MSG = {
     defaultMessage: 'Use with caution!',
   },
 };
-
-const LEARN_MORE_LINK = `https://colony.gitbook.io/colony/disclaimers/beta`;
 
 const BetaCautionAlert = () => {
   const [isHovered, setIsHovered] = useState(false);
@@ -33,7 +33,7 @@ const BetaCautionAlert = () => {
         <ExternalLink
           text={{ id: 'text.learnMore' }}
           className={styles.link}
-          href={LEARN_MORE_LINK}
+          href={BETA_DISCLAIMER}
         />
       ) : (
         <>

--- a/src/modules/core/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/src/modules/core/components/FeedbackWidget/FeedbackWidget.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import ExternalLink from '~core/ExternalLink';
-import { FEEDBACK_LINK } from '~constants';
+import { FEEDBACK_LINK } from '~externalUrls';
 
 import styles from './FeedbackWidget.css';
 

--- a/src/modules/core/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/src/modules/core/components/FeedbackWidget/FeedbackWidget.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import ExternalLink from '~core/ExternalLink';
-import { FEEDBACK_LINK } from '~externalUrls';
+import { FEEDBACK } from '~externalUrls';
 
 import styles from './FeedbackWidget.css';
 
@@ -15,7 +15,7 @@ const MSG = {
 
 const FeedbackWidget = () => (
   <div className={styles.main}>
-    <ExternalLink className={styles.link} href={FEEDBACK_LINK}>
+    <ExternalLink className={styles.link} href={FEEDBACK}>
       <FormattedMessage
         {...MSG.loveFeedback}
         values={{

--- a/src/modules/core/sagas/utils/getGasPrices.ts
+++ b/src/modules/core/sagas/utils/getGasPrices.ts
@@ -6,6 +6,7 @@ import { GasPricesProps } from '~immutable/index';
 import { ContextModule, TEMP_getContext } from '~context/index';
 import { log } from '~utils/debug';
 import { DEFAULT_NETWORK } from '~constants';
+import { ETH_GAS_STATION, XDAI_GAS_STATION } from '~externalUrls';
 
 import { gasPrices as gasPricesSelector } from '../../selectors';
 import { updateGasPrices } from '../../actionCreators';
@@ -31,10 +32,6 @@ interface BlockscoutGasStationAPIResponse {
   slow: number;
 }
 
-const ETH_GAS_STATION_ENDPOINT =
-  'https://ethgasstation.info/json/ethgasAPI.json';
-const BLOCKSCOUNT_GAS_STATION_ENDPOINT =
-  'https://blockscout.com/xdai/mainnet/api/v1/gas-price-oracle';
 const DEFAULT_GAS_PRICE = bigNumberify('1000000000');
 
 const fetchGasPrices = async (
@@ -61,13 +58,13 @@ const fetchGasPrices = async (
     let response;
 
     if (DEFAULT_NETWORK === Network.Mainnet) {
-      response = await fetch(ETH_GAS_STATION_ENDPOINT);
+      response = await fetch(ETH_GAS_STATION);
     }
     if (
       DEFAULT_NETWORK === Network.Xdai ||
       DEFAULT_NETWORK === Network.XdaiFork
     ) {
-      response = await fetch(BLOCKSCOUNT_GAS_STATION_ENDPOINT);
+      response = await fetch(XDAI_GAS_STATION);
     }
 
     if (!response.ok) {

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultAction.css
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultAction.css
@@ -1,4 +1,5 @@
 .main {
+  padding-top: 90px;
   height: 100%;
   width: 100%;
   background-color: white;
@@ -49,7 +50,6 @@
 .upperContainer {
   composes: container;
   align-items: baseline;
-  padding-top: 90px;
 }
 
 .bannerPadding {

--- a/src/modules/dashboard/components/ActionsPage/StakeRequiredBanner/StakeRequiredBanner.css
+++ b/src/modules/dashboard/components/ActionsPage/StakeRequiredBanner/StakeRequiredBanner.css
@@ -1,4 +1,5 @@
 .stakeRequiredBannerContainer {
+  margin-top: -90px;
   width: 100%;
   position: static;
   font-size: var(--size-normal);

--- a/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
+++ b/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
@@ -32,6 +32,7 @@ import {
 import { getMainClasses } from '~utils/css';
 import { mapPayload, withMeta, pipe } from '~utils/actions';
 import { DEFAULT_TOKEN_DECIMALS } from '~constants';
+import { CM_LEARN_MORE } from '~externalUrls';
 
 import GetWhitelisted from '../GetWhitelisted';
 
@@ -87,8 +88,6 @@ const MSG = defineMessages({
     defaultMessage: 'Sold Out',
   },
 });
-
-const TELL_ME_MORE_LINK = `https://colony.gitbook.io/colony/extensions/coin-machine`;
 
 type Props = {
   colony: Colony;
@@ -556,7 +555,7 @@ const BuyTokens = ({
               <ExternalLink
                 className={styles.link}
                 text={MSG.tellMore}
-                href={TELL_ME_MORE_LINK}
+                href={CM_LEARN_MORE}
               />
             </div>
           </div>

--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -20,7 +20,10 @@ import {
   useCoinMachineCurrentPeriodMaxUserPurchaseQuery,
   useCoinMachineTotalTokensQuery,
   useLoggedInUser,
+  useMetaColonyQuery,
 } from '~data/index';
+
+import { CM_LEARN_MORE_LINK, CM_GET_WHITELISTED } from '~externalUrls';
 
 import Chat from './Chat';
 import SaleStateWidget from './SaleStateWidget';
@@ -44,9 +47,9 @@ const MSG = defineMessages({
     id: 'dashboard.CoinMachine.buyTokens',
     defaultMessage: 'Buy {symbol}',
   },
-  learnMore: {
-    id: 'dashboard.CoinMachine.learnMore',
-    defaultMessage: 'Learn More',
+  getWhitelisted: {
+    id: 'dashboard.CoinMachine.getWhitelisted',
+    defaultMessage: 'How to get whitelisted',
   },
 });
 
@@ -55,9 +58,6 @@ type Props = {
 };
 
 const displayName = 'dashboard.CoinMachine';
-
-const LEARN_MORE_LINK =
-  'https://colony.gitbook.io/colony/extensions/coin-machine';
 
 /*
  * @TEMP This is temporary while we get ready for the token sale
@@ -73,6 +73,7 @@ const CoinMachine = ({
     transactionHash: string;
   }>();
   const { walletAddress } = useLoggedInUser();
+  const { data: metaColonyData } = useMetaColonyQuery();
 
   const {
     data: extensionsData,
@@ -285,11 +286,19 @@ const CoinMachine = ({
         {...MSG.buyTokens}
         values={{ symbol: sellableToken?.symbol }}
       />
-      <ExternalLink
-        className={styles.learnMore}
-        text={{ id: 'text.learnMore' }}
-        href={LEARN_MORE_LINK}
-      />
+      {metaColonyData?.processedMetaColony?.colonyAddress === colonyAddress ? (
+        <ExternalLink
+          className={styles.learnMore}
+          text={MSG.getWhitelisted}
+          href={CM_GET_WHITELISTED}
+        />
+      ) : (
+        <ExternalLink
+          className={styles.learnMore}
+          text={{ id: 'text.learnMore' }}
+          href={CM_LEARN_MORE_LINK}
+        />
+      )}
     </div>,
   ];
 

--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -23,7 +23,7 @@ import {
   useMetaColonyQuery,
 } from '~data/index';
 
-import { CM_LEARN_MORE_LINK, CM_GET_WHITELISTED } from '~externalUrls';
+import { CM_LEARN_MORE, CM_GET_WHITELISTED } from '~externalUrls';
 
 import Chat from './Chat';
 import SaleStateWidget from './SaleStateWidget';
@@ -296,7 +296,7 @@ const CoinMachine = ({
         <ExternalLink
           className={styles.learnMore}
           text={{ id: 'text.learnMore' }}
-          href={CM_LEARN_MORE_LINK}
+          href={CM_LEARN_MORE}
         />
       )}
     </div>,

--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -63,6 +63,7 @@ const LEARN_MORE_LINK =
  * @TEMP This is temporary while we get ready for the token sale
  */
 const DISABLE_CHAT_UTIL_SALE = false;
+const SHARE_ENABLED = true;
 
 const CoinMachine = ({
   colony: { colonyAddress, colonyName },
@@ -307,6 +308,7 @@ const CoinMachine = ({
               purchaseToken={
                 saleTokensData?.coinMachineSaleTokens?.purchaseToken
               }
+              canShare={SHARE_ENABLED}
             />
           </div>
         )) || (

--- a/src/modules/dashboard/components/CoinMachine/SaleStateWidget/SaleStateWidget.css
+++ b/src/modules/dashboard/components/CoinMachine/SaleStateWidget/SaleStateWidget.css
@@ -48,6 +48,7 @@
 
 .text {
   margin-bottom: 22px;
+  padding-right: 50px;
   font-size: var(--size-normal);
   font-weight: var(--weight-normal);
   line-height: 18px;
@@ -62,6 +63,11 @@
   position: relative;
 }
 
+.footerSmall {
+  composes: footer;
+  margin-top: 25px;
+}
+
 .nextSale {
   position: absolute;
   left: 0;
@@ -72,4 +78,33 @@
 
 .buttonWrapper button {
   width: 160px;
+}
+
+.share {
+  /*
+   * @NOTE Negative margin to compensate for the buttons high top margin
+   * when interpolating this message
+   */
+  margin-bottom: -32px;
+  font-size: var(--size-normal);
+  font-weight: var(--weight-normal);
+  line-height: 18px;
+  color: var(--dark);
+}
+
+.share span {
+  margin-left: 10px;
+  vertical-align: middle;
+}
+
+/*
+ * @NOTE Overrides to make the twitter share widget properly aligned with the
+ * inline text
+ */
+.share div {
+  display: inline;
+}
+
+.share div div {
+  display: inline;
 }

--- a/src/modules/dashboard/components/CoinMachine/SaleStateWidget/SaleStateWidget.css.d.ts
+++ b/src/modules/dashboard/components/CoinMachine/SaleStateWidget/SaleStateWidget.css.d.ts
@@ -7,5 +7,7 @@ export const label: string;
 export const content: string;
 export const text: string;
 export const footer: string;
+export const footerSmall: string;
 export const nextSale: string;
 export const buttonWrapper: string;
+export const share: string;

--- a/src/modules/dashboard/components/CoinMachine/SaleStateWidget/SaleStateWidget.tsx
+++ b/src/modules/dashboard/components/CoinMachine/SaleStateWidget/SaleStateWidget.tsx
@@ -25,6 +25,7 @@ import {
 import useSplitTime from '~utils/hooks/useSplitTime';
 
 import { DEFAULT_NETWORK_INFO } from '~constants';
+import { TOKEN_ACTIVATION_INFO } from '~externalUrls';
 
 import styles from './SaleStateWidget.css';
 
@@ -156,9 +157,6 @@ const MSG = defineMessages({
     defaultMessage: `Success! I just bought {amount} {tokenSymbol} via`,
   },
 });
-
-const ACTIVATE_LINK =
-  'https://colony.gitbook.io/colony/key-concepts/token-activation';
 
 const SaleStateWidget = ({
   sellableToken,
@@ -326,7 +324,7 @@ const SaleStateWidget = ({
               <ExternalLink
                 text={MSG.activate}
                 className={styles.blockExplorer}
-                href={ACTIVATE_LINK}
+                href={TOKEN_ACTIVATION_INFO}
               />
             ),
           }}

--- a/src/modules/dashboard/components/CoinMachine/SaleStateWidget/SaleStateWidget.tsx
+++ b/src/modules/dashboard/components/CoinMachine/SaleStateWidget/SaleStateWidget.tsx
@@ -154,7 +154,7 @@ const MSG = defineMessages({
   },
   shareMessage: {
     id: 'dashboard.CoinMachine.SaleStateWidget.shareLabel',
-    defaultMessage: `Success! I just bought {amount} {tokenSymbol} via`,
+    defaultMessage: `Success! I just used @joincolony #CoinMachine to buy {amount} {tokenSymbol} from`,
   },
 });
 
@@ -347,7 +347,7 @@ const SaleStateWidget = ({
                     options={{
                       text: formatMessage(MSG.shareMessage, {
                         amount: decimalAmount,
-                        tokenSymbol: sellableToken?.symbol || '???',
+                        tokenSymbol: `$${sellableToken?.symbol || '???'}`,
                       }),
                       dnt: true,
                     }}

--- a/src/modules/dashboard/components/ColonyHome/WrongNetworkDialog/WrongNetworkDialog.tsx
+++ b/src/modules/dashboard/components/ColonyHome/WrongNetworkDialog/WrongNetworkDialog.tsx
@@ -7,6 +7,8 @@ import Dialog, { DialogProps, DialogSection } from '~core/Dialog';
 import ExternalLink from '~core/ExternalLink';
 import Heading from '~core/Heading';
 
+import { WALLET_CONNECT_XDAI } from '~externalUrls';
+
 import styles from './WrongNetworkDialog.css';
 
 const MSG = defineMessages({
@@ -21,9 +23,6 @@ const MSG = defineMessages({
 });
 
 const displayName = 'dashboard.ColonyHome.WrongNetworkDialog';
-
-const WRONG_NETWORK_XDAI_HELP_LINK =
-  'https://colony.gitbook.io/colony/get-started/connect-metamask-to-xdai';
 
 const WrongNetworkDialog = ({ cancel }: DialogProps) => {
   const networkName = NETWORK_DATA[process.env.NETWORK || DEFAULT_NETWORK].name;
@@ -47,7 +46,7 @@ const WrongNetworkDialog = ({ cancel }: DialogProps) => {
                 <>
                   {process.env.NETWORK === Network.Xdai ||
                     (process.env.NETWORK === Network.XdaiFork && (
-                      <ExternalLink href={WRONG_NETWORK_XDAI_HELP_LINK}>
+                      <ExternalLink href={WALLET_CONNECT_XDAI}>
                         {chunks}
                       </ExternalLink>
                     ))}

--- a/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.tsx
@@ -98,8 +98,6 @@ const StepCreateToken = ({
         to be parallel to this one after the wizard steps diverge,
         while making sure that the data form the previous wizard steps
         doesn't get lost
-        TODO: there will be smoother solution or this:
-        https://github.com/JoinColony/colonyDapp/issues/1057
       */
     const wizardValuesCopy = { ...wizardValues };
     previousStep();

--- a/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.tsx
@@ -114,8 +114,6 @@ const StepSelectToken = ({
     /* This is a custom link since it goes to a sibling step that appears
       to be parallel to this one after the wizard steps diverge,
       while making sure that the data form the previous wizard steps doesn't get lost
-      TODO: there will be smoother solution or this, we already have an issue for it:
-      https://github.com/JoinColony/colonyDapp/issues/1057
     */
     const wizardValuesCopy: FormValues = { ...wizardValues };
     previousStep();

--- a/src/modules/dashboard/components/HookedTokenIcon/HookedTokenIcon.tsx
+++ b/src/modules/dashboard/components/HookedTokenIcon/HookedTokenIcon.tsx
@@ -10,7 +10,7 @@ import Icon from '~core/Icon';
 import { getBase64image } from '~utils/dataReader';
 
 import { DEFAULT_NETWORK } from '~constants';
-import { TOKEN_LOGOS_REPO_URL } from '~externalUrls';
+import { TOKEN_LOGOS_REPO } from '~externalUrls';
 
 import { ipfsDataFetcher } from '../../../core/fetchers';
 
@@ -45,9 +45,9 @@ const ICON_STORAGE = 'tokenImages';
 const loadTokenImages = async (address: Address): Promise<Response> => {
   const network =
     DEFAULT_NETWORK === Network.Mainnet ? 'ethereum' : DEFAULT_NETWORK;
-  let tokenImageUrl = `${TOKEN_LOGOS_REPO_URL}/${network}/${address}/logo.png`;
+  let tokenImageUrl = `${TOKEN_LOGOS_REPO}/${network}/${address}/logo.png`;
   if (address === AddressZero) {
-    tokenImageUrl = `${TOKEN_LOGOS_REPO_URL}/${network}/info/logo.png`;
+    tokenImageUrl = `${TOKEN_LOGOS_REPO}/${network}/info/logo.png`;
   }
   return fetch(tokenImageUrl);
 };

--- a/src/modules/dashboard/components/HookedTokenIcon/HookedTokenIcon.tsx
+++ b/src/modules/dashboard/components/HookedTokenIcon/HookedTokenIcon.tsx
@@ -9,7 +9,8 @@ import { Address } from '~types/index';
 import Icon from '~core/Icon';
 import { getBase64image } from '~utils/dataReader';
 
-import { TOKEN_LOGOS_REPO_URL, DEFAULT_NETWORK } from '~constants';
+import { DEFAULT_NETWORK } from '~constants';
+import { TOKEN_LOGOS_REPO_URL } from '~externalUrls';
 
 import { ipfsDataFetcher } from '../../../core/fetchers';
 

--- a/src/modules/dashboard/components/RaiseObjectionDialog/RaiseObjectionDialogForm.tsx
+++ b/src/modules/dashboard/components/RaiseObjectionDialog/RaiseObjectionDialogForm.tsx
@@ -14,6 +14,7 @@ import {
 } from '~dashboard/ActionsPage/StakingWidget';
 
 import { Colony } from '~data/index';
+import { MD_OBJECTIONS_HELP } from '~externalUrls';
 
 import { FormValues } from './RaiseObjectionDialog';
 import styles from './RaiseObjectionDialogForm.css';
@@ -39,8 +40,6 @@ const MSG = defineMessages({
     defaultMessage: 'Stake',
   },
 });
-
-const OBJECTION_HELP_LINK = `https://colony.io/dev/docs/colonynetwork/whitepaper-tldr-objections-and-disputes#objections`;
 
 export interface Props extends StakingAmounts {
   colony: Colony;
@@ -79,7 +78,7 @@ const RaiseObjectionDialogForm = ({
           {...MSG.objectionDescription}
           values={{
             a: (chunks) => (
-              <ExternalLink href={OBJECTION_HELP_LINK} className={styles.link}>
+              <ExternalLink href={MD_OBJECTIONS_HELP} className={styles.link}>
                 {chunks}
               </ExternalLink>
             ),

--- a/src/modules/dashboard/components/RecoveryModeDialog/RecoveryModeDialogForm.tsx
+++ b/src/modules/dashboard/components/RecoveryModeDialog/RecoveryModeDialogForm.tsx
@@ -16,6 +16,8 @@ import { useTransformer } from '~utils/hooks';
 import { getAllUserRoles } from '../../../transformers';
 import { canEnterRecoveryMode } from '../../../users/checks';
 
+import { RECOVERY_HELP } from '~externalUrls';
+
 import { FormValues } from './RecoveryModeDialog';
 import styles from './RecoveryModeDialogForm.css';
 
@@ -52,8 +54,6 @@ interface Props {
   back: () => void;
   colony: Colony;
 }
-
-const RECOVERY_MODE_HELP_LINK = `https://help.colony.io/docs/en/how-to-turn-off-recovery-mode`;
 
 const RecoveryModeDialogForm = ({
   back,
@@ -102,7 +102,7 @@ const RecoveryModeDialogForm = ({
               ),
               a: (chunks) => (
                 <a
-                  href={RECOVERY_MODE_HELP_LINK}
+                  href={RECOVERY_HELP}
                   target="_blank"
                   rel="noopener noreferrer"
                   className={styles.link}

--- a/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenForm.tsx
+++ b/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenForm.tsx
@@ -16,6 +16,8 @@ import PermissionsLabel from '~core/PermissionsLabel';
 import { getAllUserRoles } from '../../../transformers';
 import { hasRoot } from '../../../users/checks';
 
+import { TOKEN_UNLOCK_INFO } from '~externalUrls';
+
 import styles from './UnlockTokenForm.css';
 
 const MSG = defineMessages({
@@ -53,8 +55,6 @@ interface Props {
   colony: Colony;
   back?: () => void;
 }
-
-const LEARN_MORE_URL = `https://colony.gitbook.io/colony/manage-funds/unlock-token`;
 
 const UnlockTokenForm = ({
   colony: { isNativeTokenLocked, canUnlockNativeToken },
@@ -103,7 +103,7 @@ const UnlockTokenForm = ({
             <ExternalLink
               className={styles.learnMoreLink}
               text={{ id: 'text.learnMore' }}
-              href={LEARN_MORE_URL}
+              href={TOKEN_UNLOCK_INFO}
             />
           </div>
         </DialogSection>

--- a/src/modules/dashboard/sagas/coinMachine/buyTokens.ts
+++ b/src/modules/dashboard/sagas/coinMachine/buyTokens.ts
@@ -217,6 +217,7 @@ function* buyTokens({
         colonyAddress: colonyAddress.toLowerCase(),
         extensionAddress: coinMachineClient.address.toLowerCase(),
         limit: 1,
+        periodsCreatedAfter: '1000',
       },
       fetchPolicy: 'network-only',
     });

--- a/src/modules/externalUrls.ts
+++ b/src/modules/externalUrls.ts
@@ -3,3 +3,9 @@
 export const TOKEN_LOGOS_REPO_URL = `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains`;
 export const NETWORK_RELEASES_URL = `https://github.com/JoinColony/colonyNetwork/releases/tag`;
 export const FEEDBACK_LINK = `https://portal.productboard.com/colony/1-colony-portal/tabs/4-bugs`;
+
+/*
+ * Coin Machine
+ */
+export const CM_LEARN_MORE_LINK = `https://colony.gitbook.io/colony/extensions/coin-machine`;
+export const CM_GET_WHITELISTED = `https://colony.gitbook.io/colony/get-started/how-to-get-whitelisted-for-the-clny-sale.`;

--- a/src/modules/externalUrls.ts
+++ b/src/modules/externalUrls.ts
@@ -1,11 +1,45 @@
 /* eslint-disable max-len */
 
-export const TOKEN_LOGOS_REPO_URL = `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains`;
-export const NETWORK_RELEASES_URL = `https://github.com/JoinColony/colonyNetwork/releases/tag`;
-export const FEEDBACK_LINK = `https://portal.productboard.com/colony/1-colony-portal/tabs/4-bugs`;
+export const FEEDBACK = `https://portal.productboard.com/colony/1-colony-portal/tabs/4-bugs`;
+export const HELP = `https://colony.gitbook.io/colony`;
+export const BETA_DISCLAIMER = `https://colony.gitbook.io/colony/disclaimers/beta`;
+export const TERMS_AND_CONDITIONS = `https://colony.io/pdf/terms.pdf`;
+
+/*
+ * Utils
+ */
+export const TOKEN_LOGOS_REPO = `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains`;
+export const NETWORK_RELEASES = `https://github.com/JoinColony/colonyNetwork/releases/tag`;
+export const ETHERSCAN_CONVERSION_RATE = `https://api.etherscan.io/api?module=stats&action=ethprice`;
+export const ETH_GAS_STATION = `https://ethgasstation.info/json/ethgasAPI.json`;
+export const XDAI_GAS_STATION = `https://blockscout.com/xdai/mainnet/api/v1/gas-price-oracle`;
 
 /*
  * Coin Machine
  */
-export const CM_LEARN_MORE_LINK = `https://colony.gitbook.io/colony/extensions/coin-machine`;
+export const CM_LEARN_MORE = `https://colony.gitbook.io/colony/extensions/coin-machine`;
 export const CM_GET_WHITELISTED = `https://colony.gitbook.io/colony/get-started/how-to-get-whitelisted-for-the-clny-sale.`;
+export const CM_BLOG_POST = `https://blog.colony.io/introducing-coin-machine/`;
+export const CM_GOOGLE_SHEET = `https://docs.google.com/spreadsheets/d/1ZCuFcwqI4S6ZK5OwTl1yN7AK8mjv5d_V3g-_kMen01Y/edit#gid=2013814210`;
+export const CM_DESCRIPTION = 'https://colony.gitbook.io/colony/';
+
+/*
+ * Motions and Disputes
+ */
+export const MD_OBJECTIONS_HELP = `https://colony.io/dev/docs/colonynetwork/whitepaper-tldr-objections-and-disputes#objections`;
+
+/*
+ * Token
+ */
+export const TOKEN_ACTIVATION_INFO = `https://colony.gitbook.io/colony/key-concepts/token-activation`;
+export const TOKEN_UNLOCK_INFO = `https://colony.gitbook.io/colony/manage-funds/unlock-token`;
+
+/*
+ * Wallet
+ */
+export const WALLET_CONNECT_XDAI = `https://colony.gitbook.io/colony/get-started/connect-metamask-to-xdai`;
+
+/*
+ * Recovery Mode
+ */
+export const RECOVERY_HELP = `https://help.colony.io/docs/en/how-to-turn-off-recovery-mode`;

--- a/src/modules/externalUrls.ts
+++ b/src/modules/externalUrls.ts
@@ -1,0 +1,5 @@
+/* eslint-disable max-len */
+
+export const TOKEN_LOGOS_REPO_URL = `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains`;
+export const NETWORK_RELEASES_URL = `https://github.com/JoinColony/colonyNetwork/releases/tag`;
+export const FEEDBACK_LINK = `https://portal.productboard.com/colony/1-colony-portal/tabs/4-bugs`;

--- a/src/modules/users/components/AvatarDropdown/AvatarDropdownPopover.tsx
+++ b/src/modules/users/components/AvatarDropdown/AvatarDropdownPopover.tsx
@@ -4,7 +4,7 @@ import { defineMessages } from 'react-intl';
 import { ActionButton } from '~core/Button';
 import NavLink from '~core/NavLink';
 import ExternalLink from '~core/ExternalLink';
-import { FEEDBACK_LINK } from '~constants';
+import { FEEDBACK_LINK } from '~externalUrls';
 
 import { Colony } from '~data/index';
 import DropdownMenu, {

--- a/src/modules/users/components/AvatarDropdown/AvatarDropdownPopover.tsx
+++ b/src/modules/users/components/AvatarDropdown/AvatarDropdownPopover.tsx
@@ -4,7 +4,7 @@ import { defineMessages } from 'react-intl';
 import { ActionButton } from '~core/Button';
 import NavLink from '~core/NavLink';
 import ExternalLink from '~core/ExternalLink';
-import { FEEDBACK_LINK } from '~externalUrls';
+import { FEEDBACK, HELP } from '~externalUrls';
 
 import { Colony } from '~data/index';
 import DropdownMenu, {
@@ -122,14 +122,14 @@ const AvatarDropdownPopover = ({
     <DropdownMenuSection separator>
       <DropdownMenuItem>
         <ExternalLink
-          href={FEEDBACK_LINK}
+          href={FEEDBACK}
           text={MSG.reportBugs}
           className={styles.externalLink}
         />
       </DropdownMenuItem>
       <DropdownMenuItem>
         <ExternalLink
-          href="https://colony.gitbook.io/colony"
+          href={HELP}
           text={MSG.helpCenter}
           className={styles.externalLink}
         />

--- a/src/modules/users/components/ConnectWalletWizard/StepStart/StepStart.tsx
+++ b/src/modules/users/components/ConnectWalletWizard/StepStart/StepStart.tsx
@@ -12,6 +12,7 @@ import styles from './StepStart.css';
 import { useAutoLogin } from '~utils/autoLogin';
 import { SpinnerLoader } from '~core/Preloaders';
 import { DEFAULT_NETWORK_INFO } from '~constants';
+import { TERMS_AND_CONDITIONS } from '~externalUrls';
 
 const MSG = defineMessages({
   heading: {
@@ -80,10 +81,7 @@ type Props = {
 const StepStart = ({ nextStep, wizardValues, simplified = false }: Props) => {
   const attemptingAutoLogin = useAutoLogin();
   const tos = (
-    <ExternalLink
-      text={MSG.termsOfService}
-      href="https://colony.io/pdf/terms.pdf"
-    />
+    <ExternalLink text={MSG.termsOfService} href={TERMS_AND_CONDITIONS} />
   );
   return (
     <Form onSubmit={nextStep} initialValues={wizardValues}>

--- a/src/utils/contracts/index.ts
+++ b/src/utils/contracts/index.ts
@@ -4,7 +4,6 @@ import Decimal from 'decimal.js';
 
 import { WhitelistPolicy } from '~types/index';
 
-let inMemoryEMAIntake: BigNumber | undefined;
 /*
  * Replicates the period price evolution logic that is being done by the
  * Coin Machine Extension contracts:
@@ -18,9 +17,7 @@ export const getCoinMachinePeriodPrice = (
 ): BigNumber => {
   const WAD = WeiPerEther;
 
-  if (!inMemoryEMAIntake) {
-    inMemoryEMAIntake = prevPrice.mul(targetPerPeriod);
-  }
+  let inMemoryEMAIntake = prevPrice.mul(targetPerPeriod);
 
   /*
    * We need to use BigDecimal here since we're dealing with decimal values
@@ -38,6 +35,25 @@ export const getCoinMachinePeriodPrice = (
     .div(WAD);
 
   return inMemoryEMAIntake.div(targetPerPeriod);
+};
+
+export const getCoinMachinePreDecayPeriodPrice = (
+  windowSize = 24,
+  nextPrice: BigNumber = bigNumberify(0),
+): BigNumber => {
+  const WAD = WeiPerEther;
+
+  /*
+   * We need to use BigDecimal here since we're dealing with decimal values
+   * At the end we convert it back to a BigNumber
+   */
+  const alpha = bigNumberify(
+    new Decimal(2 / (windowSize + 1))
+      .mul(new Decimal(WAD.toString()))
+      .toString(),
+  );
+
+  return nextPrice.mul(WAD).div(WAD.sub(alpha));
 };
 
 export const getWhitelistPolicy = (

--- a/src/utils/events/index.ts
+++ b/src/utils/events/index.ts
@@ -569,11 +569,22 @@ export const getMotionState = async (
     18,
   );
   switch (motionNetworkState) {
-    case NetworkMotionState.Staking:
-      return bigNumberify(motion.stakes[1]).gte(bigNumberify(requiredStakes)) &&
-        bigNumberify(motion.stakes[0]).isZero()
-        ? MotionState.Staked
-        : MotionState.Staking;
+    case NetworkMotionState.Staking: {
+      const [nayStakes, yayStakes] = motion.stakes;
+      if (
+        bigNumberify(yayStakes).gte(bigNumberify(requiredStakes)) &&
+        bigNumberify(nayStakes).lt(bigNumberify(requiredStakes))
+      ) {
+        return MotionState.Staked;
+      }
+      if (
+        bigNumberify(nayStakes).gte(bigNumberify(requiredStakes)) &&
+        bigNumberify(yayStakes).lt(bigNumberify(requiredStakes))
+      ) {
+        return MotionState.Objection;
+      }
+      return MotionState.Staking;
+    }
     case NetworkMotionState.Submit:
       return MotionState.Voting;
     case NetworkMotionState.Reveal:

--- a/src/utils/events/subgraphEvents.ts
+++ b/src/utils/events/subgraphEvents.ts
@@ -249,7 +249,7 @@ export const parseSubgraphEvent = ({
     topic: topicId(name),
     address,
     ...(blockNumber && { blockNumber }),
-    ...(timestamp && { timestamp: parseInt(timestamp, 10) }),
+    ...(timestamp && { timestamp: parseInt(timestamp, 10) * 1000 }),
     /*
      * Parse the normal values, and any specialized parsers we might have
      */

--- a/src/utils/external/index.ts
+++ b/src/utils/external/index.ts
@@ -1,7 +1,8 @@
 import { BigNumber, formatUnits } from 'ethers/utils';
 import { Network, ColonyVersion, releaseMap } from '@colony/colony-js';
 
-import { DEFAULT_NETWORK, NETWORK_RELEASES_URL } from '~constants';
+import { DEFAULT_NETWORK } from '~constants';
+import { NETWORK_RELEASES_URL } from '~externalUrls';
 
 interface EthUsdResponse {
   status: string;

--- a/src/utils/external/index.ts
+++ b/src/utils/external/index.ts
@@ -2,7 +2,7 @@ import { BigNumber, formatUnits } from 'ethers/utils';
 import { Network, ColonyVersion, releaseMap } from '@colony/colony-js';
 
 import { DEFAULT_NETWORK } from '~constants';
-import { NETWORK_RELEASES_URL } from '~externalUrls';
+import { NETWORK_RELEASES, ETHERSCAN_CONVERSION_RATE } from '~externalUrls';
 
 interface EthUsdResponse {
   status: string;
@@ -29,9 +29,6 @@ interface BlockExplorerLinkProps {
 export const getEthToUsd = (ethValue: BigNumber): Promise<number | void> => {
   const ETH_USD_KEY = 'ethUsd';
   const ETH_USD_TIMESTAMP_KEY = 'ethUsdTimestamp';
-
-  const conversionRateEndpoint =
-    'https://api.etherscan.io/api?module=stats&action=ethprice';
 
   const cachedEthUsd = localStorage.getItem(ETH_USD_KEY) || null;
   const cachedEthUsdTimestamp =
@@ -64,7 +61,7 @@ export const getEthToUsd = (ethValue: BigNumber): Promise<number | void> => {
     }
   }
 
-  return fetch(conversionRateEndpoint)
+  return fetch(ETHERSCAN_CONVERSION_RATE)
     .then((response) => {
       if (!response.ok) {
         throw Error(response.statusText);
@@ -113,4 +110,4 @@ export const getBlockExplorerLink = ({
 };
 
 export const getNetworkRelaseLink = (version: ColonyVersion) =>
-  `${NETWORK_RELEASES_URL}/${releaseMap[version]}`;
+  `${NETWORK_RELEASES}/${releaseMap[version]}`;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,6 +3,7 @@
     "baseUrl": ".",
     "paths": {
       "~constants": ["src/modules/constants.ts"],
+      "~externalUrls": ["src/modules/externalUrls.ts"],
       "~admin/*": ["src/modules/admin/components/*"],
       "~context/*": ["src/context/*"],
       "~core/*": ["src/modules/core/components/*"],

--- a/webpack.base.js
+++ b/webpack.base.js
@@ -38,6 +38,7 @@ const config = {
       {},
       {
         '~constants': path.resolve(__dirname, 'src/modules/constants'),
+        '~externalUrls': path.resolve(__dirname, 'src/modules/externalUrls'),
         '~context': path.resolve(__dirname, 'src/context'),
         '~lib': path.resolve(__dirname, 'src/lib'),
         '~data': path.resolve(__dirname, 'src/data'),


### PR DESCRIPTION
![screenshot-2021-12-08_12-37-21](https://user-images.githubusercontent.com/311812/145209587-1f541fc7-65dc-45f7-ae6f-bd25540c0850.png)

This PR updates the logic for calculating historical prices for coinmachine periods where no tokens have been sold. I've just lightly touched the maths rather than anything more radical, and as a result there are two wrinkles here that I have not solved, but for the majority of historical periods the prices are now correct. 

1. When calculating the price of periods prior to the first sale, I have assumed that the price is evolving and decays. That is not currently the case, but I believe is the intended behaviour. The 'correct' way to solve this is to look at the `PriceEvolutionSet` event on the contracts, which has a boolean argument to track whether the price is evolving or not.
2. If no tokens have been sold yet, the historical prices will show as 0.

We can either fix these here (I suspect the second point, at least, needs to be fixed, with [Raul's proposed solution](https://github.com/JoinColony/colonyDapp/issues/2938#issuecomment-975307170) the way to go), or elsewhere.

Resolves #3006
Resolves #2995 
Resolves #2938
Resolves #2996