### PR TITLE
Add "confusable characters present" warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,6 +78,7 @@
         "reselect": "^4.0.0",
         "scroll-into-view-if-needed": "^2.2.16",
         "subscriptions-transport-ws": "^0.9.18",
+        "unicode-confusables": "^0.1.1",
         "userflow.js": "^2.2.0",
         "utility-types": "^3.7.0",
         "web3-eth-abi": "1.3.0",
@@ -54958,6 +54959,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/unicode-confusables": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/unicode-confusables/-/unicode-confusables-0.1.1.tgz",
+      "integrity": "sha512-XTPBWmT88BDpXz9NycWk4KxDn+/AJmJYYaYBwuIH9119sopwk2E9GxU9azc+JNbhEsfiPul78DGocEihCp6MFQ=="
+    },
     "node_modules/unicode-match-property-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
@@ -102721,6 +102727,11 @@
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
       "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
       "dev": true
+    },
+    "unicode-confusables": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/unicode-confusables/-/unicode-confusables-0.1.1.tgz",
+      "integrity": "sha512-XTPBWmT88BDpXz9NycWk4KxDn+/AJmJYYaYBwuIH9119sopwk2E9GxU9azc+JNbhEsfiPul78DGocEihCp6MFQ=="
     },
     "unicode-match-property-ecmascript": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -205,6 +205,7 @@
     "reselect": "^4.0.0",
     "scroll-into-view-if-needed": "^2.2.16",
     "subscriptions-transport-ws": "^0.9.18",
+    "unicode-confusables": "^0.1.1",
     "userflow.js": "^2.2.0",
     "utility-types": "^3.7.0",
     "web3-eth-abi": "1.3.0",

--- a/src/modules/core/components/ConfusableWarning/ConfusableWarning.css
+++ b/src/modules/core/components/ConfusableWarning/ConfusableWarning.css
@@ -20,7 +20,6 @@
   display: flex;
   justify-content: space-between;
   margin-top: 15px;
-  margin-bottom: 33px;
   padding-bottom: 15px;
   border-bottom: 1px solid color-mod(var(--temp-grey-blue-7) alpha(15%));
 }

--- a/src/modules/core/components/ConfusableWarning/ConfusableWarning.css
+++ b/src/modules/core/components/ConfusableWarning/ConfusableWarning.css
@@ -1,0 +1,36 @@
+.warningContainer {
+  margin-top: 20px;
+  padding: 20px 15px;
+  border-radius: var(--radius-normal);
+  background-color: color-mod(var(--danger) alpha(15%));
+}
+
+.warningText {
+  font-size: var(--size-smallish);
+  font-weight: var(--weight-bold);
+  line-height: 18px;
+  color: var(--dark);
+}
+
+.warningLabel {
+  color: var(--danger);
+}
+
+.reputationContainer {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 15px;
+  margin-bottom: 33px;
+  padding-bottom: 15px;
+  border-bottom: 1px solid color-mod(var(--temp-grey-blue-7) alpha(15%));
+}
+
+.reputationLabel {
+  font-weight: var(--weight-bold);
+  color: var(--temp-grey-blue-7);
+}
+
+.noReputation {
+  margin-bottom: 15px;
+  margin-top: 0;
+}

--- a/src/modules/core/components/ConfusableWarning/ConfusableWarning.css.d.ts
+++ b/src/modules/core/components/ConfusableWarning/ConfusableWarning.css.d.ts
@@ -1,0 +1,6 @@
+export const warningContainer: string;
+export const warningText: string;
+export const warningLabel: string;
+export const reputationContainer: string;
+export const reputationLabel: string;
+export const noReputation: string;

--- a/src/modules/core/components/ConfusableWarning/ConfusableWarning.tsx
+++ b/src/modules/core/components/ConfusableWarning/ConfusableWarning.tsx
@@ -16,6 +16,10 @@ const MSG = {
     id: 'ConfusableWarning.warningText',
     defaultMessage: `<span>Warning.</span> This username has confusable characters; it may be trying to impersonate another user.`,
   },
