### PR TITLE
Handle long strings & URLs in comments

### DIFF
--- a/src/modules/core/components/Comment/Comment.css
+++ b/src/modules/core/components/Comment/Comment.css
@@ -5,6 +5,7 @@
   padding: 11px 0 11px 0;
   width: 100%;
   border-radius: var(--radius-large);
+  word-break: break-word;
 }
 
 .main:not(.stateDisableHover):hover, .main.stateActiveActions:not(.stateDisableHover) {


### PR DESCRIPTION
**Description**

- This PR handles the wrapping of long words and URLs within comments. As `Comment` core component is updated, the fix should be dapp wide. The fix maintains the page layout.

Resolves #3048 

**After Fix**

CoinMachine
<img width="1074" alt="Screenshot 2022-01-12 at 17 44 20" src="https://user-images.githubusercontent.com/582700/149235099-4a6bf0c6-56cc-4282-b0a0-e4e073c3d823.png">

<img width="577" alt="Screenshot 2022-01-12 at 17 43 54" src="https://user-images.githubusercontent.com/582700/149235015-29191f0b-9445-4bd1-b895-c68095019fd5.png">

From Action Page
<img width="983" alt="Screenshot 2022-01-12 at 17 54 39" src="https://user-images.githubusercontent.com/582700/149236100-677c6b47-a7e6-43ec-b47a-b3223c95be66.png">

<img width="576" alt="Screenshot 2022-01-12 at 17 56 53" src="https://user-images.githubusercontent.com/582700/149236520-c6a0ef2d-65c9-42de-b674-c7c30751e5d3.png">



**Before Fix**

<img width="1440" alt="Screenshot 2022-01-12 at 14 14 40" src="https://user-images.githubusercontent.com/582700/149234546-25d1fe59-a43d-463e-9c90-c092036c944c.png">

<img width="1440" alt="Screenshot 2022-01-12 at 14 14 33" src="https://user-images.githubusercontent.com/582700/149234516-830f2f0d-78f2-4e84-9f78-787082acc78d.png">

A bug was discovered in the delete comment dialog, with URLs overflowing.

CoinMachine 
<img width="604" alt="Screenshot 2022-01-12 at 14 05 21" src="https://user-images.githubusercontent.com/582700/149234594-e5e2c2f7-d23d-4504-a3cf-f562dae4aa17.png">

From Action Page
<img width="569" alt="Screenshot 2022-01-12 at 17 58 14" src="https://user-images.githubusercontent.com/582700/149236541-d29cca02-920f-4da0-93a4-465150135b74.png">


