### PR TITLE
Add a default tooltip theme for the IconTooltip component

### DIFF
--- a/src/modules/core/components/IconTooltip/IconTooltip.tsx
+++ b/src/modules/core/components/IconTooltip/IconTooltip.tsx
@@ -49,7 +49,10 @@ const IconTooltip = ({
 }: Props) => (
   <div className={cx(getMainClasses(appearance, styles), className)}>
     <Tooltip
-      appearance={{ theme: appearance.theme, size: 'medium' }}
+      appearance={{
+        theme: appearance.theme ? appearance.theme : 'dark',
+        size: 'medium',
+      }}
       content={
         typeof tooltipText === 'string' ? (
           tooltipText


### PR DESCRIPTION
## Description

Adds a default theme to the IconToolTip components Tooltip. Fixing a bug introduced in this PR https://github.com/JoinColony/colonyDapp/pull/3197

### After
![ac250805-4a32-4a19-87b7-6bfaef0ca529](https://user-images.githubusercontent.com/33682027/154673612-c11181ff-ea35-4d78-9a79-eb3f68561b15.png)

### Before
![08ee7617-57fa-40f1-b3eb-f5de77e93be0](https://user-images.githubusercontent.com/33682027/154673646-cfcd8e09-a81d-40ef-8e88-25e5cfcde01d.png)


Resolves #3199
