### PR TITLE
Fix claiming tokens when coin machine is installed and token is unlocked

### DIFF
--- a/src/modules/dashboard/sagas/extensions/colonyExtensionEnable.ts
+++ b/src/modules/dashboard/sagas/extensions/colonyExtensionEnable.ts
@@ -182,11 +182,14 @@ function* colonyExtensionEnable({
       }
 
       if (shouldSetNewTokenAuthority) {
+        const { networkClient } = colonyManager;
+        const tokenLockingAddress = yield networkClient.getTokenLocking();
+
         yield createGroupTransaction(deployTokenAuthority, {
           context: ClientType.ColonyClient,
           methodName: 'deployTokenAuthority',
           identifier: colonyAddress,
-          params: [payload.tokenToBeSold, [address]],
+          params: [payload.tokenToBeSold, [address, tokenLockingAddress]],
         });
 
         yield createGroupTransaction(makeArbitraryTransaction, {


### PR DESCRIPTION
## Description

This PR fixes the bug where you can't activate tokens when coin machine is installed and token is still locked.

The fix is to add `tokenLockingAddress` to the `deployTokenAuthority` transaction when you enable coin machine.

Testing:

- create a colony
- mint tokens
- install & enable coin machine
- send tokens to coin machine
- buy tokens
- create a payment
- activate tokens

All of this operations should work without any problems. Before the fix the activate tokens part wouldn't work.

**Changes** 🏗

- update `extensionEnable` saga

Resolves #3033 