### PR TITLE
Cancel team selector disable when no reputation in Smite

### DIFF
--- a/src/modules/dashboard/components/SmiteDialog/SmiteDialogForm.tsx
+++ b/src/modules/dashboard/components/SmiteDialog/SmiteDialogForm.tsx
@@ -302,7 +302,7 @@ const SmiteDialogForm = ({
               name="domainId"
               appearance={{ theme: 'grey', width: 'fluid' }}
               renderActiveOption={renderActiveOption}
-              disabled={inputDisabled}
+              disabled={!userHasPermission && !isVotingExtensionEnabled}
             />
           </div>
         </div>


### PR DESCRIPTION
## Description

This PR removes disabled state from team selector when voting extension is enabled and there is no reputation in a team. This way we can choose a different team where potentially there is reputation and a motion can be created.

**Changes** 🏗

- update `SmiteDialogForm`

resolves #3135 
<img width="596" alt="Screenshot 2022-01-27 at 17 39 08" src="https://user-images.githubusercontent.com/34057551/151461324-279ae40b-2f8f-4703-a6a8-05be9347d13d.png">

