### PR TITLE
Fix interpretation of the decimal points in amount fields

### DIFF
--- a/src/data/staticData/extensionData.tsx
+++ b/src/data/staticData/extensionData.tsx
@@ -450,6 +450,7 @@ const extensions: { [key: string]: ExtensionData } = {
         validation: yup
           .number()
           .transform((value) => toFinite(value))
+          .positive()
           .required(),
         title: MSG.coinMachinePeriodLengthTitle,
         description: MSG.coinMachinePeriodLengthDescription,
@@ -463,7 +464,7 @@ const extensions: { [key: string]: ExtensionData } = {
         validation: yup
           .number()
           .transform((value) => toFinite(value))
-          .integer()
+          .positive()
           .required(),
         title: MSG.coinMachineWindowSizeTitle,
         description: MSG.coinMachineWindowSizeDescription,
@@ -477,6 +478,7 @@ const extensions: { [key: string]: ExtensionData } = {
         validation: yup
           .number()
           .transform((value) => toFinite(value))
+          .positive()
           .required(),
         title: MSG.coinMachineTargetPerPeriodTitle,
         description: MSG.coinMachineTargetPerPeriodDescription,
@@ -490,6 +492,7 @@ const extensions: { [key: string]: ExtensionData } = {
         validation: yup
           .number()
           .transform((value) => toFinite(value))
+          .positive()
           .required(),
         title: MSG.coinMachineMaxPerPeriodTitle,
         description: MSG.coinMachineMaxPerPeriodDescription,
@@ -503,6 +506,7 @@ const extensions: { [key: string]: ExtensionData } = {
         validation: yup
           .number()
           .transform((value) => toFinite(value))
+          .positive()
           .required()
           .max(100, () => MSG.votingReputationLessThan100Error),
         title: MSG.coinMachineUserLimitFractionTitle,
@@ -517,6 +521,7 @@ const extensions: { [key: string]: ExtensionData } = {
         validation: yup
           .number()
           .transform((value) => toFinite(value))
+          .min(0)
           .required(),
         title: MSG.coinMachineStartingPriceTitle,
         description: MSG.coinMachineStartingPriceDescription,

--- a/src/data/staticData/extensionData.tsx
+++ b/src/data/staticData/extensionData.tsx
@@ -7,6 +7,7 @@ import {
 import { ColonyRole, Extension } from '@colony/colony-js';
 import { AddressZero } from 'ethers/constants';
 import * as yup from 'yup';
+import toFinite from 'lodash/toFinite';
 
 import Whitelist from '~dashboard/Whitelist';
 import { CustomRadioProps } from '~core/Fields';
@@ -446,7 +447,10 @@ const extensions: { [key: string]: ExtensionData } = {
     initializationParams: [
       {
         paramName: 'periodLength',
-        validation: yup.number().required(),
+        validation: yup
+          .number()
+          .transform((value) => toFinite(value))
+          .required(),
         title: MSG.coinMachinePeriodLengthTitle,
         description: MSG.coinMachinePeriodLengthDescription,
         defaultValue: 1,
@@ -456,7 +460,11 @@ const extensions: { [key: string]: ExtensionData } = {
       },
       {
         paramName: 'windowSize',
-        validation: yup.number().integer().required(),
+        validation: yup
+          .number()
+          .transform((value) => toFinite(value))
+          .integer()
+          .required(),
         title: MSG.coinMachineWindowSizeTitle,
         description: MSG.coinMachineWindowSizeDescription,
         defaultValue: 24,
@@ -466,7 +474,10 @@ const extensions: { [key: string]: ExtensionData } = {
       },
       {
         paramName: 'targetPerPeriod',
-        validation: yup.number().required(),
+        validation: yup
+          .number()
+          .transform((value) => toFinite(value))
+          .required(),
         title: MSG.coinMachineTargetPerPeriodTitle,
         description: MSG.coinMachineTargetPerPeriodDescription,
         defaultValue: 200000,
@@ -476,7 +487,10 @@ const extensions: { [key: string]: ExtensionData } = {
       },
       {
         paramName: 'maxPerPeriod',
-        validation: yup.number().required(),
+        validation: yup
+          .number()
+          .transform((value) => toFinite(value))
+          .required(),
         title: MSG.coinMachineMaxPerPeriodTitle,
         description: MSG.coinMachineMaxPerPeriodDescription,
         defaultValue: 400000,
@@ -488,6 +502,7 @@ const extensions: { [key: string]: ExtensionData } = {
         paramName: 'userLimitFraction',
         validation: yup
           .number()
+          .transform((value) => toFinite(value))
           .required()
           .max(100, () => MSG.votingReputationLessThan100Error),
         title: MSG.coinMachineUserLimitFractionTitle,
@@ -499,7 +514,10 @@ const extensions: { [key: string]: ExtensionData } = {
       },
       {
         paramName: 'startingPrice',
-        validation: yup.number().required(),
+        validation: yup
+          .number()
+          .transform((value) => toFinite(value))
+          .required(),
         title: MSG.coinMachineStartingPriceTitle,
         description: MSG.coinMachineStartingPriceDescription,
         defaultValue: 0.1,
@@ -529,6 +547,7 @@ const extensions: { [key: string]: ExtensionData } = {
         paramName: 'totalStakeFraction',
         validation: yup
           .number()
+          .transform((value) => toFinite(value))
           .positive()
           .required(() => MSG.votingReputationRequiredError)
           .max(50, () => MSG.votingReputationLessThan50Error),
@@ -542,6 +561,7 @@ const extensions: { [key: string]: ExtensionData } = {
         paramName: 'voterRewardFraction',
         validation: yup
           .number()
+          .transform((value) => toFinite(value))
           .positive()
           .required(() => MSG.votingReputationRequiredError)
           .max(50, () => MSG.votingReputationLessThan50Error),
@@ -555,6 +575,7 @@ const extensions: { [key: string]: ExtensionData } = {
         paramName: 'userMinStakeFraction',
         validation: yup
           .number()
+          .transform((value) => toFinite(value))
           .positive()
           .required(() => MSG.votingReputationRequiredError)
           .max(100, () => MSG.votingReputationLessThan100Error),
@@ -568,6 +589,7 @@ const extensions: { [key: string]: ExtensionData } = {
         paramName: 'maxVoteFraction',
         validation: yup
           .number()
+          .transform((value) => toFinite(value))
           .positive()
           .required(() => MSG.votingReputationRequiredError)
           .max(100, () => MSG.votingReputationLessThan100Error),
@@ -581,6 +603,7 @@ const extensions: { [key: string]: ExtensionData } = {
         paramName: 'stakePeriod',
         validation: yup
           .number()
+          .transform((value) => toFinite(value))
           .positive()
           .required(() => MSG.votingReputationRequiredError)
           .max(8760, () => MSG.votingReputationLessThan1YearError),
@@ -594,6 +617,7 @@ const extensions: { [key: string]: ExtensionData } = {
         paramName: 'submitPeriod',
         validation: yup
           .number()
+          .transform((value) => toFinite(value))
           .positive()
           .required(() => MSG.votingReputationRequiredError)
           .max(8760, () => MSG.votingReputationLessThan1YearError),
@@ -607,6 +631,7 @@ const extensions: { [key: string]: ExtensionData } = {
         paramName: 'revealPeriod',
         validation: yup
           .number()
+          .transform((value) => toFinite(value))
           .positive()
           .required(() => MSG.votingReputationRequiredError)
           .max(8760, () => MSG.votingReputationLessThan1YearError),
@@ -620,6 +645,7 @@ const extensions: { [key: string]: ExtensionData } = {
         paramName: 'escalationPeriod',
         validation: yup
           .number()
+          .transform((value) => toFinite(value))
           .positive()
           .required(() => MSG.votingReputationRequiredError)
           .max(8760, () => MSG.votingReputationLessThan1YearError),

--- a/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
+++ b/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
@@ -6,6 +6,7 @@ import { FormikProps } from 'formik';
 import { AddressZero } from 'ethers/constants';
 import { BigNumber, bigNumberify } from 'ethers/utils';
 import Decimal from 'decimal.js';
+import toFinite from 'lodash/toFinite';
 
 import Heading from '~core/Heading';
 import QuestionMarkTooltip from '~core/QuestionMarkTooltip';
@@ -119,6 +120,7 @@ const validationSchema = (userBalance: string, tokenDecimals: number) => {
 
   let amountFieldValidation = yup
     .number()
+    .transform((value) => toFinite(value))
     .moreThan(0)
     .max(
       uncappedUserBalance.toNumber(),
@@ -199,7 +201,7 @@ const BuyTokens = ({
 
   const getFormattedCost = useCallback(
     (amount) => {
-      const decimalCost = new Decimal(amount)
+      const decimalCost = new Decimal(toFinite(amount))
         .times(salePriceData?.coinMachineCurrentPeriodPrice || '0')
         .toFixed(0, Decimal.ROUND_HALF_UP);
 
@@ -507,7 +509,7 @@ const BuyTokens = ({
                                  * and that will try to fetch the balance for, which, obviously, will fail
                                  */
                                 values.amount
-                                  ? parseInt(values.amount, 10) *
+                                  ? toFinite(values.amount) *
                                     parseFloat(currentSalePrice)
                                   : '0'
                               }
@@ -538,7 +540,7 @@ const BuyTokens = ({
                         globalDisable ||
                         isSoldOut ||
                         !isValid ||
-                        parseFloat(values.amount) <= 0
+                        toFinite(values.amount) <= 0
                       }
                     />
                   )}

--- a/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialog.tsx
+++ b/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialog.tsx
@@ -4,6 +4,7 @@ import * as yup from 'yup';
 import { ROOT_DOMAIN_ID } from '@colony/colony-js';
 import { defineMessages } from 'react-intl';
 import { useHistory } from 'react-router-dom';
+import toFinite from 'lodash/toFinite';
 
 import Dialog, { DialogProps, ActionDialogProps } from '~core/Dialog';
 import { ActionForm } from '~core/Fields';
@@ -79,6 +80,7 @@ const CreatePaymentDialog = ({
     }),
     amount: yup
       .number()
+      .transform((value) => toFinite(value))
       .required()
       .moreThan(0, () => MSG.amountZero),
     tokenAddress: yup.string().address().required(),

--- a/src/modules/dashboard/components/TokenMintDialog/TokenMintDialog.tsx
+++ b/src/modules/dashboard/components/TokenMintDialog/TokenMintDialog.tsx
@@ -5,6 +5,7 @@ import * as yup from 'yup';
 import { useHistory } from 'react-router-dom';
 import { bigNumberify } from 'ethers/utils';
 import moveDecimal from 'move-decimal-point';
+import toFinite from 'lodash/toFinite';
 
 import Dialog, { DialogProps, ActionDialogProps } from '~core/Dialog';
 import { ActionForm } from '~core/Fields';
@@ -45,6 +46,7 @@ const validationSchema = yup.object().shape({
   annotation: yup.string().max(4000),
   mintAmount: yup
     .number()
+    .transform((value) => toFinite(value))
     .required(() => MSG.errorAmountRequired)
     .moreThan(0, () => MSG.errorAmountMin),
 });

--- a/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialog.tsx
+++ b/src/modules/dashboard/components/TransferFundsDialog/TransferFundsDialog.tsx
@@ -7,6 +7,7 @@ import { useHistory } from 'react-router-dom';
 import { defineMessages } from 'react-intl';
 import sortBy from 'lodash/sortBy';
 import { ROOT_DOMAIN_ID } from '@colony/colony-js';
+import toFinite from 'lodash/toFinite';
 
 import { pipe, mapPayload, withMeta } from '~utils/actions';
 import { Address } from '~types/index';
@@ -84,6 +85,7 @@ const TransferFundsDialog = ({
     toDomain: yup.number().required(),
     amount: yup
       .number()
+      .transform((value) => toFinite(value))
       .required()
       .moreThan(0, () => MSG.amountZero),
     tokenAddress: yup.string().address().required(),

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/ChangeTokenStateForm.tsx
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/ChangeTokenStateForm.tsx
@@ -5,6 +5,7 @@ import { FormikProps } from 'formik';
 import moveDecimal from 'move-decimal-point';
 import * as yup from 'yup';
 import Decimal from 'decimal.js';
+import toFinite from 'lodash/toFinite';
 
 import Button from '~core/Button';
 import { ActionForm, Input } from '~core/Fields';
@@ -53,7 +54,11 @@ const MSG = defineMessages({
 });
 
 const validationSchema = yup.object({
-  amount: yup.number().required().moreThan(0),
+  amount: yup
+    .number()
+    .transform((value) => toFinite(value))
+    .required()
+    .moreThan(0),
 });
 
 type FormValues = {
@@ -242,7 +247,7 @@ const ChangeTokenStateForm = ({
               disabled={
                 !isValid ||
                 values.amount === undefined ||
-                new Decimal(unformattedTokenBalance).lt(values.amount || 0)
+                new Decimal(unformattedTokenBalance).lt(toFinite(values.amount))
               }
             />
           </div>


### PR DESCRIPTION
The problem was that `Decimal` and `parseFloat`/`parseInteger` don't interpret '.' as '0.0', so I had to use an alternative like `toFinite` to get a safe value.

- If it's `parseFloat`/`parseInteger`, it would interpret it as `NaN`, resulting in the validation of the form throwing a really long validation error message that could break the interface, and it's not user friendly (`TransferFundsDialog`, `TokenMintDialog`, `CreatePaymentDialog`)
- If it's `Decimal` the one that receives the `.`, it would just crash the page and if it somehow doesn't, it still would show the long weird error (`BuyTokens`) 

Please check all of the places where we use an amount field, all of them should be able to perceive `.` as a `0` without crashing or throwing a user-unfriendly error.

Resolves #3011 
