### PR TITLE
Fixes various bugs in the events list

### DIFF
--- a/src/data/resolvers/transactions.ts
+++ b/src/data/resolvers/transactions.ts
@@ -131,6 +131,7 @@ export const getColonyUnclaimedTransfers = async (
     variables: {
       colonyAddress: colonyClient.address.toLowerCase(),
     },
+    fetchPolicy: 'network-only',
   });
   const colonyFundsClaimedEvents =
     colonyFundsClaimedEventsData?.colonyFundsClaimedEvents || [];

--- a/src/modules/dashboard/components/ColonyEvents/ColonyEvents.tsx
+++ b/src/modules/dashboard/components/ColonyEvents/ColonyEvents.tsx
@@ -66,7 +66,8 @@ const ColonyEvents = ({
     },
     onSubscriptionData: ({ subscriptionData: { data: newSubscriptionData } }) =>
       setStreamedEvents([
-        ...new Set([...streamedEvents, ...(newSubscriptionData?.events || [])]),
+        ...streamedEvents,
+        ...(newSubscriptionData?.events || []),
       ]),
   });
 
@@ -90,11 +91,17 @@ const ColonyEvents = ({
     setDataPage(dataPage + 1);
   }, [dataPage]);
 
+  /* Remove duplicate events */
+  const mappedEvents = events?.map((event) => event.id);
+  const uniqueEvents = events?.filter(
+    (event, index) => mappedEvents.indexOf(event.id) === index,
+  );
+
   const filteredEvents = useMemo(
     () =>
       !ethDomainId
-        ? events
-        : events?.filter(
+        ? uniqueEvents
+        : uniqueEvents?.filter(
             (event) =>
               Number(event.domainId) === ethDomainId ||
               /* when no specific domain in the event it is displayed in Root */
@@ -102,7 +109,7 @@ const ColonyEvents = ({
                 event.domainId === null &&
                 event.fundingPot === undefined),
           ),
-    [ethDomainId, events],
+    [ethDomainId, uniqueEvents],
   );
 
   const sortedEvents = useMemo(

--- a/src/modules/dashboard/components/UnclaimedTransfers/UnclaimedTransfers.tsx
+++ b/src/modules/dashboard/components/UnclaimedTransfers/UnclaimedTransfers.tsx
@@ -27,6 +27,7 @@ const MSG = defineMessages({
 const UnclaimedTransfers = ({ colony }: Props) => {
   const { data, error, loading } = useColonyTransfersQuery({
     variables: { address: colony.colonyAddress },
+    fetchPolicy: 'network-only',
   });
   if (error) console.warn(error);
 


### PR DESCRIPTION
## Description
This PR addresses 3 issues discovered while looking into this issue - https://github.com/JoinColony/colonyDapp/issues/3148
These include events duplicating when claiming funds, events showing the wrong token symbol if the claimed funds is not native, and the incoming funds not disappear after claiming.

**New stuff** ✨
* Adds token query to `ColonyEventsListItem`
* Adds filter to remove duplicated events in `ColonyEvents`
* Kind of fixed incoming funds not disappearing after claiming (This seems temperamental), would love some tips on how to make it more reliable.

## Testing

* Create two colonies with different tokens.
* Send tokens from one colony to the other (without adding the second colonies tokens to the first colony's token list).
* Go to events and claim the token transfer.
* You should now see the correct token symbol on the event.
* You should also now not get duplicate events.
* The claim transfer should also disappear on the claimed token.


## Before

![claiming-tokens-not-in-manage-before](https://user-images.githubusercontent.com/33682027/153666769-bf5a3473-d291-4627-8e74-726be830a5cd.gif)


## After

![claiming-tokens-not-in-manage-after](https://user-images.githubusercontent.com/33682027/153672213-5c4ee3ca-e983-48e9-abca-fd305aa6ad85.gif)



Resolves #3148