### PR TITLE
Make hover state on select items non-sticky

### DIFF
--- a/src/modules/core/components/Fields/SelectOption/SelectOption.css
+++ b/src/modules/core/components/Fields/SelectOption/SelectOption.css
@@ -8,7 +8,7 @@
   cursor: pointer;
 }
 
-.main[aria-selected="true"] {
+.main:hover {
   background-color: var(--grey-blue-0);
   outline: none;
 }


### PR DESCRIPTION
## Description


**Changes** 🏗

CSS selector changed from `[aria-selected="true"]` to `:hover` on SelectOption component. 


Resolves #3131.
![Colony](https://user-images.githubusercontent.com/14034137/151492740-03e391cf-1b86-4a1c-ab39-129a14ae85a6.gif)

