### PR TITLE
Hotfix: guard against undefined totalToken prop

### DIFF
--- a/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
+++ b/src/modules/dashboard/components/CoinMachine/CoinMachine.tsx
@@ -185,7 +185,12 @@ const CoinMachine = ({
   ]);
 
   const totalTokens = useMemo(() => {
-    if (!saleTokensData || !totalTokensData || !hasSaleStarted) {
+    if (
+      !saleTokensData ||
+      !totalTokensData ||
+      !totalTokensData.coinMachineTotalTokens ||
+      !hasSaleStarted
+    ) {
       return undefined;
     }
     return {

--- a/src/modules/dashboard/components/CoinMachine/Confetti/Confetti.tsx
+++ b/src/modules/dashboard/components/CoinMachine/Confetti/Confetti.tsx
@@ -32,7 +32,7 @@ const Confetti = ({ colonyAddress }: Props) => {
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    if (periodTokensData) {
+    if (periodTokensData && periodTokensData.currentPeriodTokens) {
       const soldPeriodTokens = bigNumberify(
         periodTokensData.currentPeriodTokens.activeSoldTokens,
       );


### PR DESCRIPTION
## Description

By analyzing the errors in the console I found that sometimes the `totalTokensData.coinMachineTotalTokens` property is not defined. Judging by the types that shouldn't happen so we can only call this a hotfix.

**Changes** 🏗

* Add `totalTokensData` property guard

This bug would lead to a total site crash which required a reload to get rid off.