### PR TITLE
Fix motions using old motion events

### DIFF
--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -2206,6 +2206,7 @@ export type SubgraphMotionEventsQuery = { motionEvents: Array<(
 export type SubgraphMotionSystemEventsQueryVariables = Exact<{
   colonyAddress: Scalars['String'];
   motionId: Scalars['String'];
+  extensionAddress: Scalars['String'];
   sortDirection?: Maybe<Scalars['String']>;
 }>;
 
@@ -5935,8 +5936,8 @@ export type SubgraphMotionEventsQueryHookResult = ReturnType<typeof useSubgraphM
 export type SubgraphMotionEventsLazyQueryHookResult = ReturnType<typeof useSubgraphMotionEventsLazyQuery>;
 export type SubgraphMotionEventsQueryResult = Apollo.QueryResult<SubgraphMotionEventsQuery, SubgraphMotionEventsQueryVariables>;
 export const SubgraphMotionSystemEventsDocument = gql`
-    query SubgraphMotionSystemEvents($colonyAddress: String!, $motionId: String!, $sortDirection: String = asc) {
-  motionSystemEvents: events(orderBy: "timestamp", orderDirection: $sortDirection, where: {name_in: ["MotionStaked(uint256,address,uint256,uint256)", "MotionVoteSubmitted(uint256,address)", "MotionVoteRevealed(uint256,address,uint256)"], associatedColony: $colonyAddress, args_contains: $motionId}) {
+    query SubgraphMotionSystemEvents($colonyAddress: String!, $motionId: String!, $extensionAddress: String!, $sortDirection: String = asc) {
+  motionSystemEvents: events(orderBy: "timestamp", orderDirection: $sortDirection, where: {name_in: ["MotionStaked(uint256,address,uint256,uint256)", "MotionVoteSubmitted(uint256,address)", "MotionVoteRevealed(uint256,address,uint256)"], associatedColony: $colonyAddress, address: $extensionAddress, args_contains: $motionId}) {
     id
     address
     name
@@ -5969,6 +5970,7 @@ export const SubgraphMotionSystemEventsDocument = gql`
  *   variables: {
  *      colonyAddress: // value for 'colonyAddress'
  *      motionId: // value for 'motionId'
+ *      extensionAddress: // value for 'extensionAddress'
  *      sortDirection: // value for 'sortDirection'
  *   },
  * });

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -2263,6 +2263,7 @@ export type SubgraphMotionVoteRevealedEventsQuery = { motionVoteRevealedEvents: 
 export type SubgraphMotionStakedEventsQueryVariables = Exact<{
   colonyAddress: Scalars['String'];
   motionId: Scalars['String'];
+  extensionAddress: Scalars['String'];
   sortDirection?: Maybe<Scalars['String']>;
 }>;
 
@@ -6078,8 +6079,8 @@ export type SubgraphMotionVoteRevealedEventsQueryHookResult = ReturnType<typeof 
 export type SubgraphMotionVoteRevealedEventsLazyQueryHookResult = ReturnType<typeof useSubgraphMotionVoteRevealedEventsLazyQuery>;
 export type SubgraphMotionVoteRevealedEventsQueryResult = Apollo.QueryResult<SubgraphMotionVoteRevealedEventsQuery, SubgraphMotionVoteRevealedEventsQueryVariables>;
 export const SubgraphMotionStakedEventsDocument = gql`
-    query SubgraphMotionStakedEvents($colonyAddress: String!, $motionId: String!, $sortDirection: String = asc) {
-  motionStakedEvents: events(orderBy: "timestamp", orderDirection: $sortDirection, where: {name_contains: "MotionStaked", associatedColony: $colonyAddress, args_contains: $motionId}) {
+    query SubgraphMotionStakedEvents($colonyAddress: String!, $motionId: String!, $extensionAddress: String!, $sortDirection: String = asc) {
+  motionStakedEvents: events(orderBy: "timestamp", orderDirection: $sortDirection, where: {name_contains: "MotionStaked", associatedColony: $colonyAddress, address: $extensionAddress, args_contains: $motionId}) {
     id
     address
     name
@@ -6112,6 +6113,7 @@ export const SubgraphMotionStakedEventsDocument = gql`
  *   variables: {
  *      colonyAddress: // value for 'colonyAddress'
  *      motionId: // value for 'motionId'
+ *      extensionAddress: // value for 'extensionAddress'
  *      sortDirection: // value for 'sortDirection'
  *   },
  * });

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -2246,6 +2246,7 @@ export type SubgraphMotionVoteSubmittedEventsQuery = { motionVoteSubmittedEvents
 export type SubgraphMotionVoteRevealedEventsQueryVariables = Exact<{
   colonyAddress: Scalars['String'];
   motionId: Scalars['String'];
+  extensionAddress: Scalars['String'];
   sortDirection?: Maybe<Scalars['String']>;
 }>;
 
@@ -6036,8 +6037,8 @@ export type SubgraphMotionVoteSubmittedEventsQueryHookResult = ReturnType<typeof
 export type SubgraphMotionVoteSubmittedEventsLazyQueryHookResult = ReturnType<typeof useSubgraphMotionVoteSubmittedEventsLazyQuery>;
 export type SubgraphMotionVoteSubmittedEventsQueryResult = Apollo.QueryResult<SubgraphMotionVoteSubmittedEventsQuery, SubgraphMotionVoteSubmittedEventsQueryVariables>;
 export const SubgraphMotionVoteRevealedEventsDocument = gql`
-    query SubgraphMotionVoteRevealedEvents($colonyAddress: String!, $motionId: String!, $sortDirection: String = asc) {
-  motionVoteRevealedEvents: events(orderBy: "timestamp", orderDirection: $sortDirection, where: {name_contains: "MotionVoteRevealed", associatedColony: $colonyAddress, args_contains: $motionId}) {
+    query SubgraphMotionVoteRevealedEvents($colonyAddress: String!, $motionId: String!, $extensionAddress: String!, $sortDirection: String = asc) {
+  motionVoteRevealedEvents: events(orderBy: "timestamp", orderDirection: $sortDirection, where: {name_contains: "MotionVoteRevealed", associatedColony: $colonyAddress, address: $extensionAddress, args_contains: $motionId}) {
     id
     address
     name
@@ -6070,6 +6071,7 @@ export const SubgraphMotionVoteRevealedEventsDocument = gql`
  *   variables: {
  *      colonyAddress: // value for 'colonyAddress'
  *      motionId: // value for 'motionId'
+ *      extensionAddress: // value for 'extensionAddress'
  *      sortDirection: // value for 'sortDirection'
  *   },
  * });

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -2284,6 +2284,7 @@ export type SubgraphMotionStakedEventsQuery = { motionStakedEvents: Array<(
 export type SubgraphUserMotionTokenEventsQueryVariables = Exact<{
   colonyAddress: Scalars['String'];
   walletAddress: Scalars['String'];
+  extensionAddress: Scalars['String'];
   sortDirection?: Maybe<Scalars['String']>;
 }>;
 
@@ -6130,8 +6131,8 @@ export type SubgraphMotionStakedEventsQueryHookResult = ReturnType<typeof useSub
 export type SubgraphMotionStakedEventsLazyQueryHookResult = ReturnType<typeof useSubgraphMotionStakedEventsLazyQuery>;
 export type SubgraphMotionStakedEventsQueryResult = Apollo.QueryResult<SubgraphMotionStakedEventsQuery, SubgraphMotionStakedEventsQueryVariables>;
 export const SubgraphUserMotionTokenEventsDocument = gql`
-    query SubgraphUserMotionTokenEvents($colonyAddress: String!, $walletAddress: String!, $sortDirection: String = asc) {
-  motionStakedEvents: events(orderBy: "timestamp", orderDirection: $sortDirection, where: {associatedColony: $colonyAddress, name_contains: "MotionStaked", args_contains: $walletAddress}) {
+    query SubgraphUserMotionTokenEvents($colonyAddress: String!, $walletAddress: String!, $extensionAddress: String!, $sortDirection: String = asc) {
+  motionStakedEvents: events(orderBy: "timestamp", orderDirection: $sortDirection, where: {associatedColony: $colonyAddress, name_contains: "MotionStaked", address: $extensionAddress, args_contains: $walletAddress}) {
     id
     address
     name
@@ -6147,7 +6148,7 @@ export const SubgraphUserMotionTokenEventsDocument = gql`
     }
     timestamp
   }
