### PR TITLE
Fixes question mark tooltip alignment

### DIFF
--- a/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.css
@@ -55,6 +55,7 @@
   display: inline-block;
   margin-left: 7px;
   width: 33px;
+  vertical-align: middle;
   cursor: pointer;
 }
 

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css
@@ -40,6 +40,7 @@
 .help {
   margin-right: auto;
   margin-left: 8px;
+  margin-top: 1px;
 }
 
 .tooltip {

--- a/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteWidget.css
@@ -37,6 +37,7 @@
   display: inline-block;
   margin-left: 7px;
   width: 33px;
+  vertical-align: middle;
   cursor: pointer;
 }
 


### PR DESCRIPTION
## Description

- [x] Align properly question mark icon tooltips in motions related areas.

## How to test
This changes affect mainly motions and disputes, so you'll need to enable the extension.
Create a motion, and see in different stages if all question marks look good to you. I've adjusted them with vertical-align middle and some margin-top in one case.

**I've only tested in MacOS, if you're a Linux user, please let me know how it looks in your environment!**

**Changes** 🏗

* Adds 'vertical-align: middle;' to FinalizeMotionAndClaimWidget.css and VoteWidget.css .help classes.
* Adds 1px margin-top in TotalStakeWidget.css .help class


**Screenshots** 📸 
<img width="438" alt="Captura de pantalla 2021-12-21 a las 15 05 05" src="https://user-images.githubusercontent.com/6601142/146944720-f6adb472-e04e-45d0-a18f-621e95ce3b44.png">
<img width="472" alt="Captura de pantalla 2021-12-21 a las 15 01 13" src="https://user-images.githubusercontent.com/6601142/146944725-744435e6-7615-45df-a7e2-8443f0faa0b9.png">
<img width="501" alt="Captura de pantalla 2021-12-21 a las 14 58 11" src="https://user-images.githubusercontent.com/6601142/146944727-f4b9cdfd-78d6-4534-ac73-8c36ac664c55.png">


Resolves #2825
