### PR TITLE
Fix annotations transaction failure

### DIFF
--- a/src/modules/dashboard/sagas/actions/createDomain.ts
+++ b/src/modules/dashboard/sagas/actions/createDomain.ts
@@ -129,13 +129,27 @@ function* createDomainAction({
       /*
        * Upload domain metadata to IPFS
        */
-      let annotationMessageIpfsHash = null;
+      let annotationMessageIpfsHash: null | string = null;
       annotationMessageIpfsHash = yield call(
         ipfsUpload,
         JSON.stringify({
           annotationMessage,
         }),
       );
+
+      /* If the ipfs upload failed we try again, then if it fails again we just assign
+      an empty string so that the `transactionAddParams` won't fail */
+      if (!annotationMessageIpfsHash) {
+        annotationMessageIpfsHash = yield call(
+          ipfsUpload,
+          JSON.stringify({
+            annotationMessage,
+          }),
+        );
+        if (!annotationMessageIpfsHash) {
+          annotationMessageIpfsHash = '';
+        }
+      }
 
       yield put(
         transactionAddParams(annotateCreateDomain.id, [

--- a/src/modules/dashboard/sagas/actions/createDomain.ts
+++ b/src/modules/dashboard/sagas/actions/createDomain.ts
@@ -9,6 +9,8 @@ import {
 } from '~data/index';
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
+
+import { uploadIfpsAnnotation } from '../utils';
 import {
   createTransaction,
   createTransactionChannels,
@@ -129,27 +131,10 @@ function* createDomainAction({
       /*
        * Upload domain metadata to IPFS
        */
-      let annotationMessageIpfsHash: null | string = null;
-      annotationMessageIpfsHash = yield call(
-        ipfsUpload,
-        JSON.stringify({
-          annotationMessage,
-        }),
+      const annotationMessageIpfsHash = yield call(
+        uploadIfpsAnnotation,
+        annotationMessage,
       );
-
-      /* If the ipfs upload failed we try again, then if it fails again we just assign
-      an empty string so that the `transactionAddParams` won't fail */
-      if (!annotationMessageIpfsHash) {
-        annotationMessageIpfsHash = yield call(
-          ipfsUpload,
-          JSON.stringify({
-            annotationMessage,
-          }),
-        );
-        if (!annotationMessageIpfsHash) {
-          annotationMessageIpfsHash = '';
-        }
-      }
 
       yield put(
         transactionAddParams(annotateCreateDomain.id, [

--- a/src/modules/dashboard/sagas/actions/editColony.ts
+++ b/src/modules/dashboard/sagas/actions/editColony.ts
@@ -152,13 +152,27 @@ function* editColonyAction({
       /*
        * Upload annotation metadata to IPFS
        */
-      let annotationMessageIpfsHash = null;
+      let annotationMessageIpfsHash: null | string = null;
       annotationMessageIpfsHash = yield call(
         ipfsUpload,
         JSON.stringify({
           annotationMessage,
         }),
       );
+
+      /* If the ipfs upload failed we try again, then if it fails again we just assign
+      an empty string so that the `transactionAddParams` won't fail */
+      if (!annotationMessageIpfsHash) {
+        annotationMessageIpfsHash = yield call(
+          ipfsUpload,
+          JSON.stringify({
+            annotationMessage,
+          }),
+        );
+        if (!annotationMessageIpfsHash) {
+          annotationMessageIpfsHash = '';
+        }
+      }
 
       yield put(
         transactionAddParams(annotateEditColony.id, [

--- a/src/modules/dashboard/sagas/actions/editColony.ts
+++ b/src/modules/dashboard/sagas/actions/editColony.ts
@@ -9,6 +9,7 @@ import {
 } from '~data/index';
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
+
 import {
   createTransaction,
   createTransactionChannels,
@@ -20,7 +21,7 @@ import {
   transactionPending,
   transactionAddParams,
 } from '../../../core/actionCreators';
-import { updateColonyDisplayCache } from '../utils';
+import { updateColonyDisplayCache, uploadIfpsAnnotation } from '../utils';
 
 function* editColonyAction({
   payload: {
@@ -152,27 +153,10 @@ function* editColonyAction({
       /*
        * Upload annotation metadata to IPFS
        */
-      let annotationMessageIpfsHash: null | string = null;
-      annotationMessageIpfsHash = yield call(
-        ipfsUpload,
-        JSON.stringify({
-          annotationMessage,
-        }),
+      const annotationMessageIpfsHash = yield call(
+        uploadIfpsAnnotation,
+        annotationMessage,
       );
-
-      /* If the ipfs upload failed we try again, then if it fails again we just assign
-      an empty string so that the `transactionAddParams` won't fail */
-      if (!annotationMessageIpfsHash) {
-        annotationMessageIpfsHash = yield call(
-          ipfsUpload,
-          JSON.stringify({
-            annotationMessage,
-          }),
-        );
-        if (!annotationMessageIpfsHash) {
-          annotationMessageIpfsHash = '';
-        }
-      }
 
       yield put(
         transactionAddParams(annotateEditColony.id, [

--- a/src/modules/dashboard/sagas/actions/editDomain.ts
+++ b/src/modules/dashboard/sagas/actions/editDomain.ts
@@ -127,14 +127,26 @@ function* editDomainAction({
       /*
        * Upload annotationMessage to IPFS
        */
-      let annotationMessageIpfsHash = null;
-      if (annotationMessage) {
+      let annotationMessageIpfsHash: null | string = null;
+      annotationMessageIpfsHash = yield call(
+        ipfsUpload,
+        JSON.stringify({
+          annotationMessage,
+        }),
+      );
+
+      /* If the ipfs upload failed we try again, then if it fails again we just assign
+      an empty string so that the `transactionAddParams` won't fail */
+      if (!annotationMessageIpfsHash) {
         annotationMessageIpfsHash = yield call(
           ipfsUpload,
           JSON.stringify({
             annotationMessage,
           }),
         );
+        if (!annotationMessageIpfsHash) {
+          annotationMessageIpfsHash = '';
+        }
       }
 
       yield put(

--- a/src/modules/dashboard/sagas/actions/editDomain.ts
+++ b/src/modules/dashboard/sagas/actions/editDomain.ts
@@ -9,6 +9,8 @@ import {
 } from '~data/index';
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
+
+import { uploadIfpsAnnotation } from '../utils';
 import {
   createTransaction,
   createTransactionChannels,
@@ -127,27 +129,10 @@ function* editDomainAction({
       /*
        * Upload annotationMessage to IPFS
        */
-      let annotationMessageIpfsHash: null | string = null;
-      annotationMessageIpfsHash = yield call(
-        ipfsUpload,
-        JSON.stringify({
-          annotationMessage,
-        }),
+      const annotationMessageIpfsHash = yield call(
+        uploadIfpsAnnotation,
+        annotationMessage,
       );
-
-      /* If the ipfs upload failed we try again, then if it fails again we just assign
-      an empty string so that the `transactionAddParams` won't fail */
-      if (!annotationMessageIpfsHash) {
-        annotationMessageIpfsHash = yield call(
-          ipfsUpload,
-          JSON.stringify({
-            annotationMessage,
-          }),
-        );
-        if (!annotationMessageIpfsHash) {
-          annotationMessageIpfsHash = '';
-        }
-      }
 
       yield put(
         transactionAddParams(annotateEditDomain.id, [

--- a/src/modules/dashboard/sagas/actions/enterRecovery.ts
+++ b/src/modules/dashboard/sagas/actions/enterRecovery.ts
@@ -105,13 +105,27 @@ function* enterRecoveryAction({
     if (annotationMessage) {
       yield put(transactionPending(annotateRecoveryAction.id));
 
-      let ipfsHash = null;
+      let ipfsHash: string | null = null;
       ipfsHash = yield call(
         ipfsUpload,
         JSON.stringify({
           annotationMessage,
         }),
       );
+
+      /* If the ipfs upload failed we try again, then if it fails again we just assign
+      an empty string so that the `transactionAddParams` won't fail */
+      if (!ipfsHash) {
+        ipfsHash = yield call(
+          ipfsUpload,
+          JSON.stringify({
+            annotationMessage,
+          }),
+        );
+        if (!ipfsHash) {
+          ipfsHash = '';
+        }
+      }
 
       yield put(
         transactionAddParams(annotateRecoveryAction.id, [txHash, ipfsHash]),

--- a/src/modules/dashboard/sagas/actions/managePermissions.ts
+++ b/src/modules/dashboard/sagas/actions/managePermissions.ts
@@ -10,12 +10,13 @@ import {
 } from '~data/index';
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
+
+import { uploadIfpsAnnotation } from '../utils';
 import {
   createTransaction,
   createTransactionChannels,
   getTxChannel,
 } from '../../../core/sagas';
-import { ipfsUpload } from '../../../core/sagas/ipfs';
 import {
   transactionReady,
   transactionPending,
@@ -124,27 +125,10 @@ function* managePermissionsAction({
     if (annotationMessage) {
       yield put(transactionPending(annotateSetUserRoles.id));
 
-      let annotationMessageIpfsHash: null | string = null;
-      annotationMessageIpfsHash = yield call(
-        ipfsUpload,
-        JSON.stringify({
-          annotationMessage,
-        }),
+      const annotationMessageIpfsHash = yield call(
+        uploadIfpsAnnotation,
+        annotationMessage,
       );
-
-      /* If the ipfs upload failed we try again, then if it fails again we just assign
-      an empty string so that the `transactionAddParams` won't fail */
-      if (!annotationMessageIpfsHash) {
-        annotationMessageIpfsHash = yield call(
-          ipfsUpload,
-          JSON.stringify({
-            annotationMessage,
-          }),
-        );
-        if (!annotationMessageIpfsHash) {
-          annotationMessageIpfsHash = '';
-        }
-      }
 
       yield put(
         transactionAddParams(annotateSetUserRoles.id, [

--- a/src/modules/dashboard/sagas/actions/managePermissions.ts
+++ b/src/modules/dashboard/sagas/actions/managePermissions.ts
@@ -124,13 +124,27 @@ function* managePermissionsAction({
     if (annotationMessage) {
       yield put(transactionPending(annotateSetUserRoles.id));
 
-      let annotationMessageIpfsHash = null;
+      let annotationMessageIpfsHash: null | string = null;
       annotationMessageIpfsHash = yield call(
         ipfsUpload,
         JSON.stringify({
           annotationMessage,
         }),
       );
+
+      /* If the ipfs upload failed we try again, then if it fails again we just assign
+      an empty string so that the `transactionAddParams` won't fail */
+      if (!annotationMessageIpfsHash) {
+        annotationMessageIpfsHash = yield call(
+          ipfsUpload,
+          JSON.stringify({
+            annotationMessage,
+          }),
+        );
+        if (!annotationMessageIpfsHash) {
+          annotationMessageIpfsHash = '';
+        }
+      }
 
       yield put(
         transactionAddParams(annotateSetUserRoles.id, [

--- a/src/modules/dashboard/sagas/actions/mintTokens.ts
+++ b/src/modules/dashboard/sagas/actions/mintTokens.ts
@@ -120,13 +120,27 @@ function* createMintTokensAction({
     if (annotationMessage) {
       yield put(transactionPending(annotateMintTokens.id));
 
-      let ipfsHash = null;
+      let ipfsHash: string | null = null;
       ipfsHash = yield call(
         ipfsUpload,
         JSON.stringify({
           annotationMessage,
         }),
       );
+
+      /* If the ipfs upload failed we try again, then if it fails again we just assign
+      an empty string so that the `transactionAddParams` won't fail */
+      if (!ipfsHash) {
+        ipfsHash = yield call(
+          ipfsUpload,
+          JSON.stringify({
+            annotationMessage,
+          }),
+        );
+        if (!ipfsHash) {
+          ipfsHash = '';
+        }
+      }
 
       yield put(
         transactionAddParams(annotateMintTokens.id, [txHash, ipfsHash]),

--- a/src/modules/dashboard/sagas/actions/mintTokens.ts
+++ b/src/modules/dashboard/sagas/actions/mintTokens.ts
@@ -9,12 +9,13 @@ import {
 } from '~data/index';
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
+
+import { uploadIfpsAnnotation } from '../utils';
 import {
   createTransaction,
   createTransactionChannels,
   getTxChannel,
 } from '../../../core/sagas';
-import { ipfsUpload } from '../../../core/sagas/ipfs';
 import {
   transactionReady,
   transactionPending,
@@ -120,27 +121,7 @@ function* createMintTokensAction({
     if (annotationMessage) {
       yield put(transactionPending(annotateMintTokens.id));
 
-      let ipfsHash: string | null = null;
-      ipfsHash = yield call(
-        ipfsUpload,
-        JSON.stringify({
-          annotationMessage,
-        }),
-      );
-
-      /* If the ipfs upload failed we try again, then if it fails again we just assign
-      an empty string so that the `transactionAddParams` won't fail */
-      if (!ipfsHash) {
-        ipfsHash = yield call(
-          ipfsUpload,
-          JSON.stringify({
-            annotationMessage,
-          }),
-        );
-        if (!ipfsHash) {
-          ipfsHash = '';
-        }
-      }
+      const ipfsHash = yield call(uploadIfpsAnnotation, annotationMessage);
 
       yield put(
         transactionAddParams(annotateMintTokens.id, [txHash, ipfsHash]),

--- a/src/modules/dashboard/sagas/actions/moveFunds.ts
+++ b/src/modules/dashboard/sagas/actions/moveFunds.ts
@@ -149,13 +149,27 @@ function* createMoveFundsAction({
     if (annotationMessage) {
       yield put(transactionPending(annotateMoveFunds.id));
 
-      let ipfsHash = null;
+      let ipfsHash: string | null = null;
       ipfsHash = yield call(
         ipfsUpload,
         JSON.stringify({
           annotationMessage,
         }),
       );
+
+      /* If the ipfs upload failed we try again, then if it fails again we just assign
+      an empty string so that the `transactionAddParams` won't fail */
+      if (!ipfsHash) {
+        ipfsHash = yield call(
+          ipfsUpload,
+          JSON.stringify({
+            annotationMessage,
+          }),
+        );
+        if (!ipfsHash) {
+          ipfsHash = '';
+        }
+      }
 
       yield put(transactionAddParams(annotateMoveFunds.id, [txHash, ipfsHash]));
 

--- a/src/modules/dashboard/sagas/actions/moveFunds.ts
+++ b/src/modules/dashboard/sagas/actions/moveFunds.ts
@@ -9,12 +9,13 @@ import {
 } from '~data/index';
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
+
+import { uploadIfpsAnnotation } from '../utils';
 import {
   createTransaction,
   createTransactionChannels,
   getTxChannel,
 } from '../../../core/sagas';
-import { ipfsUpload } from '../../../core/sagas/ipfs';
 import {
   transactionReady,
   transactionPending,
@@ -149,27 +150,7 @@ function* createMoveFundsAction({
     if (annotationMessage) {
       yield put(transactionPending(annotateMoveFunds.id));
 
-      let ipfsHash: string | null = null;
-      ipfsHash = yield call(
-        ipfsUpload,
-        JSON.stringify({
-          annotationMessage,
-        }),
-      );
-
-      /* If the ipfs upload failed we try again, then if it fails again we just assign
-      an empty string so that the `transactionAddParams` won't fail */
-      if (!ipfsHash) {
-        ipfsHash = yield call(
-          ipfsUpload,
-          JSON.stringify({
-            annotationMessage,
-          }),
-        );
-        if (!ipfsHash) {
-          ipfsHash = '';
-        }
-      }
+      const ipfsHash = yield call(uploadIfpsAnnotation, annotationMessage);
 
       yield put(transactionAddParams(annotateMoveFunds.id, [txHash, ipfsHash]));
 

--- a/src/modules/dashboard/sagas/actions/payment.ts
+++ b/src/modules/dashboard/sagas/actions/payment.ts
@@ -16,12 +16,13 @@ import {
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
 import { COLONY_TOTAL_BALANCE_DOMAIN_ID } from '~constants';
+
+import { uploadIfpsAnnotation } from '../utils';
 import {
   createTransaction,
   createTransactionChannels,
   getTxChannel,
 } from '../../../core/sagas';
-import { ipfsUpload } from '../../../core/sagas/ipfs';
 import {
   transactionReady,
   transactionPending,
@@ -160,27 +161,7 @@ function* createPaymentAction({
     if (annotationMessage) {
       yield put(transactionPending(annotatePaymentAction.id));
 
-      let ipfsHash: string | null = null;
-      ipfsHash = yield call(
-        ipfsUpload,
-        JSON.stringify({
-          annotationMessage,
-        }),
-      );
-
-      /* If the ipfs upload failed we try again, then if it fails again we just assign
-      an empty string so that the `transactionAddParams` won't fail */
-      if (!ipfsHash) {
-        ipfsHash = yield call(
-          ipfsUpload,
-          JSON.stringify({
-            annotationMessage,
-          }),
-        );
-        if (!ipfsHash) {
-          ipfsHash = '';
-        }
-      }
+      const ipfsHash = yield call(uploadIfpsAnnotation, annotationMessage);
 
       yield put(
         transactionAddParams(annotatePaymentAction.id, [txHash, ipfsHash]),

--- a/src/modules/dashboard/sagas/actions/payment.ts
+++ b/src/modules/dashboard/sagas/actions/payment.ts
@@ -160,13 +160,27 @@ function* createPaymentAction({
     if (annotationMessage) {
       yield put(transactionPending(annotatePaymentAction.id));
 
-      let ipfsHash = null;
+      let ipfsHash: string | null = null;
       ipfsHash = yield call(
         ipfsUpload,
         JSON.stringify({
           annotationMessage,
         }),
       );
+
+      /* If the ipfs upload failed we try again, then if it fails again we just assign
+      an empty string so that the `transactionAddParams` won't fail */
+      if (!ipfsHash) {
+        ipfsHash = yield call(
+          ipfsUpload,
+          JSON.stringify({
+            annotationMessage,
+          }),
+        );
+        if (!ipfsHash) {
+          ipfsHash = '';
+        }
+      }
 
       yield put(
         transactionAddParams(annotatePaymentAction.id, [txHash, ipfsHash]),

--- a/src/modules/dashboard/sagas/actions/versionUpgrade.ts
+++ b/src/modules/dashboard/sagas/actions/versionUpgrade.ts
@@ -94,6 +94,7 @@ function* createVersionUpgradeAction({
 
     yield takeFrom(upgrade.channel, ActionTypes.TRANSACTION_SUCCEEDED);
 
+    /* need to check for annotaiton message here again because there is a TS error when pushing */
     if (annotationMessage && supportAnnotation) {
       yield put(transactionPending(annotateUpgrade.id));
 

--- a/src/modules/dashboard/sagas/actions/versionUpgrade.ts
+++ b/src/modules/dashboard/sagas/actions/versionUpgrade.ts
@@ -96,13 +96,27 @@ function* createVersionUpgradeAction({
     if (supportAnnotation) {
       yield put(transactionPending(annotateUpgrade.id));
 
-      let ipfsHash = null;
+      let ipfsHash: string | null = null;
       ipfsHash = yield call(
         ipfsUpload,
         JSON.stringify({
           annotationMessage,
         }),
       );
+
+      /* If the ipfs upload failed we try again, then if it fails again we just assign
+      an empty string so that the `transactionAddParams` won't fail */
+      if (!ipfsHash) {
+        ipfsHash = yield call(
+          ipfsUpload,
+          JSON.stringify({
+            annotationMessage,
+          }),
+        );
+        if (!ipfsHash) {
+          ipfsHash = '';
+        }
+      }
 
       yield put(transactionAddParams(annotateUpgrade.id, [txHash, ipfsHash]));
 

--- a/src/modules/dashboard/sagas/actions/versionUpgrade.ts
+++ b/src/modules/dashboard/sagas/actions/versionUpgrade.ts
@@ -10,12 +10,13 @@ import {
 } from '~data/index';
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
+
+import { uploadIfpsAnnotation } from '../utils';
 import {
   createTransaction,
   createTransactionChannels,
   getTxChannel,
 } from '../../../core/sagas';
-import { ipfsUpload } from '../../../core/sagas/ipfs';
 import {
   transactionReady,
   transactionPending,
@@ -96,27 +97,7 @@ function* createVersionUpgradeAction({
     if (supportAnnotation) {
       yield put(transactionPending(annotateUpgrade.id));
 
-      let ipfsHash: string | null = null;
-      ipfsHash = yield call(
-        ipfsUpload,
-        JSON.stringify({
-          annotationMessage,
-        }),
-      );
-
-      /* If the ipfs upload failed we try again, then if it fails again we just assign
-      an empty string so that the `transactionAddParams` won't fail */
-      if (!ipfsHash) {
-        ipfsHash = yield call(
-          ipfsUpload,
-          JSON.stringify({
-            annotationMessage,
-          }),
-        );
-        if (!ipfsHash) {
-          ipfsHash = '';
-        }
-      }
+      const ipfsHash = yield call(uploadIfpsAnnotation, annotationMessage);
 
       yield put(transactionAddParams(annotateUpgrade.id, [txHash, ipfsHash]));
 

--- a/src/modules/dashboard/sagas/motions/createEditDomainMotion.ts
+++ b/src/modules/dashboard/sagas/motions/createEditDomainMotion.ts
@@ -11,6 +11,8 @@ import { AddressZero } from 'ethers/constants';
 import { ContextModule, TEMP_getContext } from '~context/index';
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
+
+import { uploadIfpsAnnotation } from '../utils';
 import {
   createTransaction,
   createTransactionChannels,
@@ -170,14 +172,6 @@ function* createEditDomainMotion({
       yield takeFrom(annotateMotion.channel, ActionTypes.TRANSACTION_CREATED);
     }
 
-    let ipfsHash = null;
-    ipfsHash = yield call(
-      ipfsUpload,
-      JSON.stringify({
-        annotationMessage,
-      }),
-    );
-
     yield put(transactionReady(createMotion.id));
 
     const {
@@ -189,6 +183,7 @@ function* createEditDomainMotion({
     yield takeFrom(createMotion.channel, ActionTypes.TRANSACTION_SUCCEEDED);
 
     if (annotationMessage) {
+      const ipfsHash = yield call(uploadIfpsAnnotation, annotationMessage);
       yield put(transactionPending(annotateMotion.id));
 
       yield put(transactionAddParams(annotateMotion.id, [txHash, ipfsHash]));

--- a/src/modules/dashboard/sagas/motions/editColonyMotion.ts
+++ b/src/modules/dashboard/sagas/motions/editColonyMotion.ts
@@ -5,6 +5,8 @@ import { AddressZero } from 'ethers/constants';
 import { ContextModule, TEMP_getContext } from '~context/index';
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
+
+import { uploadIfpsAnnotation } from '../utils';
 import {
   createTransaction,
   createTransactionChannels,
@@ -160,14 +162,6 @@ function* editColonyMotion({
       );
     }
 
-    let ipfsHash = null;
-    ipfsHash = yield call(
-      ipfsUpload,
-      JSON.stringify({
-        annotationMessage,
-      }),
-    );
-
     yield put(transactionReady(createMotion.id));
 
     const {
@@ -179,6 +173,7 @@ function* editColonyMotion({
     yield takeFrom(createMotion.channel, ActionTypes.TRANSACTION_SUCCEEDED);
 
     if (annotationMessage) {
+      const ipfsHash = yield call(uploadIfpsAnnotation, annotationMessage);
       yield put(transactionPending(annotateEditColonyMotion.id));
 
       yield put(

--- a/src/modules/dashboard/sagas/motions/managePermissionsMotion.ts
+++ b/src/modules/dashboard/sagas/motions/managePermissionsMotion.ts
@@ -12,12 +12,13 @@ import { hexlify, hexZeroPad } from 'ethers/utils';
 import { ContextModule, TEMP_getContext } from '~context/index';
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
+
+import { uploadIfpsAnnotation } from '../utils';
 import {
   createTransaction,
   createTransactionChannels,
   getTxChannel,
 } from '../../../core/sagas';
-import { ipfsUpload } from '../../../core/sagas/ipfs';
 import {
   transactionReady,
   transactionPending,
@@ -169,14 +170,6 @@ function* managePermissionsMotion({
       );
     }
 
-    let ipfsHash = null;
-    ipfsHash = yield call(
-      ipfsUpload,
-      JSON.stringify({
-        annotationMessage,
-      }),
-    );
-
     yield put(transactionReady(createMotion.id));
 
     const {
@@ -188,6 +181,7 @@ function* managePermissionsMotion({
     yield takeFrom(createMotion.channel, ActionTypes.TRANSACTION_SUCCEEDED);
 
     if (annotationMessage) {
+      const ipfsHash = yield call(uploadIfpsAnnotation, annotationMessage);
       yield put(transactionPending(annotateSetUserRolesMotion.id));
 
       yield put(

--- a/src/modules/dashboard/sagas/motions/moveFundsMotion.ts
+++ b/src/modules/dashboard/sagas/motions/moveFundsMotion.ts
@@ -11,12 +11,13 @@ import { AddressZero, MaxUint256 } from 'ethers/constants';
 import { ContextModule, TEMP_getContext } from '~context/index';
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
+
+import { uploadIfpsAnnotation } from '../utils';
 import {
   createTransaction,
   createTransactionChannels,
   getTxChannel,
 } from '../../../core/sagas';
-import { ipfsUpload } from '../../../core/sagas/ipfs';
 import {
   transactionReady,
   transactionPending,
@@ -185,14 +186,6 @@ function* moveFundsMotion({
       );
     }
 
-    let ipfsHash = null;
-    ipfsHash = yield call(
-      ipfsUpload,
-      JSON.stringify({
-        annotationMessage,
-      }),
-    );
-
     yield put(transactionReady(createMotion.id));
 
     const {
@@ -204,6 +197,7 @@ function* moveFundsMotion({
     yield takeFrom(createMotion.channel, ActionTypes.TRANSACTION_SUCCEEDED);
 
     if (annotationMessage) {
+      const ipfsHash = yield call(uploadIfpsAnnotation, annotationMessage);
       yield put(transactionPending(annotateMoveFundsMotion.id));
 
       yield put(

--- a/src/modules/dashboard/sagas/motions/paymentMotion.ts
+++ b/src/modules/dashboard/sagas/motions/paymentMotion.ts
@@ -11,12 +11,13 @@ import moveDecimal from 'move-decimal-point';
 import { ContextModule, TEMP_getContext } from '~context/index';
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
+
+import { uploadIfpsAnnotation } from '../utils';
 import {
   createTransaction,
   createTransactionChannels,
   getTxChannel,
 } from '../../../core/sagas';
-import { ipfsUpload } from '../../../core/sagas/ipfs';
 import {
   transactionReady,
   transactionPending,
@@ -205,13 +206,7 @@ function* createPaymentMotion({
     if (annotationMessage) {
       yield put(transactionPending(annotatePaymentMotion.id));
 
-      let ipfsHash = null;
-      ipfsHash = yield call(
-        ipfsUpload,
-        JSON.stringify({
-          annotationMessage,
-        }),
-      );
+      const ipfsHash = yield call(uploadIfpsAnnotation, annotationMessage);
 
       yield put(
         transactionAddParams(annotatePaymentMotion.id, [txHash, ipfsHash]),

--- a/src/modules/dashboard/sagas/motions/rootMotion.ts
+++ b/src/modules/dashboard/sagas/motions/rootMotion.ts
@@ -5,12 +5,13 @@ import { AddressZero } from 'ethers/constants';
 import { ContextModule, TEMP_getContext } from '~context/index';
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
+
+import { uploadIfpsAnnotation } from '../utils';
 import {
   createTransaction,
   createTransactionChannels,
   getTxChannel,
 } from '../../../core/sagas';
-import { ipfsUpload } from '../../../core/sagas/ipfs';
 import {
   transactionReady,
   transactionPending,
@@ -134,13 +135,7 @@ function* createRootMotionSaga({
     if (annotationMessage) {
       yield put(transactionPending(annotateRootMotion.id));
 
-      let ipfsHash = null;
-      ipfsHash = yield call(
-        ipfsUpload,
-        JSON.stringify({
-          annotationMessage,
-        }),
-      );
+      const ipfsHash = yield call(uploadIfpsAnnotation, annotationMessage);
 
       yield put(
         transactionAddParams(annotateRootMotion.id, [txHash, ipfsHash]),

--- a/src/modules/dashboard/sagas/utils/index.ts
+++ b/src/modules/dashboard/sagas/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './updateColonyDisplayCache';
 export { updateMotionValues } from './updateMotionValues';
 export { refreshExtension } from './refreshExtension';
+export { uploadIfpsAnnotation } from './uploadIfpsAnnotation';

--- a/src/modules/dashboard/sagas/utils/uploadIfpsAnnotation.ts
+++ b/src/modules/dashboard/sagas/utils/uploadIfpsAnnotation.ts
@@ -1,0 +1,28 @@
+import { call } from 'redux-saga/effects';
+import { ipfsUpload } from '../../../core/sagas/ipfs';
+
+export function* uploadIfpsAnnotation(annotationMessage: string) {
+  let ipfsHash: string | null = null;
+  ipfsHash = yield call(
+    ipfsUpload,
+    JSON.stringify({
+      annotationMessage,
+    }),
+  );
+
+  /* If the ipfs upload failed we try again, then if it fails again we just assign
+      an empty string so that the `transactionAddParams` won't fail */
+  if (!ipfsHash) {
+    ipfsHash = yield call(
+      ipfsUpload,
+      JSON.stringify({
+        annotationMessage,
+      }),
+    );
+    if (!ipfsHash) {
+      ipfsHash = '';
+    }
+  }
+
+  return ipfsHash;
+}


### PR DESCRIPTION
## Description

This PR fixes the error that we have when ipfs fails to upload an annotation (both for motion & action). The action and motion both go through but because there is an error in annotation (you can't upload null, but need a string), there is no redirect.

The fix I implemented is to try again and if it failed again then just assign an empty string.

I had a problem with types when I pushed my commits from the `versionUpgrade` action so I just copy pasted the code instead of calling a helper. Hopefully will find out why it happens & fix it.

resolves #2654 
