### PR TITLE
Fix duplicate events on events page

### DIFF
--- a/src/modules/dashboard/components/ColonyEvents/ColonyEvents.tsx
+++ b/src/modules/dashboard/components/ColonyEvents/ColonyEvents.tsx
@@ -44,7 +44,7 @@ const ColonyEvents = ({
 
   const [eventsSort, setEventsSort] = useState<string>(SortOptions.NEWEST);
   const [dataPage, setDataPage] = useState<number>(1);
-  const [streamedEvents, setstreamedEvents] = useState<
+  const [streamedEvents, setStreamedEvents] = useState<
     SubgraphEventsSubscription['events']
   >([]);
 
@@ -65,9 +65,8 @@ const ColonyEvents = ({
       sortDirection: 'desc',
     },
     onSubscriptionData: ({ subscriptionData: { data: newSubscriptionData } }) =>
-      setstreamedEvents([
-        ...streamedEvents,
-        ...(newSubscriptionData?.events || []),
+      setStreamedEvents([
+        ...new Set([...streamedEvents, ...(newSubscriptionData?.events || [])]),
       ]),
   });
 


### PR DESCRIPTION
## Description

- [x] Make sure duplicate events are not possible on events list component in events page.
- Sorry team, this one is a hard to reproduce bug from metacolony, if anyone knows how to test it direclty with metacolony prod data that'd be nice..
Otherwise, we can introduce artificially duplicate streamedEvents at the new Set:
```ColonyEvents.tsx
  const {
    data,
    loading: subgraphEventsLoading,
    error,
  } = useSubgraphEventsSubscription({
    variables: {
      skip: dataPage === 1 ? 0 : ITEMS_PER_PAGE * dataPage,
      first: ITEMS_PER_PAGE,
      colonyAddress: colonyAddress.toLowerCase(),
      sortDirection: 'desc',
    },
    onSubscriptionData: ({ subscriptionData: { data: newSubscriptionData } }) =>
      setStreamedEvents([
        ...new Set([
          ...streamedEvents,
          ...streamedEvents,
          ...(newSubscriptionData?.events || []),
        ]),
      ]),
  });
```

and see if Set catches and removes 'em.

**Changes** 🏗

* Wrap current array for events into set, so it filters them by ID.

**Minor cosmetic changes** ⚰️

* setstreamedEvents uppercased to -> setStreamedEvents

## TODO


Resolves #3045