### PR TITLE
Header reputation and network info styling

### DIFF
--- a/src/modules/core/components/Icon/Icon.tsx
+++ b/src/modules/core/components/Icon/Icon.tsx
@@ -38,7 +38,7 @@ interface Props extends Omit<HTMLAttributes<HTMLElement>, 'title'> {
   name: string;
 
   /** Html title for the icon element */
-  title: string | MessageDescriptor;
+  title?: string | MessageDescriptor;
 
   /** Values for html title (react-intl interpolation) */
   titleValues?: SimpleMessageValues;
@@ -77,7 +77,7 @@ const Icon = ({
     typeof title === 'object' ? formatMessage(title, titleValues) : title;
   return (
     <i
-      title={iconTitle}
+      title={title ? iconTitle : undefined}
       className={
         className || getMainClasses(multiColorAppearance || appearance, styles)
       }

--- a/src/modules/core/components/MemberReputation/MemberReputation.css
+++ b/src/modules/core/components/MemberReputation/MemberReputation.css
@@ -9,7 +9,7 @@
 
 .icon {
   display: inline-block;
-  margin-right: 3px;
+  margin-left: 3px;
   height: 11px;
   width: 11px;
 }

--- a/src/modules/core/components/MemberReputation/MemberReputation.tsx
+++ b/src/modules/core/components/MemberReputation/MemberReputation.tsx
@@ -64,19 +64,6 @@ const MemberReputation = ({
 
   return (
     <div>
-      <Icon
-        name="star"
-        appearance={{ size: 'extraTiny' }}
-        className={styles.icon}
-        title={
-          userPercentageReputation
-            ? MSG.starReputationTitle
-            : MSG.starNoReputationTitle
-        }
-        titleValues={{
-          reputation: userPercentageReputation,
-        }}
-      />
       {!userPercentageReputation && (
         <div className={styles.reputation}>— %</div>
       )}
@@ -92,6 +79,19 @@ const MemberReputation = ({
             suffix="%"
           />
         )}
+      <Icon
+        name="star"
+        appearance={{ size: 'extraTiny' }}
+        className={styles.icon}
+        title={
+          userPercentageReputation
+            ? MSG.starReputationTitle
+            : MSG.starNoReputationTitle
+        }
+        titleValues={{
+          reputation: userPercentageReputation,
+        }}
+      />
     </div>
   );
 };

--- a/src/modules/core/components/MemberReputation/MemberReputation.tsx
+++ b/src/modules/core/components/MemberReputation/MemberReputation.tsx
@@ -28,6 +28,7 @@ interface Props {
   domainId?: number;
   rootHash?: string;
   onReputationLoaded?: (reputationLoaded: boolean) => void;
+  showIconTitle?: boolean;
 }
 
 const displayName = 'MemberReputation';
@@ -38,6 +39,7 @@ const MemberReputation = ({
   domainId = ROOT_DOMAIN_ID,
   rootHash,
   onReputationLoaded = () => null,
+  showIconTitle = true,
 }: Props) => {
   const { data: userReputationData } = useUserReputationQuery({
     variables: { address: walletAddress, colonyAddress, domainId, rootHash },
@@ -62,6 +64,16 @@ const MemberReputation = ({
     onReputationLoaded(!!userReputationData);
   }, [userReputationData, onReputationLoaded]);
 
+  /* Doing this cause Eslint yells at me if I use nested ternary */
+  let iconTitle;
+  if (!showIconTitle) {
+    iconTitle = undefined;
+  } else {
+    iconTitle = userPercentageReputation
+      ? MSG.starReputationTitle
+      : MSG.starNoReputationTitle;
+  }
+
   return (
     <div>
       {!userPercentageReputation && (
@@ -83,14 +95,14 @@ const MemberReputation = ({
         name="star"
         appearance={{ size: 'extraTiny' }}
         className={styles.icon}
-        title={
-          userPercentageReputation
-            ? MSG.starReputationTitle
-            : MSG.starNoReputationTitle
+        title={iconTitle}
+        titleValues={
+          showIconTitle
+            ? {
+                reputation: userPercentageReputation,
+              }
+            : undefined
         }
-        titleValues={{
-          reputation: userPercentageReputation,
-        }}
       />
     </div>
   );

--- a/src/modules/core/components/MemberReputation/MemberReputation.tsx
+++ b/src/modules/core/components/MemberReputation/MemberReputation.tsx
@@ -43,7 +43,7 @@ const MemberReputation = ({
 }: Props) => {
   const { data: userReputationData } = useUserReputationQuery({
     variables: { address: walletAddress, colonyAddress, domainId, rootHash },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-and-network',
   });
 
   const { data: totalReputation } = useUserReputationQuery({
@@ -52,7 +52,7 @@ const MemberReputation = ({
       colonyAddress,
       domainId,
     },
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-and-network',
   });
 
   const userPercentageReputation = calculatePercentageReputation(

--- a/src/modules/pages/components/RouteLayouts/UserNavigation.css
+++ b/src/modules/pages/components/RouteLayouts/UserNavigation.css
@@ -161,6 +161,22 @@
   background-color: color-mod(var(--temp-grey-blue-7) alpha(10%));
 }
 
+.reputation:hover {
+  background-color: color-mod(var(--colony-blue) alpha(10%));
+  cursor: pointer;
+}
+
+/* The first selector is for the reputation value text when reputation shows `- %`
+ * in the create colony wizard. The second one is for other reputation value texts.
+*/
+.reputation:hover div, .reputation:hover span {
+  color: var(--colony-blue);
+}
+
+.reputation:hover svg {
+  stroke: var(--colony-blue);
+}
+
 .walletAutoLogin {
   margin-right: 12px;
   padding: 4px 10px 0;

--- a/src/modules/pages/components/RouteLayouts/UserNavigation.css
+++ b/src/modules/pages/components/RouteLayouts/UserNavigation.css
@@ -88,6 +88,12 @@
   cursor: default;
 }
 
+.networkInfo:hover {
+  background-color: color-mod(var(--colony-blue) alpha(10%));
+  color: var(--colony-blue);
+  cursor: pointer;
+}
+
 .wrongNetwork {
   composes: networkInfo;
   padding: 4px 10px;

--- a/src/modules/pages/components/RouteLayouts/UserNavigation.tsx
+++ b/src/modules/pages/components/RouteLayouts/UserNavigation.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useEffect } from 'react';
-import { defineMessages, FormattedMessage } from 'react-intl';
+import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
 import { useParams } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 
@@ -7,6 +7,7 @@ import Icon from '~core/Icon';
 import MaskedAddress from '~core/MaskedAddress';
 import MemberReputation from '~core/MemberReputation';
 import { MiniSpinnerLoader } from '~core/Preloaders';
+import { Tooltip } from '~core/Popover';
 
 import { GasStationPopover } from '~users/GasStation';
 import UserTokenActivationButton from '~users/UserTokenActivationButton';
@@ -47,6 +48,10 @@ const MSG = defineMessages({
   walletAutologin: {
     id: 'pages.NavigationWrapper.UserNavigation.walletAutologin',
     defaultMessage: 'Connecting wallet...',
+  },
+  userReputationTooltip: {
+    id: 'pages.NavigationWrapper.UserNavigation.userReputationTooltip',
+    defaultMessage: 'This is your share of the reputation in this colony',
   },
 });
 
@@ -102,6 +107,8 @@ const UserNavigation = () => {
   const attemptingAutoLogin = useAutoLogin();
   const previousWalletConnected = lastWalletType && lastWalletAddress;
 
+  const { formatMessage } = useIntl();
+
   useEffect(() => {
     if (!userDataLoading && !ethereal) {
       dispatch({ type: 'USER_CONNECTED', payload: { isUserConnected: true } });
@@ -128,12 +135,27 @@ const UserNavigation = () => {
         </div>
       )}
       {userCanNavigate && colonyData?.colonyAddress && (
-        <div className={styles.reputation}>
-          <MemberReputation
-            walletAddress={walletAddress}
-            colonyAddress={colonyData?.colonyAddress}
-          />
-        </div>
+        <Tooltip
+          content={formatMessage(MSG.userReputationTooltip)}
+          placement="bottom-start"
+          popperProps={{
+            modifiers: [
+              {
+                name: 'offset',
+                options: {
+                  offset: [0, 8],
+                },
+              },
+            ],
+          }}
+        >
+          <div className={styles.reputation}>
+            <MemberReputation
+              walletAddress={walletAddress}
+              colonyAddress={colonyData?.colonyAddress}
+            />
+          </div>
+        </Tooltip>
       )}
       {ethereal && (
         <ConnectWalletPopover>

--- a/src/modules/pages/components/RouteLayouts/UserNavigation.tsx
+++ b/src/modules/pages/components/RouteLayouts/UserNavigation.tsx
@@ -149,11 +149,14 @@ const UserNavigation = () => {
             ],
           }}
         >
-          <div className={styles.reputation}>
-            <MemberReputation
-              walletAddress={walletAddress}
-              colonyAddress={colonyData?.colonyAddress}
-            />
+          <div>
+            <div className={styles.reputation}>
+              <MemberReputation
+                walletAddress={walletAddress}
+                colonyAddress={colonyData?.colonyAddress}
+                showIconTitle={false}
+              />
+            </div>
           </div>
         </Tooltip>
       )}


### PR DESCRIPTION
## Description


**New stuff** ✨

Added hover state and tooltip to the current user reputation in the nav bar.
![Colony](https://user-images.githubusercontent.com/14034137/151590265-e73b4b9b-3f46-49cf-b9db-cfb0486840c4.png)

![Colony (2)](https://user-images.githubusercontent.com/14034137/151592844-705131ca-aa65-4f06-806f-0e0f6eb12dfb.png)


Also added hover state to the network info in the nav bar since that was missing too.

![Colony (1)](https://user-images.githubusercontent.com/14034137/151590817-d57fc72d-7c92-443a-a963-618236e5f5d7.png)


**Changes** 🏗

Switched the star icon to the right in MemberReputation component. This affects all places where the MemberReputation component is.

**Notes**

Used a slightly different copy than the spec to avoid introducing a new variable in the MemberReputation component. (Displaying the reputation percentage in the tooltip is complicated since the value of that is computed in the MemberReputation component, which is a child of the Tooltip component.

Resolves  #3129.
