### PR TITLE
Fixes wrong datetimes in motions

### DIFF
--- a/src/modules/core/components/Comment/Comment.tsx
+++ b/src/modules/core/components/Comment/Comment.tsx
@@ -40,7 +40,7 @@ export interface Props {
   colony: Colony;
   user?: AnyUser | null;
   annotation?: boolean;
-  createdAt?: Date | number;
+  createdAt?: number;
   showControls?: boolean;
 }
 

--- a/src/modules/core/components/TimeRelative/TimeRelative.tsx
+++ b/src/modules/core/components/TimeRelative/TimeRelative.tsx
@@ -5,7 +5,7 @@ interface Props extends HTMLAttributes<HTMLSpanElement> {
   /** Time in seconds to update */
   updateInterval?: number;
   /** Datetime to calculate relative/difference from. */
-  value: Date;
+  value: Date | number;
 }
 
 const nearestIntervalOf = (value: number, increment: number) =>

--- a/src/modules/dashboard/components/ActionsPage/TransactionMeta/TransactionMeta.tsx
+++ b/src/modules/dashboard/components/ActionsPage/TransactionMeta/TransactionMeta.tsx
@@ -35,7 +35,9 @@ const TransactionMeta = ({ createdAt, transactionHash, status }: Props) => (
   <ul className={styles.main}>
     {createdAt && (
       <li className={styles.items}>
-        <TimeRelative value={new Date(createdAt)} />
+        <TimeRelative
+          value={new Date(Number(createdAt.toString().substr(0, 10)) * 1000)}
+        />
       </li>
     )}
     {transactionHash && (

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageEvent/ActionsPageEvent.tsx
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageEvent/ActionsPageEvent.tsx
@@ -76,7 +76,7 @@ interface Props {
   eventName?: string;
   eventValues?: Record<string, any>;
   transactionHash: string;
-  createdAt: Date;
+  createdAt: Date | number;
   values?: EventValues;
   emmitedBy?: string;
   actionData: ColonyAction;

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeed.tsx
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeed.tsx
@@ -229,7 +229,7 @@ const ActionsPageFeed = ({
           <ActionsPageEvent
             key={uniqueId}
             eventIndex={index}
-            createdAt={new Date(createdAt)}
+            createdAt={createdAt}
             transactionHash={eventTransactionHash}
             eventName={name}
             actionData={actionData}


### PR DESCRIPTION
## Description
1. Enable motions
2. Create a motion
3. Date times would show wrongly before, should be OK now (Still not real, but I think 10 days in the future is OK for dev env)

- [x] Fix wrong datetimes in motions
**New stuff** ✨

* Handles miliseconds from MotionCreated by dropping all characters after 10 in the createdAt timestamp string.
* Doesn't cast dates before passing to TimeRelative since TimeRelative already handles this.

**Changes** 🏗

* Changed some props number / Date etc..

## TODO

- [ ] Find out why MotionCreated get's a createdAt in miliseconds (more than 10 characters) epoch time.



## Screenshots

<img width="436" alt="Screenshot 2021-12-08 at 23 42 10" src="https://user-images.githubusercontent.com/6601142/145304532-67a67c71-16d9-4af9-be42-5c4c5fd43e73.png">
<img width="1522" alt="Screenshot 2021-12-08 at 23 30 36" src="https://user-images.githubusercontent.com/6601142/145304535-5ab5f7f8-4955-44eb-bab6-357f1c522574.png">

Resolves #3017
