### PR TITLE
Make shabang in provision script more compatible

### DIFF
--- a/scripts/provision_submodules.sh
+++ b/scripts/provision_submodules.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 while [ $# -gt 0 ]; do
   case "$1" in


### PR DESCRIPTION
In some systems `bash` is not located at `/bin/bash` - for example in NixOS it is symlinked at `/run/current-system/sw/bin/bash`. `/usr/bin/env bash` searches `PATH` for the bash executable.