### PR TITLE
Remove caret `onClick` when input disabled in SingleUserPicker

### DIFF
--- a/src/modules/core/components/SingleUserPicker/SingleUserPicker.tsx
+++ b/src/modules/core/components/SingleUserPicker/SingleUserPicker.tsx
@@ -230,7 +230,7 @@ const SingleUserPicker = ({
             </div>
             {(!value || (value && !isResettable)) && (
               <Icon
-                onClick={openOmniPicker}
+                {...(disabled ? {} : { onClick: openOmniPicker })}
                 className={classnames(styles.arrowIcon, {
                   [styles.arrowIconActive]: omniPickerIsOpen,
                 })}


### PR DESCRIPTION
## Description

When `SingleUserPicker` input is disabled the `caret` was still working and you could change user by clicking on it. I have removed the `onClick` prop from `caret` when input is disabled.

**Changes** 🏗

- update `SingleUserPicker`

resolves #3136 