### PR TITLE
Bought token showing incorrectly in events list

### DIFF
--- a/src/utils/hooks/useEnabledExtensions.tsx
+++ b/src/utils/hooks/useEnabledExtensions.tsx
@@ -19,6 +19,9 @@ export const useEnabledExtensions = ({ colonyAddress }: Props) => {
   const installedOneTxPaymentExtension = installedExtensions.find(
     ({ extensionId }) => extensionId === Extension.OneTxPayment,
   );
+  const installedCoinMachineExtension = installedExtensions.find(
+    ({ extensionId }) => extensionId === Extension.CoinMachine,
+  );
 
   const installedWhitelistExtension = installedExtensions.find(
     ({ extensionId }) => extensionId === Extension.Whitelist,
@@ -34,6 +37,11 @@ export const useEnabledExtensions = ({ colonyAddress }: Props) => {
     installedOneTxPaymentExtension.details.initialized &&
     !installedOneTxPaymentExtension.details.deprecated
   );
+  const isCoinMachineExtensionEnabled = !!(
+    installedCoinMachineExtension &&
+    installedCoinMachineExtension.details.initialized &&
+    !installedCoinMachineExtension.details.deprecated
+  );
 
   const installedExtensionsAddresses = installedExtensions.map((extension) =>
     extension.address?.toLowerCase(),
@@ -47,6 +55,7 @@ export const useEnabledExtensions = ({ colonyAddress }: Props) => {
   return {
     isVotingExtensionEnabled,
     isOneTxPaymentExtensionEnabled,
+    isCoinMachineExtensionEnabled,
     installedExtensionsAddresses,
     isWhitelistExtensionEnabled,
     whitelistAddress: installedWhitelistExtension?.address,


### PR DESCRIPTION
## Description

This adds a request to pull the token for the TokenBought event to match the one being sold in the current active CoinMachine sale.

This fix only works while the CoinMachine is enabled. In which case it will fallback to the colonies native token, as before. I have raised this with network to see if we can get the tokenAddress emitted in this event.

Also, there is an error if CoinMachine is not installed `Error: CoinMachine extension is not installed for this colony`. Let me know if you have a good way to avoid this, all checks cause more severe errors.

**New stuff** ✨

* Check if the CoinMachine extension is enabled
* Grab the sellable token from the CoinMachine for TokenBought event

## Testing

* You will need to create two colonies with different tokens
Add the token from `Colony #2` to `Colony #1` via the Funds > Manage Tokens dialog
* You can obtain the token contract address via Funds
* Install a new CoinMachine and set the Purchase Token to `Colony #2's` token
* Send some tokens from `Colony #2` to `Colony #1`.
  I used MetaMask to achieve this by adding a dev wallet to it. You can find the private key of the dev wallet for importing within lib > colonyNetwork > ganache-accounts.json at the bottom of that file is a list of addresses and their corresponding private keys. I had unlocked `Colony #2's` token and sent some to the wallet I imported. Then from MetaMask send `Colony #2's` tokens to `Colony #1`
* Fund the CoinMachine contract in `Colony #1` with the newly received `Colony #2` token
* Make some buys
* Go to Events and notice the bought event correctly showing the `Colony #2` symbol. You will have to wait a second for the query to load.


## Before

![first-issue-this-should-be-BLD](https://user-images.githubusercontent.com/33682027/150162298-94832d1f-511a-406a-9ee0-e69938571ac8.png)


## After

![first-issue-this-should-be-BLD-after](https://user-images.githubusercontent.com/33682027/150164037-0cc78a9b-fa25-4484-8497-839f2f9f1a2f.png)



Resolves #3058 
