### PR TITLE
Fix max button calculation in `BuyTokens` widget

### DIFF
--- a/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
+++ b/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
@@ -258,17 +258,17 @@ const BuyTokens = ({
         : bigNumberify(1);
 
       const maxUserBalancePurchase = userTokenBalance
-        .div(currentPrice)
         /*
-        when we divide by a number with moved decimal our final number
-        gets smaller by the '10 * the number of 0 that are added'
-        so we need to counteract it by multiplying it back
-         */
+      when we divide by a number with moved decimal our final number
+      gets smaller by the '10 * the number of 0 that are added'
+      so we need to counteract it by multiplying it back
+      */
         .mul(
           bigNumberify(10).pow(
             getTokenDecimalsWithFallback(purchaseToken.decimals),
           ),
-        );
+        )
+        .div(currentPrice);
       if (maxUserBalancePurchase.gt(maxContractPurchase)) {
         return bigNumberify(maxContractPurchase);
       }


### PR DESCRIPTION
## Description

This PR fixes the bug when the max button doesn't work when max value is decimal.

**Changes** 🏗

- update `BuyTokens`

resolves #3046 
