### PR TITLE
Add `Claim all` button with saga

### DIFF
--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -313,7 +313,8 @@ export type QueryBannedUsersArgs = {
 
 
 export type QueryClaimableStakedMotionsArgs = {
-  motionIds: Array<Scalars['Int']>;
+  colonyAddress: Scalars['String'];
+  walletAddress: Scalars['String'];
 };
 
 
@@ -1326,8 +1327,28 @@ export type StakeAmounts = {
   requiredStake: Scalars['String'];
 };
 
+export type ParsedMotionStakedEventValues = {
+  amount: Scalars['String'];
+  motionId: Scalars['String'];
+  stakeAmount: Scalars['String'];
+  staker: Scalars['String'];
+  vote: Scalars['Int'];
+};
+
+export type ParsedMotionStakedEvent = {
+  address: Scalars['String'];
+  blockNumber: Scalars['Int'];
+  hash: Scalars['String'];
+  index: Scalars['String'];
+  name: Scalars['String'];
+  signature: Scalars['String'];
+  timestamp: Scalars['Int'];
+  topic: Scalars['String'];
+  values: ParsedMotionStakedEventValues;
+};
+
 export type ClaimableMotions = {
-  motionIds: Array<Scalars['Int']>;
+  unclaimedMotionStakeEvents: Array<ParsedMotionStakedEvent>;
 };
 
 export type MotionObjectionAnnotation = {
@@ -2447,7 +2468,7 @@ export type ClaimableStakedMotionsQueryVariables = Exact<{
 }>;
 
 
-export type ClaimableStakedMotionsQuery = { claimableStakedMotions: Pick<ClaimableMotions, 'motionIds'> };
+export type ClaimableStakedMotionsQuery = { claimableStakedMotions: Pick<ClaimableMotions, 'unclaimedMotionStakeEvents'> };
 
 export type MotionObjectionAnnotationQueryVariables = Exact<{
   motionId: Scalars['Int'];
@@ -6681,7 +6702,7 @@ export type StakeAmountsForMotionQueryResult = Apollo.QueryResult<StakeAmountsFo
 export const ClaimableStakedMotionsDocument = gql`
     query ClaimableStakedMotions($colonyAddress: String!, $walletAddress: String!) {
   claimableStakedMotions(colonyAddress: $colonyAddress, walletAddress: $walletAddress) @client {
-    motionIds
+    unclaimedMotionStakeEvents
   }
 }
     `;

--- a/src/data/graphql/queries/motions.graphql
+++ b/src/data/graphql/queries/motions.graphql
@@ -323,7 +323,7 @@ query StakeAmountsForMotion($colonyAddress: String!, $userAddress: String!, $mot
 
 query ClaimableStakedMotions($colonyAddress: String!, $walletAddress: String!) {
   claimableStakedMotions(colonyAddress: $colonyAddress, walletAddress: $walletAddress) @client {
-    motionIds
+    unclaimedMotionStakeEvents
   }
 }
 

--- a/src/data/graphql/typeDefs/motions.ts
+++ b/src/data/graphql/typeDefs/motions.ts
@@ -47,8 +47,28 @@ export default gql`
     requiredStake: String!
   }
 
+  type ParsedMotionStakedEventValues {
+    amount: String!
+    motionId: String!
+    stakeAmount: String!
+    staker: String!
+    vote: Int!
+  }
+
+  type ParsedMotionStakedEvent {
+    address: String!
+    blockNumber: Int!
+    hash: String!
+    index: String!
+    name: String!
+    signature: String!
+    timestamp: Int!
+    topic: String!
+    values: ParsedMotionStakedEventValues!
+  }
+
   type ClaimableMotions {
-    motionIds: [Int!]!
+    unclaimedMotionStakeEvents: [ParsedMotionStakedEvent!]!
   }
 
   type MotionObjectionAnnotation {
@@ -112,7 +132,10 @@ export default gql`
       userAddress: String!
       motionId: Int!
     ): StakeAmounts!
-    claimableStakedMotions(motionIds: [Int!]!): ClaimableMotions!
+    claimableStakedMotions(
+      colonyAddress: String!
+      walletAddress: String!
+    ): ClaimableMotions!
     motionObjectionAnnotation(
       motionId: Int!
       colonyAddress: String!

--- a/src/data/resolvers/stakes.ts
+++ b/src/data/resolvers/stakes.ts
@@ -150,7 +150,7 @@ export const stakesResolvers = ({
           ) || [];
 
         return {
-          motionIds: finalizedUnclaimedMotions,
+          unclaimedMotionStakeEvents: finalizedUnclaimedMotions,
         };
       } catch (error) {
         console.error(error);

--- a/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
@@ -206,11 +206,20 @@ const FinalizeMotionAndClaimWidget = ({
     ({ address }) => address === nativeTokenAddress,
   );
 
-  const transform = useCallback(
+  const finalizeTransform = useCallback(
     mapPayload(() => ({
       colonyAddress,
       userAddress: walletAddress,
       motionId,
+    })),
+    [walletAddress],
+  );
+
+  const claimTransform = useCallback(
+    mapPayload(() => ({
+      colonyAddress,
+      userAddress: walletAddress,
+      motionIds: [bigNumberify(motionId)],
     })),
     [walletAddress],
   );
@@ -303,7 +312,7 @@ const FinalizeMotionAndClaimWidget = ({
           submit={ActionTypes.COLONY_MOTION_FINALIZE}
           error={ActionTypes.COLONY_MOTION_FINALIZE_ERROR}
           success={ActionTypes.COLONY_MOTION_FINALIZE_SUCCESS}
-          transform={transform}
+          transform={finalizeTransform}
           onSuccess={handleSuccess}
         >
           {({ handleSubmit, isSubmitting }: FormikProps<{}>) => (
@@ -347,7 +356,7 @@ const FinalizeMotionAndClaimWidget = ({
           submit={ActionTypes.COLONY_MOTION_CLAIM}
           error={ActionTypes.COLONY_MOTION_CLAIM_ERROR}
           success={ActionTypes.COLONY_MOTION_CLAIM_SUCCESS}
-          transform={transform}
+          transform={claimTransform}
           onSuccess={handleSuccess}
         >
           {({ handleSubmit, isSubmitting }: FormikProps<{}>) => (

--- a/src/modules/dashboard/sagas/motions/claimMotionRewards.ts
+++ b/src/modules/dashboard/sagas/motions/claimMotionRewards.ts
@@ -1,21 +1,25 @@
-import { call, fork, put, takeEvery } from 'redux-saga/effects';
+import { all, call, fork, put, takeEvery } from 'redux-saga/effects';
 import { ClientType, ExtensionClient } from '@colony/colony-js';
+import { $Values } from 'utility-types';
+import { BigNumber } from 'ethers/utils';
 
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { TEMP_getContext, ContextModule } from '~context/index';
 import { putError, takeFrom } from '~utils/saga/effects';
+import { TxConfig } from '~types/index';
 
 import {
+  ChannelDefinition,
   createTransaction,
   createTransactionChannels,
   getTxChannel,
 } from '../../../core/sagas';
-import { transactionReady } from '../../../core/actionCreators';
+
 import { updateMotionValues } from '../utils';
 
 function* claimMotionRewards({
   meta,
-  payload: { userAddress, colonyAddress, motionId },
+  payload: { userAddress, colonyAddress, motionIds },
 }: Action<ActionTypes.COLONY_MOTION_CLAIM>) {
   const txChannel = yield call(getTxChannel, meta.id);
   try {
@@ -27,26 +31,6 @@ function* claimMotionRewards({
       colonyAddress,
     );
 
-    const {
-      claimMotionRewardsYay,
-      claimMotionRewardsNay,
-    } = yield createTransactionChannels(meta.id, [
-      'claimMotionRewardsYay',
-      'claimMotionRewardsNay',
-    ]);
-
-    const batchKey = 'claimMotionRewards';
-
-    const createGroupTransaction = ({ id, index }, config) =>
-      fork(createTransaction, id, {
-        ...config,
-        group: {
-          key: batchKey,
-          id: meta.id,
-          index,
-        },
-      });
-
     /*
      * We need to do the claim reward transaction, potentially for both sides,
      * Once for yay and once of nay (if the user staked both sides)
@@ -54,101 +38,116 @@ function* claimMotionRewards({
      * To do that we try to estimate both transactions, and the one that fails,
      * we know there are no rewards to be claimed on that side
      */
-    let sideYay = false;
-    let sideNay = false;
-    try {
-      /*
-       * @NOTE For some reason colonyJS doesn't export types for the estimate methods
-       */
-      // @ts-ignore
-      yield votingReputationClient.estimate.claimRewardWithProofs(
-        motionId,
-        userAddress,
-        1,
-      );
-      sideYay = true;
-    } catch (error) {
-      /*
-       * We don't want to handle the error here as we are doing this to
-       * inferr the user's reward
-       *
-       * This is a "cheaper" alternative to looking through events, since
-       * this doesn't use so many requests
-       */
-      // silent error
+    const motionWithYAYClaims: BigNumber[] = [];
+    const motionWithNAYClaims: BigNumber[] = [];
+
+    yield Promise.all(
+      motionIds.map(async (motionId) => {
+        try {
+          /*
+           * @NOTE For some reason colonyJS doesn't export types for the estimate methods
+           */
+          // @ts-ignore
+          await votingReputationClient.estimate.claimRewardWithProofs(
+            motionId,
+            userAddress,
+            1,
+          );
+          motionWithYAYClaims.push(motionId);
+        } catch (error) {
+          /*
+           * We don't want to handle the error here as we are doing this to
+           * inferr the user's reward
+           *
+           * This is a "cheaper" alternative to looking through events, since
+           * this doesn't use so many requests
+           */
+          // silent error
+        }
+        try {
+          /*
+           * @NOTE For some reason colonyJS doesn't export types for the estimate methods
+           */
+          // @ts-ignore
+          await votingReputationClient.estimate.claimRewardWithProofs(
+            motionId,
+            userAddress,
+            0,
+          );
+          motionWithNAYClaims.push(motionId);
+        } catch (error) {
+          /*
+           * We don't want to handle the error here as we are doing this to
+           * inferr the user's reward
+           *
+           * This is a "cheaper" alternative to looking through events, since
+           * this doesn't use so many requests
+           */
+          // silent error
+        }
+      }),
+    );
+
+    const allMotionClaims = motionWithYAYClaims.concat(motionWithNAYClaims);
+    const channelNames: string[] = [];
+
+    for (let index = 0; index < allMotionClaims.length; index += 1) {
+      channelNames.push(String(index));
     }
-    try {
-      /*
-       * @NOTE For some reason colonyJS doesn't export types for the estimate methods
-       */
-      // @ts-ignore
-      yield votingReputationClient.estimate.claimRewardWithProofs(
-        motionId,
-        userAddress,
-        0,
-      );
-      sideNay = true;
-    } catch (error) {
-      /*
-       * We don't want to handle the error here as we are doing this to
-       * inferr the user's reward
-       *
-       * This is a "cheaper" alternative to looking through events, since
-       * this doesn't use so many requests
-       */
-      // silent error
-    }
-    if (sideYay) {
-      yield createGroupTransaction(claimMotionRewardsYay, {
-        context: ClientType.VotingReputationClient,
-        methodName: 'claimRewardWithProofs',
-        identifier: colonyAddress,
-        params: [motionId, userAddress, 1],
-        ready: false,
+
+    const channels: { [id: string]: ChannelDefinition } = yield call(
+      createTransactionChannels,
+      meta.id,
+      channelNames,
+    );
+
+    const createGroupTransaction = (
+      { id, index }: $Values<typeof channels>,
+      config: TxConfig,
+    ) =>
+      fork(createTransaction, id, {
+        ...config,
+        group: {
+          key: 'claimMotionRewards',
+          id: meta.id,
+          index,
+        },
       });
-    }
-    if (sideNay) {
-      yield createGroupTransaction(claimMotionRewardsNay, {
-        context: ClientType.VotingReputationClient,
-        methodName: 'claimRewardWithProofs',
-        identifier: colonyAddress,
-        params: [motionId, userAddress, 0],
-        ready: false,
-      });
-    }
 
-    if (sideYay) {
-      yield takeFrom(
-        claimMotionRewardsYay.channel,
-        ActionTypes.TRANSACTION_CREATED,
-      );
-    }
-    if (sideNay) {
-      yield takeFrom(
-        claimMotionRewardsNay.channel,
-        ActionTypes.TRANSACTION_CREATED,
-      );
-    }
+    yield all(
+      Object.keys(channels).map((id) =>
+        createGroupTransaction(channels[id], {
+          context: ClientType.VotingReputationClient,
+          methodName: 'claimRewardWithProofs',
+          identifier: colonyAddress,
+          params: [
+            allMotionClaims[id],
+            userAddress,
+            parseInt(id, 10) > motionWithYAYClaims.length - 1 ? 0 : 1,
+          ],
+        }),
+      ),
+    );
 
-    if (sideYay) {
-      yield put(transactionReady(claimMotionRewardsYay.id));
-      yield takeFrom(
-        claimMotionRewardsYay.channel,
-        ActionTypes.TRANSACTION_SUCCEEDED,
-      );
-    }
-    if (sideNay) {
-      yield put(transactionReady(claimMotionRewardsNay.id));
-      yield takeFrom(
-        claimMotionRewardsNay.channel,
-        ActionTypes.TRANSACTION_SUCCEEDED,
-      );
-    }
+    yield all(
+      Object.keys(channels).map((id) =>
+        takeFrom(channels[id].channel, ActionTypes.TRANSACTION_CREATED),
+      ),
+    );
 
-    /*
-     * Update motion page values
-     */
-    yield fork(updateMotionValues, colonyAddress, userAddress, motionId);
+    yield all(
+      Object.keys(channels).map((id) =>
+        takeFrom(channels[id].channel, ActionTypes.TRANSACTION_SUCCEEDED),
+      ),
+    );
+
+    yield all(
+      [
+        ...new Set([...motionWithYAYClaims, ...motionWithNAYClaims]),
+      ].map((motionId) =>
+        fork(updateMotionValues, colonyAddress, userAddress, motionId),
+      ),
+    );
 
     yield put<AllActions>({
       type: ActionTypes.COLONY_MOTION_CLAIM_SUCCESS,

--- a/src/modules/dashboard/sagas/motions/claimMotionRewards.ts
+++ b/src/modules/dashboard/sagas/motions/claimMotionRewards.ts
@@ -12,6 +12,9 @@ import {
   ClaimableStakedMotionsDocument,
   ClaimableStakedMotionsQuery,
   ClaimableStakedMotionsQueryVariables,
+  UserBalanceWithLockDocument,
+  UserBalanceWithLockQuery,
+  UserBalanceWithLockQueryVariables,
 } from '~data/generated';
 
 import {
@@ -36,6 +39,10 @@ function* claimMotionRewards({
     // eslint-disable-next-line max-len
     const votingReputationClient: ExtensionClient = yield colonyManager.getClient(
       ClientType.VotingReputationClient,
+      colonyAddress,
+    );
+    const colonyClient = yield colonyManager.getClient(
+      ClientType.ColonyClient,
       colonyAddress,
     );
 
@@ -170,6 +177,19 @@ function* claimMotionRewards({
       variables: {
         colonyAddress: colonyAddress.toLowerCase(),
         walletAddress: userAddress.toLowerCase(),
+      },
+      fetchPolicy: 'network-only',
+    });
+
+    yield apolloClient.query<
+      UserBalanceWithLockQuery,
+      UserBalanceWithLockQueryVariables
+    >({
+      query: UserBalanceWithLockDocument,
+      variables: {
+        colonyAddress: colonyAddress.toLowerCase(),
+        address: userAddress.toLowerCase(),
+        tokenAddress: colonyClient.tokenClient.address.toLowerCase(),
       },
       fetchPolicy: 'network-only',
     });

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/ClaimAllButton.tsx
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/ClaimAllButton.tsx
@@ -5,6 +5,7 @@ import { defineMessages } from 'react-intl';
 
 import Button from '~core/Button';
 import { ActionForm } from '~core/Fields';
+import { ParsedMotionStakedEvent } from '~data/generated';
 import { ActionTypes } from '~redux/actionTypes';
 import { Address } from '~types/index';
 import { mapPayload } from '~utils/actions';
@@ -20,17 +21,24 @@ const MSG = defineMessages({
 });
 
 interface Props {
-  motionIds: number[];
+  unclaimedMotionStakeEvents: ParsedMotionStakedEvent[];
   colonyAddress: Address;
   userAddress: Address;
 }
 
-const ClaimAllButton = ({ motionIds, userAddress, colonyAddress }: Props) => {
+const ClaimAllButton = ({
+  unclaimedMotionStakeEvents,
+  userAddress,
+  colonyAddress,
+}: Props) => {
+  const motionIds = unclaimedMotionStakeEvents.map((motionStakeEvent) =>
+    bigNumberify(motionStakeEvent.values.motionId),
+  );
   const transform = useCallback(
     mapPayload(() => ({
       colonyAddress,
       userAddress,
-      motionIds: motionIds.map((motionId) => bigNumberify(motionId)),
+      motionIds: [...new Set([...motionIds])],
     })),
     [],
   );

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/ClaimAllButton.tsx
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/ClaimAllButton.tsx
@@ -31,14 +31,18 @@ const ClaimAllButton = ({
   userAddress,
   colonyAddress,
 }: Props) => {
-  const motionIds = unclaimedMotionStakeEvents.map((motionStakeEvent) =>
-    bigNumberify(motionStakeEvent.values.motionId),
-  );
+  const uniqueMotionIds = [
+    ...new Set(
+      unclaimedMotionStakeEvents.map(
+        (motionStakeEvent) => motionStakeEvent.values.motionId,
+      ),
+    ),
+  ];
   const transform = useCallback(
     mapPayload(() => ({
       colonyAddress,
       userAddress,
-      motionIds: [...new Set([...motionIds])],
+      motionIds: uniqueMotionIds.map((motionId) => bigNumberify(motionId)),
     })),
     [],
   );

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/ClaimAllButton.tsx
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/ClaimAllButton.tsx
@@ -1,0 +1,61 @@
+import { bigNumberify } from 'ethers/utils';
+import { FormikProps } from 'formik';
+import React, { useCallback } from 'react';
+import { defineMessages } from 'react-intl';
+
+import Button from '~core/Button';
+import { ActionForm } from '~core/Fields';
+import { ActionTypes } from '~redux/actionTypes';
+import { Address } from '~types/index';
+import { mapPayload } from '~utils/actions';
+
+const displayName =
+  'users.TokenActivation.TokenActivationContent.ClaimsTab.ClaimAllButton';
+
+const MSG = defineMessages({
+  claimAll: {
+    id: `users.TokenActivation.TokenActivationContent.ClaimsTab.ClaimAllButton.claimAll`,
+    defaultMessage: 'Claim all',
+  },
+});
+
+interface Props {
+  motionIds: number[];
+  colonyAddress: Address;
+  userAddress: Address;
+}
+
+const ClaimAllButton = ({ motionIds, userAddress, colonyAddress }: Props) => {
+  const transform = useCallback(
+    mapPayload(() => ({
+      colonyAddress,
+      userAddress,
+      motionIds: motionIds.map((motionId) => bigNumberify(motionId)),
+    })),
+    [],
+  );
+
+  return (
+    <ActionForm
+      initialValues={{}}
+      submit={ActionTypes.COLONY_MOTION_CLAIM}
+      error={ActionTypes.COLONY_MOTION_CLAIM_ERROR}
+      success={ActionTypes.COLONY_MOTION_CLAIM_SUCCESS}
+      transform={transform}
+    >
+      {({ handleSubmit, isSubmitting }: FormikProps<{}>) => (
+        <Button
+          appearance={{ theme: 'primary', size: 'large' }}
+          text={MSG.claimAll}
+          onClick={() => handleSubmit()}
+          loading={isSubmitting}
+          disabled={isSubmitting}
+        />
+      )}
+    </ActionForm>
+  );
+};
+
+export default ClaimAllButton;
+
+ClaimAllButton.displayName = displayName;

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/ClaimAllButton.tsx
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/ClaimAllButton.tsx
@@ -45,7 +45,7 @@ const ClaimAllButton = ({ motionIds, userAddress, colonyAddress }: Props) => {
     >
       {({ handleSubmit, isSubmitting }: FormikProps<{}>) => (
         <Button
-          appearance={{ theme: 'primary', size: 'large' }}
+          appearance={{ theme: 'primary', size: 'medium' }}
           text={MSG.claimAll}
           onClick={() => handleSubmit()}
           loading={isSubmitting}

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/StakesTab.tsx
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/StakesTab.tsx
@@ -27,7 +27,7 @@ export interface StakesTabProps {
 }
 
 const StakesTab = ({ colonyAddress, walletAddress }: StakesTabProps) => {
-  const { data: unclaimedMotions, loading } = useClaimableStakedMotionsQuery({
+  const { data, loading } = useClaimableStakedMotionsQuery({
     variables: {
       colonyAddress: colonyAddress?.toLowerCase(),
       walletAddress: walletAddress?.toLowerCase(),
@@ -41,8 +41,8 @@ const StakesTab = ({ colonyAddress, walletAddress }: StakesTabProps) => {
         <SpinnerLoader appearance={{ size: 'medium' }} />
       ) : (
         <>
-          {unclaimedMotions &&
-          unclaimedMotions.claimableStakedMotions?.motionIds.length > 0 ? (
+          {data &&
+          data.claimableStakedMotions?.unclaimedMotionStakeEvents.length > 0 ? (
             <div className={styles.claimsContent}>
               <div className={styles.claimAllButtonSection}>
                 <Heading
@@ -50,7 +50,9 @@ const StakesTab = ({ colonyAddress, walletAddress }: StakesTabProps) => {
                   text={MSG.tabTitle}
                 />
                 <ClaimAllButton
-                  motionIds={unclaimedMotions.claimableStakedMotions.motionIds}
+                  unclaimedMotionStakeEvents={
+                    data.claimableStakedMotions.unclaimedMotionStakeEvents
+                  }
                   userAddress={walletAddress}
                   colonyAddress={colonyAddress}
                 />

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/StakesTab.tsx
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/StakesTab.tsx
@@ -5,6 +5,8 @@ import { SpinnerLoader } from '~core/Preloaders';
 import { Address } from '~types/index';
 import { useClaimableStakedMotionsQuery } from '~data/generated';
 
+import ClaimAllButton from './ClaimAllButton';
+
 import styles from './TokenActivationContent.css';
 
 const MSG = defineMessages({
@@ -30,20 +32,29 @@ const StakesTab = ({ colonyAddress, walletAddress }: StakesTabProps) => {
 
   return (
     <div className={styles.claimsContainer}>
-      <div className={styles.noClaims}>
-        {loading ? (
-          <SpinnerLoader appearance={{ size: 'medium' }} />
-        ) : (
-          <>
-            {unclaimedMotions &&
-            unclaimedMotions.claimableStakedMotions?.motionIds.length > 0 ? (
+      {loading ? (
+        <SpinnerLoader appearance={{ size: 'medium' }} />
+      ) : (
+        <>
+          {unclaimedMotions &&
+          unclaimedMotions.claimableStakedMotions?.motionIds.length > 0 ? (
+            <div className={styles.claimsContent}>
+              <div className={styles.claimAllButtonContainer}>
+                <ClaimAllButton
+                  motionIds={unclaimedMotions.claimableStakedMotions.motionIds}
+                  userAddress={walletAddress}
+                  colonyAddress={colonyAddress}
+                />
+              </div>
               <span>[Claimable stakes appear here]</span>
-            ) : (
+            </div>
+          ) : (
+            <div className={styles.noClaims}>
               <FormattedMessage {...MSG.noClaims} />
-            )}
-          </>
-        )}
-      </div>
+            </div>
+          )}
+        </>
+      )}
     </div>
   );
 };

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/StakesTab.tsx
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/StakesTab.tsx
@@ -12,11 +12,11 @@ import styles from './TokenActivationContent.css';
 
 const MSG = defineMessages({
   tabTitle: {
-    id: 'users.TokenActivation.TokenActivationContent.ClaimsTab.noClaims',
+    id: 'users.TokenActivation.TokenActivationContent.StakesTab.tabTitle',
     defaultMessage: 'Your stakes',
   },
   noClaims: {
-    id: 'users.TokenActivation.TokenActivationContent.ClaimsTab.noClaims',
+    id: 'users.TokenActivation.TokenActivationContent.StakesTab.noClaims',
     defaultMessage: 'There are no stakes to claim.',
   },
 });

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/StakesTab.tsx
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/StakesTab.tsx
@@ -4,12 +4,17 @@ import { FormattedMessage, defineMessages } from 'react-intl';
 import { SpinnerLoader } from '~core/Preloaders';
 import { Address } from '~types/index';
 import { useClaimableStakedMotionsQuery } from '~data/generated';
+import Heading from '~core/Heading';
 
 import ClaimAllButton from './ClaimAllButton';
 
 import styles from './TokenActivationContent.css';
 
 const MSG = defineMessages({
+  tabTitle: {
+    id: 'users.TokenActivation.TokenActivationContent.ClaimsTab.noClaims',
+    defaultMessage: 'Your stakes',
+  },
   noClaims: {
     id: 'users.TokenActivation.TokenActivationContent.ClaimsTab.noClaims',
     defaultMessage: 'There are no stakes to claim.',
@@ -39,7 +44,11 @@ const StakesTab = ({ colonyAddress, walletAddress }: StakesTabProps) => {
           {unclaimedMotions &&
           unclaimedMotions.claimableStakedMotions?.motionIds.length > 0 ? (
             <div className={styles.claimsContent}>
-              <div className={styles.claimAllButtonContainer}>
+              <div className={styles.claimAllButtonSection}>
+                <Heading
+                  appearance={{ size: 'normal', margin: 'none', theme: 'dark' }}
+                  text={MSG.tabTitle}
+                />
                 <ClaimAllButton
                   motionIds={unclaimedMotions.claimableStakedMotions.motionIds}
                   userAddress={walletAddress}

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/TokenActivationContent.css
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/TokenActivationContent.css
@@ -291,15 +291,24 @@
   width: 100%;
 }
 
-.claimAllButtonContainer {
+.claimAllButtonSection {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   align-self: flex-end;
-  margin-right: 12px;
   margin-bottom: 20px;
+  padding-right: 12px;
+  padding-left: 21px;
+  width: 100%;
 }
 
-.claimAllButtonContainer button {
+.claimAllButtonSection button {
   width: 100px;
-  font-size: 12px;
+  font-size: --size-small;
+}
+
+.claimAllButtonSection h4 {
+  font-size: --size-smallish;
 }
 
 .claimsContent span {

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/TokenActivationContent.css
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/TokenActivationContent.css
@@ -270,7 +270,7 @@
 .claimsContainer {
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: flex-start;
   height: 442px;
   width: 100%;
   font-size: var(--size-smallish);
@@ -280,5 +280,28 @@
 
 .noClaims {
   padding: 18px 16px 19px 16px;
+  text-align: center;
+}
+
+.claimsContent {
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  padding: 15px 0;
+  width: 100%;
+}
+
+.claimAllButtonContainer {
+  align-self: flex-end;
+  margin-right: 12px;
+  margin-bottom: 20px;
+}
+
+.claimAllButtonContainer button {
+  width: 100px;
+  font-size: 12px;
+}
+
+.claimsContent span {
   text-align: center;
 }

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/TokenActivationContent.css
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/TokenActivationContent.css
@@ -304,11 +304,11 @@
 
 .claimAllButtonSection button {
   width: 100px;
-  font-size: --size-small;
+  font-size: var(--size-small);
 }
 
 .claimAllButtonSection h4 {
-  font-size: --size-smallish;
+  font-size: var(--size-smallish);
 }
 
 .claimsContent span {

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/TokenActivationContent.css.d.ts
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/TokenActivationContent.css.d.ts
@@ -34,3 +34,5 @@ export const balanceInfoWithdrawLocked: string;
 export const balanceAmount: string;
 export const claimsContainer: string;
 export const noClaims: string;
+export const claimsContent: string;
+export const claimAllButtonContainer: string;

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/TokenActivationContent.css.d.ts
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/TokenActivationContent.css.d.ts
@@ -35,4 +35,4 @@ export const balanceAmount: string;
 export const claimsContainer: string;
 export const noClaims: string;
 export const claimsContent: string;
-export const claimAllButtonContainer: string;
+export const claimAllButtonSection: string;

--- a/src/redux/types/actions/motion.ts
+++ b/src/redux/types/actions/motion.ts
@@ -84,7 +84,7 @@ export type MotionActionTypes =
       {
         userAddress: Address;
         colonyAddress: Address;
-        motionId: BigNumber;
+        motionIds: Array<BigNumber>;
       },
       MetaWithHistory<object>
     >


### PR DESCRIPTION
## Description

- Added "Claim all" button to the stakes tab, now you should be able to claim all the stakes there. I tried to simplify the related saga as much as I could, let me know if you come up with something that can be improved.

**New stuff** ✨

* Added `ClaimAllButton` component and connected it to the stakes tab

**Changes** 🏗

* Updated `transform` on `FinalizeMotionAndClaimWidget`
* Updated `claimMotionRewards` to accept multiple motion ids

![FireShot Capture 533 - Colony - localhost](https://user-images.githubusercontent.com/18473896/153040279-87b75db9-c17f-41c2-872d-6c5c6bed7b11.png)


Resolves #3155 
