### PR TITLE
Match team colors in DomainDropDown

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyDomainSelector/ColonyDomainSelector.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyDomainSelector/ColonyDomainSelector.tsx
@@ -57,8 +57,8 @@ const ColonyDomainSelector = ({
 
   const getDomainColor = useCallback<(domainId: string | undefined) => Color>(
     (domainId) => {
-      const rootDomainColor: Color = Color.Yellow;
-      const defaultColor: Color = Color.LightPink;
+      const rootDomainColor: Color = Color.LightPink;
+      const defaultColor: Color = Color.Yellow;
       if (domainId === String(ROOT_DOMAIN_ID)) {
         return rootDomainColor;
       }


### PR DESCRIPTION
## Description

Makes the All Teams color consistent in the dropdown.

![Screenshot 2022-01-15 at 00-00-55 Colony](https://user-images.githubusercontent.com/14034137/149566957-ad8046cf-ed35-41ce-9a04-2971a28ccbdd.png)

**Changes** 🏗

Just a minor swapping of colors.


Resolves #3100.
