### PR TITLE
Match bring your own token input size and top margin

### DIFF
--- a/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.css
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.css
@@ -13,7 +13,7 @@
 }
 
 .title {
-  margin-top: 310px;
+  margin-top: 180px;
   margin-bottom: 45px;
   font-weight: var(--weight-bold);
 }

--- a/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.tsx
@@ -172,11 +172,16 @@ const StepSelectToken = ({
                   <FormattedMessage {...MSG.link} />
                 </button>
               }
+              appearance={{ theme: 'fat' }}
             />
             {values.tokenAddress && !tokenData && (
               <>
                 <div className={styles.tokenDetails}>
-                  <Input name="tokenName" label={MSG.tokenName} />
+                  <Input
+                    name="tokenName"
+                    label={MSG.tokenName}
+                    appearance={{ theme: 'fat' }}
+                  />
                 </div>
                 <div className={styles.tokenDetails}>
                   <Input
@@ -184,6 +189,7 @@ const StepSelectToken = ({
                     label={MSG.tokenSymbol}
                     help={MSG.symbolHint}
                     formattingOptions={{ uppercase: true, blocks: [5] }}
+                    appearance={{ theme: 'fat' }}
                   />
                 </div>
               </>


### PR DESCRIPTION
## Description

This PR makes the bring your own token input field size same as the create new token. It also adjusts the bring your own token components margin-top to be same as the create new token.

**Changes** 🏗

Just two minor appearance changes.

![Screenshot 2022-01-18 at 19-53-45 Colony](https://user-images.githubusercontent.com/14034137/149955430-91731030-fc9e-4199-9e52-6165a33b43f1.png)

![Screenshot 2022-01-18 at 19-55-22 Colony](https://user-images.githubusercontent.com/14034137/149955608-7625d097-59a1-4b93-b0b6-962f79bda18d.png)


Resolves #3104 
