### PR TITLE
Add extension re-enabling functionality

### DIFF
--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.css
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.css
@@ -76,7 +76,9 @@
   margin-right: 0px;
 }
 
-.buttonUninstall {
+.actionButtons {
+  display: flex;
+  justify-content: flex-end;
   margin-top: 10px;
   text-align: right;
 }

--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.css.d.ts
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.css.d.ts
@@ -9,6 +9,6 @@ export const cellData: string;
 export const installedBy: string;
 export const installedByAddress: string;
 export const permissions: string;
-export const buttonUninstall: string;
+export const actionButtons: string;
 export const iconWrapper: string;
 export const contractAddress: string;

--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
@@ -109,6 +109,10 @@ const MSG = defineMessages({
     id: 'dashboard.Extensions.ExtensionDetails.buttonDeprecate',
     defaultMessage: 'Deprecate',
   },
+  buttonReEnable: {
+    id: 'dashboard.Extensions.ExtensionDetails.buttonReEnable',
+    defaultMessage: 'Re-enable',
+  },
   headingDeprecate: {
     id: 'dashboard.Extensions.ExtensionDetails.headingDeprecate',
     defaultMessage: 'Deprecate extension',
@@ -116,6 +120,14 @@ const MSG = defineMessages({
   textDeprecate: {
     id: 'dashboard.Extensions.ExtensionDetails.textDeprecate',
     defaultMessage: `This extension must first be deprecated if you wish to uninstall it. After deprecation, any actions using this extension already ongoing may be completed, but it will no longer be possible to create new actions requiring this extension. Are you sure you wish to proceed?`,
+  },
+  headingReEnable: {
+    id: 'dashboard.Extensions.ExtensionDetails.headingReEnable',
+    defaultMessage: 'Re-enable extension',
+  },
+  textReEnable: {
+    id: 'dashboard.Extensions.ExtensionDetails.textDeprecate',
+    defaultMessage: `The extension will be re-enabled with the same parameters. Are you sure you wish to proceed?`,
   },
   headingUninstall: {
     id: 'dashboard.Extensions.ExtensionDetails.headingUninstall',
@@ -441,7 +453,7 @@ const ExtensionDetails = ({
             </TableBody>
           </Table>
           {extesionCanBeDeprecated ? (
-            <div className={styles.buttonUninstall}>
+            <div className={styles.actionButtons}>
               <DialogActionButton
                 dialog={ConfirmDialog}
                 dialogProps={{
@@ -453,13 +465,27 @@ const ExtensionDetails = ({
                 error={ActionTypes.COLONY_EXTENSION_DEPRECATE_ERROR}
                 success={ActionTypes.COLONY_EXTENSION_DEPRECATE_SUCCESS}
                 text={MSG.buttonDeprecate}
-                values={{ colonyAddress, extensionId }}
+                values={{ colonyAddress, extensionId, isToDeprecate: true }}
                 disabled={!isSupportedColonyVersion || !isNetworkAllowed}
               />
             </div>
           ) : null}
           {extesionCanBeUninstalled ? (
-            <div className={styles.buttonUninstall}>
+            <div className={styles.actionButtons}>
+              <DialogActionButton
+                dialog={ConfirmDialog}
+                dialogProps={{
+                  heading: MSG.headingReEnable,
+                  children: <FormattedMessage {...MSG.textReEnable} />,
+                }}
+                appearance={{ theme: 'blue' }}
+                submit={ActionTypes.COLONY_EXTENSION_DEPRECATE}
+                error={ActionTypes.COLONY_EXTENSION_DEPRECATE_ERROR}
+                success={ActionTypes.COLONY_EXTENSION_DEPRECATE_SUCCESS}
+                text={MSG.buttonReEnable}
+                values={{ colonyAddress, extensionId, isToDeprecate: false }}
+                disabled={!isSupportedColonyVersion || !isNetworkAllowed}
+              />
               <DialogActionButton
                 dialog={ExtensionUninstallConfirmDialog}
                 dialogProps={

--- a/src/modules/dashboard/sagas/extensions/colonyExtensionDeprecate.ts
+++ b/src/modules/dashboard/sagas/extensions/colonyExtensionDeprecate.ts
@@ -14,7 +14,7 @@ import { refreshExtension } from '../utils';
 
 function* colonyExtensionDeprecate({
   meta,
-  payload: { colonyAddress, extensionId },
+  payload: { colonyAddress, extensionId, isToDeprecate },
 }: Action<ActionTypes.COLONY_EXTENSION_DEPRECATE>) {
   const txChannel = yield call(getTxChannel, meta.id);
 
@@ -23,7 +23,7 @@ function* colonyExtensionDeprecate({
       context: ClientType.ColonyClient,
       methodName: 'deprecateExtension',
       identifier: colonyAddress,
-      params: [getExtensionHash(extensionId), true],
+      params: [getExtensionHash(extensionId), isToDeprecate],
     });
 
     yield takeFrom(txChannel, ActionTypes.TRANSACTION_CREATED);

--- a/src/redux/types/actions/colony.ts
+++ b/src/redux/types/actions/colony.ts
@@ -75,7 +75,7 @@ export type ColonyActionTypes =
   | ErrorActionType<ActionTypes.COLONY_EXTENSION_ENABLE_ERROR, object>
   | UniqueActionType<
       ActionTypes.COLONY_EXTENSION_DEPRECATE,
-      { colonyAddress: Address; extensionId: string },
+      { colonyAddress: Address; extensionId: string; isToDeprecate: boolean },
       WithKey
     >
   | UniqueActionType<


### PR DESCRIPTION
## Description

This PR adds extension re-enabling feature. It was already available on the contracts side.

The copy for the confirm dialog and the UI elements have been confirmed with Karol.

Please, note that when transaction is executed there will still be a copy:

`Deprecate Colony Extension`

This is not really possible to change due to the current implementation. But Raul is working on something that will change this implementation, and then we will be able to update a copy specifically to re-enabling extension. But for now it will stay like this.

**Changes** 🏗

- update deprecateExtension saga, action & `ExtensionDetails` component

Resolves #3061 
