### PR TITLE
Make Toggle component work when scrolled

### DIFF
--- a/src/modules/core/components/Fields/Toggle/Toggle.css
+++ b/src/modules/core/components/Fields/Toggle/Toggle.css
@@ -3,6 +3,7 @@
 
 .container {
   display: flex;
+  position: relative;
 }
 
 .container label {


### PR DESCRIPTION
## Description

Fixed toggle component invisibly shifting when scrolled.

![Colony](https://user-images.githubusercontent.com/14034137/151678897-fe0b85d8-7b78-4e2a-8942-8b2a95ce3116.gif)


**Changes** 🏗

Completed the existing checkbox hack implementation in the component. Had to make some compromises to make the linter happy.

Resolves #3143.
