### PR TITLE
Adds TokenUnlocked event to eventList

### DIFF
--- a/src/i18n/en-events.ts
+++ b/src/i18n/en-events.ts
@@ -47,6 +47,7 @@ const eventsMessageDescriptors = {
       ${ColonyAndExtensionsEvents.FundingPotAdded} {Funding pot {fundingPot} added}
       ${ColonyAndExtensionsEvents.ColonyInitialised} {{agent} created a colony with token {tokenSymbol} at address {tokenAddress}}
       ${ColonyAndExtensionsEvents.OneTxPaymentMade} {{agent} created an OneTx payment}
+      ${ColonyAndExtensionsEvents.TokenUnlocked} {Unlocked the native token {tokenSymbol}}
       ${ColonyAndExtensionsEvents.TokensMinted} {{agent} minted {amount} {tokenSymbol}}
       ${ColonyAndExtensionsEvents.ColonyFundsClaimed} {{agent} claimed {amount} {tokenSymbol} for colony}
       ${ColonyAndExtensionsEvents.PaymentAdded} {{agent} added payment with id {paymentId}}

--- a/src/modules/dashboard/components/ActionsPage/staticMaps.ts
+++ b/src/modules/dashboard/components/ActionsPage/staticMaps.ts
@@ -48,6 +48,7 @@ export const EVENT_ROLES_MAP: EventRolesMap = {
   [ColonyAndExtensionsEvents.ColonyFundsMovedBetweenFundingPots]: [
     ColonyRole.Funding,
   ],
+  [ColonyAndExtensionsEvents.TokenUnlocked]: [ColonyRole.Root],
   [ColonyAndExtensionsEvents.TokensMinted]: [ColonyRole.Root],
   [ColonyAndExtensionsEvents.DomainAdded]: [ColonyRole.Architecture],
   [ColonyAndExtensionsEvents.ColonyUpgraded]: [ColonyRole.Root],
@@ -71,6 +72,7 @@ export const ACTION_TYPES_ICONS_MAP: {
   [ColonyActions.Payment]: 'emoji-dollar-stack',
   [ColonyActions.Recovery]: 'emoji-alarm-lamp',
   [ColonyActions.MoveFunds]: 'emoji-world-globe',
+  [ColonyActions.UnlockToken]: 'emoji-padlock',
   [ColonyActions.MintTokens]: 'emoji-seed-sprout',
   [ColonyActions.CreateDomain]: 'emoji-crane',
   [ColonyActions.VersionUpgrade]: 'emoji-strong-person',
@@ -114,6 +116,7 @@ export const ACTIONS_EVENTS: ActionsEventsMap = {
   [ColonyActions.MoveFunds]: [
     ColonyAndExtensionsEvents.ColonyFundsMovedBetweenFundingPots,
   ],
+  [ColonyActions.UnlockToken]: [ColonyAndExtensionsEvents.TokenUnlocked],
   [ColonyActions.MintTokens]: [ColonyAndExtensionsEvents.TokensMinted],
   [ColonyActions.CreateDomain]: [ColonyAndExtensionsEvents.DomainAdded],
   [ColonyActions.VersionUpgrade]: [ColonyAndExtensionsEvents.ColonyUpgraded],
@@ -150,6 +153,7 @@ export const EVENTS_REQUIRED_FOR_ACTION: ActionsEventsMap = {
   [ColonyActions.MoveFunds]: [
     ColonyAndExtensionsEvents.ColonyFundsMovedBetweenFundingPots,
   ],
+  [ColonyActions.UnlockToken]: [ColonyAndExtensionsEvents.TokenUnlocked],
   [ColonyActions.MintTokens]: [ColonyAndExtensionsEvents.TokensMinted],
   /*
    * We track both configurations of this action (with metadata and without)

--- a/src/types/colonyActions.ts
+++ b/src/types/colonyActions.ts
@@ -30,6 +30,7 @@ export enum ColonyAndExtensionsEvents {
   FundingPotAdded = 'FundingPotAdded',
   PaymentAdded = 'PaymentAdded',
   PayoutClaimed = 'PayoutClaimed',
+  TokenUnlocked = 'TokenUnlocked',
   TokensMinted = 'TokensMinted',
   SkillAdded = 'SkillAdded',
   DomainAdded = 'DomainAdded',

--- a/src/types/colonyActions.ts
+++ b/src/types/colonyActions.ts
@@ -13,6 +13,7 @@ export enum ColonyActions {
   Payment = 'Payment',
   Recovery = 'Recovery',
   MoveFunds = 'MoveFunds',
+  UnlockToken = 'UnlockToken',
   MintTokens = 'MintTokens',
   CreateDomain = 'CreateDomain',
   VersionUpgrade = 'VersionUpgrade',


### PR DESCRIPTION
## Description

To bring the Token Unlock Action in line with the other actions, we need the events to be indexed by the subgraph. With updates made in [subgraph#36](https://github.com/JoinColony/subgraph/pull/36) to index the event and the update in this PR, we are now able to see the TokenUnlocked event in the UI.

**New stuff** ✨

* Adds copy for the TokenUnlocked event

![unlock-token-event](https://user-images.githubusercontent.com/33682027/147770789-e3213747-d38a-456e-b7ed-dc459c4f0761.png)

### Testing

NOTE: see @chinins comments below. The SubGraph updates are now included in this PR. So, you will likely need to run provisions again and restart your dev environment to include them and test this PR.

Previous Instructions
- Given that this requires the TokenUnlocked event to be indexed by the SubGraph and for that we need [subgraph#36](https://github.com/JoinColony/subgraph/pull/36) to be merged first. 
- So, the only way to test this beforehand is to make the changes from that PR to your SubGraph submodule in your local dev environment.



With the help of [subgraph#36](https://github.com/JoinColony/subgraph/pull/36)
Resolves #3075