### PR TITLE
Implement award action and motion copy in event list

### DIFF
--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -1221,6 +1221,16 @@ export const motionsResolvers = ({
         };
       }
 
+      if (
+        actionValues.signature ===
+        'emitDomainReputationReward(uint256,address,int256)'
+      ) {
+        return {
+          reputationChange: actionValues?.args[2].toString(),
+          recipient: actionValues?.args[1],
+        };
+      }
+
       // MintTokenMotion - default
       return {
         amount: bigNumberify(actionValues?.args[0] || '0').toString(),

--- a/src/i18n/en-actions.ts
+++ b/src/i18n/en-actions.ts
@@ -20,10 +20,10 @@ const actionsMessageDescriptors = {
       ${ColonyActions.EditDomain} {{fromDomain} team details edited}
       ${ColonyMotions.EditDomainMotion} {Edit {fromDomain} team details}
       ${ColonyActions.Recovery} {Recovery mode activated by {initiator}}
-      ${ColonyActions.EmitDomainReputationPenalty} {Smite {recipient} with a {reputationChange} reputation penalty}
-      ${ColonyMotions.EmitDomainReputationPenaltyMotion} {Smite {recipient} with a {reputationChange} reputation penalty}
-      ${ColonyActions.EmitDomainReputationReward} {Award {recipient} with a {reputationChange} reputation reward}
-      ${ColonyMotions.EmitDomainReputationRewardMotion} {Award {recipient} with a {reputationChange} reputation reward}
+      ${ColonyActions.EmitDomainReputationPenalty} {Smite {recipient} with a {reputationChange} {reputationChange, plural, one {pt} other {pts}} reputation penalty}
+      ${ColonyMotions.EmitDomainReputationPenaltyMotion} {Smite {recipient} with a {reputationChange} {reputationChange, plural, one {pt} other {pts}} reputation penalty}
+      ${ColonyActions.EmitDomainReputationReward} {Award {recipient} with a {reputationChange} {reputationChange, plural, one {pt} other {pts}} reputation reward}
+      ${ColonyMotions.EmitDomainReputationRewardMotion} {Award {recipient} with a {reputationChange} {reputationChange, plural, one {pt} other {pts}} reputation reward}
       other {Generic action we don't have information about}
     }`,
   [`action.${ColonyActions.SetUserRoles}.assign`]: `Assign the {roles} in {fromDomain} to {recipient}`,

--- a/src/i18n/en-events.ts
+++ b/src/i18n/en-events.ts
@@ -84,13 +84,19 @@ const eventsMessageDescriptors = {
       ${ColonyAndExtensionsEvents.MotionRewardClaimed} {{agent} claimed their stake in motion {motionId}}
       ${ColonyAndExtensionsEvents.MotionEventSet} {Motion {motionId} fast-forwarded to the next lifecycle}
       ${ColonyAndExtensionsEvents.AgreementSigned} {User {agent} signed the whitelist agreement}
-      ${ColonyAndExtensionsEvents.ArbitraryReputationUpdate} {{agent} smote {recipient} with a {reputationChange} reputation penalty}
       other {{eventName} emmited with values: {displayValues}}
     }`,
   [`eventList.${ColonyAndExtensionsEvents.ColonyRoleSet}.assign`]: `{agent} assigned the {role} permission in the {domain} team to {recipient}`,
   [`eventList.${ColonyAndExtensionsEvents.ColonyRoleSet}.remove`]: `{agent} removed the {role} permission in the {domain} team from {recipient}`,
   [`eventList.${ColonyAndExtensionsEvents.RecoveryRoleSet}.assign`]: `The Recovery role was assigned to {recipient}`,
   [`eventList.${ColonyAndExtensionsEvents.RecoveryRoleSet}.remove`]: `The Recovery role was removed from {recipient}`,
+  [`eventList.${ColonyAndExtensionsEvents.ArbitraryReputationUpdate}.title`]: `{agent} {isSmiteAction, select,
+    true {smote}
+    false {awarded}
+  } {recipient} with a {reputationChange} reputation {isSmiteAction, select,
+    true {penalty}
+    false {reward}
+  }`,
 };
 
 export default eventsMessageDescriptors;

--- a/src/i18n/en-events.ts
+++ b/src/i18n/en-events.ts
@@ -43,7 +43,7 @@ const eventsMessageDescriptors = {
   [`event.${ColonyAndExtensionsEvents.ArbitraryReputationUpdate}.title`]: `{initiator} {isSmiteAction, select,
     true {smote}
     false {awarded}
-  } {recipient} with a {reputationChange} reputation {isSmiteAction, select,
+  } {recipient} with a {reputationChange} {reputationChange, plural, one {pt} other {pts}} reputation {isSmiteAction, select,
     true {penalty}
     false {reward}
   }`,
@@ -93,7 +93,7 @@ const eventsMessageDescriptors = {
   [`eventList.${ColonyAndExtensionsEvents.ArbitraryReputationUpdate}.title`]: `{agent} {isSmiteAction, select,
     true {smote}
     false {awarded}
-  } {recipient} with a {reputationChange} reputation {isSmiteAction, select,
+  } {recipient} with a {reputationChange} {reputationChange, plural, one {pt} other {pts}} reputation {isSmiteAction, select,
     true {penalty}
     false {reward}
   }`,

--- a/src/i18n/en-motions.ts
+++ b/src/i18n/en-motions.ts
@@ -12,9 +12,15 @@ const motionsMessageDescriptors = {
       ${ColonyMotions.MoveFundsMotion}
         {Move {amount} {tokenSymbol} from {fromDomainName} to {toDomainName}}
       ${ColonyMotions.EmitDomainReputationPenaltyMotion}
-        {Smite {recipient} with a {reputationChange} reputation penalty}
+        {Smite {recipient} with a {reputationChange} {reputationChange, plural,
+          one {pt}
+          other {pts}
+        } reputation penalty}
       ${ColonyMotions.EmitDomainReputationRewardMotion}
-        {Award {recipient} with a {reputationChange} reputation reward}
+        {Award {recipient} with a {reputationChange} {reputationChange, plural,
+          one {pt}
+          other {pts}
+        } reputation reward}
         other {Generic motion we don't have information about}
     }`,
   [`motion.${ColonyMotions.SetUserRolesMotion}.assign`]: `Assign the {roles} in {fromDomainName} to {recipient}`,

--- a/src/modules/core/components/ActionsList/ActionsListItem.tsx
+++ b/src/modules/core/components/ActionsList/ActionsListItem.tsx
@@ -301,7 +301,7 @@ const ActionsListItem = ({
                   roles: roleTitle,
                   newVersion: newVersion || '0',
                   reputationChange: `${getFormattedTokenValue(
-                    new Decimal(reputationChange || '0').mul(-1).toString(),
+                    new Decimal(reputationChange || '0').abs().toString(),
                     decimals,
                   )} pts`,
                 }}

--- a/src/modules/core/components/ActionsList/ActionsListItem.tsx
+++ b/src/modules/core/components/ActionsList/ActionsListItem.tsx
@@ -300,10 +300,10 @@ const ActionsListItem = ({
                   toDomain: toDomain?.name || '',
                   roles: roleTitle,
                   newVersion: newVersion || '0',
-                  reputationChange: `${getFormattedTokenValue(
+                  reputationChange: getFormattedTokenValue(
                     new Decimal(reputationChange || '0').abs().toString(),
                     decimals,
-                  )} pts`,
+                  ),
                 }}
               />
             </span>

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultAction.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultAction.tsx
@@ -170,10 +170,10 @@ const DefaultAction = ({
       />
     ),
     roles,
-    reputationChange: `${getFormattedTokenValue(
+    reputationChange: getFormattedTokenValue(
       new Decimal(reputationChange).abs().toString(),
       decimals,
-    )} pts`,
+    ),
     isSmiteAction: new Decimal(reputationChange).isNegative(),
   };
 

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
@@ -326,10 +326,10 @@ const DefaultMotion = ({
       </div>
     ),
     spaceBreak: <br />,
-    reputationChange: `${getFormattedTokenValue(
+    reputationChange: getFormattedTokenValue(
       new Decimal(reputationChange).abs().toString(),
       decimals,
-    )} pts`,
+    ),
     isSmiteAction: new Decimal(reputationChange).isNegative(),
   };
 

--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
+import Decimal from 'decimal.js';
 
 import Icon from '~core/Icon';
 import DetailsWidgetUser from '~core/DetailsWidgetUser';
@@ -217,7 +218,10 @@ const DetailsWidget = ({
               values={{ isSmiteAction: values?.isSmiteAction }}
             />
           </div>
-          <div className={styles.value}>{values?.reputationChange}</div>
+          <div className={styles.value}>
+            {values?.reputationChange}{' '}
+            {new Decimal(values?.reputationChange || '0').eq(1) ? 'pt' : 'pts'}
+          </div>
         </div>
       )}
       {detailsForAction.Permissions && (

--- a/src/modules/dashboard/components/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.tsx
+++ b/src/modules/dashboard/components/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.tsx
@@ -87,7 +87,10 @@ const MSG = defineMessages({
     defaultMessage: `{isSmiteAction, select,
       true {max: }
       false {}
-    }{userReputationAmount} pts ({userPercentageReputation}%)`,
+    }{userReputationAmount} {userReputationAmount, plural,
+      one {pt}
+      other {pts}
+    } ({userPercentageReputation}%)`,
   },
 });
 

--- a/src/modules/dashboard/components/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.tsx
+++ b/src/modules/dashboard/components/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.tsx
@@ -356,6 +356,7 @@ const ManageReputationDialogForm = ({
               numeral: true,
               // @ts-ignore
               tailPrefix: true,
+              numeralDecimalScale: 10,
             }}
             elementOnly
             maxButtonParams={

--- a/src/modules/dashboard/components/ColonyEvents/ColonyEventsListItem.tsx
+++ b/src/modules/dashboard/components/ColonyEvents/ColonyEventsListItem.tsx
@@ -128,6 +128,9 @@ const ColonyEventsListItem = ({
         'event',
       );
     }
+    if (eventName === ColonyAndExtensionsEvents.ArbitraryReputationUpdate) {
+      return `eventList.${eventName}.title`;
+    }
     return 'eventList.event';
   }, [eventName, setTo, whiteListStatus]);
 
@@ -182,9 +185,10 @@ const ColonyEventsListItem = ({
     activePeriod,
     currentPeriod,
     reputationChange: `${getFormattedTokenValue(
-      new Decimal(amount || '0').mul(-1).toString(),
+      new Decimal(amount || '0').abs().toString(),
       decimals,
     )} pts`,
+    isSmiteAction: new Decimal(amount).isNegative(),
   };
 
   return (

--- a/src/modules/dashboard/components/ColonyEvents/ColonyEventsListItem.tsx
+++ b/src/modules/dashboard/components/ColonyEvents/ColonyEventsListItem.tsx
@@ -184,10 +184,10 @@ const ColonyEventsListItem = ({
     voteSide: <FormattedMessage {...MSG.voteSide} values={{ vote }} />,
     activePeriod,
     currentPeriod,
-    reputationChange: `${getFormattedTokenValue(
+    reputationChange: getFormattedTokenValue(
       new Decimal(amount || '0').abs().toString(),
       decimals,
-    )} pts`,
+    ),
     isSmiteAction: new Decimal(amount).isNegative(),
   };
 

--- a/src/modules/dashboard/transformers/transformers.ts
+++ b/src/modules/dashboard/transformers/transformers.ts
@@ -258,7 +258,7 @@ export const getActionsListData = (
               let actionEvent;
 
               if (
-                name.split('(')[0] ===
+                formatEventName(name) ===
                 ColonyAndExtensionsEvents.ArbitraryReputationUpdate
               ) {
                 const isSmiteAction = new Decimal(
@@ -273,7 +273,7 @@ export const getActionsListData = (
                 );
               } else {
                 actionEvent = Object.entries(ACTIONS_EVENTS).find((el) =>
-                  el[1]?.includes(name.split('(')[0]),
+                  el[1]?.includes(formatEventName(name)),
                 );
               }
 

--- a/src/modules/dashboard/transformers/transformers.ts
+++ b/src/modules/dashboard/transformers/transformers.ts
@@ -1,5 +1,6 @@
 import { AddressZero, HashZero } from 'ethers/constants';
 import { bigNumberify } from 'ethers/utils';
+import Decimal from 'decimal.js';
 
 import {
   TransactionsMessagesCount,
@@ -253,9 +254,29 @@ export const getActionsListData = (
                 },
                 name,
               } = unformattedAction;
-              const actionEvent = Object.entries(ACTIONS_EVENTS).find((el) =>
-                el[1]?.includes(name.split('(')[0]),
-              );
+
+              let actionEvent;
+
+              if (
+                name.split('(')[0] ===
+                ColonyAndExtensionsEvents.ArbitraryReputationUpdate
+              ) {
+                const isSmiteAction = new Decimal(
+                  processedValues.amount,
+                ).isNegative();
+                actionEvent = Object.entries(ACTIONS_EVENTS).find(
+                  (el) =>
+                    (isSmiteAction &&
+                      el[0] === ColonyActions.EmitDomainReputationPenalty) ||
+                    (!isSmiteAction &&
+                      el[0] === ColonyActions.EmitDomainReputationReward),
+                );
+              } else {
+                actionEvent = Object.entries(ACTIONS_EVENTS).find((el) =>
+                  el[1]?.includes(name.split('(')[0]),
+                );
+              }
+
               const checksummedColonyAddress = createAddress(colonyAddress);
               const actionType =
                 (actionEvent && (actionEvent[0] as ColonyActions)) ||

--- a/src/utils/colonyActions.ts
+++ b/src/utils/colonyActions.ts
@@ -114,6 +114,7 @@ export const getValuesForActionType = (
           initiator: values?.user || colonyAddress,
         };
       }
+      case ColonyActions.EmitDomainReputationReward:
       case ColonyActions.EmitDomainReputationPenalty: {
         return {
           recipient: values.user,


### PR DESCRIPTION
Integrated award action and motion with the copies for the action and event list. The action should now appear as expected and not with the copy of smite or missing data in the copy.

This should be the last feature PR for `Award` before the feature is ready to be merged and tested on QA, just like `Smite`.

Resolves #2702 
