### PR TITLE
Vertically align user avatar in notifications

### DIFF
--- a/src/modules/users/components/Inbox/InboxItem/InboxItem.css
+++ b/src/modules/users/components/Inbox/InboxItem/InboxItem.css
@@ -29,11 +29,6 @@
 }
 
 .inboxAction {
-  /*
-   * @NOTE Netative margins used to better align
-   * the event's copy with the user's avatar
-   */
-  margin-top: -5px;
   overflow: hidden;
   font-weight: 400;
   text-overflow: ellipsis;
@@ -115,4 +110,5 @@
 .avatarWrapper {
   display: inline-block;
   margin-right: 10px;
+  vertical-align: 8%;
 }


### PR DESCRIPTION
## Description

Fixed the vertical alignment of the user avatar in the notifications popup. The centering is with respect to `cap-height` (height of the first `Y` here) of the text. I can manually force it to center according to the perceived height but I personally don't like that.



**Changes** 🏗

![Screen Shot 2022-02-07 at 13 33 21](https://user-images.githubusercontent.com/14034137/152750056-820cebfb-246c-42a9-b3a2-64ae38d9b2c8.png)


Resolves  #3098.
