### PR TITLE
Fixes annotation comment hover state and spacing

### DIFF
--- a/src/modules/core/components/Comment/Comment.css
+++ b/src/modules/core/components/Comment/Comment.css
@@ -7,7 +7,7 @@
   border-radius: var(--radius-large);
 }
 
-.main:hover, .main.activeActions {
+.main:not(.stateDisableHover):hover, .main.stateActiveActions:not(.stateDisableHover) {
   background-color: color-mod(var(--action-secondary) alpha(6%));
   opacity: 1;
 }
@@ -36,7 +36,7 @@
   color: color-mod(var(--temp-grey-blue-7) alpha(80%));
 }
 
-.stateHideControls:hover {
+.stateHideControls:not(.stateDisableHover):hover {
   background-color: transparent;
 }
 
@@ -71,7 +71,7 @@
   opacity: 0;
 }
 
-.main:hover .actions, .main.activeActions .actions {
+.main:hover .actions, .main.stateActiveActions .actions {
   opacity: 1;
 }
 

--- a/src/modules/core/components/Comment/Comment.css.d.ts
+++ b/src/modules/core/components/Comment/Comment.css.d.ts
@@ -1,5 +1,6 @@
 export const main: string;
-export const activeActions: string;
+export const stateDisableHover: string;
+export const stateActiveActions: string;
 export const stateAnnotation: string;
 export const stateGhosted: string;
 export const avatar: string;

--- a/src/modules/core/components/Comment/Comment.tsx
+++ b/src/modules/core/components/Comment/Comment.tsx
@@ -42,6 +42,7 @@ export interface Props {
   annotation?: boolean;
   createdAt?: Date | number;
   showControls?: boolean;
+  disableHover?: boolean;
 }
 
 const UserAvatar = HookedUserAvatar({ fetchUser: false });
@@ -55,6 +56,7 @@ const Comment = ({
   createdAt,
   annotation = false,
   showControls = false,
+  disableHover = false,
 }: Props) => {
   const { walletAddress } = useLoggedInUser();
   const rootRoles = useTransformer(getUserRolesForDomain, [
@@ -92,18 +94,16 @@ const Comment = ({
 
   return (
     <div
-      className={`
-          ${getMainClasses(appearance, styles, {
-            annotation,
-            ghosted:
-              showControls &&
-              permission !== COMMENT_MODERATION.NONE &&
-              !!(deleted || adminDelete || userBanned),
-            hideControls:
-              !showControls || permission === COMMENT_MODERATION.NONE,
-          })}
-          ${hoverState ? styles.activeActions : ''}
-        `}
+      className={getMainClasses(appearance, styles, {
+        annotation,
+        ghosted:
+          showControls &&
+          permission !== COMMENT_MODERATION.NONE &&
+          !!(deleted || adminDelete || userBanned),
+        hideControls: !showControls || permission === COMMENT_MODERATION.NONE,
+        activeActions: hoverState,
+        disableHover,
+      })}
     >
       <div className={styles.avatar}>
         <UserAvatar

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
@@ -465,13 +465,15 @@ const DefaultMotion = ({
             </div>
           )}
           {objectionAnnotation?.motionObjectionAnnotation?.metadata && (
-            <ActionsPageFeedItemWithIPFS
-              colony={colony}
-              user={objectionAnnotationUser}
-              annotation
-              hash={objectionAnnotation.motionObjectionAnnotation.metadata}
-              appearance={{ theme: 'danger' }}
-            />
+            <div className={motionSpecificStyles.annotation}>
+              <ActionsPageFeedItemWithIPFS
+                colony={colony}
+                user={objectionAnnotationUser}
+                annotation
+                hash={objectionAnnotation.motionObjectionAnnotation.metadata}
+                appearance={{ theme: 'danger' }}
+              />
+            </div>
           )}
           <ActionsPageFeed
             actionType={actionType}

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeedItemWithIPFS/ActionsPageFeedItemWithIPFS.tsx
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeedItemWithIPFS/ActionsPageFeedItemWithIPFS.tsx
@@ -48,6 +48,7 @@ const ActionsPageFeedItemWithIPFS = ({
       {...rest}
       comment={annotation ? annotationMessage : comment}
       annotation={annotation}
+      disableHover
     />
   );
 };


### PR DESCRIPTION
## Description

This PR fixes the hover state of the annotation comment, as well as the spacing below annotation comment for staking or objection.

**New stuff** ✨

* Add a new prop to comments to allow hover state to be disabled.
* Adds the same container around main annotation, around staking and objection annotation.

![fixes-annotation-comment-hover](https://user-images.githubusercontent.com/33682027/146826478-69f8dd14-a77b-44ba-a473-685ddfce3b89.gif)


### Additional

For reference, this screenshot shows the spacing issue also fixed in this update.

![fix-gap-between-comments](https://user-images.githubusercontent.com/33682027/146826660-1dc3fa46-43c3-4f49-8e88-e92c94fe73a2.png)


Resolves #3062
