### PR TITLE
Fix arbitration permission text color in Permission Management dialog

### DIFF
--- a/src/modules/dashboard/components/Dialogs/PermissionManagementDialog/PermissionManagementCheckbox.css
+++ b/src/modules/dashboard/components/Dialogs/PermissionManagementDialog/PermissionManagementCheckbox.css
@@ -19,7 +19,3 @@
 .popoverContent {
   padding: 10px;
 }
-
-.permissionNotAvailable {
-  color: var(--text-disabled);
-}

--- a/src/modules/dashboard/components/Dialogs/PermissionManagementDialog/PermissionManagementCheckbox.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/PermissionManagementDialog/PermissionManagementCheckbox.css.d.ts
@@ -1,4 +1,3 @@
 export const permissionChoice: string;
 export const permissionChoiceDescription: string;
 export const popoverContent: string;
-export const permissionNotAvailable: string;

--- a/src/modules/dashboard/components/Dialogs/PermissionManagementDialog/PermissionManagementCheckbox.tsx
+++ b/src/modules/dashboard/components/Dialogs/PermissionManagementDialog/PermissionManagementCheckbox.tsx
@@ -116,19 +116,7 @@ const PermissionManagementCheckbox = ({
           name={formattedRole}
           inherited={asterisk}
         />
-        <span
-          className={
-            /*
-             * If the roles cannot be set, show the description faded out.
-             *
-             * Currently applicable for:
-             * - Arbitration
-             */
-            role === ColonyRole.Arbitration ? styles.permissionNotAvailable : ''
-          }
-        >
-          <FormattedMessage {...roleDescriptionMessage} />
-        </span>
+        <FormattedMessage {...roleDescriptionMessage} />
       </span>
     </Checkbox>
   );

--- a/src/modules/dashboard/components/Dialogs/PermissionManagementDialog/PermissionManagementForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/PermissionManagementDialog/PermissionManagementForm.tsx
@@ -119,9 +119,8 @@ const PermissionManagementForm = ({
   const canRoleBeSet = useCallback(
     (role: ColonyRole) => {
       switch (role) {
-        // Can't set arbitration at all yet
         case ColonyRole.Arbitration:
-          return false;
+          return true;
 
         // Can only be set by root and in root domain (and only unset if other root accounts exist)
         case ColonyRole.Root:
@@ -308,9 +307,7 @@ const PermissionManagementForm = ({
               <PermissionManagementCheckbox
                 key={role}
                 disabled={
-                  !isVotingExtensionEnabled
-                    ? inputDisabled || !canRoleBeSet(role) || roleIsInherited
-                    : false
+                  inputDisabled || !canRoleBeSet(role) || roleIsInherited
                 }
                 role={role}
                 asterisk={roleIsInherited}


### PR DESCRIPTION
## Description

This PR makes the arbitration permission description in the Permission Management dialog the same color as all other permissions.

**Changes** 🏗

- update `PermissionManagementCheckbox`

**Deletions** ⚰️

- delete leftover css class

resovles #3134 
