### PR TITLE
Fix token activation confirm check when using max button

### DIFF
--- a/src/modules/users/components/TokenActivation/TokenActivationContent/ChangeTokenStateForm.tsx
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/ChangeTokenStateForm.tsx
@@ -247,7 +247,7 @@ const ChangeTokenStateForm = ({
               disabled={
                 !isValid ||
                 values.amount === undefined ||
-                new Decimal(unformattedTokenBalance).lt(values.amount)
+                new Decimal(unformattedTokenBalance).lt(values.amount || '0')
               }
             />
           </div>

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/ChangeTokenStateForm.tsx
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/ChangeTokenStateForm.tsx
@@ -247,7 +247,7 @@ const ChangeTokenStateForm = ({
               disabled={
                 !isValid ||
                 values.amount === undefined ||
-                new Decimal(unformattedTokenBalance).lt(toFinite(values.amount))
+                new Decimal(unformattedTokenBalance).lt(values.amount)
               }
             />
           </div>

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/ChangeTokenStateForm.tsx
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/ChangeTokenStateForm.tsx
@@ -247,7 +247,9 @@ const ChangeTokenStateForm = ({
               disabled={
                 !isValid ||
                 values.amount === undefined ||
-                new Decimal(unformattedTokenBalance).lt(values.amount || '0')
+                new Decimal(unformattedTokenBalance).lt(
+                  Number(values.amount) || 0,
+                )
               }
             />
           </div>

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/ChangeTokenStateForm.tsx
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/ChangeTokenStateForm.tsx
@@ -248,7 +248,8 @@ const ChangeTokenStateForm = ({
                 !isValid ||
                 values.amount === undefined ||
                 new Decimal(unformattedTokenBalance).lt(
-                  Number(values.amount) || 0,
+                  /* a bit hacky way of doing the check but nothing else seems to be working */
+                  values.amount.toString() === '.' ? 0 : values.amount || 0,
                 )
               }
             />


### PR DESCRIPTION
## Description

This PR fixes the situation in token activation popover when we press max button. The confirm button was disabled although the value was correct. This happens because the `toFinite` method rounds up the value in the check and the value appears to be larger than it is and so fails the disabled check.

In the current fix I have removed the `toFinite` from the check (it doesn't seem appropriate to use it here). I tried to think/remember what problem it was solving or try to find bugs/problems with my solution but couldn't. If somebody knows why `toFinite` method was added, I would then know which problem I should fix if we can't use it.

The reason why `toFinite` is not working:
the `amount` comes as a string with lots of numbers after decimals and in this case `toFinite` cuts it only to 2 decimal places (often rounding up). There is no option in this method to cut to the specific number of places.

Resolves #3064