### PR TITLE
Fix sold out conditionals of coin machine

### DIFF
--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -237,7 +237,6 @@ export type Query = {
   coinMachinePeriods: Array<SalePeriod>;
   coinMachineSalePeriods: SalePeriod;
   coinMachineSaleTokens: SaleTokens;
-  coinMachineTokenBalance: Scalars['String'];
   coinMachineTotalTokens: TotalTokens;
   coinMachineTransactionAmount: TrannsactionAmount;
   colonies: Array<SubgraphColony>;
@@ -355,11 +354,6 @@ export type QueryCoinMachineSalePeriodsArgs = {
 
 
 export type QueryCoinMachineSaleTokensArgs = {
-  colonyAddress: Scalars['String'];
-};
-
-
-export type QueryCoinMachineTokenBalanceArgs = {
   colonyAddress: Scalars['String'];
 };
 
@@ -1218,6 +1212,7 @@ export type CurrentPeriodTokens = {
   maxPerPeriodTokens: Scalars['String'];
   activeSoldTokens: Scalars['String'];
   targetPerPeriodTokens: Scalars['String'];
+  tokenBalance: Scalars['String'];
 };
 
 export type BoughtTokens = {
@@ -2010,14 +2005,7 @@ export type CurrentPeriodTokensQueryVariables = Exact<{
 }>;
 
 
-export type CurrentPeriodTokensQuery = { currentPeriodTokens: Pick<CurrentPeriodTokens, 'maxPerPeriodTokens' | 'activeSoldTokens' | 'targetPerPeriodTokens'> };
-
-export type CoinMachineTokenBalanceQueryVariables = Exact<{
-  colonyAddress: Scalars['String'];
-}>;
-
-
-export type CoinMachineTokenBalanceQuery = Pick<Query, 'coinMachineTokenBalance'>;
+export type CurrentPeriodTokensQuery = { currentPeriodTokens: Pick<CurrentPeriodTokens, 'maxPerPeriodTokens' | 'activeSoldTokens' | 'targetPerPeriodTokens' | 'tokenBalance'> };
 
 export type CoinMachineTotalTokensQueryVariables = Exact<{
   colonyAddress: Scalars['String'];
@@ -5265,6 +5253,7 @@ export const CurrentPeriodTokensDocument = gql`
     maxPerPeriodTokens
     activeSoldTokens
     targetPerPeriodTokens
+    tokenBalance
   }
 }
     `;
@@ -5294,37 +5283,6 @@ export function useCurrentPeriodTokensLazyQuery(baseOptions?: Apollo.LazyQueryHo
 export type CurrentPeriodTokensQueryHookResult = ReturnType<typeof useCurrentPeriodTokensQuery>;
 export type CurrentPeriodTokensLazyQueryHookResult = ReturnType<typeof useCurrentPeriodTokensLazyQuery>;
 export type CurrentPeriodTokensQueryResult = Apollo.QueryResult<CurrentPeriodTokensQuery, CurrentPeriodTokensQueryVariables>;
-export const CoinMachineTokenBalanceDocument = gql`
-    query CoinMachineTokenBalance($colonyAddress: String!) {
-  coinMachineTokenBalance(colonyAddress: $colonyAddress) @client
-}
-    `;
-
-/**
- * __useCoinMachineTokenBalanceQuery__
- *
- * To run a query within a React component, call `useCoinMachineTokenBalanceQuery` and pass it any options that fit your needs.
- * When your component renders, `useCoinMachineTokenBalanceQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useCoinMachineTokenBalanceQuery({
- *   variables: {
- *      colonyAddress: // value for 'colonyAddress'
- *   },
- * });
- */
-export function useCoinMachineTokenBalanceQuery(baseOptions?: Apollo.QueryHookOptions<CoinMachineTokenBalanceQuery, CoinMachineTokenBalanceQueryVariables>) {
-        return Apollo.useQuery<CoinMachineTokenBalanceQuery, CoinMachineTokenBalanceQueryVariables>(CoinMachineTokenBalanceDocument, baseOptions);
-      }
-export function useCoinMachineTokenBalanceLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CoinMachineTokenBalanceQuery, CoinMachineTokenBalanceQueryVariables>) {
-          return Apollo.useLazyQuery<CoinMachineTokenBalanceQuery, CoinMachineTokenBalanceQueryVariables>(CoinMachineTokenBalanceDocument, baseOptions);
-        }
-export type CoinMachineTokenBalanceQueryHookResult = ReturnType<typeof useCoinMachineTokenBalanceQuery>;
-export type CoinMachineTokenBalanceLazyQueryHookResult = ReturnType<typeof useCoinMachineTokenBalanceLazyQuery>;
-export type CoinMachineTokenBalanceQueryResult = Apollo.QueryResult<CoinMachineTokenBalanceQuery, CoinMachineTokenBalanceQueryVariables>;
 export const CoinMachineTotalTokensDocument = gql`
     query CoinMachineTotalTokens($colonyAddress: String!) {
   coinMachineTotalTokens(colonyAddress: $colonyAddress) @client {

--- a/src/data/graphql/queries/coinMachine.graphql
+++ b/src/data/graphql/queries/coinMachine.graphql
@@ -53,11 +53,8 @@ query CurrentPeriodTokens($colonyAddress: String!) {
     maxPerPeriodTokens
     activeSoldTokens
     targetPerPeriodTokens
+    tokenBalance
   }
-}
-
-query CoinMachineTokenBalance($colonyAddress: String!) {
-  coinMachineTokenBalance(colonyAddress: $colonyAddress) @client
 }
 
 query CoinMachineTotalTokens($colonyAddress: String!) {

--- a/src/data/graphql/typeDefs/coinMachine.ts
+++ b/src/data/graphql/typeDefs/coinMachine.ts
@@ -21,6 +21,7 @@ export default gql`
     maxPerPeriodTokens: String!
     activeSoldTokens: String!
     targetPerPeriodTokens: String!
+    tokenBalance: String!
   }
 
   type BoughtTokens {
@@ -66,7 +67,6 @@ export default gql`
     ): String!
     coinMachineCurrentSalePeriod(colonyAddress: String!): CurrentSalePeriod!
     currentPeriodTokens(colonyAddress: String!): CurrentPeriodTokens!
-    coinMachineTokenBalance(colonyAddress: String!): String!
     coinMachineTotalTokens(colonyAddress: String!): TotalTokens!
     coinMachinePeriods(
       skip: Int!

--- a/src/data/resolvers/coinMachine.ts
+++ b/src/data/resolvers/coinMachine.ts
@@ -224,6 +224,8 @@ export const coinMachineResolvers = ({
 
         const maxPerPeriodTokens = await coinMachineClient.getMaxPerPeriod();
 
+        const tokenBalance = await coinMachineClient.getTokenBalance();
+
         const activeSoldTokens = await coinMachineClient.getActiveSold();
         const activePeriod = await coinMachineClient.getActivePeriod();
         const blockTime = await getBlockTime(networkClient.provider, 'latest');
@@ -244,21 +246,8 @@ export const coinMachineResolvers = ({
               ? activeSoldTokens.toString()
               : '',
           targetPerPeriodTokens: targetPerPeriodTokens.toString(),
+          tokenBalance: tokenBalance.toString(),
         };
-      } catch (error) {
-        console.error(error);
-        return null;
-      }
-    },
-    async coinMachineTokenBalance(_, { colonyAddress }) {
-      try {
-        const coinMachineClient = await colonyManager.getClient(
-          ClientType.CoinMachineClient,
-          colonyAddress,
-        );
-        const tokenBalance = await coinMachineClient.getTokenBalance();
-
-        return tokenBalance.toString();
       } catch (error) {
         console.error(error);
         return null;

--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -167,17 +167,11 @@ const CoinMachine = ({
     if (!saleTokensData || !periodTokensData || !hasSaleStarted) {
       return undefined;
     }
-    const maxPerPeriodTokens = bigNumberify(maxPerPeriod);
-    const leftAvailableTokens = bigNumberify(
-      coinMachineTokenBalanceData?.coinMachineTokenBalance || '0',
-    );
 
     return {
       decimals: saleTokensData.coinMachineSaleTokens.sellableToken.decimals,
       soldPeriodTokens: bigNumberify(activeSold),
-      maxPeriodTokens: maxPerPeriodTokens.gt(leftAvailableTokens)
-        ? leftAvailableTokens
-        : bigNumberify(maxPerPeriod),
+      maxPeriodTokens: bigNumberify(maxPerPeriod),
       targetPeriodTokens: bigNumberify(targetPerPeriod),
     };
   }, [
@@ -187,7 +181,6 @@ const CoinMachine = ({
     activeSold,
     maxPerPeriod,
     targetPerPeriod,
-    coinMachineTokenBalanceData,
   ]);
 
   const totalTokens = useMemo(() => {

--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -167,11 +167,18 @@ const CoinMachine = ({
     if (!saleTokensData || !periodTokensData || !hasSaleStarted) {
       return undefined;
     }
+    const maxPerPeriodTokens = bigNumberify(maxPerPeriod);
+    const leftAvailableTokens = bigNumberify(
+      coinMachineTokenBalanceData?.coinMachineTokenBalance || '0',
+    );
+    const isPartialMaxPeriodTokens = maxPerPeriodTokens.gt(leftAvailableTokens);
 
     return {
       decimals: saleTokensData.coinMachineSaleTokens.sellableToken.decimals,
       soldPeriodTokens: bigNumberify(activeSold),
-      maxPeriodTokens: bigNumberify(maxPerPeriod),
+      maxPeriodTokens: isPartialMaxPeriodTokens
+        ? leftAvailableTokens.add(bigNumberify(activeSold))
+        : bigNumberify(maxPerPeriod),
       targetPeriodTokens: bigNumberify(targetPerPeriod),
     };
   }, [
@@ -181,6 +188,7 @@ const CoinMachine = ({
     activeSold,
     maxPerPeriod,
     targetPerPeriod,
+    coinMachineTokenBalanceData,
   ]);
 
   const totalTokens = useMemo(() => {

--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -15,7 +15,6 @@ import {
   useCurrentPeriodTokensQuery,
   Colony,
   useCoinMachineCurrentSalePeriodQuery,
-  useCoinMachineTokenBalanceQuery,
   useCoinMachineCurrentPeriodPriceQuery,
   useCoinMachineCurrentPeriodMaxUserPurchaseQuery,
   useCoinMachineTotalTokensQuery,
@@ -116,14 +115,6 @@ const CoinMachine = ({
   });
 
   const {
-    data: coinMachineTokenBalanceData,
-    loading: coinMachineTokenBalanceLoading,
-  } = useCoinMachineTokenBalanceQuery({
-    variables: { colonyAddress },
-    fetchPolicy: 'network-only',
-  });
-
-  const {
     data: totalTokensData,
     loading: totalTokensDataLoading,
     stopPolling: stopPollingTotalTokensData,
@@ -154,7 +145,7 @@ const CoinMachine = ({
   });
 
   const hasSaleStarted = !bigNumberify(
-    coinMachineTokenBalanceData?.coinMachineTokenBalance || 0,
+    periodTokensData?.currentPeriodTokens.tokenBalance || 0,
   ).isZero();
 
   const {
@@ -169,15 +160,18 @@ const CoinMachine = ({
     }
     const maxPerPeriodTokens = bigNumberify(maxPerPeriod);
     const leftAvailableTokens = bigNumberify(
-      coinMachineTokenBalanceData?.coinMachineTokenBalance || '0',
+      periodTokensData?.currentPeriodTokens.tokenBalance || '0',
     );
-    const isPartialMaxPeriodTokens = maxPerPeriodTokens.gt(leftAvailableTokens);
+    const soldPeriodTokens = bigNumberify(activeSold);
+    const isPartialMaxPeriodTokens = maxPerPeriodTokens
+      .sub(soldPeriodTokens)
+      .gte(leftAvailableTokens);
 
     return {
       decimals: saleTokensData.coinMachineSaleTokens.sellableToken.decimals,
-      soldPeriodTokens: bigNumberify(activeSold),
+      soldPeriodTokens,
       maxPeriodTokens: isPartialMaxPeriodTokens
-        ? leftAvailableTokens.add(bigNumberify(activeSold))
+        ? leftAvailableTokens.add(soldPeriodTokens)
         : bigNumberify(maxPerPeriod),
       targetPeriodTokens: bigNumberify(targetPerPeriod),
     };
@@ -188,7 +182,6 @@ const CoinMachine = ({
     activeSold,
     maxPerPeriod,
     targetPerPeriod,
-    coinMachineTokenBalanceData,
   ]);
 
   const totalTokens = useMemo(() => {
@@ -247,7 +240,6 @@ const CoinMachine = ({
     currentSalePeriodLoading ||
     !extensionsData?.processedColony?.installedExtensions ||
     periodTokensLoading ||
-    coinMachineTokenBalanceLoading ||
     totalTokensDataLoading
   ) {
     return (

--- a/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTokens.tsx
+++ b/src/modules/dashboard/components/CoinMachine/RemainingDisplayWidgets/RemainingTokens.tsx
@@ -44,10 +44,6 @@ const MSG = defineMessages({
     id: 'dashboard.CoinMachine.RemainingDisplayWidgets.RemainingTokens.title',
     defaultMessage: '0',
   },
-  soldOut: {
-    id: 'dashboard.CoinMachine.RemainingDisplayWidgets.RemainingTokens.soldOut',
-    defaultMessage: 'SOLD OUT',
-  },
 });
 
 const RemainingTokens = ({

--- a/src/modules/dashboard/sagas/coinMachine/buyTokens.ts
+++ b/src/modules/dashboard/sagas/coinMachine/buyTokens.ts
@@ -12,9 +12,6 @@ import { ContextModule, TEMP_getContext } from '~context/index';
 import { getToken } from '~data/resolvers/token';
 import { TxConfig } from '~types/index';
 import {
-  CoinMachineTokenBalanceDocument,
-  CoinMachineTokenBalanceQuery,
-  CoinMachineTokenBalanceQueryVariables,
   CurrentPeriodTokensDocument,
   CurrentPeriodTokensQuery,
   CurrentPeriodTokensQueryVariables,
@@ -235,15 +232,6 @@ function* buyTokens({
         tokenAddress: sellableTokenAddress,
         colonyAddress,
       },
-      fetchPolicy: 'network-only',
-    });
-
-    yield apolloClient.query<
-      CoinMachineTokenBalanceQuery,
-      CoinMachineTokenBalanceQueryVariables
-    >({
-      query: CoinMachineTokenBalanceDocument,
-      variables: { colonyAddress },
       fetchPolicy: 'network-only',
     });
   } catch (caughtError) {

--- a/src/modules/dashboard/sagas/coinMachine/buyTokens.ts
+++ b/src/modules/dashboard/sagas/coinMachine/buyTokens.ts
@@ -12,6 +12,9 @@ import { ContextModule, TEMP_getContext } from '~context/index';
 import { getToken } from '~data/resolvers/token';
 import { TxConfig } from '~types/index';
 import {
+  CoinMachineTokenBalanceDocument,
+  CoinMachineTokenBalanceQuery,
+  CoinMachineTokenBalanceQueryVariables,
   CurrentPeriodTokensDocument,
   CurrentPeriodTokensQuery,
   CurrentPeriodTokensQueryVariables,
@@ -232,6 +235,15 @@ function* buyTokens({
         tokenAddress: sellableTokenAddress,
         colonyAddress,
       },
+      fetchPolicy: 'network-only',
+    });
+
+    yield apolloClient.query<
+      CoinMachineTokenBalanceQuery,
+      CoinMachineTokenBalanceQueryVariables
+    >({
+      query: CoinMachineTokenBalanceDocument,
+      variables: { colonyAddress },
       fetchPolicy: 'network-only',
     });
   } catch (caughtError) {


### PR DESCRIPTION
Updated the logic that determines the `maxPeriodTokens` amount when the coin machine has fewer tokens than what's the max in a period so that it doesn't show that the period sold out when it hasn't. Also improves consistency with the rest of the batches, to be more specific, how the last batches are portrayed.

![FireShot Capture 513 - Colony - localhost](https://user-images.githubusercontent.com/18473896/146263724-8044a669-8830-493c-be4b-77c2eec1ced6.png)

Also:
- Removed unused message descriptor from RemainingTokens
- Added refresh query for coin machine's token balance data

Resolves #3024 