-  motionRewardClaimedEvents: events(orderBy: "timestamp", orderDirection: $sortDirection, where: {associatedColony: $colonyAddress, name_contains: "MotionRewardClaimed", args_contains: $walletAddress}) {
+  motionRewardClaimedEvents: events(orderBy: "timestamp", orderDirection: $sortDirection, where: {associatedColony: $colonyAddress, name_contains: "MotionRewardClaimed", address: $extensionAddress, args_contains: $walletAddress}) {
     id
     name
     args
@@ -6180,6 +6181,7 @@ export const SubgraphUserMotionTokenEventsDocument = gql`
  *   variables: {
  *      colonyAddress: // value for 'colonyAddress'
  *      walletAddress: // value for 'walletAddress'
+ *      extensionAddress: // value for 'extensionAddress'
  *      sortDirection: // value for 'sortDirection'
  *   },
  * });

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -2226,6 +2226,7 @@ export type SubgraphMotionSystemEventsQuery = { motionSystemEvents: Array<(
 export type SubgraphMotionVoteSubmittedEventsQueryVariables = Exact<{
   colonyAddress: Scalars['String'];
   motionId: Scalars['String'];
+  extensionAddress: Scalars['String'];
   sortDirection?: Maybe<Scalars['String']>;
 }>;
 
@@ -5986,8 +5987,8 @@ export type SubgraphMotionSystemEventsQueryHookResult = ReturnType<typeof useSub
 export type SubgraphMotionSystemEventsLazyQueryHookResult = ReturnType<typeof useSubgraphMotionSystemEventsLazyQuery>;
 export type SubgraphMotionSystemEventsQueryResult = Apollo.QueryResult<SubgraphMotionSystemEventsQuery, SubgraphMotionSystemEventsQueryVariables>;
 export const SubgraphMotionVoteSubmittedEventsDocument = gql`
-    query SubgraphMotionVoteSubmittedEvents($colonyAddress: String!, $motionId: String!, $sortDirection: String = asc) {
-  motionVoteSubmittedEvents: events(orderBy: "timestamp", orderDirection: $sortDirection, where: {name_contains: "MotionVoteSubmitted", associatedColony: $colonyAddress, args_contains: $motionId}) {
+    query SubgraphMotionVoteSubmittedEvents($colonyAddress: String!, $motionId: String!, $extensionAddress: String!, $sortDirection: String = asc) {
+  motionVoteSubmittedEvents: events(orderBy: "timestamp", orderDirection: $sortDirection, where: {name_contains: "MotionVoteSubmitted", associatedColony: $colonyAddress, address: $extensionAddress, args_contains: $motionId}) {
     id
     address
     name
@@ -6020,6 +6021,7 @@ export const SubgraphMotionVoteSubmittedEventsDocument = gql`
  *   variables: {
  *      colonyAddress: // value for 'colonyAddress'
  *      motionId: // value for 'motionId'
+ *      extensionAddress: // value for 'extensionAddress'
  *      sortDirection: // value for 'sortDirection'
  *   },
  * });

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -2186,6 +2186,7 @@ export type ColonyMembersQuery = { subscribedUsers: Array<(
 export type SubgraphMotionEventsQueryVariables = Exact<{
   colonyAddress: Scalars['String'];
   motionId: Scalars['String'];
+  extensionAddress: Scalars['String'];
   sortDirection?: Maybe<Scalars['String']>;
 }>;
 
@@ -5884,8 +5885,8 @@ export type ColonyMembersQueryHookResult = ReturnType<typeof useColonyMembersQue
 export type ColonyMembersLazyQueryHookResult = ReturnType<typeof useColonyMembersLazyQuery>;
 export type ColonyMembersQueryResult = Apollo.QueryResult<ColonyMembersQuery, ColonyMembersQueryVariables>;
 export const SubgraphMotionEventsDocument = gql`
-    query SubgraphMotionEvents($colonyAddress: String!, $motionId: String!, $sortDirection: String = asc) {
-  motionEvents: events(orderBy: "timestamp", orderDirection: $sortDirection, where: {name_in: ["MotionStaked(uint256,address,uint256,uint256)", "MotionFinalized(uint256,bytes,bool)", "MotionRewardClaimed(uint256,address,uint256,uint256)"], associatedColony: $colonyAddress, args_contains: $motionId}) {
+    query SubgraphMotionEvents($colonyAddress: String!, $motionId: String!, $extensionAddress: String!, $sortDirection: String = asc) {
+  motionEvents: events(orderBy: "timestamp", orderDirection: $sortDirection, where: {name_in: ["MotionStaked(uint256,address,uint256,uint256)", "MotionFinalized(uint256,bytes,bool)", "MotionRewardClaimed(uint256,address,uint256,uint256)"], associatedColony: $colonyAddress, address: $extensionAddress, args_contains: $motionId}) {
     id
     address
     name
@@ -5918,6 +5919,7 @@ export const SubgraphMotionEventsDocument = gql`
  *   variables: {
  *      colonyAddress: // value for 'colonyAddress'
  *      motionId: // value for 'motionId'
+ *      extensionAddress: // value for 'extensionAddress'
  *      sortDirection: // value for 'sortDirection'
  *   },
  * });

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -2316,6 +2316,7 @@ export type SubgraphUserMotionTokenEventsQuery = { motionStakedEvents: Array<(
 export type SubgraphMotionRewardClaimedEventsQueryVariables = Exact<{
   colonyAddress: Scalars['String'];
   motionId: Scalars['String'];
+  extensionAddress: Scalars['String'];
   sortDirection?: Maybe<Scalars['String']>;
 }>;
 
@@ -6200,8 +6201,8 @@ export type SubgraphUserMotionTokenEventsQueryHookResult = ReturnType<typeof use
 export type SubgraphUserMotionTokenEventsLazyQueryHookResult = ReturnType<typeof useSubgraphUserMotionTokenEventsLazyQuery>;
 export type SubgraphUserMotionTokenEventsQueryResult = Apollo.QueryResult<SubgraphUserMotionTokenEventsQuery, SubgraphUserMotionTokenEventsQueryVariables>;
 export const SubgraphMotionRewardClaimedEventsDocument = gql`
-    query SubgraphMotionRewardClaimedEvents($colonyAddress: String!, $motionId: String!, $sortDirection: String = asc) {
-  motionRewardClaimedEvents: events(where: {associatedColony: $colonyAddress, name_contains: "MotionRewardClaimed", args_contains: $motionId}) {
+    query SubgraphMotionRewardClaimedEvents($colonyAddress: String!, $motionId: String!, $extensionAddress: String!, $sortDirection: String = asc) {
+  motionRewardClaimedEvents: events(where: {associatedColony: $colonyAddress, name_contains: "MotionRewardClaimed", address: $extensionAddress, args_contains: $motionId}) {
     id
     name
     args
@@ -6234,6 +6235,7 @@ export const SubgraphMotionRewardClaimedEventsDocument = gql`
  *   variables: {
  *      colonyAddress: // value for 'colonyAddress'
  *      motionId: // value for 'motionId'
+ *      extensionAddress: // value for 'extensionAddress'
  *      sortDirection: // value for 'sortDirection'
  *   },
  * });

--- a/src/data/graphql/queries/motions.graphql
+++ b/src/data/graphql/queries/motions.graphql
@@ -200,12 +200,13 @@ query SubgraphUserMotionTokenEvents($colonyAddress: String!, $walletAddress: Str
 }
 
 
-query SubgraphMotionRewardClaimedEvents($colonyAddress: String!, $motionId: String!, $sortDirection: String = asc) {
+query SubgraphMotionRewardClaimedEvents($colonyAddress: String!, $motionId: String!, $extensionAddress: String!, $sortDirection: String = asc) {
   motionRewardClaimedEvents: events(
     where: {
       associatedColony: $colonyAddress
       name_contains: "MotionRewardClaimed"
-      args_contains: $motionId,
+      address: $extensionAddress
+      args_contains: $motionId
     }
   ) {
     id

--- a/src/data/graphql/queries/motions.graphql
+++ b/src/data/graphql/queries/motions.graphql
@@ -62,13 +62,14 @@ query SubgraphMotionSystemEvents($colonyAddress: String!, $motionId: String!, $e
   }
 }
 
-query SubgraphMotionVoteSubmittedEvents($colonyAddress: String!, $motionId: String!, $sortDirection: String = asc) {
+query SubgraphMotionVoteSubmittedEvents($colonyAddress: String!, $motionId: String!, $extensionAddress: String!, $sortDirection: String = asc) {
   motionVoteSubmittedEvents: events(
     orderBy: "timestamp",
     orderDirection: $sortDirection,
     where: {
       name_contains: "MotionVoteSubmitted"
       associatedColony: $colonyAddress
+      address: $extensionAddress
       args_contains: $motionId
     }
   ) {

--- a/src/data/graphql/queries/motions.graphql
+++ b/src/data/graphql/queries/motions.graphql
@@ -144,14 +144,15 @@ query SubgraphMotionStakedEvents($colonyAddress: String!, $motionId: String!, $e
   }
 }
 
-query SubgraphUserMotionTokenEvents($colonyAddress: String!, $walletAddress: String!, $sortDirection: String = asc) {
+query SubgraphUserMotionTokenEvents($colonyAddress: String!, $walletAddress: String!, $extensionAddress: String!, $sortDirection: String = asc) {
   motionStakedEvents: events(
     orderBy: "timestamp",
     orderDirection: $sortDirection,
     where: {
       associatedColony: $colonyAddress
       name_contains: "MotionStaked"
-      args_contains: $walletAddress,
+      address: $extensionAddress
+      args_contains: $walletAddress
     }
   ) {
     id
@@ -175,7 +176,8 @@ query SubgraphUserMotionTokenEvents($colonyAddress: String!, $walletAddress: Str
     where: {
       associatedColony: $colonyAddress
       name_contains: "MotionRewardClaimed"
-      args_contains: $walletAddress,
+      address: $extensionAddress
+      args_contains: $walletAddress
     }
   ) {
     id

--- a/src/data/graphql/queries/motions.graphql
+++ b/src/data/graphql/queries/motions.graphql
@@ -30,7 +30,7 @@ query SubgraphMotionEvents($colonyAddress: String!, $motionId: String!, $extensi
   }
 }
 
-query SubgraphMotionSystemEvents($colonyAddress: String!, $motionId: String!, $sortDirection: String = asc) {
+query SubgraphMotionSystemEvents($colonyAddress: String!, $motionId: String!, $extensionAddress: String!, $sortDirection: String = asc) {
   motionSystemEvents: events(
     orderBy: "timestamp",
     orderDirection: $sortDirection,
@@ -41,6 +41,7 @@ query SubgraphMotionSystemEvents($colonyAddress: String!, $motionId: String!, $s
         "MotionVoteRevealed(uint256,address,uint256)",
       ]
       associatedColony: $colonyAddress
+      address: $extensionAddress
       args_contains: $motionId
     }
   ) {

--- a/src/data/graphql/queries/motions.graphql
+++ b/src/data/graphql/queries/motions.graphql
@@ -1,4 +1,4 @@
-query SubgraphMotionEvents($colonyAddress: String!, $motionId: String!, $sortDirection: String = asc) {
+query SubgraphMotionEvents($colonyAddress: String!, $motionId: String!, $extensionAddress: String!, $sortDirection: String = asc) {
   motionEvents: events(
     orderBy: "timestamp",
     orderDirection: $sortDirection,
@@ -9,6 +9,7 @@ query SubgraphMotionEvents($colonyAddress: String!, $motionId: String!, $sortDir
         "MotionRewardClaimed(uint256,address,uint256,uint256)",
       ]
       associatedColony: $colonyAddress
+      address: $extensionAddress
       args_contains: $motionId
     }
   ) {

--- a/src/data/graphql/queries/motions.graphql
+++ b/src/data/graphql/queries/motions.graphql
@@ -115,13 +115,14 @@ query SubgraphMotionVoteRevealedEvents($colonyAddress: String!, $motionId: Strin
   }
 }
 
-query SubgraphMotionStakedEvents($colonyAddress: String!, $motionId: String!, $sortDirection: String = asc) {
+query SubgraphMotionStakedEvents($colonyAddress: String!, $motionId: String!, $extensionAddress: String!, $sortDirection: String = asc) {
   motionStakedEvents: events(
     orderBy: "timestamp",
     orderDirection: $sortDirection,
     where: {
       name_contains: "MotionStaked"
       associatedColony: $colonyAddress
+      address: $extensionAddress
       args_contains: $motionId
     }
   ) {

--- a/src/data/graphql/queries/motions.graphql
+++ b/src/data/graphql/queries/motions.graphql
@@ -90,13 +90,14 @@ query SubgraphMotionVoteSubmittedEvents($colonyAddress: String!, $motionId: Stri
   }
 }
 
-query SubgraphMotionVoteRevealedEvents($colonyAddress: String!, $motionId: String!, $sortDirection: String = asc) {
+query SubgraphMotionVoteRevealedEvents($colonyAddress: String!, $motionId: String!, $extensionAddress: String!, $sortDirection: String = asc) {
   motionVoteRevealedEvents: events(
     orderBy: "timestamp",
     orderDirection: $sortDirection,
     where: {
       name_contains: "MotionVoteRevealed"
       associatedColony: $colonyAddress
+      address: $extensionAddress
       args_contains: $motionId
     }
   ) {

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -818,6 +818,7 @@ export const motionsResolvers = ({
              */
             colonyAddress: colonyAddress.toLowerCase(),
             motionId: `"motionId":"${motionId}"`,
+            extensionAddress: votingReputationClient.address.toLowerCase(),
           },
           fetchPolicy: 'network-only',
         });

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -216,6 +216,7 @@ export const motionsResolvers = ({
            * Subgraph addresses are not checksummed
            */
           colonyAddress: colonyAddress.toLowerCase(),
+          extensionAddress: votingReputationClient.address.toLowerCase(),
           motionId: `"motionId":"${motionId}"`,
           sortDirection: 'desc',
         },

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -544,6 +544,11 @@ export const motionsResolvers = ({
     },
     async motionCurrentUserVoted(_, { motionId, colonyAddress, userAddress }) {
       try {
+        const votingReputationClient = await colonyManager.getClient(
+          ClientType.VotingReputationClient,
+          colonyAddress,
+        );
+
         const { data } = await apolloClient.query<
           SubgraphMotionVoteSubmittedEventsQuery,
           SubgraphMotionVoteSubmittedEventsQueryVariables
@@ -554,6 +559,7 @@ export const motionsResolvers = ({
              * Subgraph addresses are not checksummed
              */
             colonyAddress: colonyAddress.toLowerCase(),
+            extensionAddress: votingReputationClient.address.toLowerCase(),
             motionId: `"motionId":"${motionId}"`,
           },
           fetchPolicy: 'network-only',

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -586,6 +586,11 @@ export const motionsResolvers = ({
           vote: null,
         };
 
+        const votingReputationClient = await colonyManager.getClient(
+          ClientType.VotingReputationClient,
+          colonyAddress,
+        );
+
         const { data } = await apolloClient.query<
           SubgraphMotionVoteRevealedEventsQuery,
           SubgraphMotionVoteRevealedEventsQueryVariables
@@ -597,6 +602,7 @@ export const motionsResolvers = ({
              */
             colonyAddress: colonyAddress.toLowerCase(),
             motionId: `"motionId":"${motionId}"`,
+            extensionAddress: votingReputationClient.address.toLowerCase(),
           },
           fetchPolicy: 'network-only',
         });
@@ -656,6 +662,7 @@ export const motionsResolvers = ({
              */
             colonyAddress: colonyAddress.toLowerCase(),
             motionId: `"motionId":"${motionId}"`,
+            extensionAddress: votingReputationClient.address.toLowerCase(),
           },
           fetchPolicy: 'network-only',
         });

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -482,6 +482,11 @@ export const motionsResolvers = ({
     },
     async eventsForMotion(_, { motionId, colonyAddress }) {
       try {
+        const votingReputationClient = (await colonyManager.getClient(
+          ClientType.VotingReputationClient,
+          colonyAddress,
+        )) as ExtensionClient;
+
         const { data } = await apolloClient.query<
           SubgraphMotionEventsQuery,
           SubgraphMotionEventsQueryVariables
@@ -493,6 +498,7 @@ export const motionsResolvers = ({
              */
             colonyAddress: colonyAddress.toLowerCase(),
             motionId: `"motionId":"${motionId}"`,
+            extensionAddress: votingReputationClient.address.toLowerCase(),
           },
           fetchPolicy: 'network-only',
         });

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -772,6 +772,11 @@ export const motionsResolvers = ({
           claimedReward: null,
         };
 
+        const votingReputationClient = await colonyManager.getClient(
+          ClientType.VotingReputationClient,
+          colonyAddress,
+        );
+
         const { data: stakeEventsData } = await apolloClient.query<
           SubgraphMotionStakedEventsQuery,
           SubgraphMotionStakedEventsQueryVariables
@@ -782,6 +787,7 @@ export const motionsResolvers = ({
              * Subgraph addresses are not checksummed
              */
             colonyAddress: colonyAddress.toLowerCase(),
+            extensionAddress: votingReputationClient.address.toLowerCase(),
             motionId: `"motionId":"${motionId}"`,
           },
           fetchPolicy: 'network-only',
@@ -818,11 +824,6 @@ export const motionsResolvers = ({
         const userRewardClaimedParsedEvents = userRewardClaimedEvents
           ? userRewardClaimedEvents.map(parseSubgraphEvent)
           : [];
-
-        const votingReputationClient = await colonyManager.getClient(
-          ClientType.VotingReputationClient,
-          colonyAddress,
-        );
 
         let stakesYay = bigNumberify(0);
         let stakesNay = bigNumberify(0);
@@ -909,6 +910,11 @@ export const motionsResolvers = ({
         metadata: null,
       };
       try {
+        const votingReputationClient = await colonyManager.getClient(
+          ClientType.VotingReputationClient,
+          colonyAddress,
+        );
+
         const { data } = await apolloClient.query<
           SubgraphMotionStakedEventsQuery,
           SubgraphMotionStakedEventsQueryVariables
@@ -919,6 +925,7 @@ export const motionsResolvers = ({
              * Subgraph addresses are not checksummed
              */
             colonyAddress: colonyAddress.toLowerCase(),
+            extensionAddress: votingReputationClient.address.toLowerCase(),
             motionId: `"motionId":"${motionId}"`,
           },
           fetchPolicy: 'network-only',

--- a/src/data/resolvers/user.ts
+++ b/src/data/resolvers/user.ts
@@ -69,6 +69,7 @@ const getUserStakedBalance = async (
   apolloClient: ApolloClient<object>,
   walletAddress: Address,
   colonyAddress: Address,
+  extensionAddress: Address,
 ): Promise<BigNumber> => {
   /**
    * @NOTE If there will be more staking events
@@ -84,8 +85,10 @@ const getUserStakedBalance = async (
     variables: {
       walletAddress: walletAddress.toLowerCase(),
       colonyAddress: colonyAddress.toLowerCase(),
+      extensionAddress: extensionAddress.toLowerCase(),
     },
   });
+
   const motionStakedEvents = (data?.motionStakedEvents || []).map(
     parseSubgraphEvent,
   );
@@ -137,6 +140,11 @@ const getUserLock = async (
     ClientType.TokenLockingClient,
     colonyAddress,
   );
+  const votingReputationClient = await colonyManager.getClient(
+    ClientType.VotingReputationClient,
+    colonyAddress,
+  );
+
   const userLock = await tokenLockingClient.getUserLock(
     tokenAddress,
     walletAddress,
@@ -150,6 +158,7 @@ const getUserLock = async (
     apolloClient,
     walletAddress,
     colonyAddress,
+    votingReputationClient.address,
   );
 
   const nativeToken = (await getToken(


### PR DESCRIPTION
Fixed the motions using events from previous instances of the voting reputation extension. The queries would use old events if the current motion id corresponds to any old motion id, so now we need to filter by the current extension's address.

In order to test, you will need to install the voting reputation extension, do some motions, and then uninstall and install the extension and do more motions and see if there are any events that don't correspond with the motions.

To see the bug in action, aside from following the instructions I wrote above in `master`, you can check the Roadrunner colony on QA: https://qaxdai.colony.io/colony/roadrunner

Resolves #2845 and #2846 
