### PR TITLE
Add token icon to details widget in DefaultAction & DefaultMotion

### DIFF
--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -1701,7 +1701,7 @@ export type TokenInfoQueryVariables = Exact<{
 }>;
 
 
-export type TokenInfoQuery = { tokenInfo: Pick<TokenInfo, 'decimals' | 'name' | 'symbol' | 'iconHash'> };
+export type TokenInfoQuery = { tokenInfo: Pick<TokenInfo, 'decimals' | 'name' | 'symbol' | 'iconHash' | 'address'> };
 
 export type UserNotificationsQueryVariables = Exact<{
   address: Scalars['String'];
@@ -4015,6 +4015,7 @@ export const TokenInfoDocument = gql`
     name
     symbol
     iconHash
+    address
   }
 }
     `;

--- a/src/data/graphql/queries.graphql
+++ b/src/data/graphql/queries.graphql
@@ -160,6 +160,7 @@ query TokenInfo($address: String!) {
     name
     symbol
     iconHash
+    address
   }
 }
 

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultAction.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultAction.tsx
@@ -49,6 +49,7 @@ interface Props {
 const DefaultAction = ({
   colony,
   colony: { colonyAddress, domains },
+  token,
   token: { decimals, symbol },
   colonyAction: {
     events = [],
@@ -142,6 +143,7 @@ const DefaultAction = ({
       </span>
     ),
     amount: decimalAmount,
+    token,
     tokenSymbol: <span>{symbol || '???'}</span>,
     decimals: getTokenDecimalsWithFallback(decimals),
     fromDomain:

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
@@ -113,6 +113,7 @@ const DefaultMotion = ({
     tokenAddress,
   },
   colonyAction,
+  token,
   token: { decimals, symbol },
   transactionHash,
   recipient,
@@ -281,6 +282,7 @@ const DefaultMotion = ({
       </span>
     ),
     amount: decimalAmount,
+    token,
     tokenSymbol: <span>{symbol || '???'}</span>,
     initiator: (
       <>

--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.css
@@ -16,8 +16,7 @@
   height: 26px;
 }
 
-.value,
-.label {
+.value, .label {
   font-size: var(--size-smallish);
   font-weight: var(--weight-bold);
   letter-spacing: var(--spacing-medium);

--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.css
@@ -13,7 +13,6 @@
 
 .tokenContainer > figure {
   margin-right: 7px;
-  height: 26px;
 }
 
 .value, .label {

--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.css
@@ -11,7 +11,7 @@
   align-items: center;
 }
 
-.icon {
+.tokenContainer > figure {
   margin-right: 7px;
   height: 26px;
 }

--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.css
@@ -1,4 +1,3 @@
-
 .item {
   display: flex;
   justify-content: space-between;
@@ -7,7 +6,18 @@
   border-bottom: 1px solid color-mod(var(--temp-grey-blue-7) alpha(15%));
 }
 
-.value, .label {
+.tokenContainer {
+  display: flex;
+  align-items: center;
+}
+
+.icon {
+  margin-right: 7px;
+  height: 26px;
+}
+
+.value,
+.label {
   font-size: var(--size-smallish);
   font-weight: var(--weight-bold);
   letter-spacing: var(--spacing-medium);

--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.css.d.ts
@@ -1,6 +1,5 @@
 export const item: string;
 export const tokenContainer: string;
-export const icon: string;
 export const value: string;
 export const label: string;
 export const descriptionValue: string;

--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.css.d.ts
@@ -1,4 +1,6 @@
 export const item: string;
+export const tokenContainer: string;
+export const icon: string;
 export const value: string;
 export const label: string;
 export const descriptionValue: string;

--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.tsx
@@ -5,6 +5,7 @@ import Icon from '~core/Icon';
 import DetailsWidgetUser from '~core/DetailsWidgetUser';
 import TransactionLink from '~core/TransactionLink';
 
+import TokenIcon from '~dashboard/HookedTokenIcon';
 import { AnyUser, Colony } from '~data/index';
 import { ColonyActions, ColonyMotions } from '~types/index';
 import { splitTransactionHash } from '~utils/strings';
@@ -175,8 +176,19 @@ const DetailsWidget = ({
           <div className={styles.label}>
             <FormattedMessage {...MSG.value} />
           </div>
-          <div className={styles.value}>
-            <Amount /> <Symbol />
+          <div className={styles.tokenContainer}>
+            <div className={styles.icon}>
+              {values.token && (
+                <TokenIcon
+                  token={values.token}
+                  name={values.token.name || undefined}
+                  size="xs"
+                />
+              )}
+            </div>
+            <div className={styles.value}>
+              <Amount /> <Symbol />
+            </div>
           </div>
         </div>
       )}

--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.tsx
@@ -181,7 +181,7 @@ const DetailsWidget = ({
               <TokenIcon
                 token={values.token}
                 name={values.token.name || undefined}
-                size="xs"
+                size="xxs"
               />
             )}
             <div className={styles.value}>

--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.tsx
@@ -177,15 +177,13 @@ const DetailsWidget = ({
             <FormattedMessage {...MSG.value} />
           </div>
           <div className={styles.tokenContainer}>
-            <div className={styles.icon}>
-              {values.token && (
-                <TokenIcon
-                  token={values.token}
-                  name={values.token.name || undefined}
-                  size="xs"
-                />
-              )}
-            </div>
+            {values.token && (
+              <TokenIcon
+                token={values.token}
+                name={values.token.name || undefined}
+                size="xs"
+              />
+            )}
             <div className={styles.value}>
               <Amount /> <Symbol />
             </div>

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeed.tsx
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeed.tsx
@@ -17,6 +17,7 @@ import {
   ParsedEvent,
   useLoggedInUser,
   useCommentsSubscription,
+  TokenInfoQuery,
 } from '~data/index';
 import { ActionUserRoles, ColonyActions, Address } from '~types/index';
 import { MotionVote } from '~utils/colonyMotions';
@@ -44,6 +45,7 @@ const MSG = defineMessages({
 export interface EventValues {
   actionType: string;
   amount?: string | ReactElement;
+  token?: TokenInfoQuery['tokenInfo'];
   tokenSymbol?: string | ReactElement;
   decimals?: number;
   fromDomain?: OneDomain;

--- a/src/modules/dashboard/components/HookedTokenIcon/HookedTokenIcon.tsx
+++ b/src/modules/dashboard/components/HookedTokenIcon/HookedTokenIcon.tsx
@@ -4,7 +4,7 @@ import { AddressZero } from 'ethers/constants';
 
 import Avatar from '~core/Avatar';
 import { useDataFetcher } from '~utils/hooks';
-import { AnyToken } from '~data/index';
+import { AnyToken, TokenInfoQuery } from '~data/index';
 import { Address } from '~types/index';
 import Icon from '~core/Icon';
 import { getBase64image } from '~utils/dataReader';
@@ -22,7 +22,7 @@ interface Response {
 
 interface Props {
   /** Token reference to display */
-  token: AnyToken;
+  token: AnyToken | TokenInfoQuery['tokenInfo'];
 
   /** Is passed through to Avatar */
   className?: string;


### PR DESCRIPTION
## Description

This PR adds token icon in detailsWidget when amount is shown.

**Changes** 🏗

- Update TokenInfoQuery
- Update DetailsWidget, TokenIcon, DefaultAction, DefaultMotion components.

resolves #2823 

Using Figma spec with an icon size of 16px. (looks rather small)
<img width="436" alt="Screenshot 2022-01-06 at 17 45 36" src="https://user-images.githubusercontent.com/582700/148463334-c89d34d8-7695-42d1-9994-5f0574c322cb.png">
