### PR TITLE
Add Unlock Token Action Page

### DIFF
--- a/src/i18n/en-actions.ts
+++ b/src/i18n/en-actions.ts
@@ -9,6 +9,7 @@ const actionsMessageDescriptors = {
       ${ColonyMotions.PaymentMotion} {Pay {recipient} {amount} {tokenSymbol}}
       ${ColonyActions.MoveFunds} {Move {amount} {tokenSymbol} from {fromDomain} to {toDomain}}
       ${ColonyMotions.MoveFundsMotion} {Move {amount} {tokenSymbol} from {fromDomain} to {toDomain}}
+      ${ColonyActions.UnlockToken} {Unlock native token {tokenSymbol}}
       ${ColonyActions.MintTokens} {Mint {amount} {tokenSymbol}}
       ${ColonyMotions.MintTokensMotion} {Mint {amount} {tokenSymbol}}
       ${ColonyActions.CreateDomain} {New team: {fromDomain}}
@@ -32,6 +33,7 @@ const actionsMessageDescriptors = {
       ${ColonyActions.WrongColony} {Not part of the Colony}
       ${ColonyActions.Payment} {Payment}
       ${ColonyActions.MoveFunds} {Move Funds}
+      ${ColonyActions.UnlockToken} {Unlock Token}
       ${ColonyActions.MintTokens} {Mint Tokens}
       ${ColonyActions.CreateDomain} {Create Team}
       ${ColonyActions.VersionUpgrade} {Version Upgrade}

--- a/src/i18n/en-events.ts
+++ b/src/i18n/en-events.ts
@@ -6,6 +6,7 @@ const eventsMessageDescriptors = {
   'event.title': `{eventName, select,
       ${ColonyAndExtensionsEvents.OneTxPaymentMade} {{initiator} paid {amount} {tokenSymbol} from {fromDomain} to {recipient}}
       ${ColonyAndExtensionsEvents.ColonyFundsMovedBetweenFundingPots} {{initiator} transferred {amount} {tokenSymbol} from the {fromDomain} to {toDomain}}
+      ${ColonyAndExtensionsEvents.TokenUnlocked} {The native token {tokenSymbol} was unlocked}
       ${ColonyAndExtensionsEvents.TokensMinted} {{initiator} minted {amount} {tokenSymbol} to {recipient}}
       ${ColonyAndExtensionsEvents.DomainAdded} {{initiator} added Team: {fromDomain}}
       ${ColonyAndExtensionsEvents.ColonyUpgraded} {This colony has upgraded to {newVersion}}

--- a/src/modules/dashboard/components/ActionsPage/staticMaps.ts
+++ b/src/modules/dashboard/components/ActionsPage/staticMaps.ts
@@ -190,6 +190,7 @@ export const DETAILS_FOR_ACTION: ActionsDetailsMap = {
     ActionPageDetails.ToDomain,
     ActionPageDetails.Amount,
   ],
+  [ColonyActions.UnlockToken]: [ActionPageDetails.Domain],
   [ColonyActions.MintTokens]: [ActionPageDetails.Amount],
   [ColonyActions.CreateDomain]: [
     ActionPageDetails.Domain,

--- a/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenDialog.tsx
+++ b/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenDialog.tsx
@@ -29,7 +29,7 @@ type Props = DialogProps &
 const displayName = 'dashboard.UnlockTokenDialog';
 
 const UnlockTokenDialog = ({
-  colony: { colonyAddress },
+  colony: { colonyAddress, colonyName },
   colony,
   cancel,
   close,
@@ -43,6 +43,7 @@ const UnlockTokenDialog = ({
       withKey(colonyAddress),
       mapPayload(({ annotationMessage }) => ({
         annotationMessage,
+        colonyName,
       })),
       mergePayload({
         colonyAddress,

--- a/src/modules/dashboard/sagas/actions/unlockToken.ts
+++ b/src/modules/dashboard/sagas/actions/unlockToken.ts
@@ -7,8 +7,8 @@ import {
   ProcessedColonyQueryVariables,
   ProcessedColonyDocument,
 } from '~data/index';
-import { Action, ActionTypes } from '~redux/index';
-import { putError, takeFrom } from '~utils/saga/effects';
+import { Action, ActionTypes, AllActions } from '~redux/index';
+import { putError, routeRedirect, takeFrom } from '~utils/saga/effects';
 import {
   createTransaction,
   createTransactionChannels,
@@ -23,8 +23,8 @@ import {
 
 function* tokenUnlockAction({
   meta,
-  meta: { id: metaId },
-  payload: { colonyAddress, annotationMessage },
+  meta: { id: metaId, history },
+  payload: { colonyAddress, annotationMessage, colonyName },
 }: Action<ActionTypes.COLONY_ACTION_UNLOCK_TOKEN>) {
   let txChannel;
 
@@ -148,20 +148,19 @@ function* tokenUnlockAction({
       fetchPolicy: 'network-only',
     });
 
-    yield put({
+    yield put<AllActions>({
       type: ActionTypes.COLONY_ACTION_UNLOCK_TOKEN_SUCCESS,
       meta,
     });
+
+    if (colonyName) {
+      yield routeRedirect(`/colony/${colonyName}/tx/${txHash}`, history);
+    }
   } catch (error) {
-    return yield putError(
-      ActionTypes.COLONY_ACTION_UNLOCK_TOKEN_ERROR,
-      error,
-      meta,
-    );
+    putError(ActionTypes.COLONY_ACTION_UNLOCK_TOKEN_ERROR, error, meta);
   } finally {
     txChannel.close();
   }
-  return null;
 }
 
 export default function* unlockTokenActionSaga() {

--- a/src/redux/types/actions/colonyActions.ts
+++ b/src/redux/types/actions/colonyActions.ts
@@ -171,6 +171,7 @@ export type ColonyActionsActionTypes =
       ActionTypes.COLONY_ACTION_UNLOCK_TOKEN,
       {
         colonyAddress: Address;
+        colonyName: string;
         annotationMessage?: string;
       },
       MetaWithHistory<object>

--- a/src/types/colonyActions.ts
+++ b/src/types/colonyActions.ts
@@ -97,6 +97,7 @@ export enum ColonyAndExtensionsEvents {
   LogSetOwner = 'LogSetOwner',
   Approval = 'Approval',
   Transfer = 'Transfer',
+  Unlock = 'Unlock',
   /*
    * Extension: One Tx Payment events
    */

--- a/src/utils/events/index.ts
+++ b/src/utils/events/index.ts
@@ -591,22 +591,11 @@ export const getMotionState = async (
     18,
   );
   switch (motionNetworkState) {
-    case NetworkMotionState.Staking: {
-      const [nayStakes, yayStakes] = motion.stakes;
-      if (
-        bigNumberify(yayStakes).gte(bigNumberify(requiredStakes)) &&
-        bigNumberify(nayStakes).lt(bigNumberify(requiredStakes))
-      ) {
-        return MotionState.Staked;
-      }
-      if (
-        bigNumberify(nayStakes).gte(bigNumberify(requiredStakes)) &&
-        bigNumberify(yayStakes).lt(bigNumberify(requiredStakes))
-      ) {
-        return MotionState.Objection;
-      }
-      return MotionState.Staking;
-    }
+    case NetworkMotionState.Staking:
+      return bigNumberify(motion.stakes[1]).gte(bigNumberify(requiredStakes)) &&
+        bigNumberify(motion.stakes[0]).isZero()
+        ? MotionState.Staked
+        : MotionState.Staking;
     case NetworkMotionState.Submit:
       return MotionState.Voting;
     case NetworkMotionState.Reveal:


### PR DESCRIPTION
## Description

This adds the Token Unlock Action page for the TokenUnlocked event.

All copy used has been confirmed by product. It uses the existing action page component.

**New stuff** ✨

* New descriptors added to describe the action and event
* Action Type label added as well as the action type emoji icon
* Management of action values, despite there being none for the TokenUnlocked event
* The contract event does not record any information about the initiator, so, the annotation is queried using the linked transaction hash

![unlock-token-action-page-built](https://user-images.githubusercontent.com/33682027/147783970-5fe8c31f-9d01-4f88-9689-22e1ad286843.png)


## Testing

NOTE: The SubGraph updates are now included in this PR. So, you will likely need to run provisions again and restart your dev environment to include them and test this PR.

Previous Instructions
* Given that this requires the TokenUnlocked event to be indexed by the SubGraph and for that we need [subgraph#36](https://github.com/JoinColony/subgraph/pull/36) to be merged first.
* So, the only way to test this beforehand is to make the changes from that PR to your SubGraph submodule in your local dev environment.
* Once you have that update you will be able to just create a standard action, which should redirect to this new page.


## TODO

- [x] Add a redirect to the action modal to the action page from the action saga
- [ ] Fix annotations on Token Unlock action page not showing, due to no initiator. **UPDATE** separate issue created #3085.

NOTE: Due to the annotations currently requiring an initiator to act as a type of spam protection (see #2407 Fix: `getAnnotationFromSubgraph address filtering) and the TokenUnlocked() contract event not passing any parameters, it is not currently possible to display annotations on the Unlock Token Action page. I have created a separate issue for this #3085.

Resolves #2817
