### PR TITLE
Return only claimable and finalized motions

### DIFF
--- a/src/modules/users/components/TokenActivation/TokenActivationContent/StakesTab.tsx
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/StakesTab.tsx
@@ -25,6 +25,7 @@ const StakesTab = ({ colonyAddress, walletAddress }: StakesTabProps) => {
       colonyAddress: colonyAddress?.toLowerCase(),
       walletAddress: walletAddress?.toLowerCase(),
     },
+    fetchPolicy: 'network-only',
   });
 
   return (


### PR DESCRIPTION
## Description

This PR modifies the `claimableStakedMotions` resolver to filter out unfinalized motions, it also now returns full motion events as opposed to just the motionIds.

**Changes** 🏗

* Add additional query and filter to `claimableStakedMotions` resolver for the `useClaimableStakedMotionsQuery` query.
* Changes `useClaimableStakedMotionsQuery` query to be `network-only`

## Testing
* You will need to have the Motions & Disputes extension installed.
* Create some motions finalize some, claim some, don't claim some. 
Reminder, you can speed up the chain 3 days using this call in console: `curl -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"evm_increaseTime","params":[260000],"id": 1}' localhost:8545 && curl -H "Content-Type: application/json" -X POST --data '{"jsonrpc":"2.0","method":"evm_mine","params":[]}' localhost:8545`
* Navigate to the `TokenActivation` popover and click on the 'Stakes' tab.
* You should see a loader while waiting for the query, then the relevant messages 'There are no stakes to claim.' or '[Claimable stakes appear here]' (this is just a temporary message).
* Console log `unclaimedMotions` in the `StakesTab.tsx` to see array of claimable motions for the user, excluding unfinalized motions.

Resolves #3174
