### PR TITLE
Fix conditions for red color text in remaining display widgets

### DIFF
--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTime.tsx
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTime.tsx
@@ -88,7 +88,7 @@ const RemainingTime = ({
     appearance.theme !== 'danger' &&
     typeof value === 'number' &&
     periodLength !== undefined &&
-    (timeLeft * 100) / periodLength <= 10;
+    (timeLeft * 1000 * 100) / periodLength <= 10;
 
   useEffect(() => {
     if (timeLeft <= 0 && colonyAddress !== undefined) {

--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTokens.tsx
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTokens.tsx
@@ -65,12 +65,7 @@ const RemainingTokens = ({
 
   const displayedValue = useMemo(() => {
     if (tokenAmounts) {
-      return (
-        <RemainingTokensValue
-          tokenAmounts={tokenAmounts}
-          tokensBought={tokenAmounts.soldPeriodTokens}
-        />
-      );
+      return <RemainingTokensValue tokenAmounts={tokenAmounts} />;
     }
 
     return <FormattedMessage {...widgetText.placeholder} />;
@@ -78,8 +73,9 @@ const RemainingTokens = ({
 
   const showValueWarning = useMemo(() => {
     if (
-      !isTotalSale ||
-      tokenAmounts?.soldPeriodTokens.gte(tokenAmounts?.maxPeriodTokens)
+      tokenAmounts?.soldPeriodTokens.gt(
+        tokenAmounts?.maxPeriodTokens.mul(90).div(100),
+      )
     ) {
       return true;
     }

--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTokens.tsx
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTokens.tsx
@@ -81,7 +81,7 @@ const RemainingTokens = ({
     }
 
     return false;
-  }, [tokenAmounts, isTotalSale]);
+  }, [tokenAmounts]);
 
   return (
     <RemainingWidget

--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTokensValue.tsx
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTokensValue.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from 'react';
 import { FormattedMessage, defineMessages } from 'react-intl';
-import { bigNumberify, BigNumberish } from 'ethers/utils';
 import { Textfit } from 'react-textfit';
 
 import Numeral from '~core/Numeral';
@@ -16,17 +15,16 @@ const MSG = defineMessages({
 
 interface Props {
   tokenAmounts: PeriodTokensType;
-  tokensBought: BigNumberish;
 }
 
 const displayedName = `dashboard.CoinMachine.RemainingDisplayWidgets.RemainingTokensValue`;
 
-const RemainingTokensValue = ({ tokenAmounts, tokensBought }: Props) => {
-  const { maxPeriodTokens, decimals } = tokenAmounts;
+const RemainingTokensValue = ({ tokenAmounts }: Props) => {
+  const { maxPeriodTokens, decimals, soldPeriodTokens } = tokenAmounts;
 
   const boughtTokens = useMemo(
-    () => getFormattedTokenValue(tokensBought, decimals),
-    [tokensBought, decimals],
+    () => getFormattedTokenValue(soldPeriodTokens, decimals),
+    [soldPeriodTokens, decimals],
   );
 
   const totalTokens = useMemo(
@@ -43,7 +41,7 @@ const RemainingTokensValue = ({ tokenAmounts, tokensBought }: Props) => {
     return combinedStringLength.length > maxCharactersOnOneLine;
   }, [totalTokens, boughtTokens]);
 
-  if (bigNumberify(tokensBought).gte(maxPeriodTokens)) {
+  if (soldPeriodTokens.gte(maxPeriodTokens)) {
     return <FormattedMessage {...MSG.soldOut} />;
   }
 


### PR DESCRIPTION
## Description

This PR fixes the conditions for color coding of the remaining display widgets (time & tokens)

**Changes** 🏗

- simplify props passing in `RemainingTokensValue` 
- update isWarning conditions in `RemainingTokens` & `RemainingTime`

Resolves #3012 
