### PR TITLE
Align and resize GasStation left caret icon

### DIFF
--- a/src/modules/users/components/GasStation/TransactionDetails/TransactionBackToList.css
+++ b/src/modules/users/components/GasStation/TransactionDetails/TransactionBackToList.css
@@ -17,3 +17,11 @@
   color: var(--text);
   cursor: pointer;
 }
+
+.returnToSummary svg {
+  /*
+   * NOTE Using this to override Icon.css's vertical-align property
+   * which might be being used elsewhere.
+   */
+  vertical-align: -5px;
+}

--- a/src/modules/users/components/GasStation/TransactionDetails/TransactionBackToList.tsx
+++ b/src/modules/users/components/GasStation/TransactionDetails/TransactionBackToList.tsx
@@ -20,7 +20,7 @@ const displayName = 'users.GasStation.TransactionBackToList';
 const TransactionBackToList = ({ onClose }: Props) => (
   <button type="button" className={styles.returnToSummary} onClick={onClose}>
     <Icon
-      appearance={{ size: 'small' }}
+      appearance={{ size: 'normal' }}
       name="caret-left"
       title={MSG.returnToSummary}
     />


### PR DESCRIPTION
## Description

Fixed the alignment and size of the left caret icon in GasStation.

Used a CSS override to avoid messing with `Icon`'s default `vertical-alignment`.


**Changes** 🏗

![Screenshot 2022-01-17 at 18-11-07 Colony](https://user-images.githubusercontent.com/14034137/149771498-5d2fcc05-cf9f-406a-901a-0cd133691b12.png)



Resolves #3103.
