### PR TITLE
Fix logic for motionDomainId in Payment & Permissions dialogs

### DIFF
--- a/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialogForm.tsx
+++ b/src/modules/dashboard/components/CreatePaymentDialog/CreatePaymentDialogForm.tsx
@@ -284,10 +284,7 @@ const CreatePaymentDialogForm = ({
       } else {
         setCurrentFromDomain(ROOT_DOMAIN_ID);
       }
-      if (
-        selectedMotionDomainId !== ROOT_DOMAIN_ID &&
-        selectedMotionDomainId !== fromDomainId
-      ) {
+      if (selectedMotionDomainId !== fromDomainId) {
         setFieldValue('motionDomainId', fromDomainId);
       }
     },

--- a/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementForm.tsx
+++ b/src/modules/dashboard/components/PermissionManagementDialog/PermissionManagementForm.tsx
@@ -202,10 +202,7 @@ const PermissionManagementForm = ({
       const fromDomainId = parseInt(domainValue, 10);
       const selectedMotionDomainId = parseInt(values.motionDomainId, 10);
       onDomainSelected(fromDomainId);
-      if (
-        selectedMotionDomainId !== ROOT_DOMAIN_ID &&
-        selectedMotionDomainId !== fromDomainId
-      ) {
+      if (selectedMotionDomainId !== fromDomainId) {
         onMotionDomainChange(fromDomainId);
       }
     },


### PR DESCRIPTION
## Description

This PR fixes the motion domain ID that is sent by the dialog to the saga.

To test it you need to create a payment & permissions motion in different domains (at least Root & another domain) by changing  From domain  (and not directly motion domain ID). This should change the motion domain id. You then need to log the values sent to the saga (on master there is another bug that doesn't display correct domain ids in the motions, this is being fixed by a separate PR #3073 

@rdig, I would like a review from you at some point as it touches the code that you were implementing (if I recall correctly). I would like to make sure that I am not misunderstanding the logic and the implementation.

Resolves #3074
