### PR TITLE
Show full colony name while creating colony

### DIFF
--- a/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.css
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.css
@@ -6,6 +6,10 @@
   margin-top: 180px;
 }
 
+.titleSection span {
+  word-break: break-word;
+}
+
 .inputFields {
   margin-top: 40px;
 }

--- a/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.tsx
@@ -7,7 +7,6 @@ import { Form, FormStatus, Input } from '~core/Fields';
 import Heading from '~core/Heading';
 import Button from '~core/Button';
 import { multiLineTextEllipsis } from '~utils/strings';
-import ENS from '~lib/ENS';
 import styles from './StepCreateToken.css';
 
 const MSG = defineMessages({
@@ -82,6 +81,7 @@ type FormValues = {
   tokenAddress: string;
   colonyName: string;
   tokenChoice: string;
+  displayName: string;
 };
 
 type Props = WizardProps<FormValues>;
@@ -135,11 +135,8 @@ const StepCreateToken = ({
                    * inside a sentence that does not
                    */
                   colony: (
-                    <span title={ENS.normalizeAsText(wizardValues.colonyName)}>
-                      {multiLineTextEllipsis(
-                        ENS.normalizeAsText(wizardValues.colonyName),
-                        40,
-                      )}
+                    <span title={wizardValues.displayName}>
+                      {multiLineTextEllipsis(wizardValues.displayName, 40)}
                     </span>
                   ),
                 }}

--- a/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.tsx
@@ -136,7 +136,7 @@ const StepCreateToken = ({
                    */
                   colony: (
                     <span title={wizardValues.displayName}>
-                      {multiLineTextEllipsis(wizardValues.displayName, 40)}
+                      {multiLineTextEllipsis(wizardValues.displayName, 120)}
                     </span>
                   ),
                 }}

--- a/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.css
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.css
@@ -18,6 +18,10 @@
   font-weight: var(--weight-bold);
 }
 
+.title span {
+  word-break: break-word;
+}
+
 .tokenDetails {
   margin-top: 50px;
 }

--- a/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.tsx
@@ -11,7 +11,6 @@ import { Form, Input } from '~core/Fields';
 import Heading from '~core/Heading';
 import Button from '~core/Button';
 import { multiLineTextEllipsis } from '~utils/strings';
-import ENS from '~lib/ENS';
 import { OneToken } from '~data/index';
 
 import TokenSelector from './TokenSelector';
@@ -26,6 +25,7 @@ interface FormValues {
   tokenIcon?: string;
   tokenData: OneToken | null;
   colonyName: string;
+  displayName: string;
 }
 
 type Bag = FormikBag<object, FormValues>;
@@ -146,11 +146,8 @@ const StepSelectToken = ({
                * inside a sentence that does not
                */
               colony: (
-                <span title={ENS.normalizeAsText(wizardValues.colonyName)}>
-                  {multiLineTextEllipsis(
-                    ENS.normalizeAsText(wizardValues.colonyName),
-                    38,
-                  )}
+                <span title={wizardValues.displayName}>
+                  {multiLineTextEllipsis(wizardValues.displayName, 38)}
                 </span>
               ),
             }}

--- a/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.tsx
@@ -147,7 +147,7 @@ const StepSelectToken = ({
                */
               colony: (
                 <span title={wizardValues.displayName}>
-                  {multiLineTextEllipsis(wizardValues.displayName, 38)}
+                  {multiLineTextEllipsis(wizardValues.displayName, 120)}
                 </span>
               ),
             }}

--- a/src/modules/dashboard/components/CreateColonyWizard/StepTokenChoice.css
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepTokenChoice.css
@@ -12,6 +12,10 @@
   font-weight: var(--weight-bold);
 }
 
+.title span {
+  word-break: break-word;
+}
+
 .subtitle {
   margin-bottom: -7px;
   font-size: 14px;

--- a/src/modules/dashboard/components/CreateColonyWizard/StepTokenChoice.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepTokenChoice.tsx
@@ -108,7 +108,7 @@ const StepTokenChoice = ({ nextStep, wizardForm, wizardValues }: Props) => (
                */
               colony: (
                 <span title={wizardValues.displayName}>
-                  {multiLineTextEllipsis(wizardValues.displayName, 29)}
+                  {multiLineTextEllipsis(wizardValues.displayName, 120)}
                 </span>
               ),
             }}

--- a/src/modules/dashboard/components/CreateColonyWizard/StepTokenChoice.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepTokenChoice.tsx
@@ -7,7 +7,6 @@ import ExternalLink from '~core/ExternalLink';
 import DecisionHub from '~core/DecisionHub';
 import { Form } from '~core/Fields';
 import { multiLineTextEllipsis } from '~utils/strings';
-import ENS from '~lib/ENS';
 
 import styles from './StepTokenChoice.css';
 
@@ -87,6 +86,7 @@ const options = [
 interface FormValues {
   tokenChoice: string;
   colonyName: string;
+  displayName: string;
 }
 
 type Props = WizardProps<FormValues>;
@@ -107,11 +107,8 @@ const StepTokenChoice = ({ nextStep, wizardForm, wizardValues }: Props) => (
                * inside a sentence that does not
                */
               colony: (
-                <span title={ENS.normalizeAsText(wizardValues.colonyName)}>
-                  {multiLineTextEllipsis(
-                    ENS.normalizeAsText(wizardValues.colonyName),
-                    29,
-                  )}
+                <span title={wizardValues.displayName}>
+                  {multiLineTextEllipsis(wizardValues.displayName, 29)}
                 </span>
               ),
             }}


### PR DESCRIPTION
## Description

Shows full colony name instead of ENS name in the Create Colony Wizard.

![Screenshot 2022-01-25 at 13-34-57 Colony](https://user-images.githubusercontent.com/14034137/150942866-e71b3867-7f3e-4a8c-bf6e-f4229ff9fa93.png)
![Screenshot 2022-01-25 at 13-35-10 Colony](https://user-images.githubusercontent.com/14034137/150942877-f7126e61-4cca-4065-a98d-5f40fb891eca.png)
![Screenshot 2022-01-25 at 13-35-16 Colony](https://user-images.githubusercontent.com/14034137/150942881-1be75ace-2900-4e6f-ad63-1fddd34d53ec.png)


**Note to reviewers**
- Was the ENS normalization useful for something I am totally missing?


Resolves #3128.