+  warningCurrentUserText: {
+    id: 'ConfusableWarning.warningCurrentUserText',
+    defaultMessage: `<span>Warning.</span> Your username has confusable characters. This will show a warning when selected by users.`,
+  },
   reputationLabel: {
     id: 'ConfusableWarning.reputationLabel',
     defaultMessage: "Recipient's reputation",
@@ -32,7 +36,9 @@ const ConfusableWarning = ({ walletAddress, colonyAddress }: Props) => {
       >
         <p className={styles.warningText}>
           <FormattedMessage
-            {...MSG.warningText}
+            {...(!walletAddress && !colonyAddress
+              ? MSG.warningCurrentUserText
+              : MSG.warningText)}
             values={{
               span: (chunks) => (
                 <span className={styles.warningLabel}>{chunks}</span>

--- a/src/modules/core/components/ConfusableWarning/ConfusableWarning.tsx
+++ b/src/modules/core/components/ConfusableWarning/ConfusableWarning.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+import classnames from 'classnames';
+
+import MemberReputation from '~core/MemberReputation';
+
+import styles from './ConfusableWarning.css';
+
+interface Props {
+  walletAddress?: string;
+  colonyAddress?: string;
+}
+
+const MSG = {
+  warningText: {
+    id: 'ConfusableWarning.warningText',
+    defaultMessage: `<span>Warning.</span> This username has confusable characters; it may be trying to impersonate another user.`,
+  },
+  reputationLabel: {
+    id: 'ConfusableWarning.reputationLabel',
+    defaultMessage: "Recipient's reputation",
+  },
+};
+
+const ConfusableWarning = ({ walletAddress, colonyAddress }: Props) => {
+  return (
+    <>
+      <div
+        className={classnames(styles.warningContainer, {
+          [styles.noReputation]: !walletAddress && !colonyAddress,
+        })}
+      >
+        <p className={styles.warningText}>
+          <FormattedMessage
+            {...MSG.warningText}
+            values={{
+              span: (chunks) => (
+                <span className={styles.warningLabel}>{chunks}</span>
+              ),
+            }}
+          />
+        </p>
+      </div>
+      {walletAddress && colonyAddress && (
+        <div className={styles.reputationContainer}>
+          <div className={styles.reputationLabel}>
+            <FormattedMessage {...MSG.reputationLabel} />
+          </div>
+          <MemberReputation
+            walletAddress={walletAddress}
+            colonyAddress={colonyAddress}
+          />
+        </div>
+      )}
+    </>
+  );
+};
+
+export default ConfusableWarning;

--- a/src/modules/core/components/ConfusableWarning/index.ts
+++ b/src/modules/core/components/ConfusableWarning/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ConfusableWarning';

--- a/src/modules/dashboard/components/CreateColonyWizard/StepUserName.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepUserName.tsx
@@ -2,7 +2,9 @@ import React, { useCallback } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import * as yup from 'yup';
 import { useApolloClient } from '@apollo/client';
+import { isConfusing } from 'unicode-confusables';
 
+import ConfusableWarning from '~core/ConfusableWarning';
 import { WizardProps } from '~core/Wizard';
 import { Form, Input } from '~core/Fields';
 import Heading from '~core/Heading';
@@ -147,6 +149,7 @@ const StepUserName = ({ stepCompleted, wizardForm, nextStep }: Props) => {
                   data-test="claimUsernameInput"
                   disabled={!isNetworkAllowed || isSubmitting}
                 />
+                {username && isConfusing(username) && <ConfusableWarning />}
                 <div className={styles.buttons}>
                   <p className={styles.reminder}>
                     <FormattedMessage

--- a/src/modules/dashboard/components/CreateUserWizard/StepUserName.tsx
+++ b/src/modules/dashboard/components/CreateUserWizard/StepUserName.tsx
@@ -2,7 +2,9 @@ import React, { useCallback } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import * as yup from 'yup';
 import { useApolloClient } from '@apollo/client';
+import { isConfusing } from 'unicode-confusables';
 
+import ConfusableWarning from '~core/ConfusableWarning';
 import { WizardProps } from '~core/Wizard';
 import { ActionForm, Input } from '~core/Fields';
 import Heading from '~core/Heading';
@@ -149,6 +151,7 @@ const StepUserName = ({ wizardValues, nextStep }: Props) => {
                   formattingOptions={{ lowercase: true, blocks: [100] }}
                   disabled={!isNetworkAllowed || isSubmitting}
                 />
+                {username && isConfusing(username) && <ConfusableWarning />}
                 <div className={styles.buttons}>
                   <Button
                     appearance={{ theme: 'primary', size: 'large' }}

--- a/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialog.tsx
@@ -11,7 +11,7 @@ import { ActionForm } from '~core/Fields';
 
 import { Address } from '~types/index';
 import { ActionTypes } from '~redux/index';
-import { useMembersSubscription } from '~data/index';
+import { AnyUser, useMembersSubscription } from '~data/index';
 import { getTokenDecimalsWithFallback } from '~utils/tokens';
 import { pipe, withMeta, mapPayload } from '~utils/actions';
 import { WizardDialogType } from '~utils/hooks';
@@ -32,7 +32,7 @@ const MSG = defineMessages({
 export interface FormValues {
   forceAction: boolean;
   domainId: string;
-  recipient: Address;
+  recipient: AnyUser;
   amount: string;
   tokenAddress: Address;
   annotation: string;

--- a/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
@@ -10,11 +10,13 @@ import moveDecimal from 'move-decimal-point';
 import sortBy from 'lodash/sortBy';
 import { ColonyRole, ROOT_DOMAIN_ID } from '@colony/colony-js';
 import { AddressZero } from 'ethers/constants';
+import { isConfusing } from 'unicode-confusables';
 
 import EthUsd from '~core/EthUsd';
 import Numeral from '~core/Numeral';
 import PermissionsLabel from '~core/PermissionsLabel';
 import Button from '~core/Button';
+import ConfusableWarning from '~core/ConfusableWarning';
 import { ItemDataType } from '~core/OmniPicker';
 import { ActionDialogProps } from '~core/Dialog';
 import DialogSection from '~core/Dialog/DialogSection';
@@ -402,6 +404,12 @@ const CreatePaymentDialogForm = ({
             placeholder={MSG.userPickerPlaceholder}
           />
         </div>
+        {values.recipient && isConfusing(values.recipient.profile.username) && (
+          <ConfusableWarning
+            walletAddress={values.recipient.profile.walletAddress}
+            colonyAddress={colonyAddress}
+          />
+        )}
       </DialogSection>
       <DialogSection>
         <div className={styles.tokenAmount}>

--- a/src/modules/users/components/UserProfileEdit/UserProfileEdit.tsx
+++ b/src/modules/users/components/UserProfileEdit/UserProfileEdit.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import { defineMessages } from 'react-intl';
 import * as yup from 'yup';
 import { Redirect } from 'react-router-dom';
+import { isConfusing } from 'unicode-confusables';
 
 import CopyableAddress from '~core/CopyableAddress';
 import UserMention from '~core/UserMention';
@@ -15,6 +16,7 @@ import {
   Textarea,
 } from '~core/Fields';
 import Button from '~core/Button';
+import ConfusableWarning from '~core/ConfusableWarning';
 import ProfileTemplate from '~pages/ProfileTemplate';
 import { useLoggedInUser, useUser, useEditUserMutation } from '~data/index';
 import { LANDING_PAGE_ROUTE } from '~routes/index';
@@ -108,7 +110,7 @@ const UserProfileEdit = () => {
         onSubmit={onSubmit}
         validationSchema={validationSchema}
       >
-        {({ status, isSubmitting }) => (
+        {({ status, isSubmitting, values }) => (
           <div className={styles.main}>
             <FieldSet>
               <InputLabel label={MSG.labelWallet} />
@@ -131,6 +133,9 @@ const UserProfileEdit = () => {
                 name="displayName"
                 data-test="userSettingsName"
               />
+              {values.displayName && isConfusing(values.displayName) && (
+                <ConfusableWarning />
+              )}
               <Textarea
                 label={MSG.labelBio}
                 name="bio"


### PR DESCRIPTION
Added `unicode-confusables` package which comes with a `isConfusing` function that detects if the string has any confusable letters/characters, now a warning should be shown in the payment modal when the user has a confusable character in their name.

An example of a name with a confusable character: `fоо`

![FireShot Capture 538 - Colony - localhost](https://user-images.githubusercontent.com/18473896/154133969-ff1456e0-77e8-4910-bb8d-9c46ca162e6e.png)

Resolves #3185 and #3186
