### PR TITLE
Fix initial motion domain selection in `CreatePayment` & `Permissions` dialogs

### DIFF
--- a/src/modules/dashboard/components/MotionDomainSelect/MotionDomainSelect.tsx
+++ b/src/modules/dashboard/components/MotionDomainSelect/MotionDomainSelect.tsx
@@ -72,6 +72,7 @@ const MotionDomainSelect = ({
       initialValues={{
         motionDomainId: String(initialSelectedDomain),
       }}
+      enableReinitialize
       onSubmit={() => {}}
     >
       <div className={styles.main}>

--- a/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementForm.tsx
+++ b/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementForm.tsx
@@ -253,7 +253,7 @@ const PermissionManagementForm = ({
                  * create a payment from that subdomain
                  */
                 filterDomains={handleFilterMotionDomains}
-                initialSelectedDomain={parseInt(values.motionDomainId, 10)}
+                initialSelectedDomain={parseInt(values.domainId, 10)}
               />
             </div>
           )}


### PR DESCRIPTION
## Description

This PR fixes the motion domain selection in `CreatePayment` & `PermissionManagement` dialogs (please refer to the issue for the bug description):
https://github.com/JoinColony/colonyDapp/issues/3039

**Changes** 🏗

- update `MotionDomainSelect` component
- update `PermissionManagementForm` component

resolves #3039 
