### PR TITLE
Remove `force` toggle for unauthorised users from Mint Token dialog

### DIFF
--- a/src/modules/dashboard/components/Dialogs/TokenMintDialog/TokenMintForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/TokenMintDialog/TokenMintForm.tsx
@@ -65,9 +65,8 @@ const TokenMintForm = ({
   const { walletAddress } = useLoggedInUser();
   const allUserRoles = useTransformer(getAllUserRoles, [colony, walletAddress]);
 
-  const canUserMintNativeToken = !isVotingExtensionEnabled
-    ? colony.canColonyMintNativeToken
-    : hasRoot(allUserRoles) && colony.canColonyMintNativeToken;
+  const canUserMintNativeToken =
+    hasRoot(allUserRoles) && colony.canColonyMintNativeToken;
 
   const [userHasPermission, onlyForceAction] = useDialogActionPermissions(
     colony.colonyAddress,

--- a/src/modules/dashboard/components/Dialogs/TokenMintDialog/TokenMintForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/TokenMintDialog/TokenMintForm.tsx
@@ -65,7 +65,7 @@ const TokenMintForm = ({
   const { walletAddress } = useLoggedInUser();
   const allUserRoles = useTransformer(getAllUserRoles, [colony, walletAddress]);
 
-  const canUserMintNativeToken = isVotingExtensionEnabled
+  const canUserMintNativeToken = !isVotingExtensionEnabled
     ? colony.canColonyMintNativeToken
     : hasRoot(allUserRoles) && colony.canColonyMintNativeToken;
 


### PR DESCRIPTION
## Description

This PR updates the Mint token dialog. It removes the `force` toggle only for users that do not have permissions. 

After fix, unauthorised user:

<img width="558" alt="Screenshot 2022-02-01 at 17 58 17" src="https://user-images.githubusercontent.com/582700/152073063-48a585be-1315-4af3-87df-ddd77c65a398.png">


Authorised user:

<img width="548" alt="Screenshot 2022-02-01 at 18 02 50" src="https://user-images.githubusercontent.com/582700/152073046-8eee1c77-c3d2-4e82-8797-cb47e883085f.png">



Resolves #3147
