### PR TITLE
Disable action submit button on submit

### DIFF
--- a/src/modules/core/components/Button/Button.css
+++ b/src/modules/core/components/Button/Button.css
@@ -68,7 +68,7 @@
  * Disabled styles via `disabled` attribute
  */
 
-.main[disabled]:not([aria-busy="true"]) {
+.main[disabled] {
   border-color: disabledBackground;
   background-color: disabledBackground;
   color: disabledColor;

--- a/src/modules/core/components/Comment/Dialogs/BanUser/BanUser.tsx
+++ b/src/modules/core/components/Comment/Dialogs/BanUser/BanUser.tsx
@@ -170,7 +170,9 @@ const BanUser = ({ colonyAddress, cancel, close, isBanning = true }: Props) => {
                 name="userAddress"
                 filter={filterUserSelection}
                 renderAvatar={supRenderAvatar}
-                disabled={loadingBannedUsers || loadingBanAction}
+                disabled={
+                  loadingBannedUsers || loadingBanAction || isSubmitting
+                }
               />
             </div>
           </DialogSection>
@@ -194,7 +196,7 @@ const BanUser = ({ colonyAddress, cancel, close, isBanning = true }: Props) => {
                   size: 'large',
                 }}
                 text={isBanning ? MSG.banish : MSG.deactivateBan}
-                disabled={!isValid}
+                disabled={!isValid || isSubmitting}
                 loading={loadingBanAction || isSubmitting}
                 onClick={submitForm}
               />

--- a/src/modules/core/components/TokenEditDialog/TokenEditDialog.tsx
+++ b/src/modules/core/components/TokenEditDialog/TokenEditDialog.tsx
@@ -144,7 +144,11 @@ const TokenEditDialog = ({
               text={MSG.title}
             />
             {canEditTokens && isVotingExtensionEnabled && (
-              <Toggle label={{ id: 'label.force' }} name="forceAction" />
+              <Toggle
+                label={{ id: 'label.force' }}
+                name="forceAction"
+                disabled={isSubmitting}
+              />
             )}
           </div>
         </div>

--- a/src/modules/core/components/TokenEditDialog/TokenEditDialog.tsx
+++ b/src/modules/core/components/TokenEditDialog/TokenEditDialog.tsx
@@ -111,7 +111,7 @@ const TokenEditDialog = ({
     values.forceAction,
   );
 
-  const inputDisabled = !userHasPermission || onlyForceAction;
+  const inputDisabled = !userHasPermission || onlyForceAction || isSubmitting;
 
   const allTokens = useMemo(() => {
     return [...tokens, ...(canEditTokens ? tokensList : [])].filter(

--- a/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
@@ -327,7 +327,9 @@ const FinalizeMotionAndClaimWidget = ({
                   <Button
                     appearance={{ theme: 'primary', size: 'medium' }}
                     text={MSG.finalizeButton}
-                    disabled={!hasRegisteredProfile || !isFinalizable}
+                    disabled={
+                      !hasRegisteredProfile || !isFinalizable || isSubmitting
+                    }
                     onClick={() => handleSubmit()}
                     loading={isSubmitting}
                   />
@@ -370,7 +372,8 @@ const FinalizeMotionAndClaimWidget = ({
                     disabled={
                       !hasRegisteredProfile ||
                       !canClaimStakes ||
-                      stakerRewards?.motionStakerReward?.claimedReward
+                      stakerRewards?.motionStakerReward?.claimedReward ||
+                      isSubmitting
                     }
                     onClick={() => handleSubmit()}
                     loading={isSubmitting}

--- a/src/modules/dashboard/components/ActionsPage/InputStorageWidget/InputStorageWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/InputStorageWidget/InputStorageWidget.tsx
@@ -233,7 +233,7 @@ const InputStorageWidget = ({
                 theme: 'fat',
                 colorSchema: 'grey',
               }}
-              disabled={!hasRegisteredProfile}
+              disabled={!hasRegisteredProfile || isSubmitting}
             />
             {storageSlotLocationError && (
               <span className={styles.inputValidationError}>
@@ -273,7 +273,9 @@ const InputStorageWidget = ({
                 theme: 'fat',
                 colorSchema: 'grey',
               }}
-              disabled={!hasRegisteredProfile || !userHasPermission}
+              disabled={
+                !hasRegisteredProfile || !userHasPermission || isSubmitting
+              }
             />
             {newStorageSlotValueError && (
               <span className={styles.inputValidationError}>
@@ -290,7 +292,8 @@ const InputStorageWidget = ({
                   disabled={
                     !isValid ||
                     !storageSlotLocationValue ||
-                    !newStorageSlotValue
+                    !newStorageSlotValue ||
+                    isSubmitting
                   }
                 />
               </div>

--- a/src/modules/dashboard/components/ActionsPage/RevealWidget/RevealWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/RevealWidget/RevealWidget.tsx
@@ -178,7 +178,8 @@ const RevealWidget = ({
                 disabled={
                   !hasRegisteredProfile ||
                   revealed ||
-                  !userVoted?.motionCurrentUserVoted
+                  !userVoted?.motionCurrentUserVoted ||
+                  isSubmitting
                 }
                 onClick={() => handleSubmit()}
                 loading={isSubmitting}

--- a/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteWidget.tsx
@@ -169,7 +169,7 @@ const VoteWidget = ({
             options={options(values.vote)}
             currentlyCheckedValue={values.vote}
             name="vote"
-            disabled={inputDisabled}
+            disabled={inputDisabled || isSubmitting}
           />
           <VoteDetails
             colony={colony}
@@ -184,7 +184,8 @@ const VoteWidget = ({
                   !isValid ||
                   !hasRegisteredProfile ||
                   !values.vote ||
-                  !hasReputationToVote
+                  !hasReputationToVote ||
+                  isSubmitting
                 }
                 onClick={() => handleSubmit()}
                 loading={isSubmitting}

--- a/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
+++ b/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
@@ -402,7 +402,7 @@ const BuyTokens = ({
                       }}
                       label={MSG.amountLabel}
                       name="amount"
-                      disabled={globalDisable || isSoldOut}
+                      disabled={globalDisable || isSoldOut || isSubmitting}
                       elementOnly
                     />
                     {errors?.amount && (
@@ -432,7 +432,7 @@ const BuyTokens = ({
                           onClick={(event) =>
                             handleSetMaxAmount(event, setFieldValue)
                           }
-                          disabled={isSoldOut}
+                          disabled={isSoldOut || isSubmitting}
                         />
                       </div>
                     )}
@@ -540,7 +540,8 @@ const BuyTokens = ({
                         globalDisable ||
                         isSoldOut ||
                         !isValid ||
-                        toFinite(values.amount) <= 0
+                        toFinite(values.amount) <= 0 ||
+                        isSubmitting
                       }
                     />
                   )}

--- a/src/modules/dashboard/components/CreateColonyWizard/StepColonyName.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepColonyName.tsx
@@ -200,7 +200,7 @@ const StepColonyName = ({
                 name="displayName"
                 data-test="claimColonyDisplayNameInput"
                 label={MSG.labelDisplay}
-                disabled={!isNetworkAllowed}
+                disabled={!isNetworkAllowed || isSubmitting}
               />
               <Input
                 appearance={{ theme: 'fat' }}
@@ -212,7 +212,7 @@ const StepColonyName = ({
                 status={normalized !== colonyName ? MSG.statusText : undefined}
                 formattingOptions={{ lowercase: true, blocks: [256] }}
                 statusValues={{ normalized }}
-                disabled={!isNetworkAllowed}
+                disabled={!isNetworkAllowed || isSubmitting}
                 extra={
                   <QuestionMarkTooltip
                     iconTitle="helper"
@@ -231,7 +231,10 @@ const StepColonyName = ({
                   type="submit"
                   data-test="claimColonyNameConfirm"
                   disabled={
-                    !isNetworkAllowed || !isValid || (!dirty && !stepCompleted)
+                    !isNetworkAllowed ||
+                    !isValid ||
+                    (!dirty && !stepCompleted) ||
+                    isSubmitting
                   }
                   loading={isSubmitting}
                   text={MSG.continue}

--- a/src/modules/dashboard/components/CreateColonyWizard/StepConfirmAllInput.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepConfirmAllInput.tsx
@@ -112,6 +112,7 @@ const StepConfirmAllInput = ({
               data-test="userInputConfirm"
               text={MSG.continue}
               loading={isSubmitting}
+              disabled={isSubmitting}
             />
           </div>
         </section>

--- a/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.tsx
@@ -154,6 +154,7 @@ const StepCreateToken = ({
                 label={MSG.labelTokenName}
                 help={MSG.helpTokenName}
                 data-test="defineTokenName"
+                disabled={isSubmitting}
                 extra={
                   <button
                     type="button"
@@ -175,6 +176,7 @@ const StepCreateToken = ({
                 formattingOptions={{ uppercase: true, blocks: [5] }}
                 label={MSG.labelTokenSymbol}
                 help={MSG.helpTokenSymbol}
+                disabled={isSubmitting}
               />
             </div>
           </section>
@@ -185,7 +187,7 @@ const StepCreateToken = ({
               text={MSG.nextButton}
               type="submit"
               data-test="definedTokenConfirm"
-              disabled={!isValid || (!dirty && !stepCompleted)}
+              disabled={!isValid || (!dirty && !stepCompleted) || isSubmitting}
               loading={isSubmitting}
             />
           </section>

--- a/src/modules/dashboard/components/CreateColonyWizard/StepUserName.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepUserName.tsx
@@ -145,7 +145,7 @@ const StepUserName = ({ stepCompleted, wizardForm, nextStep }: Props) => {
                   }}
                   formattingOptions={{ lowercase: true, blocks: [100] }}
                   data-test="claimUsernameInput"
-                  disabled={!isNetworkAllowed}
+                  disabled={!isNetworkAllowed || isSubmitting}
                 />
                 <div className={styles.buttons}>
                   <p className={styles.reminder}>
@@ -163,7 +163,8 @@ const StepUserName = ({ stepCompleted, wizardForm, nextStep }: Props) => {
                     disabled={
                       !isNetworkAllowed ||
                       !isValid ||
-                      (!dirty && !stepCompleted)
+                      (!dirty && !stepCompleted) ||
+                      isSubmitting
                     }
                     loading={isSubmitting}
                     text={MSG.continue}

--- a/src/modules/dashboard/components/CreateUserWizard/StepUserName.tsx
+++ b/src/modules/dashboard/components/CreateUserWizard/StepUserName.tsx
@@ -147,13 +147,15 @@ const StepUserName = ({ wizardValues, nextStep }: Props) => {
                     normalized,
                   }}
                   formattingOptions={{ lowercase: true, blocks: [100] }}
-                  disabled={!isNetworkAllowed}
+                  disabled={!isNetworkAllowed || isSubmitting}
                 />
                 <div className={styles.buttons}>
                   <Button
                     appearance={{ theme: 'primary', size: 'large' }}
                     type="submit"
-                    disabled={!isNetworkAllowed || !isValid || !dirty}
+                    disabled={
+                      !isNetworkAllowed || !isValid || !dirty || isSubmitting
+                    }
                     loading={isSubmitting}
                     text={MSG.continue}
                     data-test="claimUsernameConfirm"

--- a/src/modules/dashboard/components/Dialogs/CreateDomainDialog/CreateDomainDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/CreateDomainDialog/CreateDomainDialogForm.tsx
@@ -82,7 +82,7 @@ const CreateDomainDialogForm = ({
     values.forceAction,
   );
 
-  const inputDisabled = !userHasPermission || onlyForceAction;
+  const inputDisabled = !userHasPermission || onlyForceAction || isSubmitting;
 
   return (
     <>

--- a/src/modules/dashboard/components/Dialogs/CreateDomainDialog/CreateDomainDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/CreateDomainDialog/CreateDomainDialogForm.tsx
@@ -105,7 +105,11 @@ const CreateDomainDialogForm = ({
               text={MSG.titleCreate}
             />
             {canCreateDomain && isVotingExtensionEnabled && (
-              <Toggle label={{ id: 'label.force' }} name="forceAction" />
+              <Toggle
+                label={{ id: 'label.force' }}
+                name="forceAction"
+                disabled={isSubmitting}
+              />
             )}
           </div>
         </div>

--- a/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
@@ -311,7 +311,7 @@ const CreatePaymentDialogForm = ({
 
   const canMakePayment = userHasPermission && isOneTxPaymentExtensionEnabled;
 
-  const inputDisabled = !canMakePayment || onlyForceAction;
+  const inputDisabled = !canMakePayment || onlyForceAction || isSubmitting;
 
   return (
     <>
@@ -322,7 +322,7 @@ const CreatePaymentDialogForm = ({
               <MotionDomainSelect
                 colony={colony}
                 onDomainChange={handleMotionDomainChange}
-                disabled={values.forceAction}
+                disabled={values.forceAction || isSubmitting}
                 /*
                  * @NOTE We can only create a motion to vote in a subdomain if we
                  * create a payment from that subdomain
@@ -361,6 +361,7 @@ const CreatePaymentDialogForm = ({
               name="domainId"
               appearance={{ theme: 'grey', width: 'fluid' }}
               onChange={handleFromDomainChange}
+              disabled={isSubmitting}
             />
             {!!tokenAddress && (
               <div className={styles.domainPotBalance}>

--- a/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
@@ -341,7 +341,7 @@ const CreatePaymentDialogForm = ({
               <Toggle
                 label={{ id: 'label.force' }}
                 name="forceAction"
-                disabled={!canMakePayment}
+                disabled={!canMakePayment || isSubmitting}
               />
             )}
           </div>

--- a/src/modules/dashboard/components/Dialogs/EditColonyDetailsDialog/EditColonyDetailsDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/EditColonyDetailsDialog/EditColonyDetailsDialogForm.tsx
@@ -91,7 +91,7 @@ const EditColonyDetailsDialogForm = ({
     forceAction,
   );
 
-  const inputDisabled = !userHasPermission || onlyForceAction;
+  const inputDisabled = !userHasPermission || onlyForceAction || isSubmitting;
 
   /*
    * Note that these threee methods just read the file locally, they don't actually
@@ -279,7 +279,11 @@ const EditColonyDetailsDialogForm = ({
           onClick={() => handleSubmit()}
           loading={isSubmitting}
           disabled={
-            inputDisabled || !isValid || avatarFileError || !canValuesBeUpdate
+            inputDisabled ||
+            !isValid ||
+            avatarFileError ||
+            !canValuesBeUpdate ||
+            isSubmitting
           }
         />
       </DialogSection>

--- a/src/modules/dashboard/components/Dialogs/EditColonyDetailsDialog/EditColonyDetailsDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/EditColonyDetailsDialog/EditColonyDetailsDialogForm.tsx
@@ -157,7 +157,11 @@ const EditColonyDetailsDialogForm = ({
               text={MSG.title}
             />
             {canEdit && isVotingExtensionEnabled && (
-              <Toggle label={{ id: 'label.force' }} name="forceAction" />
+              <Toggle
+                label={{ id: 'label.force' }}
+                name="forceAction"
+                disabled={isSubmitting}
+              />
             )}
           </div>
         </div>

--- a/src/modules/dashboard/components/Dialogs/EditDomainDialog/EditDomainDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/EditDomainDialog/EditDomainDialogForm.tsx
@@ -203,7 +203,7 @@ const EditDomainDialogForm = ({
               <Toggle
                 label={{ id: 'label.force' }}
                 name="forceAction"
-                disabled={!canEditDomain}
+                disabled={!canEditDomain || isSubmitting}
               />
             )}
           </div>

--- a/src/modules/dashboard/components/Dialogs/EditDomainDialog/EditDomainDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/EditDomainDialog/EditDomainDialogForm.tsx
@@ -112,7 +112,7 @@ const EditDomainDialogForm = ({
   const canEditDomain =
     userHasPermission && Object.keys(domainOptions).length > 0;
 
-  const inputDisabled = !canEditDomain || onlyForceAction;
+  const inputDisabled = !canEditDomain || onlyForceAction || isSubmitting;
 
   const handleDomainChange = useCallback(
     (selectedDomainValue) => {
@@ -223,6 +223,7 @@ const EditDomainDialogForm = ({
               onChange={handleDomainChange}
               name="domainId"
               appearance={{ theme: 'grey', width: 'fluid' }}
+              disabled={isSubmitting}
             />
           </div>
           <ColorSelect

--- a/src/modules/dashboard/components/Dialogs/NetworkContractUpgradeDialog/NetworkContractUpgradeDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/NetworkContractUpgradeDialog/NetworkContractUpgradeDialogForm.tsx
@@ -152,7 +152,11 @@ const NetworkContractUpgradeDialogForm = ({
               text={MSG.title}
             />
             {canUpgradeVersion && isVotingExtensionEnabled && (
-              <Toggle label={{ id: 'label.force' }} name="forceAction" />
+              <Toggle
+                label={{ id: 'label.force' }}
+                name="forceAction"
+                disabled={isSubmitting}
+              />
             )}
           </div>
         </div>

--- a/src/modules/dashboard/components/Dialogs/NetworkContractUpgradeDialog/NetworkContractUpgradeDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/NetworkContractUpgradeDialog/NetworkContractUpgradeDialogForm.tsx
@@ -119,7 +119,7 @@ const NetworkContractUpgradeDialogForm = ({
   const canUpgradeVersion =
     userHasPermission && !!colonyCanBeUpgraded(colony, newVersion as string);
 
-  const inputDisabled = !canUpgradeVersion || onlyForceAction;
+  const inputDisabled = !canUpgradeVersion || onlyForceAction || isSubmitting;
 
   const PREVENT_UPGRADE_IF_LEGACY_RECOVERY_ROLES =
     /*
@@ -263,7 +263,11 @@ const NetworkContractUpgradeDialogForm = ({
         <Button
           appearance={{ theme: 'primary', size: 'large' }}
           text={{ id: 'button.confirm' }}
-          disabled={inputDisabled || PREVENT_UPGRADE_IF_LEGACY_RECOVERY_ROLES}
+          disabled={
+            inputDisabled ||
+            PREVENT_UPGRADE_IF_LEGACY_RECOVERY_ROLES ||
+            isSubmitting
+          }
           onClick={() => handleSubmit()}
           loading={isSubmitting || loadingLegacyRecoveyRole}
         />

--- a/src/modules/dashboard/components/Dialogs/PermissionManagementDialog/PermissionManagementDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/PermissionManagementDialog/PermissionManagementDialog.tsx
@@ -231,6 +231,7 @@ const PermissionManagementDialog = ({
                   onMotionDomainChange={setSelectedMoitonDomainId}
                   onChangeSelectedUser={setSelectedUser}
                   inputDisabled={inputDisabled || isSubmitting}
+                  isSubmitting={isSubmitting}
                   userHasPermission={userHasPermission}
                   isVotingExtensionEnabled={isVotingExtensionEnabled}
                 />

--- a/src/modules/dashboard/components/Dialogs/PermissionManagementDialog/PermissionManagementDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/PermissionManagementDialog/PermissionManagementDialog.tsx
@@ -230,7 +230,7 @@ const PermissionManagementDialog = ({
                   onDomainSelected={setSelectedDomainId}
                   onMotionDomainChange={setSelectedMoitonDomainId}
                   onChangeSelectedUser={setSelectedUser}
-                  inputDisabled={inputDisabled}
+                  inputDisabled={inputDisabled || isSubmitting}
                   userHasPermission={userHasPermission}
                   isVotingExtensionEnabled={isVotingExtensionEnabled}
                 />
@@ -278,7 +278,11 @@ const PermissionManagementDialog = ({
                     disabled={
                       inputDisabled ||
                       !isValid ||
-                      isEqual(sortBy(values.roles), sortBy(initialValues.roles))
+                      isEqual(
+                        sortBy(values.roles),
+                        sortBy(initialValues.roles),
+                      ) ||
+                      isSubmitting
                     }
                   />
                 </DialogSection>

--- a/src/modules/dashboard/components/Dialogs/PermissionManagementDialog/PermissionManagementForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/PermissionManagementDialog/PermissionManagementForm.tsx
@@ -92,6 +92,7 @@ const PermissionManagementForm = ({
   onMotionDomainChange,
   onChangeSelectedUser,
   values,
+  isSubmitting,
 }: Props & FormikProps<FormValues>) => {
   const { data: colonyMembers } = useMembersSubscription({
     variables: {
@@ -260,7 +261,11 @@ const PermissionManagementForm = ({
               textValues={{ domain: domain?.name }}
             />
             {canEditPermissions && isVotingExtensionEnabled && (
-              <Toggle label={{ id: 'label.force' }} name="forceAction" />
+              <Toggle
+                label={{ id: 'label.force' }}
+                name="forceAction"
+                disabled={isSubmitting}
+              />
             )}
           </div>
         </div>

--- a/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialogForm.tsx
@@ -89,7 +89,7 @@ const RaiseObjectionDialogForm = ({
         <div className={styles.slider}>
           <StakingSlider
             colony={colony}
-            canUserStake={canUserStake}
+            canUserStake={canUserStake && !isSubmitting}
             values={values}
             appearance={{ theme: 'danger', size: 'thick' }}
             isObjection
@@ -105,7 +105,7 @@ const RaiseObjectionDialogForm = ({
           label={MSG.annotation}
           name="annotation"
           maxLength={4000}
-          disabled={!canUserStake}
+          disabled={!canUserStake || isSubmitting}
         />
       </DialogSection>
       <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
@@ -121,7 +121,11 @@ const RaiseObjectionDialogForm = ({
             onClick={() => handleSubmit()}
             type="submit"
             loading={isSubmitting}
-            disabled={!canUserStake || userActivatedTokens.lt(decimalAmount)}
+            disabled={
+              !canUserStake ||
+              userActivatedTokens.lt(decimalAmount) ||
+              isSubmitting
+            }
           />
         </span>
       </DialogSection>

--- a/src/modules/dashboard/components/Dialogs/RecoveryModeDialog/RecoveryModeDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/RecoveryModeDialog/RecoveryModeDialogForm.tsx
@@ -117,7 +117,7 @@ const RecoveryModeDialogForm = ({
         <Annotations
           label={MSG.annotation}
           name="annotation"
-          disabled={!userHasPermission}
+          disabled={!userHasPermission || isSubmitting}
         />
       </DialogSection>
       {!userHasPermission && (
@@ -150,7 +150,7 @@ const RecoveryModeDialogForm = ({
           text={{ id: 'button.confirm' }}
           onClick={() => handleSubmit()}
           loading={isSubmitting}
-          disabled={!userHasPermission}
+          disabled={!userHasPermission || isSubmitting}
         />
       </DialogSection>
     </>

--- a/src/modules/dashboard/components/Dialogs/SmiteDialog/SmiteDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/SmiteDialog/SmiteDialogForm.tsx
@@ -267,7 +267,7 @@ const SmiteDialogForm = ({
               <Toggle
                 label={{ id: 'label.force' }}
                 name="forceAction"
-                disabled={!userHasPermission}
+                disabled={!userHasPermission || isSubmitting}
               />
             )}
           </div>

--- a/src/modules/dashboard/components/Dialogs/TokenMintDialog/TokenMintForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/TokenMintDialog/TokenMintForm.tsx
@@ -76,7 +76,7 @@ const TokenMintForm = ({
     values.forceAction,
   );
 
-  const inputDisabled = !userHasPermission || onlyForceAction;
+  const inputDisabled = !userHasPermission || onlyForceAction || isSubmitting;
 
   return (
     <>

--- a/src/modules/dashboard/components/Dialogs/TokenMintDialog/TokenMintForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/TokenMintDialog/TokenMintForm.tsx
@@ -99,7 +99,11 @@ const TokenMintForm = ({
               text={MSG.title}
             />
             {canUserMintNativeToken && isVotingExtensionEnabled && (
-              <Toggle label={{ id: 'label.force' }} name="forceAction" />
+              <Toggle
+                label={{ id: 'label.force' }}
+                name="forceAction"
+                disabled={isSubmitting}
+              />
             )}
           </div>
         </div>

--- a/src/modules/dashboard/components/Dialogs/TransferFundsDialog/TransferFundsDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/TransferFundsDialog/TransferFundsDialogForm.tsx
@@ -150,7 +150,7 @@ const TransferFundsDialogForm = ({
     values.forceAction,
   );
 
-  const inputDisabled = !userHasPermission || onlyForceAction;
+  const inputDisabled = !userHasPermission || onlyForceAction || isSubmitting;
 
   const [
     loadTokenBalances,

--- a/src/modules/dashboard/components/Dialogs/TransferFundsDialog/TransferFundsDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/TransferFundsDialog/TransferFundsDialogForm.tsx
@@ -259,7 +259,11 @@ const TransferFundsDialogForm = ({
               text={MSG.title}
             />
             {canTransferFunds && isVotingExtensionEnabled && (
-              <Toggle label={{ id: 'label.force' }} name="forceAction" />
+              <Toggle
+                label={{ id: 'label.force' }}
+                name="forceAction"
+                disabled={isSubmitting}
+              />
             )}
           </div>
         </div>

--- a/src/modules/dashboard/components/Dialogs/UnlockTokenDialog/UnlockTokenForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/UnlockTokenDialog/UnlockTokenForm.tsx
@@ -139,7 +139,7 @@ const UnlockTokenForm = ({
           onClick={() => handleSubmit()}
           text={{ id: 'button.confirm' }}
           loading={isSubmitting}
-          disabled={!isValid || !canUserUnlockNativeToken}
+          disabled={!isValid || !canUserUnlockNativeToken || isSubmitting}
         />
       </DialogSection>
     </>

--- a/src/modules/dashboard/components/Extensions/ExtensionSetup.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionSetup.tsx
@@ -385,6 +385,7 @@ const ExtensionSetup = ({
                     ? MSG[`${paramName}Error`]
                     : undefined
                 }
+                disabled={formikBag.isSubmitting}
               />
               <p className={styles.inputsDescription}>
                 <FormattedMessage
@@ -415,7 +416,10 @@ const ExtensionSetup = ({
                 appearance={{ colorSchema: 'grey' }}
                 label={title}
                 name={paramName}
-                disabled={disabled && disabled(formikBag.values)}
+                disabled={
+                  (disabled && disabled(formikBag.values)) ||
+                  formikBag.isSubmitting
+                }
                 extra={
                   description && (
                     <p className={styles.textAreaDescription}>
@@ -461,6 +465,7 @@ const ExtensionSetup = ({
                       formikBag,
                     )
                   }
+                  disabled={formikBag.isSubmitting}
                 />
               </div>
               <div className={styles.tokenAddessLink}>
@@ -533,7 +538,11 @@ const ExtensionSetup = ({
             </div>
           )}
           <div className={styles.inputContainer}>
-            {displayParams(initializationParams, formikBag, false)}
+            {displayParams(
+              initializationParams,
+              { ...formikBag, isSubmitting },
+              false,
+            )}
           </div>
           {extraInitParams && <div className={styles.divider} />}
           <IconButton
@@ -543,7 +552,8 @@ const ExtensionSetup = ({
             loading={isSubmitting}
             disabled={
               !isValid ||
-              Object.values(formikBag?.status || {}).some((value) => !!value)
+              Object.values(formikBag?.status || {}).some((value) => !!value) ||
+              isSubmitting
             }
           />
         </div>

--- a/src/modules/dashboard/components/Wallet/UserTokenEditDialogForm.tsx
+++ b/src/modules/dashboard/components/Wallet/UserTokenEditDialogForm.tsx
@@ -182,7 +182,7 @@ const UserTokenEditDialogForm = ({
                 tokenData={tokenData}
                 label={MSG.fieldLabel}
                 appearance={{ colorSchema: 'grey', theme: 'fat' }}
-                disabled={!hasRegisteredProfile}
+                disabled={!hasRegisteredProfile || isSubmitting}
               />
             </DialogSection>
             {!hasRegisteredProfile && (
@@ -206,7 +206,8 @@ const UserTokenEditDialogForm = ({
                   tokenSelectorHasError ||
                   !isValid ||
                   !hasRegisteredProfile ||
-                  !hasTokensListChanged(values)
+                  !hasTokensListChanged(values) ||
+                  isSubmitting
                 }
                 type="submit"
                 style={{ width: styles.wideButton }}

--- a/src/modules/dashboard/components/Whitelist/UploadAddressesWidget/UploadAddressesWidget.tsx
+++ b/src/modules/dashboard/components/Whitelist/UploadAddressesWidget/UploadAddressesWidget.tsx
@@ -155,7 +155,7 @@ const UploadAddressesWidget = ({
                 appearance={{ theme: 'blue' }}
                 text={showInput ? MSG.upload : MSG.input}
                 onClick={toggleShowInput}
-                disabled={processingCSVData}
+                disabled={processingCSVData || isSubmitting}
               />
             </div>
           </div>

--- a/src/modules/users/components/ConnectWalletWizard/StepGanache/StepGanache.tsx
+++ b/src/modules/users/components/ConnectWalletWizard/StepGanache/StepGanache.tsx
@@ -128,6 +128,7 @@ const StepGanache = ({
               name="privateKey"
               onChange={(value) => setPrivateKey(value)}
               options={accounts}
+              disabled={isSubmitting}
             />
           </div>
           <div className={styles.actions}>


### PR DESCRIPTION
All the submit buttons which had a loading state when submitting should now be disabled instead of showing the primary color.

This includes all the submit buttons in the UAC, and some others like the one in the banning user dialog (So long as a button has a loading state, they are included).

Resolves #3124
