### PR TITLE
Improve Icon's alignment

### DIFF
--- a/src/modules/core/components/DecisionHub/DecisionOption.css
+++ b/src/modules/core/components/DecisionHub/DecisionOption.css
@@ -36,6 +36,7 @@
 
 .rowIcon {
   flex: 0 0 50px;
+  height: 16px;
   text-align: center;
 }
 

--- a/src/modules/core/components/Fields/InputLabel/InputLabel.css
+++ b/src/modules/core/components/Fields/InputLabel/InputLabel.css
@@ -1,5 +1,7 @@
 .main {
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   margin-bottom: 6px;
   width: 100%;
   position: relative;
@@ -58,12 +60,6 @@
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-}
-
-.extra {
-  position: absolute;
-  top: 0;
-  right: 0;
 }
 
 .stateScreenReaderOnly {

--- a/src/modules/core/components/Fields/InputLabel/InputLabel.css.d.ts
+++ b/src/modules/core/components/Fields/InputLabel/InputLabel.css.d.ts
@@ -9,6 +9,5 @@ export const colorSchemaGrey: string;
 export const error: string;
 export const help: string;
 export const helpAlignRight: string;
-export const extra: string;
 export const stateScreenReaderOnly: string;
 export const sizeMedium: string;

--- a/src/modules/core/components/Fields/InputLabel/InputLabel.tsx
+++ b/src/modules/core/components/Fields/InputLabel/InputLabel.tsx
@@ -70,7 +70,7 @@ const InputLabel = ({
     >
       <span className={styles.labelText}>{labelText}</span>
       {helpText && <span className={styles.help}>{helpText}</span>}
-      {extra && <span className={styles.extra}>{extra}</span>}
+      {extra && <span>{extra}</span>}
     </label>
   );
 };

--- a/src/modules/core/components/Fields/InputLabel/InputLabel.tsx
+++ b/src/modules/core/components/Fields/InputLabel/InputLabel.tsx
@@ -68,8 +68,10 @@ const InputLabel = ({
       id={inputId ? `${inputId}-label` : undefined}
       htmlFor={inputId || undefined}
     >
-      <span className={styles.labelText}>{labelText}</span>
-      {helpText && <span className={styles.help}>{helpText}</span>}
+      <div>
+        <span className={styles.labelText}>{labelText}</span>
+        {helpText && <span className={styles.help}>{helpText}</span>}
+      </div>
       {extra && <span>{extra}</span>}
     </label>
   );

--- a/src/modules/core/components/Fields/InputLabel/__tests__/__snapshots__/InputLabel.test.tsx.snap
+++ b/src/modules/core/components/Fields/InputLabel/__tests__/__snapshots__/InputLabel.test.tsx.snap
@@ -12,12 +12,14 @@ exports[`InputLabel intl={intl} component Renders initial component 1`] = `
     htmlFor="foo"
     id="foo-label"
   >
-    <span>
-      awesome
-    </span>
-    <span>
-      halp
-    </span>
+    <div>
+      <span>
+        awesome
+      </span>
+      <span>
+        halp
+      </span>
+    </div>
   </label>
 </InputLabel>
 `;

--- a/src/modules/core/components/Fields/Radio/CustomRadio.css
+++ b/src/modules/core/components/Fields/Radio/CustomRadio.css
@@ -89,6 +89,7 @@
 
 .icon {
   margin-right: 10px;
+  height: 28px;
 }
 
 .content {

--- a/src/modules/core/components/Fields/Radio/__tests__/__snapshots__/Radio.test.tsx.snap
+++ b/src/modules/core/components/Fields/Radio/__tests__/__snapshots__/Radio.test.tsx.snap
@@ -43,12 +43,14 @@ exports[`Radio component Renders initial component 1`] = `
             htmlFor="halpHalp"
             id="halpHalp-label"
           >
-            <span>
-              awesome
-            </span>
-            <span>
-              halp
-            </span>
+            <div>
+              <span>
+                awesome
+              </span>
+              <span>
+                halp
+              </span>
+            </div>
           </label>
         </InputLabel>
       </span>

--- a/src/modules/core/components/Fields/Select/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/src/modules/core/components/Fields/Select/__tests__/__snapshots__/Select.test.tsx.snap
@@ -60,9 +60,11 @@ exports[`Select component Renders initial component 1`] = `
                 htmlFor="someStaticId"
                 id="someStaticId-label"
               >
-                <span>
-                  Select me
-                </span>
+                <div>
+                  <span>
+                    Select me
+                  </span>
+                </div>
               </label>
             </InputLabel>
             <div>

--- a/src/modules/core/components/Fields/Toggle/Toggle.css
+++ b/src/modules/core/components/Fields/Toggle/Toggle.css
@@ -79,6 +79,7 @@
 
 .icon {
   margin-left: 11px;
+  height: 16px;
 }
 
 .main {

--- a/src/modules/core/components/FileUpload/__tests__/__snapshots__/FileUpload.test.tsx.snap
+++ b/src/modules/core/components/FileUpload/__tests__/__snapshots__/FileUpload.test.tsx.snap
@@ -145,12 +145,14 @@ exports[`FileUpload component Renders initial component 1`] = `
                 <label
                   className=""
                 >
-                  <span>
-                    Basic file upload
-                  </span>
-                  <span>
-                    Some help text
-                  </span>
+                  <div>
+                    <span>
+                      Basic file upload
+                    </span>
+                    <span>
+                      Some help text
+                    </span>
+                  </div>
                 </label>
               </InputLabel>
               <div

--- a/src/modules/core/components/Icon/Icon.css
+++ b/src/modules/core/components/Icon/Icon.css
@@ -7,10 +7,6 @@
   display: inline-block;
 }
 
-.main svg {
-  vertical-align: top;
-}
-
 .main svg use {
   pointer-events: none;
 }

--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.css
@@ -22,12 +22,19 @@
 }
 
 .label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  line-height: 18px;
   color: color-mod(var(--temp-grey-blue-7) alpha(85%));
 }
 
 .value {
   composes: inlineEllipsis from '~styles/text.css';
+  display: flex;
+  align-items: center;
   max-width: 200px;
+  line-height: 18px;
   color: color-mod(var(--dark) alpha(85%));
 }
 

--- a/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.css
@@ -54,6 +54,7 @@
 .help {
   display: inline-block;
   margin-left: 7px;
+  height: 16px;
   width: 33px;
   cursor: pointer;
 }

--- a/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
@@ -312,17 +312,15 @@ const FinalizeMotionAndClaimWidget = ({
             <>
               <div className={styles.itemWithForcedBorder}>
                 <div className={styles.label}>
-                  <div>
-                    <FormattedMessage {...MSG.finalizeLabel} />
-                    <QuestionMarkTooltip
-                      tooltipText={MSG.finalizeTooltip}
-                      className={styles.help}
-                      tooltipClassName={styles.tooltip}
-                      tooltipPopperProps={{
-                        placement: 'right',
-                      }}
-                    />
-                  </div>
+                  <FormattedMessage {...MSG.finalizeLabel} />
+                  <QuestionMarkTooltip
+                    tooltipText={MSG.finalizeTooltip}
+                    className={styles.help}
+                    tooltipClassName={styles.tooltip}
+                    tooltipPopperProps={{
+                      placement: 'right',
+                    }}
+                  />
                 </div>
                 <div className={styles.value}>
                   <Button

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css
@@ -5,6 +5,7 @@
 .widgetHeading {
   display: flex;
   justify-content: space-between;
+  align-items: center;
   margin-bottom: 7px;
 }
 
@@ -40,6 +41,7 @@
 .help {
   margin-right: auto;
   margin-left: 8px;
+  height: 16px;
 }
 
 .tooltip {

--- a/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteDetails.tsx
+++ b/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteDetails.tsx
@@ -108,17 +108,15 @@ const VoteDetails = ({
     <div>
       <div className={styles.item}>
         <div className={styles.label}>
-          <div>
-            <FormattedMessage {...MSG.votingMethodLabel} />
-            <QuestionMarkTooltip
-              tooltipText={MSG.votingMethodTooltip}
-              className={styles.help}
-              tooltipClassName={styles.tooltip}
-              tooltipPopperProps={{
-                placement: 'right',
-              }}
-            />
-          </div>
+          <FormattedMessage {...MSG.votingMethodLabel} />
+          <QuestionMarkTooltip
+            tooltipText={MSG.votingMethodTooltip}
+            className={styles.help}
+            tooltipClassName={styles.tooltip}
+            tooltipPopperProps={{
+              placement: 'right',
+            }}
+          />
         </div>
         <div className={styles.value}>
           {/*
@@ -134,17 +132,15 @@ const VoteDetails = ({
         <>
           <div className={styles.item}>
             <div className={styles.label}>
-              <div>
-                <FormattedMessage {...MSG.reputationTeamLabel} />
-                <QuestionMarkTooltip
-                  tooltipText={MSG.reputationTeamTooltip}
-                  className={styles.help}
-                  tooltipClassName={styles.tooltip}
-                  tooltipPopperProps={{
-                    placement: 'right',
-                  }}
-                />
-              </div>
+              <FormattedMessage {...MSG.reputationTeamLabel} />
+              <QuestionMarkTooltip
+                tooltipText={MSG.reputationTeamTooltip}
+                className={styles.help}
+                tooltipClassName={styles.tooltip}
+                tooltipPopperProps={{
+                  placement: 'right',
+                }}
+              />
             </div>
             <div className={styles.value}>
               <div className={styles.reputation}>
@@ -157,17 +153,15 @@ const VoteDetails = ({
           </div>
           <div className={styles.item}>
             <div className={styles.label}>
-              <div>
-                <FormattedMessage {...MSG.rewardLabel} />
-                <QuestionMarkTooltip
-                  tooltipText={MSG.rewardTooltip}
-                  className={styles.help}
-                  tooltipClassName={styles.tooltip}
-                  tooltipPopperProps={{
-                    placement: 'right',
-                  }}
-                />
-              </div>
+              <FormattedMessage {...MSG.rewardLabel} />
+              <QuestionMarkTooltip
+                tooltipText={MSG.rewardTooltip}
+                className={styles.help}
+                tooltipClassName={styles.tooltip}
+                tooltipPopperProps={{
+                  placement: 'right',
+                }}
+              />
             </div>
             <div className={styles.value}>
               {voterReward?.motionVoterReward && (
@@ -239,17 +233,15 @@ const VoteDetails = ({
       {buttonComponent && (
         <div className={styles.item}>
           <div className={styles.label}>
-            <div>
-              <FormattedMessage {...MSG.rulesLabel} />
-              <QuestionMarkTooltip
-                tooltipText={MSG.rulesTooltip}
-                className={styles.help}
-                tooltipClassName={styles.tooltip}
-                tooltipPopperProps={{
-                  placement: 'right',
-                }}
-              />
-            </div>
+            <FormattedMessage {...MSG.rulesLabel} />
+            <QuestionMarkTooltip
+              tooltipText={MSG.rulesTooltip}
+              className={styles.help}
+              tooltipClassName={styles.tooltip}
+              tooltipPopperProps={{
+                placement: 'right',
+              }}
+            />
           </div>
           <div className={styles.value}>{buttonComponent}</div>
         </div>

--- a/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteWidget.css
@@ -34,9 +34,8 @@
 }
 
 .help {
-  display: inline-block;
   margin-left: 7px;
-  width: 33px;
+  height: 16px;
   cursor: pointer;
 }
 
@@ -76,8 +75,5 @@
 }
 
 .tokenIcon {
-  display: inline-block;
-  margin-top: -3px;
   margin-right: 6px;
-  vertical-align: middle;
 }

--- a/src/modules/dashboard/components/CreateColonyWizard/StepColonyName.css
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepColonyName.css
@@ -28,8 +28,7 @@
 }
 
 .iconContainer {
-  position: relative;
-  bottom: 5px;
+  height: 16px;
 }
 
 .tooltipContent {

--- a/src/modules/users/components/GasStation/TransactionCard/TransactionStatus.css
+++ b/src/modules/users/components/GasStation/TransactionCard/TransactionStatus.css
@@ -1,5 +1,6 @@
 .main {
   flex: 0 1 auto;
+  height: 100%;
   cursor: default;
 }
 


### PR DESCRIPTION
An attempt to improve the alignment of the many icons that we use in the dapp, with an emphasis on the `QuestionMarkTooltip` icon.

I removed a CSS property from the core `Icon` component that, as expected, affects all of the icons in the dapp so make sure to watch out for any misaligned icon.

![FireShot Capture 546 - Colony - localhost](https://user-images.githubusercontent.com/18473896/155404731-fae84258-28b9-4801-9a88-85834818b519.png)

![FireShot Capture 544 - Colony - localhost](https://user-images.githubusercontent.com/18473896/155403983-3c810467-515e-4dae-ad75-34f955d9df5f.png)

Resolves #2825 