### PR TITLE
Add verified icon to MembersListItem

### DIFF
--- a/src/modules/core/components/MembersList/MembersListItem.css
+++ b/src/modules/core/components/MembersList/MembersListItem.css
@@ -27,6 +27,12 @@
   margin-left: 5px;
 }
 
+.address {
+  display: flex;
+  align-items: center;
+  line-height: 13px;
+}
+
 .address span {
   font-weight: 500;
 }
@@ -46,4 +52,17 @@
 
 .stateHasReputation.stateReputationLoaded {
   opacity: 1;
+}
+
+.whitelistedIcon {
+  margin-left: 10px;
+  position: relative;
+}
+
+.whitelistedIcon svg {
+  fill: var(--primary);
+}
+
+.whitelistedIconTooltip {
+  width: initial;
 }

--- a/src/modules/core/components/MembersList/MembersListItem.css.d.ts
+++ b/src/modules/core/components/MembersList/MembersListItem.css.d.ts
@@ -7,3 +7,5 @@ export const address: string;
 export const reputationSection: string;
 export const stateHasReputation: string;
 export const stateReputationLoaded: string;
+export const whitelistedIcon: string;
+export const whitelistedIconTooltip: string;

--- a/src/modules/core/components/MembersList/MembersListItem.tsx
+++ b/src/modules/core/components/MembersList/MembersListItem.tsx
@@ -7,10 +7,10 @@ import React, {
 } from 'react';
 import { AddressZero } from 'ethers/constants';
 
+import { defineMessages } from 'react-intl';
 import { createAddress } from '~utils/web3';
 import UserMention from '~core/UserMention';
 import { ListGroupItem } from '~core/ListGroup';
-import CopyableAddress from '~core/CopyableAddress';
 import { AnyUser, Colony, useUser } from '~data/index';
 import { ENTER } from '~types/index';
 import HookedUserAvatar from '~users/HookedUserAvatar';
@@ -18,6 +18,9 @@ import { getMainClasses } from '~utils/css';
 import MemberReputation from '~core/MemberReputation';
 
 import styles from './MembersListItem.css';
+import InvisibleCopyableAddress from '~core/InvisibleCopyableAddress';
+import MaskedAddress from '~core/MaskedAddress';
+import IconTooltip from '~core/IconTooltip';
 
 interface Props<U> {
   extraItemContent?: (user: U) => ReactNode;
@@ -26,8 +29,16 @@ interface Props<U> {
   showUserInfo: boolean;
   showUserReputation: boolean;
   domainId: number | undefined;
+  isWhiteListed?: boolean;
   user: U;
 }
+
+const MSG = defineMessages({
+  whitelistedTooltip: {
+    id: 'core.MembersList.MembersListItem.whitelistedTooltip',
+    defaultMessage: `Address added to whitelist`,
+  },
+});
 
 const UserAvatar = HookedUserAvatar({ fetchUser: false });
 
@@ -42,6 +53,7 @@ const MembersListItem = <U extends AnyUser = AnyUser>(props: Props<U>) => {
     showUserInfo,
     showUserReputation,
     user,
+    isWhiteListed,
   } = props;
   const {
     profile: { walletAddress },
@@ -127,7 +139,22 @@ const MembersListItem = <U extends AnyUser = AnyUser>(props: Props<U>) => {
             </span>
           )}
           <div className={styles.address}>
-            <CopyableAddress>{walletAddress}</CopyableAddress>
+            <InvisibleCopyableAddress address={walletAddress}>
+              <MaskedAddress address={walletAddress} />
+            </InvisibleCopyableAddress>
+            {isWhiteListed && (
+              <IconTooltip
+                icon="check-mark"
+                tooltipText={MSG.whitelistedTooltip}
+                iconSize="13px"
+                tooltipClassName={styles.whitelistedIconTooltip}
+                tooltipPopperProps={{
+                  placement: 'top',
+                  strategy: 'fixed',
+                }}
+                className={styles.whitelistedIcon}
+              />
+            )}
           </div>
         </div>
         {renderedExtraItemContent && <div>{renderedExtraItemContent}</div>}


### PR DESCRIPTION
## Description
![2022-02-14_14-32](https://user-images.githubusercontent.com/14034137/153837145-9efb48f8-0090-426b-8ef2-8c516a7f4d29.png)


**New stuff** ✨

* Adds an optional check-mark of primary color in the MembersListItem component.

**Changes** 🏗

* Changed `CopyableAddress` to `InvisibleCopyableAddress` in the same component.

**Testing the PR**

Since the logic for whitelisting will be implemented in different PR, try the following hack to test it locally.

On https://github.com/JoinColony/colonyDapp/blob/ae47419bae3068bdd79d78f3d615776ce4803104/src/modules/core/components/MembersList/MembersListItem.tsx#L56

change 

```diff
-    isWhiteListed,
+    isWhiteListed = true,
```

and visit the Members page on your colony.


Resolves #3183.