### PR TITLE
UX Improvements to members list views

### DIFF
--- a/src/modules/core/components/MemberReputation/MemberReputation.tsx
+++ b/src/modules/core/components/MemberReputation/MemberReputation.tsx
@@ -63,29 +63,26 @@ const MemberReputation = ({
   );
 
   useEffect(() => {
-    if (userReputationData) {
-      onReputationLoaded(true);
-    } else {
-      onReputationLoaded(false);
-    }
+    onReputationLoaded(!!userReputationData);
   }, [userReputationData, onReputationLoaded]);
 
   return (
     <div>
-      {userPercentageReputation && (
-        <Icon
-          name="star"
-          appearance={{ size: 'extraTiny' }}
-          className={styles.icon}
-          title={
-            userPercentageReputation
-              ? MSG.starReputationTitle
-              : MSG.starNoReputationTitle
-          }
-          titleValues={{
-            reputation: userPercentageReputation,
-          }}
-        />
+      <Icon
+        name="star"
+        appearance={{ size: 'extraTiny' }}
+        className={styles.icon}
+        title={
+          userPercentageReputation
+            ? MSG.starReputationTitle
+            : MSG.starNoReputationTitle
+        }
+        titleValues={{
+          reputation: userPercentageReputation,
+        }}
+      />
+      {!userPercentageReputation && (
+        <div className={styles.reputation}>— %</div>
       )}
       {userPercentageReputation === ZeroValue.NearZero && (
         <div className={styles.reputation}>{userPercentageReputation}</div>

--- a/src/modules/core/components/MemberReputation/MemberReputation.tsx
+++ b/src/modules/core/components/MemberReputation/MemberReputation.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { defineMessages } from 'react-intl';
 import { ROOT_DOMAIN_ID } from '@colony/colony-js';
 import { AddressZero } from 'ethers/constants';
@@ -31,6 +31,7 @@ interface Props {
   colonyAddress: Address;
   domainId?: number;
   rootHash?: string;
+  onReputationLoaded?: (reputationLoaded: boolean) => void;
 }
 
 const displayName = 'MemberReputation';
@@ -40,6 +41,7 @@ const MemberReputation = ({
   colonyAddress,
   domainId = ROOT_DOMAIN_ID,
   rootHash,
+  onReputationLoaded = () => null,
 }: Props) => {
   const { data: userReputationData } = useUserReputationQuery({
     variables: { address: walletAddress, colonyAddress, domainId, rootHash },
@@ -59,23 +61,31 @@ const MemberReputation = ({
     userReputationData?.userReputation,
     totalReputation?.userReputation,
   );
+
+  useEffect(() => {
+    if (userReputationData) {
+      onReputationLoaded(true);
+    } else {
+      onReputationLoaded(false);
+    }
+  }, [userReputationData, onReputationLoaded]);
+
   return (
     <div>
-      <Icon
-        name="star"
-        appearance={{ size: 'extraTiny' }}
-        className={styles.icon}
-        title={
-          userPercentageReputation
-            ? MSG.starReputationTitle
-            : MSG.starNoReputationTitle
-        }
-        titleValues={{
-          reputation: userPercentageReputation,
-        }}
-      />
-      {!userPercentageReputation && (
-        <div className={styles.reputation}>— %</div>
+      {userPercentageReputation && (
+        <Icon
+          name="star"
+          appearance={{ size: 'extraTiny' }}
+          className={styles.icon}
+          title={
+            userPercentageReputation
+              ? MSG.starReputationTitle
+              : MSG.starNoReputationTitle
+          }
+          titleValues={{
+            reputation: userPercentageReputation,
+          }}
+        />
       )}
       {userPercentageReputation === ZeroValue.NearZero && (
         <div className={styles.reputation}>{userPercentageReputation}</div>

--- a/src/modules/core/components/MembersList/MembersListItem.css
+++ b/src/modules/core/components/MembersList/MembersListItem.css
@@ -38,3 +38,12 @@
   margin-left: 30px;
   width: 65px;
 }
+
+.stateHasReputation {
+  opacity: 0;
+  transition: opacity 0.3s ease-out;
+}
+
+.stateHasReputation.stateReputationLoaded {
+  opacity: 1;
+}

--- a/src/modules/core/components/MembersList/MembersListItem.css.d.ts
+++ b/src/modules/core/components/MembersList/MembersListItem.css.d.ts
@@ -5,3 +5,5 @@ export const displayName: string;
 export const username: string;
 export const address: string;
 export const reputationSection: string;
+export const stateHasReputation: string;
+export const stateReputationLoaded: string;

--- a/src/modules/core/components/MembersList/MembersListItem.tsx
+++ b/src/modules/core/components/MembersList/MembersListItem.tsx
@@ -83,8 +83,8 @@ const MembersListItem = <U extends AnyUser = AnyUser>(props: Props<U>) => {
       <div
         className={getMainClasses({}, styles, {
           hasCallbackFn: !!onRowClick,
-          hasReputation: !!showUserReputation,
-          reputationLoaded: !!reputationLoaded,
+          hasReputation: showUserReputation,
+          reputationLoaded,
         })}
         onClick={onRowClick ? handleRowClick : undefined}
         onKeyDown={onRowClick ? handleRowKeydown : undefined}

--- a/src/modules/core/components/MembersList/MembersListItem.tsx
+++ b/src/modules/core/components/MembersList/MembersListItem.tsx
@@ -1,4 +1,10 @@
-import React, { KeyboardEvent, ReactNode, useCallback, useMemo } from 'react';
+import React, {
+  KeyboardEvent,
+  ReactNode,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
 import { AddressZero } from 'ethers/constants';
 
 import { createAddress } from '~utils/web3';
@@ -44,6 +50,9 @@ const MembersListItem = <U extends AnyUser = AnyUser>(props: Props<U>) => {
 
   const userProfile = useUser(createAddress(walletAddress || AddressZero));
 
+  // Determine when reputation has loaded
+  const [reputationLoaded, setReputationLoaded] = useState<boolean>(false);
+
   const handleRowClick = useCallback(() => {
     if (onRowClick) {
       onRowClick(user);
@@ -72,7 +81,11 @@ const MembersListItem = <U extends AnyUser = AnyUser>(props: Props<U>) => {
       {/* Disable, as `role` is conditional */}
       {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
       <div
-        className={getMainClasses({}, styles, { hasCallbackFn: !!onRowClick })}
+        className={getMainClasses({}, styles, {
+          hasCallbackFn: !!onRowClick,
+          hasReputation: !!showUserReputation,
+          reputationLoaded: !!reputationLoaded,
+        })}
         onClick={onRowClick ? handleRowClick : undefined}
         onKeyDown={onRowClick ? handleRowKeydown : undefined}
         role={onRowClick ? 'button' : undefined}
@@ -86,6 +99,7 @@ const MembersListItem = <U extends AnyUser = AnyUser>(props: Props<U>) => {
               walletAddress={walletAddress}
               colonyAddress={colony.colonyAddress}
               domainId={domainId}
+              onReputationLoaded={setReputationLoaded}
             />
           </div>
         )}

--- a/src/modules/dashboard/components/Members/Members.tsx
+++ b/src/modules/dashboard/components/Members/Members.tsx
@@ -129,7 +129,10 @@ const Members = ({ colony: { colonyAddress }, colony, bannedUsers }: Props) => {
   } = useColonyMembersWithReputationQuery({
     variables: {
       colonyAddress,
-      domainId: currentDomainId,
+      domainId:
+        currentDomainId !== COLONY_TOTAL_BALANCE_DOMAIN_ID
+          ? currentDomainId
+          : ROOT_DOMAIN_ID,
     },
   });
 
@@ -158,11 +161,17 @@ const Members = ({ colony: { colonyAddress }, colony, bannedUsers }: Props) => {
    */
   const skelethonUsers = useMemo(() => {
     let displayMembers =
-      allMembers?.subscribedUsers.map(
-        ({ profile: { walletAddress } }) => walletAddress,
+      membersWithReputation?.colonyMembersWithReputation?.map((walletAddress) =>
+        createAddress(walletAddress),
       ) || [];
-    if (currentDomainId !== COLONY_TOTAL_BALANCE_DOMAIN_ID) {
-      displayMembers = membersWithReputation?.colonyMembersWithReputation || [];
+    if (currentDomainId === COLONY_TOTAL_BALANCE_DOMAIN_ID) {
+      const membersWithoutReputation =
+        allMembers?.subscribedUsers.map(({ profile: { walletAddress } }) =>
+          createAddress(walletAddress),
+        ) || [];
+      displayMembers = [
+        ...new Set([...displayMembers, ...membersWithoutReputation]),
+      ];
     }
 
     return displayMembers.map((walletAddress) => ({

--- a/src/modules/dashboard/components/Members/Members.tsx
+++ b/src/modules/dashboard/components/Members/Members.tsx
@@ -282,7 +282,7 @@ const Members = ({ colony: { colonyAddress }, colony, bannedUsers }: Props) => {
         banned: boolean;
       }) =>
         banned &&
-        bannedUserWalletAddress.toLowerCase() === walletAddress.toLowerCase(),
+        createAddress(bannedUserWalletAddress) === createAddress(walletAddress),
     );
     const domainRole = domainRolesArray.find(
       (rolesObject) =>

--- a/src/modules/dashboard/components/Members/Members.tsx
+++ b/src/modules/dashboard/components/Members/Members.tsx
@@ -280,7 +280,9 @@ const Members = ({ colony: { colonyAddress }, colony, bannedUsers }: Props) => {
       }: {
         id: Address;
         banned: boolean;
-      }) => banned && bannedUserWalletAddress === walletAddress,
+      }) =>
+        banned &&
+        bannedUserWalletAddress.toLowerCase() === walletAddress.toLowerCase(),
     );
     const domainRole = domainRolesArray.find(
       (rolesObject) =>


### PR DESCRIPTION
## Description

Makes improvements to the members list view. 

1. Ensuring all addresses with reputation in root, also appear within the "All teams" view. This solution continues with the limitations of the current query as mentioned in PR #2981

2. Sorts the users within the "All teams" view by reputation.

![all-teams-view](https://user-images.githubusercontent.com/33682027/145853884-ba229105-b9a7-4427-a19f-18465839ed4f.jpg)

3. Improves the loading of individual members

![loading-in-members](https://user-images.githubusercontent.com/33682027/145987357-bad367ec-4b63-47d6-81d0-deac04e87d54.gif)

4. Fixes banned tag not showing within teams.

![Screenshot 2021-12-13 111807](https://user-images.githubusercontent.com/33682027/145794302-de71dfd7-350c-4d2e-928e-ec344d168486.jpg)

## TODO

- [x] Add sorting by reputation to "All teams"
- [x] Include non-subscribers with reputation in "All teams"
- [x] Banned user tags in all team views
- [x] Better loading of each team member

Resolves #3002
