### PR TITLE
Use public submodule URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,9 @@
 	url = https://github.com/JoinColony/colonyServer.git
 [submodule "src/lib/subgraph"]
 	path = src/lib/subgraph
-	url = git@github.com:JoinColony/subgraph.git
+	url = https://github.com/JoinColony/subgraph.git
 	ignore = dirty
 [submodule "src/lib/graph-node"]
 	path = src/lib/graph-node
-	url = git@github.com:graphprotocol/graph-node.git
+	url = https://github.com/graphprotocol/graph-node.git
 	ignore = dirty


### PR DESCRIPTION
## Description

- [x] Point all submodules to public repo URLs.

**Changes** 🏗

* Change submodule URLs to be a public ones so that non-team members would be able to checkout and build the project. Currently this trigger errors that some remote repositories cannot be cloned.

Goes together with https://github.com/JoinColony/colonyServer/pull/148.