### PR TITLE
Fix extensions page overflowing on lower resolutions

### DIFF
--- a/src/modules/dashboard/components/Extensions/Extensions.css
+++ b/src/modules/dashboard/components/Extensions/Extensions.css
@@ -23,14 +23,6 @@
   display: block;
 }
 
-/*
- * @NOTE We don't realy use the sidebar here, it's just easier this way
- * to properly align the grid with the one on the details page
- */
-.sidebar {
-  display: block;
-}
-
 .availableExtensionsWrapper {
   margin-top: 40px;
 }

--- a/src/modules/dashboard/components/Extensions/Extensions.css.d.ts
+++ b/src/modules/dashboard/components/Extensions/Extensions.css.d.ts
@@ -2,7 +2,6 @@ export const lineHeight: string;
 export const main: string;
 export const description: string;
 export const content: string;
-export const sidebar: string;
 export const availableExtensionsWrapper: string;
 export const cards: string;
 export const loadingSpinner: string;

--- a/src/modules/dashboard/components/Extensions/Extensions.tsx
+++ b/src/modules/dashboard/components/Extensions/Extensions.tsx
@@ -153,7 +153,6 @@ const Extensions = ({ colonyAddress }: Props) => {
           </div>
         ) : null}
       </div>
-      <div className={styles.sidebar} />
     </div>
   );
 };


### PR DESCRIPTION
Removed unused sidebar from the extensions page to stop the page from overflowing on lower resolutions. 

The page is still overflowing on even lower resolutions but changing that would require a rework of the grid that we use on a lot of pages, a rework which will probably come when we start improving the responsiveness of the dapp.

Resolves #3035 
