### PR TITLE
Add motion support in unlock token modal & root motion saga

### DIFF
--- a/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenDialog.tsx
+++ b/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenDialog.tsx
@@ -1,53 +1,66 @@
 import { FormikProps } from 'formik';
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useHistory } from 'react-router-dom';
+import * as yup from 'yup';
 
-import Dialog, { DialogProps } from '~core/Dialog';
+import Dialog, { ActionDialogProps, DialogProps } from '~core/Dialog';
 import { ActionForm } from '~core/Fields';
 import { ActionTypes } from '~redux/index';
-import {
-  pipe,
-  mergePayload,
-  withMeta,
-  withKey,
-  mapPayload,
-} from '~utils/actions';
-import { Colony } from '~data/index';
+import { RootMotionOperationNames } from '~redux/types/actions';
+import { pipe, withMeta, withKey, mapPayload } from '~utils/actions';
 import { WizardDialogType } from '~utils/hooks';
 
 import UnlockTokenForm from './UnlockTokenForm';
 
-interface CustomWizardDialogProps {
-  prevStep?: string;
-  colony: Colony;
+export interface FormValues {
+  forceAction: boolean;
+  annotation: string;
 }
 
 type Props = DialogProps &
   Partial<WizardDialogType<object>> &
-  CustomWizardDialogProps;
+  ActionDialogProps;
 
 const displayName = 'dashboard.UnlockTokenDialog';
+
+const validationSchema = yup.object().shape({
+  forceAction: yup.bool(),
+  annotation: yup.string().max(4000),
+});
 
 const UnlockTokenDialog = ({
   colony: { colonyAddress, colonyName },
   colony,
+  isVotingExtensionEnabled,
   cancel,
   close,
   callStep,
   prevStep,
 }: Props) => {
+  const [isForce, setIsForce] = useState(false);
   const history = useHistory();
+
+  const getFormAction = useCallback(
+    (actionType: 'SUBMIT' | 'ERROR' | 'SUCCESS') => {
+      const actionEnd = actionType === 'SUBMIT' ? '' : `_${actionType}`;
+
+      return isVotingExtensionEnabled && !isForce
+        ? ActionTypes[`COLONY_ROOT_MOTION${actionEnd}`]
+        : ActionTypes[`COLONY_ACTION_UNLOCK_TOKEN${actionEnd}`];
+    },
+    [isVotingExtensionEnabled, isForce],
+  );
 
   const transform = useCallback(
     pipe(
       withKey(colonyAddress),
       mapPayload(({ annotationMessage }) => ({
         annotationMessage,
+        colonyAddress,
+        operationName: RootMotionOperationNames.UNLOCK_TOKEN,
+        motionParams: [],
         colonyName,
       })),
-      mergePayload({
-        colonyAddress,
-      }),
       withMeta({ history }),
     ),
     [colonyAddress],
@@ -56,23 +69,37 @@ const UnlockTokenDialog = ({
   return (
     <ActionForm
       initialValues={{
+        forceAction: false,
         annotationMessage: undefined,
+        /*
+         * @NOTE That since this a root motion, and we don't actually make use
+         * of the motion domain selected (it's disabled), we don't need to actually
+         * pass the value over to the motion, since it will always be 1
+         */
       }}
-      submit={ActionTypes.COLONY_ACTION_UNLOCK_TOKEN}
-      error={ActionTypes.COLONY_ACTION_UNLOCK_TOKEN_ERROR}
-      success={ActionTypes.COLONY_ACTION_UNLOCK_TOKEN_SUCCESS}
+      validationSchema={validationSchema}
+      submit={getFormAction('SUBMIT')}
+      error={getFormAction('ERROR')}
+      success={getFormAction('SUCCESS')}
       onSuccess={close}
       transform={transform}
     >
-      {(formValues: FormikProps<any>) => (
-        <Dialog cancel={cancel}>
-          <UnlockTokenForm
-            {...formValues}
-            colony={colony}
-            back={prevStep && callStep ? () => callStep(prevStep) : undefined}
-          />
-        </Dialog>
-      )}
+      {(formValues: FormikProps<FormValues>) => {
+        if (formValues.values.forceAction !== isForce) {
+          setIsForce(formValues.values.forceAction);
+        }
+
+        return (
+          <Dialog cancel={cancel}>
+            <UnlockTokenForm
+              {...formValues}
+              colony={colony}
+              back={prevStep && callStep ? () => callStep(prevStep) : undefined}
+              isVotingExtensionEnabled={isVotingExtensionEnabled}
+            />
+          </Dialog>
+        );
+      }}
     </ActionForm>
   );
 };

--- a/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenForm.css
+++ b/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenForm.css
@@ -1,3 +1,14 @@
+.modalHeading {
+  padding: 32px 0 20px;
+  width: 100%;
+}
+
+.headingContainer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
 .noPermissionMessage {
   margin-bottom: 20px;
   font-size: var(--size-tiny);
@@ -29,4 +40,8 @@
 
 .wrapper {
   margin-bottom: 20px;
+}
+
+.motionVoteDomain {
+  margin: 6px 0;
 }

--- a/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenForm.css.d.ts
+++ b/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenForm.css.d.ts
@@ -1,4 +1,7 @@
+export const modalHeading: string;
+export const headingContainer: string;
 export const noPermissionMessage: string;
 export const note: string;
 export const learnMoreLink: string;
 export const wrapper: string;
+export const motionVoteDomain: string;

--- a/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenForm.tsx
+++ b/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenForm.tsx
@@ -6,7 +6,7 @@ import { ColonyRole } from '@colony/colony-js';
 
 import Button from '~core/Button';
 import ExternalLink from '~core/ExternalLink';
-import DialogSection from '~core/Dialog/DialogSection';
+import { DialogSection, ActionDialogProps } from '~core/Dialog';
 import PermissionRequiredInfo from '~core/PermissionRequiredInfo';
 import Heading from '~core/Heading';
 import PermissionsLabel from '~core/PermissionsLabel';
@@ -23,7 +23,6 @@ import { hasRoot } from '../../../users/checks';
 
 import styles from './UnlockTokenForm.css';
 import { Annotations } from '~core/Fields';
-import { ActionDialogProps } from '~core/Dialog';
 
 const MSG = defineMessages({
   title: {

--- a/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenForm.tsx
+++ b/src/modules/dashboard/components/UnlockTokenDialog/UnlockTokenForm.tsx
@@ -11,6 +11,7 @@ import PermissionRequiredInfo from '~core/PermissionRequiredInfo';
 import Heading from '~core/Heading';
 import PermissionsLabel from '~core/PermissionsLabel';
 import Toggle from '~core/Fields/Toggle';
+import NotEnoughReputation from '~dashboard/NotEnoughReputation';
 import MotionDomainSelect from '~dashboard/MotionDomainSelect';
 
 import { useLoggedInUser } from '~data/index';
@@ -47,7 +48,7 @@ const MSG = defineMessages({
   },
   annotation: {
     id: `dashboard.UnlockTokenDialog.UnlockTokenForm.annotation`,
-    defaultMessage: 'Explain why you’re making these changes (optional)',
+    defaultMessage: "Explain why you're unlocking the native token (optional)",
   },
 });
 
@@ -150,6 +151,7 @@ const UnlockTokenForm = ({
           </div>
         </DialogSection>
       )}
+      {onlyForceAction && <NotEnoughReputation />}
       <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
         <Button
           appearance={{ theme: 'secondary', size: 'large' }}

--- a/src/redux/types/actions/motion.ts
+++ b/src/redux/types/actions/motion.ts
@@ -16,6 +16,7 @@ import {
 export enum RootMotionOperationNames {
   MINT_TOKENS = 'mintTokens',
   UPGRADE = 'upgrade',
+  UNLOCK_TOKEN = 'unlockToken',
 }
 
 export type MotionActionTypes =


### PR DESCRIPTION
## Description

This PR adds motion support to Unlock token modal similar to other dialogs.

Right now there is a bug that doesn't allow mint tokens or unlock token item to be seen in the Manage funds dialog menu even if voting extension is installed. So to test you need to remove the filtered part from the `ManageFunds` dialog. I've already raised an issue and am trying to fix this bug: #3086 

The testing should be done with a user that has necessary permissions & the one who doesn't with voting extension enabled and without.

Resolves #2818 
resolves #2819 
