### PR TITLE
Filter duplicated actions for passed motions

### DIFF
--- a/src/modules/dashboard/components/ColonyActions/ColonyActions.tsx
+++ b/src/modules/dashboard/components/ColonyActions/ColonyActions.tsx
@@ -24,6 +24,7 @@ import {
 import { SortOptions, SortSelectOptions } from '../shared/sortOptions';
 import { getActionsListData } from '../../transformers';
 import { useTransformer } from '~utils/hooks';
+import { createAddress } from '~utils/web3';
 import {
   ColonyActions as ColonyActionTypes,
   FormattedAction,
@@ -31,7 +32,6 @@ import {
 } from '~types/index';
 
 import styles from './ColonyActions.css';
-import { createAddress } from '~utils/web3';
 
 const MSG = defineMessages({
   labelFilter: {
@@ -175,8 +175,7 @@ const ColonyActions = ({
 
   /* Needs to be tested when all action types are wirde up & reflected in the list */
   const filteredActions = useMemo(() => {
-    let filterActions = actions;
-    filterActions = !ethDomainId
+    const filterActions = !ethDomainId
       ? actions
       : actions.filter(
           (action) =>
@@ -195,7 +194,7 @@ const ColonyActions = ({
           .filter((motion) => motion.extensionAddress)
           .map((motion) => createAddress(motion.extensionAddress)) || [];
       if (motionExtensionAddresses.length > 0) {
-        filterActions = actions.filter((action) => {
+        return filterActions.filter((action) => {
           return !motionExtensionAddresses.includes(
             createAddress(action.initiator),
           );


### PR DESCRIPTION
## Description

This PR is intended to remove the duplicate actions appearing for a passed motion and the incorrectly displayed 'Forced' tag on a passed motion action.

However, due to non-persistence of an uninstalled extension, the forced tag fix will only work for the currently installed Motions & Disputes extension.

The filter will only take effect once the motions have loaded into the actions list.

**These are the circumstances that have been tested and the expected results:**

- Motions & Disputes extension is enabled - _It should correctly only show the passed motion action_
- Motions & Disputes extension is depreciated - _It should correctly only show the passed motion action_
- Motions & Disputes extension is depreciated then re-enabled - _It should correctly only show the passed motion action_

- Motions & Disputes extension is uninstalled - _It will show the action with no tag_

- Motions & Disputes extension is re-installed - _It will show previous extension's motions as the singular action with a forced tag and correctly only show the passed motion action for the newly installed extension_

- Motions & Disputes extension is re-installed then depreciated - _It will show previous extension motions as the action with no tag and only show the passed motion action for the most recently depreciated extension_

**Changes** 🏗

* Updated the actions filter to also filter out the actions initiated by the Motions & Disputes extension


### Testing

- Install the Motions & Disputes extension
- Add Reputation to the colony by making a forced payment
- Refresh the page to ensure reputation is loaded
- Unlock the received funds, ready for staking against motion
- Create a motion and stake for it
- Speed up the chain by at least the time left in the motion. You can do this using this request in your console (which is a little over 3 days)
`curl -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"evm_increaseTime","params":[260000],"id": 1}' localhost:8545 && curl -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"evm_mine","params":[]}' localhost:8545`
- Check your 'Actions' list to ensure that there is no duplicate for the same action.



### Before
![repeated-event-incorrectly-forced](https://user-images.githubusercontent.com/33682027/148998938-84559c59-d857-44e2-9eaf-988b558f09fb.png)

### After
![correctly-filtered-motion-action](https://user-images.githubusercontent.com/33682027/148998942-7856b3fc-96bb-460f-ba05-b66baefd1e39.jpg)


Resolves #3070
