### PR TITLE
Fix apollo error in user resolver

### DIFF
--- a/src/data/resolvers/user.ts
+++ b/src/data/resolvers/user.ts
@@ -140,10 +140,16 @@ const getUserLock = async (
     ClientType.TokenLockingClient,
     colonyAddress,
   );
-  const votingReputationClient = await colonyManager.getClient(
-    ClientType.VotingReputationClient,
-    colonyAddress,
-  );
+  let votingReputationClient;
+
+  try {
+    votingReputationClient = await colonyManager.getClient(
+      ClientType.VotingReputationClient,
+      colonyAddress,
+    );
+  } catch (error) {
+    console.error(error);
+  }
 
   const userLock = await tokenLockingClient.getUserLock(
     tokenAddress,
@@ -154,12 +160,15 @@ const getUserLock = async (
     tokenAddress,
   );
 
-  const stakedTokens = await getUserStakedBalance(
-    apolloClient,
-    walletAddress,
-    colonyAddress,
-    votingReputationClient.address,
-  );
+  const stakedTokens =
+    votingReputationClient === undefined
+      ? 0
+      : await getUserStakedBalance(
+          apolloClient,
+          walletAddress,
+          colonyAddress,
+          votingReputationClient.address,
+        );
 
   const nativeToken = (await getToken(
     { colonyManager, client: apolloClient },

--- a/src/data/resolvers/user.ts
+++ b/src/data/resolvers/user.ts
@@ -148,7 +148,11 @@ const getUserLock = async (
       colonyAddress,
     );
   } catch (error) {
-    console.error(error);
+    /*
+     * We don't care to catch the error as the value depending on the extension
+     * will jsut default to 0
+     */
+    // silent error
   }
 
   const userLock = await tokenLockingClient.getUserLock(


### PR DESCRIPTION
## Description

This PR adds a try catch block around initiation of voting extension client in user resolver. If we don't do it and the voting extension is not installed then we will get an apollo error when creating a payment. This is because we use a query in the create payment saga that uses this resolver.

Resolves #3078 