### PR TITLE
Improve UI of Claiming Tokens for a Colony

### DIFF
--- a/src/modules/dashboard/components/UnclaimedTransfers/UnclaimedTransfers.tsx
+++ b/src/modules/dashboard/components/UnclaimedTransfers/UnclaimedTransfers.tsx
@@ -16,7 +16,7 @@ interface Props {
 const MSG = defineMessages({
   title: {
     id: 'dashboard.UnclaimedTransfers.title',
-    defaultMessage: 'Incoming funds',
+    defaultMessage: 'Incoming funds for {colony}',
   },
   loadingData: {
     id: 'dashboard.UnclaimedTransfers.title',
@@ -24,9 +24,9 @@ const MSG = defineMessages({
   },
 });
 
-const UnclaimedTransfers = ({ colony: { colonyAddress } }: Props) => {
+const UnclaimedTransfers = ({ colony }: Props) => {
   const { data, error, loading } = useColonyTransfersQuery({
-    variables: { address: colonyAddress },
+    variables: { address: colony.colonyAddress },
   });
   if (error) console.warn(error);
 
@@ -44,7 +44,12 @@ const UnclaimedTransfers = ({ colony: { colonyAddress } }: Props) => {
       {data && data.processedColony.unclaimedTransfers.length ? (
         <div className={styles.main}>
           <div className={styles.title}>
-            <FormattedMessage {...MSG.title} />
+            <FormattedMessage
+              {...MSG.title}
+              values={{
+                colony: colony.displayName || 'colony',
+              }}
+            />
           </div>
           <ul>
             {data.processedColony.unclaimedTransfers.map((transaction) => (

--- a/src/modules/dashboard/components/UnclaimedTransfers/UnclaimedTransfersItem.css
+++ b/src/modules/dashboard/components/UnclaimedTransfers/UnclaimedTransfersItem.css
@@ -19,7 +19,7 @@
   justify-content: center;
   align-items: center;
   height: 30px;
-  width: 100px;
+  width: 133px;
 }
 
 .amount {

--- a/src/modules/dashboard/components/UnclaimedTransfers/UnclaimedTransfersItem.tsx
+++ b/src/modules/dashboard/components/UnclaimedTransfers/UnclaimedTransfersItem.tsx
@@ -31,7 +31,7 @@ const displayName = 'UnclaimedTransfers.UnclaimedTransfersItem';
 const MSG = defineMessages({
   buttonClaim: {
     id: 'dashboard.UnclaimedTransfers.UnclaimedTransfersItem.buttonClaim',
-    defaultMessage: 'Claim',
+    defaultMessage: 'Claim for colony',
   },
   from: {
     id: 'dashboard.UnclaimedTransfers.UnclaimedTransfersItem.from',


### PR DESCRIPTION
## Description

This PR is intended to address any misunderstandings there may be with the 'Claim' button on the 'Events' page of a colony, as described in #3044.

![better-claim-funds-ui](https://user-images.githubusercontent.com/33682027/146426961-9b170e75-d7e7-44ce-a65c-83b3531abf57.png)

The design and changes have been raised in Product, with approval from Karol.

**Changes** 🏗

* New title for the section.
* New button text for claiming.

**Testing** 

To replicate, you will need to send funds to a colony.

- One way to test is to run a CoinMachine token sale and make some buy orders.
- Go to the events page to view the 'Claim' button appear.

Resolves #3044
