### PR TITLE
Adds loading text to synaps KYC dialog

### DIFF
--- a/src/modules/core/components/Preloaders/SpinnerLoader.css
+++ b/src/modules/core/components/Preloaders/SpinnerLoader.css
@@ -87,3 +87,7 @@
 .layoutHorizontal .loader {
   margin: 0 10px 0 0;
 }
+
+.loadingText {
+  padding-top: 30px;
+}

--- a/src/modules/core/components/Preloaders/SpinnerLoader.css.d.ts
+++ b/src/modules/core/components/Preloaders/SpinnerLoader.css.d.ts
@@ -10,3 +10,4 @@ export const loadingTextContainer: string;
 export const themeGrey: string;
 export const themePrimary: string;
 export const layoutHorizontal: string;
+export const loadingText: string;

--- a/src/modules/core/components/Preloaders/SpinnerLoader.tsx
+++ b/src/modules/core/components/Preloaders/SpinnerLoader.tsx
@@ -34,7 +34,7 @@ const SpinnerLoader = ({
       <div className={styles.loader} />
       {loadingText && (
         <div className={styles.loadingTextContainer}>
-          <div>
+          <div className={styles.loadingText}>
             {typeof loadingText === 'string'
               ? loadingText
               : formatMessage(loadingText, textValues)}

--- a/src/modules/dashboard/components/CoinMachine/SynapsKYCDialog/SynapsKYCDialog.tsx
+++ b/src/modules/dashboard/components/CoinMachine/SynapsKYCDialog/SynapsKYCDialog.tsx
@@ -31,6 +31,10 @@ const MSG = defineMessages({
     id: 'dashboard.CoinMachine.SynapsKYCDialog.verifiedIconTitle',
     defaultMessage: 'You are verified! Congrats',
   },
+  loadingText: {
+    id: 'dashboard.CoinMachine.SynapsKYCDialog.loadingText',
+    defaultMesage: 'Sign transaction with your wallet',
+  },
 });
 
 const displayName = 'dashboard.CoinMachine.SynapsKYCDialog';
@@ -115,7 +119,12 @@ const SynapsKYCDialog = ({ cancel, colonyAddress, emailAddress }: Props) => {
     <Dialog cancel={cancel}>
       <DialogSection appearance={{ theme: 'sidePadding' }}>
         <div className={styles.content}>
-          {isLoading && <SpinnerLoader appearance={{ size: 'large' }} />}
+          {isLoading && (
+            <SpinnerLoader
+              loadingText={MSG.loadingText.defaultMesage}
+              appearance={{ size: 'large' }}
+            />
+          )}
           {!isLoading && isValid && (
             <div className={styles.verified}>
               <Icon name="emoji-party" title={MSG.verifiedIconTitle} />


### PR DESCRIPTION
## Description
For testing purposes you might add the spinner loader somewhere else on the dapp with the appropriate text value. 
Btw I had to pass defaultMessage explicitly. not sure if good but is how it worked. otherwise it showed the label instead of the text.

 
- [x] Add loading text when Synaps KYC loading asks for wallet access / confirmation

**How to test:** 
In order to test this, since it's a loading state, I just placed the SpinnerLoader component in the landing page. So you can see how it looks.
`src/modules/pages/components/LandingPage/LandingPage.tsx`
```tsx
<SpinnerLoader
  loadingText="Sign transaction with your wallet"
  appearance={{ size: 'large' }}
/>
```
**New stuff** ✨

* Adds new message for loadingText in KYCDialog
* Adds new .loadingText css class with a padding-top 30px property. I double checked and it seems this is the first instance of using loadingText on SpinnerLoader, so this should not break any existing implementation and I guessued we would want such a padding in all cases of showing the loadingText props. Let me know if you don't think that's a good approach!

```diff
+  loadingText: {
+    id: 'dashboard.CoinMachine.SynapsKYCDialog.loadingText',
+    defaultMesage: 'Sign transaction with your wallet',
+  },
```
**Changes** 🏗

* Adds loadingText prop to SpinnerLoader in KYCDialog component
```diff
-          {isLoading && <SpinnerLoader appearance={{ size: 'large' }} />}
+          {isLoading && (
+            <SpinnerLoader
+              loadingText={MSG.loadingText.defaultMesage}
+              appearance={{ size: 'large' }}
+            />
+          )}
```
Resolves #2903 