### PR TITLE
Improve word wrapping on team descriptions

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyDomainDescription/ColonyDomainDescription.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyDomainDescription/ColonyDomainDescription.css
@@ -18,7 +18,7 @@
   margin-top: 15px;
   width: 220px;
   font-size: var(--size-normal);
-  word-break: break-all;
+  word-break: break-word;
   color: var(--dark: rgb(60, 68, 77));
   -webkit-line-clamp: 5;
 }


### PR DESCRIPTION
## Description

This PR stops the team descriptions text from being broken at an inappropriate place. Instead long lines are split in between words.

Resolves #3097 

**Before**
<img width="262" alt="Screenshot 2022-01-14 at 17 13 36" src="https://user-images.githubusercontent.com/582700/149599305-54f9b204-8126-49bf-a2d6-88f9bb45f703.png">

**After**
<img width="247" alt="Screenshot 2022-01-14 at 17 14 12" src="https://user-images.githubusercontent.com/582700/149599321-48d59fcb-aaa5-4f73-9f41-a734ac10a7cd.png">


