### PR TITLE
Fix alignment of max button on smite dialog

### DIFF
--- a/src/modules/dashboard/components/Dialogs/SmiteDialog/SmiteDialogForm.css
+++ b/src/modules/dashboard/components/Dialogs/SmiteDialog/SmiteDialogForm.css
@@ -27,7 +27,7 @@
 }
 
 .inputContainer button {
-  right: auto;
+  right: initial;
   left: -6px;
 }
 

--- a/src/modules/dashboard/components/Dialogs/SmiteDialog/SmiteDialogForm.css
+++ b/src/modules/dashboard/components/Dialogs/SmiteDialog/SmiteDialogForm.css
@@ -27,6 +27,7 @@
 }
 
 .inputContainer button {
+  right: auto;
   left: -6px;
 }
 


### PR DESCRIPTION
It seems like at some point, don't know why, something in the styles of the max button changed and it resulted in the button being badly aligned in `master`:

Before:
![FireShot Capture 535 - Colony - localhost](https://user-images.githubusercontent.com/18473896/153053411-9a5170bf-eced-495c-84d2-35fe63cb7b6f.png)

After:
![FireShot Capture 534 - Colony - localhost](https://user-images.githubusercontent.com/18473896/153053381-c28b64a0-5148-4ba0-a6fb-97ab8ec32dae.png)


