### PR TITLE
Fixes motions not appearing in the correct domain in actions list

### DIFF
--- a/src/modules/dashboard/transformers/transformers.ts
+++ b/src/modules/dashboard/transformers/transformers.ts
@@ -278,42 +278,51 @@ export const getActionsListData = (
             }
           }
           if (subgraphActionType === FilteredUnformattedAction.Motions) {
-            const {
-              args,
-              agent,
-              type,
-              state,
-              fundamentalChainId,
-              timeoutPeriods,
-              stakes,
-              requiredStake,
-            } = unformattedAction;
-
-            if (args?.token) {
+            try {
               const {
-                args: {
-                  token: { address: tokenAddress, symbol, decimals },
-                },
+                args,
+                agent,
+                type,
+                state,
+                fundamentalChainId,
+                domain: { ethDomainId },
+                timeoutPeriods,
+                stakes,
+                requiredStake,
               } = unformattedAction;
 
-              formatedAction.tokenAddress = tokenAddress;
-              formatedAction.symbol = symbol;
-              formatedAction.decimals = decimals;
-            }
-            formatedAction.initiator = agent;
-            formatedAction.actionType = type;
-            formatedAction.motionState = state;
-            formatedAction.motionId = fundamentalChainId;
-            formatedAction.timeoutPeriods = timeoutPeriods;
-            formatedAction.totalNayStake = bigNumberify(
-              stakes[0] || 0,
-            ).toString();
-            formatedAction.requiredStake = requiredStake;
-            if (args) {
-              const actionTypeKeys = Object.keys(args);
-              actionTypeKeys.forEach((key) => {
-                formatedAction[key] = args[key];
-              });
+              if (args?.token) {
+                const {
+                  args: {
+                    token: { address: tokenAddress, symbol, decimals },
+                  },
+                } = unformattedAction;
+
+                formatedAction.tokenAddress = tokenAddress;
+                formatedAction.symbol = symbol;
+                formatedAction.decimals = decimals;
+              }
+              formatedAction.initiator = agent;
+              formatedAction.actionType = type;
+              formatedAction.motionState = state;
+              formatedAction.fromDomain = ethDomainId;
+              formatedAction.motionId = fundamentalChainId;
+              formatedAction.timeoutPeriods = timeoutPeriods;
+              formatedAction.totalNayStake = bigNumberify(
+                stakes[0] || 0,
+              ).toString();
+              formatedAction.requiredStake = requiredStake;
+              if (args) {
+                const actionTypeKeys = Object.keys(args);
+                actionTypeKeys.forEach((key) => {
+                  formatedAction[key] = args[key];
+                });
+              }
+            } catch (error) {
+              log.verbose(
+                'Could not deconstruct the subgraph motion event object',
+              );
+              log.verbose(error);
             }
           }
           formatedAction.transactionHash = hash;


### PR DESCRIPTION
## Description

Fixes motions correctly appearing in the actions list and actions team filter. See this issue for details #3056.


**New stuff** ✨

* Adds assignment of ethDomainId to motion action item.
* Adds expectation check to actions motion transformer.


### Testing

* Ensure the 'Motions' extension is enabled.
* Create a child team.
* You will need to make sure there is funds and reputation in the team.
* Perform a motion action in the child team and ensure it finishes. You can speed up the time with the following script, this passes 3 days of time. Just run it in your terminal.
`curl -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"evm_increaseTime","params":[260000],"id": 1}' localhost:8545 && curl -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"evm_mine","params":[]}' localhost:8545`
* Ensure the motion action appears in the list. It may take a second to load after the other actions load.
* Check the domain label of the action.
* Filter the actions by the team, and ensure the motion appears in the list.


### Before

![actions-wrong-team-2](https://user-images.githubusercontent.com/33682027/147272307-ee7104b6-390e-4455-a063-56e13d79933d.png)

![actions-wrong-team](https://user-images.githubusercontent.com/33682027/147272308-a43e80fb-3c7a-45b9-b060-e1e8b3ca2d69.png)

### After  ✨

![actions-right-team](https://user-images.githubusercontent.com/33682027/147272454-96492d22-d205-4bdc-ba3c-93eb06c433c8.png)

![actions-right-team-2](https://user-images.githubusercontent.com/33682027/147272455-11856854-9c24-4e2d-91f1-13fc0cbac176.png)


Resolves #3056
