### PR TITLE
Add Unlock Token action to the Actions List

### DIFF
--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -7671,7 +7671,7 @@ export type SubgraphOneTxSubscriptionHookResult = ReturnType<typeof useSubgraphO
 export type SubgraphOneTxSubscriptionResult = Apollo.SubscriptionResult<SubgraphOneTxSubscription>;
 export const SubgraphEventsThatAreActionsDocument = gql`
     subscription SubgraphEventsThatAreActions($skip: Int = 0, $first: Int = 1000, $colonyAddress: String!, $sortDirection: String = asc) {
-  events(skip: $skip, first: $first, orderBy: "timestamp", orderDirection: $sortDirection, where: {associatedColony_contains: $colonyAddress, name_in: ["TokensMinted(address,address,uint256)", "DomainAdded(address,uint256)", "ColonyMetadata(address,string)", "ColonyFundsMovedBetweenFundingPots(address,uint256,uint256,uint256,address)", "DomainMetadata(address,uint256,string)", "ColonyRoleSet(address,address,uint256,uint8,bool)", "ColonyUpgraded(address,uint256,uint256)", "ColonyUpgraded(uint256,uint256)", "RecoveryModeEntered(address)"]}) {
+  events(skip: $skip, first: $first, orderBy: "timestamp", orderDirection: $sortDirection, where: {associatedColony_contains: $colonyAddress, name_in: ["TokensMinted(address,address,uint256)", "DomainAdded(address,uint256)", "ColonyMetadata(address,string)", "ColonyFundsMovedBetweenFundingPots(address,uint256,uint256,uint256,address)", "DomainMetadata(address,uint256,string)", "ColonyRoleSet(address,address,uint256,uint8,bool)", "ColonyUpgraded(address,uint256,uint256)", "ColonyUpgraded(uint256,uint256)", "RecoveryModeEntered(address)", "TokenUnlocked()"]}) {
     id
     address
     associatedColony {

--- a/src/data/graphql/subscriptions.graphql
+++ b/src/data/graphql/subscriptions.graphql
@@ -88,7 +88,8 @@ subscription SubgraphEventsThatAreActions($skip: Int = 0, $first: Int = 1000, $c
         "ColonyRoleSet(address,address,uint256,uint8,bool)",
         "ColonyUpgraded(address,uint256,uint256)",
         "ColonyUpgraded(uint256,uint256)",
-        "RecoveryModeEntered(address)"
+        "RecoveryModeEntered(address)",
+        "TokenUnlocked()"
       ]
     }) {
     id


### PR DESCRIPTION
## Description

- This PR adds unlock native token action to the Action List page.

**New stuff** ✨

- Update SubgraphEventsThatAreActions subscription

Resolves #2816

<img width="796" alt="Screenshot 2022-01-11 at 21 29 37" src="https://user-images.githubusercontent.com/582700/149054889-8ab683a8-0dbc-452b-901f-2919905f9e03.png">

