### PR TITLE
Refresh transactions after sign out

### DIFF
--- a/src/modules/core/reducers/transactions.ts
+++ b/src/modules/core/reducers/transactions.ts
@@ -216,6 +216,9 @@ const coreTransactionsReducer: ReducerType<CoreTransactionsRecord> = (
       }
       return state.deleteIn([CORE_TRANSACTIONS_LIST, id]);
     }
+    case ActionTypes.USER_LOGOUT: {
+      return state.delete(CORE_TRANSACTIONS_LIST);
+    }
     default:
       return state;
   }


### PR DESCRIPTION
Added reducer to refresh wallet's transactions after signing out.

To test it you simply need to complete some transactions, like creating a colony or an action, log out and then log in with the same or a different wallet to check if the previous transactions appear in the gas station.

Resolves #3038 
