### PR TITLE
Retrieve transaction hashes for a list of MotionIds

### DIFF
--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -227,7 +227,6 @@ export type MutationUnsubscribeFromColonyArgs = {
 };
 
 export type Query = {
-  SubgraphMotionsTx: Array<MotionTxHash>;
   actionsThatNeedAttention: Array<Maybe<ActionThatNeedsAttention>>;
   bannedUsers: Array<Maybe<BannedUser>>;
   claimableStakedMotions: ClaimableMotions;
@@ -273,7 +272,7 @@ export type Query = {
   motionVoterReward: MotionVoterReward;
   motions: Array<SubgraphMotion>;
   motionsSystemMessages: Array<SystemMessage>;
-  motionsTxHashes: Array<MotionTxHash>;
+  motionsTxHashes: MotionsTxHashes;
   networkContracts: NetworkContracts;
   networkExtensionVersion: Array<Maybe<ColonyExtensionVersion>>;
   processedColony: ProcessedColony;
@@ -301,15 +300,6 @@ export type Query = {
   whitelistAgreement: Scalars['String'];
   whitelistPolicies: WhitelistPolicy;
   whitelistedUsers: Array<Maybe<WhitelistedUser>>;
-};
-
-
-export type QuerySubgraphMotionsTxArgs = {
-  skip?: Maybe<Scalars['Int']>;
-  first?: Maybe<Scalars['Int']>;
-  orderBy?: Maybe<Scalars['String']>;
-  orderDirection?: Maybe<Scalars['String']>;
-  where: MotionsFilter;
 };
 
 
@@ -1406,9 +1396,17 @@ export type MotionTimeoutPeriods = {
   timeLeftToSubmit: Scalars['Int'];
 };
 
-export type MotionTxHash = {
-  motionId: Scalars['String'];
-  transactionHash: Scalars['String'];
+export type TxHash = {
+  txHash: Scalars['String'];
+};
+
+export type MotionTxHashMapTuple = {
+  key: Scalars['Int'];
+  value: TxHash;
+};
+
+export type MotionsTxHashes = {
+  motionTxHash: Array<MotionTxHashMapTuple>;
 };
 
 export type UsersAndRecoveryApprovals = {

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -227,7 +227,7 @@ export type MutationUnsubscribeFromColonyArgs = {
 };
 
 export type Query = {
-  SubgraphMotionsTx: Array<MotionsTxHash>;
+  SubgraphMotionsTx: Array<MotionTxHash>;
   actionsThatNeedAttention: Array<Maybe<ActionThatNeedsAttention>>;
   bannedUsers: Array<Maybe<BannedUser>>;
   claimableStakedMotions: ClaimableMotions;
@@ -273,7 +273,7 @@ export type Query = {
   motionVoterReward: MotionVoterReward;
   motions: Array<SubgraphMotion>;
   motionsSystemMessages: Array<SystemMessage>;
-  motionsTxHashes?: Maybe<Array<Maybe<MotionsTxHash>>>;
+  motionsTxHashes: Array<MotionTxHash>;
   networkContracts: NetworkContracts;
   networkExtensionVersion: Array<Maybe<ColonyExtensionVersion>>;
   processedColony: ProcessedColony;
@@ -1406,7 +1406,7 @@ export type MotionTimeoutPeriods = {
   timeLeftToSubmit: Scalars['Int'];
 };
 
-export type MotionsTxHash = {
+export type MotionTxHash = {
   motionId: Scalars['String'];
   transactionHash: Scalars['String'];
 };
@@ -2294,7 +2294,7 @@ export type SubgraphMotionsTxQueryVariables = Exact<{
 
 
 export type SubgraphMotionsTxQuery = { motionsTx: Array<(
-    Pick<SubgraphMotion, 'fundamentalChainId'>
+    { motionId: SubgraphMotion['fundamentalChainId'] }
     & { transaction: { hash: SubgraphTransaction['id'] } }
   )> };
 
@@ -6078,7 +6078,7 @@ export type SubgraphMotionEventsQueryResult = Apollo.QueryResult<SubgraphMotionE
 export const SubgraphMotionsTxDocument = gql`
     query SubgraphMotionsTx($skip: Int = 0, $first: Int = 1000, $motionIds: [String!]!, $colonyAddress: String!, $extensionAddress: String!) {
   motionsTx: motions(skip: $skip, first: $first, where: {fundamentalChainId_in: $motionIds, associatedColony: $colonyAddress, extensionAddress: $extensionAddress}, orderBy: "fundamentalChainId", orderDirection: "asc") {
-    fundamentalChainId
+    motionId: fundamentalChainId
     transaction {
       hash: id
     }

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -272,7 +272,7 @@ export type Query = {
   motionVoterReward: MotionVoterReward;
   motions: Array<SubgraphMotion>;
   motionsSystemMessages: Array<SystemMessage>;
-  motionsTxHashes: MotionsTxHashes;
+  motionsTxHashes: MotionTxHashMap;
   networkContracts: NetworkContracts;
   networkExtensionVersion: Array<Maybe<ColonyExtensionVersion>>;
   processedColony: ProcessedColony;
@@ -1400,13 +1400,9 @@ export type TxHash = {
   txHash: Scalars['String'];
 };
 
-export type MotionTxHashMapTuple = {
+export type MotionTxHashMap = {
   key: Scalars['Int'];
   value: TxHash;
-};
-
-export type MotionsTxHashes = {
-  motionTxHash: Array<MotionTxHashMapTuple>;
 };
 
 export type UsersAndRecoveryApprovals = {

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -271,6 +271,7 @@ export type Query = {
   motionVoteResults: MotionVoteResults;
   motionVoterReward: MotionVoterReward;
   motionsSystemMessages: Array<SystemMessage>;
+  motionsTxHashes?: Maybe<Array<Maybe<MotionIdTxHash>>>;
   networkContracts: NetworkContracts;
   networkExtensionVersion: Array<Maybe<ColonyExtensionVersion>>;
   processedColony: ProcessedColony;
@@ -558,6 +559,12 @@ export type QueryMotionVoterRewardArgs = {
 
 export type QueryMotionsSystemMessagesArgs = {
   motionId: Scalars['Int'];
+  colonyAddress: Scalars['String'];
+};
+
+
+export type QueryMotionsTxHashesArgs = {
+  motionIds?: Maybe<Array<Maybe<Scalars['String']>>>;
   colonyAddress: Scalars['String'];
 };
 
@@ -1300,6 +1307,11 @@ export type MotionVoteReveal = {
   vote: Scalars['Int'];
 };
 
+export type MotionIdTxHash = {
+  motionId: Scalars['String'];
+  transactionHash: Scalars['String'];
+};
+
 export type MotionVoteResults = {
   currentUserVoteSide: Scalars['Int'];
   yayVotes: Scalars['String'];
@@ -1759,6 +1771,14 @@ export type NetworkContractsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type NetworkContractsQuery = { networkContracts: Pick<NetworkContracts, 'version' | 'feeInverse'> };
+
+export type MotionsTxHashesQueryVariables = Exact<{
+  motionIds?: Maybe<Array<Scalars['String']>>;
+  colonyAddress: Scalars['String'];
+}>;
+
+
+export type MotionsTxHashesQuery = Pick<Query, 'motionsTxHashes'>;
 
 export type ColonyActionQueryVariables = Exact<{
   transactionHash: Scalars['String'];
@@ -4195,6 +4215,38 @@ export function useNetworkContractsLazyQuery(baseOptions?: Apollo.LazyQueryHookO
 export type NetworkContractsQueryHookResult = ReturnType<typeof useNetworkContractsQuery>;
 export type NetworkContractsLazyQueryHookResult = ReturnType<typeof useNetworkContractsLazyQuery>;
 export type NetworkContractsQueryResult = Apollo.QueryResult<NetworkContractsQuery, NetworkContractsQueryVariables>;
+export const MotionsTxHashesDocument = gql`
+    query MotionsTxHashes($motionIds: [String!], $colonyAddress: String!) {
+  motionsTxHashes(motionIds: $MotionIds, colonyAddress: $colonyAddress) @client
+}
+    `;
+
+/**
+ * __useMotionsTxHashesQuery__
+ *
+ * To run a query within a React component, call `useMotionsTxHashesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useMotionsTxHashesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useMotionsTxHashesQuery({
+ *   variables: {
+ *      motionIds: // value for 'motionIds'
+ *      colonyAddress: // value for 'colonyAddress'
+ *   },
+ * });
+ */
+export function useMotionsTxHashesQuery(baseOptions?: Apollo.QueryHookOptions<MotionsTxHashesQuery, MotionsTxHashesQueryVariables>) {
+        return Apollo.useQuery<MotionsTxHashesQuery, MotionsTxHashesQueryVariables>(MotionsTxHashesDocument, baseOptions);
+      }
+export function useMotionsTxHashesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<MotionsTxHashesQuery, MotionsTxHashesQueryVariables>) {
+          return Apollo.useLazyQuery<MotionsTxHashesQuery, MotionsTxHashesQueryVariables>(MotionsTxHashesDocument, baseOptions);
+        }
+export type MotionsTxHashesQueryHookResult = ReturnType<typeof useMotionsTxHashesQuery>;
+export type MotionsTxHashesLazyQueryHookResult = ReturnType<typeof useMotionsTxHashesLazyQuery>;
+export type MotionsTxHashesQueryResult = Apollo.QueryResult<MotionsTxHashesQuery, MotionsTxHashesQueryVariables>;
 export const ColonyActionDocument = gql`
     query ColonyAction($transactionHash: String!, $colonyAddress: String!) {
   colonyAction(transactionHash: $transactionHash, colonyAddress: $colonyAddress) @client {

--- a/src/data/graphql/queries.graphql
+++ b/src/data/graphql/queries.graphql
@@ -196,6 +196,11 @@ query NetworkContracts {
   }
 }
 
+query MotionsTxHashes($motionIds: [String!], $colonyAddress: String!) {
+  motionsTxHashes(motionIds: $MotionIds, colonyAddress: $colonyAddress) @client
+}
+
+
 query ColonyAction($transactionHash: String!, $colonyAddress: String!) {
   colonyAction(transactionHash: $transactionHash, colonyAddress: $colonyAddress) @client {
     hash

--- a/src/data/graphql/queries.graphql
+++ b/src/data/graphql/queries.graphql
@@ -196,8 +196,8 @@ query NetworkContracts {
   }
 }
 
-query MotionsTxHashes($motionIds: [String!], $colonyAddress: String!) {
-  motionsTxHashes(motionIds: $MotionIds, colonyAddress: $colonyAddress) @client
+query MotionsTxHashes($motionIds: [String!]!, $colonyAddress: String!) {
+  motionsTxHashes(motionIds: $motionIds, colonyAddress: $colonyAddress) @client
 }
 
 

--- a/src/data/graphql/queries/motions.graphql
+++ b/src/data/graphql/queries/motions.graphql
@@ -42,10 +42,11 @@ query SubgraphMotionsTx($skip: Int = 0, $first: Int = 1000, $motionIds: [String!
     orderBy: "fundamentalChainId",
     orderDirection: "asc"
   ) {
-      fundamentalChainId
+      motionId: fundamentalChainId
       transaction {
         hash: id
     }
+
   }
 }
 

--- a/src/data/graphql/queries/motions.graphql
+++ b/src/data/graphql/queries/motions.graphql
@@ -30,6 +30,25 @@ query SubgraphMotionEvents($colonyAddress: String!, $motionId: String!, $extensi
   }
 }
 
+query SubgraphMotionsTx($skip: Int = 0, $first: Int = 1000, $motionIds: [String!]!, $colonyAddress: String!, $extensionAddress: String!) {
+  motionsTx: motions(
+    skip: $skip,
+    first: $first,
+    where: {
+      fundamentalChainId_in: $motionIds
+      associatedColony: $colonyAddress,
+      extensionAddress: $extensionAddress,
+    },
+    orderBy: "fundamentalChainId",
+    orderDirection: "asc"
+  ) {
+      fundamentalChainId
+      transaction {
+        hash: id
+    }
+  }
+}
+
 query SubgraphMotionSystemEvents($colonyAddress: String!, $motionId: String!, $extensionAddress: String!, $sortDirection: String = asc) {
   motionSystemEvents: events(
     orderBy: "timestamp",

--- a/src/data/graphql/typeDefs.ts
+++ b/src/data/graphql/typeDefs.ts
@@ -66,6 +66,16 @@ export default gql`
     processedValues: SugraphEventProcessedValues!
   }
 
+  type SubgraphMotion {
+    fundamentalChainId: String!
+    transaction: SubgraphTransaction!
+    address: String!
+    name: String!
+    args: String!
+    timestamp: String!
+    associatedColony: SubgraphColony!
+  }
+
   type ParsedEvent {
     type: String!
     name: String!

--- a/src/data/graphql/typeDefs/motions.ts
+++ b/src/data/graphql/typeDefs/motions.ts
@@ -89,7 +89,7 @@ export default gql`
     timeLeftToEscalate: Int!
   }
 
-  type MotionsTxHash {
+  type MotionTxHash {
     motionId: String!
     transactionHash: String!
   }
@@ -153,13 +153,13 @@ export default gql`
     motionsTxHashes(
       motionIds: [String!]!
       colonyAddress: String!
-    ): [MotionsTxHash]
+    ): [MotionTxHash!]!
     SubgraphMotionsTx(
       skip: Int
       first: Int
       orderBy: String
       orderDirection: String
       where: MotionsFilter!
-    ): [MotionsTxHash!]!
+    ): [MotionTxHash!]!
   }
 `;

--- a/src/data/graphql/typeDefs/motions.ts
+++ b/src/data/graphql/typeDefs/motions.ts
@@ -20,11 +20,6 @@ export default gql`
     vote: Int!
   }
 
-  type MotionIdTxHash {
-    motionId: String!
-    transactionHash: String!
-  }
-
   type MotionVoteResults {
     currentUserVoteSide: Int!
     yayVotes: String!
@@ -94,6 +89,11 @@ export default gql`
     timeLeftToEscalate: Int!
   }
 
+  type MotionsTxHash {
+    motionId: String!
+    transactionHash: String!
+  }
+
   extend type Query {
     eventsForMotion(motionId: Int!, colonyAddress: String!): [ParsedEvent!]!
     motionStakes(
@@ -151,8 +151,15 @@ export default gql`
       colonyAddress: String!
     ): MotionTimeoutPeriods!
     motionsTxHashes(
-      motionIds: [String]
+      motionIds: [String!]!
       colonyAddress: String!
-    ): [MotionIdTxHash]
+    ): [MotionsTxHash]
+    SubgraphMotionsTx(
+      skip: Int
+      first: Int
+      orderBy: String
+      orderDirection: String
+      where: MotionsFilter!
+    ): [MotionsTxHash!]!
   }
 `;

--- a/src/data/graphql/typeDefs/motions.ts
+++ b/src/data/graphql/typeDefs/motions.ts
@@ -20,6 +20,11 @@ export default gql`
     vote: Int!
   }
 
+  type MotionIdTxHash {
+    motionId: String!
+    transactionHash: String!
+  }
+
   type MotionVoteResults {
     currentUserVoteSide: Int!
     yayVotes: String!
@@ -145,5 +150,9 @@ export default gql`
       motionId: Int!
       colonyAddress: String!
     ): MotionTimeoutPeriods!
+    motionsTxHashes(
+      motionIds: [String]
+      colonyAddress: String!
+    ): [MotionIdTxHash]
   }
 `;

--- a/src/data/graphql/typeDefs/motions.ts
+++ b/src/data/graphql/typeDefs/motions.ts
@@ -89,9 +89,17 @@ export default gql`
     timeLeftToEscalate: Int!
   }
 
-  type MotionTxHash {
-    motionId: String!
-    transactionHash: String!
+  type TxHash {
+    txHash: String!
+  }
+
+  type MotionTxHashMapTuple {
+    key: Int!
+    value: TxHash!
+  }
+
+  type MotionsTxHashes {
+    motionTxHash: [MotionTxHashMapTuple!]!
   }
 
   extend type Query {
@@ -153,13 +161,6 @@ export default gql`
     motionsTxHashes(
       motionIds: [String!]!
       colonyAddress: String!
-    ): [MotionTxHash!]!
-    SubgraphMotionsTx(
-      skip: Int
-      first: Int
-      orderBy: String
-      orderDirection: String
-      where: MotionsFilter!
-    ): [MotionTxHash!]!
+    ): MotionsTxHashes!
   }
 `;

--- a/src/data/graphql/typeDefs/motions.ts
+++ b/src/data/graphql/typeDefs/motions.ts
@@ -93,13 +93,9 @@ export default gql`
     txHash: String!
   }
 
-  type MotionTxHashMapTuple {
+  type MotionTxHashMap {
     key: Int!
     value: TxHash!
-  }
-
-  type MotionsTxHashes {
-    motionTxHash: [MotionTxHashMapTuple!]!
   }
 
   extend type Query {
@@ -161,6 +157,6 @@ export default gql`
     motionsTxHashes(
       motionIds: [String!]!
       colonyAddress: String!
-    ): MotionsTxHashes!
+    ): MotionTxHashMap!
   }
 `;

--- a/src/data/graphql/typeDefs/subgraphGeneral.ts
+++ b/src/data/graphql/typeDefs/subgraphGeneral.ts
@@ -28,6 +28,13 @@ export default gql`
       orderDirection: String
       block: ToBlockInput
     ): [SubgraphEvent!]!
+    motions(
+      skip: Int
+      first: Int
+      orderBy: String
+      orderDirection: String
+      where: MotionsFilter!
+    ): [SubgraphMotion!]!
     domain(id: Int!, block: SubgraphMetaBlock): SubgraphUnusedDomain!
   }
 `;

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -50,10 +50,9 @@ import {
   // MotionsTxHashesQuery,
   // MotionsTxHashesQueryVariables,
   // MotionsTxHashesDocument
-  SubgraphMotionsSubscription,
-  SubgraphMotionsSubscriptionVariables,
-  SubgraphMotionsDocument,
-  // SubgraphMotionsSubscriptionDocument,
+  SubgraphMotionsTxQuery,
+  SubgraphMotionsTxQueryVariables,
+  SubgraphMotionsTxDocument,
   UserReputationQuery,
   UserReputationQueryVariables,
   UserReputationDocument,
@@ -68,7 +67,7 @@ import { availableRoles } from '~dialogs/PermissionManagementDialog';
 import { DEFAULT_NETWORK_TOKEN } from '~constants';
 
 import { ProcessedEvent } from './colonyActions';
-import { subscription } from '../../lib/colonyServer/src/graphql/resolvers/Subscription';
+// import { subscription } from '../../lib/colonyServer/src/graphql/resolvers/Subscription';
 
 const getMotionEvents = (
   isSystemEvents: boolean,
@@ -1004,23 +1003,22 @@ export const motionsResolvers = ({
           colonyAddress,
         );
 
-        const data = await apolloClient.subscribe<
-          SubgraphMotionsSubscription,
-          SubgraphMotionsSubscriptionVariables
+        const { data } = await apolloClient.query<
+          SubgraphMotionsTxQuery,
+          SubgraphMotionsTxQueryVariables
         >({
-          query: SubgraphMotionsDocument,
+          query: SubgraphMotionsTxDocument,
           variables: {
             /*
              * Subgraph addresses are not checksummed
              */
-            // motionIds,
+            motionIds,
             extensionAddress: votingReputationClient.address.toLowerCase(),
             colonyAddress: colonyAddress.toLowerCase(),
           },
           fetchPolicy: 'network-only',
         });
-        console.log('resolver data: ', data);
-        return 'data';
+        return data?.motionsTx;
       } catch (error) {
         console.error('Could not fetch the TxHashes for the motion IDs');
         console.error(error);

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -64,7 +64,6 @@ import { availableRoles } from '~dialogs/PermissionManagementDialog';
 import { DEFAULT_NETWORK_TOKEN } from '~constants';
 
 import { ProcessedEvent } from './colonyActions';
-// import { subscription } from '../../lib/colonyServer/src/graphql/resolvers/Subscription';
 
 const getMotionEvents = (
   isSystemEvents: boolean,
@@ -1026,6 +1025,7 @@ export const motionsResolvers = ({
             }),
             {},
           );
+
         return motionIdTxHash;
       } catch (error) {
         console.error('Could not fetch the TxHashes for the motion IDs');

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -47,9 +47,6 @@ import {
   SubgraphMotionRewardClaimedEventsQuery,
   SubgraphMotionRewardClaimedEventsQueryVariables,
   SubgraphMotionRewardClaimedEventsDocument,
-  // MotionsTxHashesQuery,
-  // MotionsTxHashesQueryVariables,
-  // MotionsTxHashesDocument
   SubgraphMotionsTxQuery,
   SubgraphMotionsTxQueryVariables,
   SubgraphMotionsTxDocument,
@@ -1018,7 +1015,18 @@ export const motionsResolvers = ({
           },
           fetchPolicy: 'network-only',
         });
-        return data?.motionsTx;
+
+        // extract only motionId & txHash for easy access
+        const motionIdTxHash =
+          data &&
+          data?.motionsTx.reduce(
+            (accum, item) => ({
+              ...accum,
+              [item?.motionId]: item?.transaction.hash,
+            }),
+            {},
+          );
+        return motionIdTxHash;
       } catch (error) {
         console.error('Could not fetch the TxHashes for the motion IDs');
         console.error(error);

--- a/src/modules/users/components/TokenActivation/StakesTab/StakesListItem.tsx
+++ b/src/modules/users/components/TokenActivation/StakesTab/StakesListItem.tsx
@@ -11,7 +11,7 @@ const MSG = defineMessages({
     defaultMessage: 'Go to motion',
   },
 });
-interface StakesListItemProps {
+interface Props {
   stakedAmount: string;
   tokenSymbol: string;
   colonyName: string;
@@ -25,7 +25,7 @@ const StakesListItem = ({
   colonyName,
   txHash,
   setIsPopoverOpen,
-}: StakesListItemProps) => {
+}: Props) => {
   return (
     <li className={styles.stakesListItem}>
       <Link to={`/colony/${colonyName}/tx/${txHash}`}>
@@ -44,14 +44,6 @@ const StakesListItem = ({
           <div className={styles.falseLink}>
             <FormattedMessage {...MSG.motionUrl} />
           </div>
-
-          {/* {colonyName && txHash && (
-          <Link
-            className={styles.link}
-            text={MSG.motionUrl}
-            to={`/colony/${colonyName}/tx/${txHash}`}
-          />
-        )} */}
         </div>
       </Link>
     </li>

--- a/src/modules/users/components/TokenActivation/StakesTab/StakesListItem.tsx
+++ b/src/modules/users/components/TokenActivation/StakesTab/StakesListItem.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { defineMessages } from 'react-intl';
+import React, { MouseEvent } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
 
 import Link from '~core/Link';
 
@@ -11,12 +11,13 @@ const MSG = defineMessages({
     defaultMessage: 'Go to motion',
   },
 });
-
 interface StakesListItemProps {
   stakedAmount?: string;
   tokenSymbol?: string;
   colonyName?: string;
   txHash?: string;
+  // setIsPopoverOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsPopoverOpen: () => void;
 }
 
 const StakesListItem = ({
@@ -24,23 +25,43 @@ const StakesListItem = ({
   tokenSymbol,
   colonyName,
   txHash,
+  setIsPopoverOpen,
 }: StakesListItemProps) => {
+  // const handleSyntheticEvent = useCallback(() => {
+  //   // setIsPopoverOpen(false);
+  //   console.log('got here');
+  // }, [setIsPopoverOpen]);
+  const clickHandler = (e: React.MouseEvent) => {
+    console.log('ClickHandler called');
+    setIsPopoverOpen();
+  };
   return (
-    <li className={styles.stakesListItem}>
-      <div>
-        <p>
-          <span>
-            {stakedAmount} {tokenSymbol}
-          </span>
-        </p>
-        {colonyName && txHash && (
+    <li>
+      <Link to={`/colony/${colonyName}/tx/${txHash}`}>
+        <div
+          role="button"
+          onClick={clickHandler}
+          onKeyPress={clickHandler}
+          tabIndex={0}
+        >
+          <p>
+            <span>
+              {stakedAmount} {tokenSymbol}
+            </span>
+          </p>
+          <div className={styles.falseLink}>
+            <FormattedMessage {...MSG.motionUrl} />
+          </div>
+
+          {/* {colonyName && txHash && (
           <Link
             className={styles.link}
             text={MSG.motionUrl}
             to={`/colony/${colonyName}/tx/${txHash}`}
           />
-        )}
-      </div>
+        )} */}
+        </div>
+      </Link>
     </li>
   );
 };

--- a/src/modules/users/components/TokenActivation/StakesTab/StakesListItem.tsx
+++ b/src/modules/users/components/TokenActivation/StakesTab/StakesListItem.tsx
@@ -12,10 +12,10 @@ const MSG = defineMessages({
   },
 });
 interface StakesListItemProps {
-  stakedAmount?: string;
-  tokenSymbol?: string;
-  colonyName?: string;
-  txHash?: string;
+  stakedAmount: string;
+  tokenSymbol: string;
+  colonyName: string;
+  txHash: string;
   setIsPopoverOpen: Dispatch<SetStateAction<boolean>>;
 }
 

--- a/src/modules/users/components/TokenActivation/StakesTab/StakesListItem.tsx
+++ b/src/modules/users/components/TokenActivation/StakesTab/StakesListItem.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEvent } from 'react';
+import React, { Dispatch, SetStateAction } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
 import Link from '~core/Link';
@@ -16,8 +16,7 @@ interface StakesListItemProps {
   tokenSymbol?: string;
   colonyName?: string;
   txHash?: string;
-  // setIsPopoverOpen: React.Dispatch<React.SetStateAction<boolean>>;
-  setIsPopoverOpen: () => void;
+  setIsPopoverOpen: Dispatch<SetStateAction<boolean>>;
 }
 
 const StakesListItem = ({
@@ -27,21 +26,14 @@ const StakesListItem = ({
   txHash,
   setIsPopoverOpen,
 }: StakesListItemProps) => {
-  // const handleSyntheticEvent = useCallback(() => {
-  //   // setIsPopoverOpen(false);
-  //   console.log('got here');
-  // }, [setIsPopoverOpen]);
-  const clickHandler = (e: React.MouseEvent) => {
-    console.log('ClickHandler called');
-    setIsPopoverOpen();
-  };
   return (
-    <li>
+    <li className={styles.stakesListItem}>
       <Link to={`/colony/${colonyName}/tx/${txHash}`}>
         <div
           role="button"
-          onClick={clickHandler}
-          onKeyPress={clickHandler}
+          // 'any' used to stop warnings about MouseEvent incompatible types
+          onClick={setIsPopoverOpen as any}
+          onKeyPress={setIsPopoverOpen as any}
           tabIndex={0}
         >
           <p>

--- a/src/modules/users/components/TokenActivation/StakesTab/StakesTab.css
+++ b/src/modules/users/components/TokenActivation/StakesTab/StakesTab.css
@@ -23,8 +23,14 @@
   outline: 0;
 }
 
-.link {
-  font-size: var(--size-tiny);
+a {
+  height: 100%;
+  width: 100%;
+}
+
+.falseLink {
+  margin-top: 3px;
+  font-size: var(--size-small);
   font-weight: var(--weight-bold);
   color: var(--dark-blue);
 
@@ -48,7 +54,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  margin-top: 18px;
+  height: 477px;
 }
 
 .claimAllButtonSection {

--- a/src/modules/users/components/TokenActivation/StakesTab/StakesTab.css
+++ b/src/modules/users/components/TokenActivation/StakesTab/StakesTab.css
@@ -24,7 +24,7 @@
   outline: 0;
 }
 
-a {
+.stakesListItem > a {
   height: 100%;
   width: 100%;
 }

--- a/src/modules/users/components/TokenActivation/StakesTab/StakesTab.css
+++ b/src/modules/users/components/TokenActivation/StakesTab/StakesTab.css
@@ -11,6 +11,7 @@
   justify-content: space-between;
   align-items: center;
   margin-bottom: 1px;
+  padding-top: 12px;
   padding-right: 12px;
   padding-left: 16px;
   height: 63px;

--- a/src/modules/users/components/TokenActivation/StakesTab/StakesTab.css.d.ts
+++ b/src/modules/users/components/TokenActivation/StakesTab/StakesTab.css.d.ts
@@ -1,6 +1,6 @@
 export const stakesContainer: string;
 export const stakesListItem: string;
-export const link: string;
+export const falseLink: string;
 export const noClaims: string;
 export const loader: string;
 export const claimAllButtonSection: string;

--- a/src/modules/users/components/TokenActivation/StakesTab/StakesTab.tsx
+++ b/src/modules/users/components/TokenActivation/StakesTab/StakesTab.tsx
@@ -34,6 +34,7 @@ export interface StakesTabProps {
   colony?: FullColonyFragment;
   walletAddress: Address;
   token: UserToken;
+  setIsPopoverOpen: () => void;
 }
 
 const StakesTab = ({
@@ -42,6 +43,7 @@ const StakesTab = ({
   colony,
   walletAddress,
   token,
+  setIsPopoverOpen,
 }: StakesTabProps) => {
   // extract flat array of motionIds
   const motionIds = useMemo(
@@ -93,6 +95,7 @@ const StakesTab = ({
                   data?.motionsTxHashes &&
                   data?.motionsTxHashes[motion.values.motionId]
                 }
+                setIsPopoverOpen={setIsPopoverOpen}
                 key={motion.values.motionId}
               />
             ))}

--- a/src/modules/users/components/TokenActivation/StakesTab/StakesTab.tsx
+++ b/src/modules/users/components/TokenActivation/StakesTab/StakesTab.tsx
@@ -6,7 +6,7 @@ import { SpinnerLoader } from '~core/Preloaders';
 import { ParsedMotionStakedEvent, UserToken } from '~data/generated';
 
 import { getFormattedTokenValue } from '~utils/tokens';
-import { FullColonyFragment } from '~data/index';
+import { FullColonyFragment, useMotionsTxHashesQuery } from '~data/index';
 
 import ClaimAllButton from './ClaimAllButton';
 import StakesListItem from './StakesListItem';
@@ -43,6 +43,16 @@ const StakesTab = ({
   walletAddress,
   token,
 }: StakesTabProps) => {
+  const { data } = useMotionsTxHashesQuery({
+    variables: {
+      motionIds: ['1', '2'],
+      colonyAddress: colony?.colonyAddress || '',
+    },
+    fetchPolicy: 'network-only',
+  });
+
+  console.log('data: ', data);
+
   if (isLoadingMotions) {
     return (
       <div className={styles.loader}>

--- a/src/modules/users/components/TokenActivation/StakesTab/StakesTab.tsx
+++ b/src/modules/users/components/TokenActivation/StakesTab/StakesTab.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { FormattedMessage, defineMessages } from 'react-intl';
 
 import { Address } from '~types/index';
@@ -45,13 +45,36 @@ const StakesTab = ({
 }: StakesTabProps) => {
   const { data } = useMotionsTxHashesQuery({
     variables: {
-      motionIds: ['1', '2'],
+      motionIds: ['7', '3'],
       colonyAddress: colony?.colonyAddress || '',
     },
     fetchPolicy: 'network-only',
   });
 
-  console.log('data: ', data);
+  console.log('StakesTab motionsTx: ', data?.motionsTxHashes);
+  console.log('unclaimedMotionStakeEvents: ', unclaimedMotionStakeEvents);
+
+  // const motionIds = useMemo(
+  //   () =>
+  //     unclaimedMotionStakeEvents &&
+  //     unclaimedMotionStakeEvents.map((item) => ({ ...accum, item.values.motionId }),
+  //       {},
+  //     ),
+  //   [unclaimedMotionStakeEvents],
+  // );
+
+  const motionIdTxHash = useMemo(
+    () =>
+      data &&
+      data.motionsTxHashes?.reduce(
+        (accum, item) => ({
+          ...accum,
+          [item?.fundamentalChainId]: item?.transaction.hash,
+        }),
+        {},
+      ),
+    [data],
+  );
 
   if (isLoadingMotions) {
     return (
@@ -83,7 +106,11 @@ const StakesTab = ({
                 tokenSymbol={token.symbol}
                 colonyName={colony?.colonyName}
                 // This hash is incorrect. I suspect the ID should be used.
-                txHash={motion.hash}
+                txHash={
+                  motionIdTxHash && motionIdTxHash[motion.values.motionId]
+                }
+                // data?.motionsTxHashes?.findIndex((element) => element?.motionId === "motion.values.motionId).transaction.hash
+                // }
                 key={motion.values.motionId}
               />
             ))}

--- a/src/modules/users/components/TokenActivation/StakesTab/StakesTab.tsx
+++ b/src/modules/users/components/TokenActivation/StakesTab/StakesTab.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, Dispatch, SetStateAction } from 'react';
 import { FormattedMessage, defineMessages } from 'react-intl';
 
 import { Address } from '~types/index';
@@ -34,7 +34,7 @@ export interface StakesTabProps {
   colony?: FullColonyFragment;
   walletAddress: Address;
   token: UserToken;
-  setIsPopoverOpen: () => void;
+  setIsPopoverOpen: Dispatch<SetStateAction<boolean>>;
 }
 
 const StakesTab = ({

--- a/src/modules/users/components/TokenActivation/StakesTab/StakesTab.tsx
+++ b/src/modules/users/components/TokenActivation/StakesTab/StakesTab.tsx
@@ -43,38 +43,22 @@ const StakesTab = ({
   walletAddress,
   token,
 }: StakesTabProps) => {
+  // extract flat array of motionIds
+  const motionIds = useMemo(
+    () =>
+      unclaimedMotionStakeEvents &&
+      unclaimedMotionStakeEvents.map((item) => item.values.motionId),
+    [unclaimedMotionStakeEvents],
+  );
+
+  // get TX hashes for the motionIds
   const { data } = useMotionsTxHashesQuery({
     variables: {
-      motionIds: ['7', '3'],
+      motionIds: motionIds || [],
       colonyAddress: colony?.colonyAddress || '',
     },
     fetchPolicy: 'network-only',
   });
-
-  console.log('StakesTab motionsTx: ', data?.motionsTxHashes);
-  console.log('unclaimedMotionStakeEvents: ', unclaimedMotionStakeEvents);
-
-  // const motionIds = useMemo(
-  //   () =>
-  //     unclaimedMotionStakeEvents &&
-  //     unclaimedMotionStakeEvents.map((item) => ({ ...accum, item.values.motionId }),
-  //       {},
-  //     ),
-  //   [unclaimedMotionStakeEvents],
-  // );
-
-  const motionIdTxHash = useMemo(
-    () =>
-      data &&
-      data.motionsTxHashes?.reduce(
-        (accum, item) => ({
-          ...accum,
-          [item?.fundamentalChainId]: item?.transaction.hash,
-        }),
-        {},
-      ),
-    [data],
-  );
 
   if (isLoadingMotions) {
     return (
@@ -105,12 +89,10 @@ const StakesTab = ({
                 )}
                 tokenSymbol={token.symbol}
                 colonyName={colony?.colonyName}
-                // This hash is incorrect. I suspect the ID should be used.
                 txHash={
-                  motionIdTxHash && motionIdTxHash[motion.values.motionId]
+                  data?.motionsTxHashes &&
+                  data?.motionsTxHashes[motion.values.motionId]
                 }
-                // data?.motionsTxHashes?.findIndex((element) => element?.motionId === "motion.values.motionId).transaction.hash
-                // }
                 key={motion.values.motionId}
               />
             ))}

--- a/src/modules/users/components/TokenActivation/StakesTab/StakesTab.tsx
+++ b/src/modules/users/components/TokenActivation/StakesTab/StakesTab.tsx
@@ -28,7 +28,7 @@ const MSG = defineMessages({
   },
 });
 
-export interface StakesTabProps {
+export interface Props {
   unclaimedMotionStakeEvents?: Array<ParsedMotionStakedEvent>;
   isLoadingMotions: boolean;
   colony?: FullColonyFragment;
@@ -44,7 +44,7 @@ const StakesTab = ({
   walletAddress,
   token,
   setIsPopoverOpen,
-}: StakesTabProps) => {
+}: Props) => {
   // extract flat array of motionIds
   const motionIds = useMemo(
     () =>

--- a/src/modules/users/components/TokenActivation/StakesTab/StakesTab.tsx
+++ b/src/modules/users/components/TokenActivation/StakesTab/StakesTab.tsx
@@ -90,7 +90,7 @@ const StakesTab = ({
                   token.decimals,
                 )}
                 tokenSymbol={token.symbol}
-                colonyName={colony?.colonyName}
+                colonyName={colony?.colonyName || ''}
                 txHash={
                   data?.motionsTxHashes &&
                   data?.motionsTxHashes[motion.values.motionId]

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/TokenActivationContent.tsx
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/TokenActivationContent.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, Dispatch, SetStateAction } from 'react';
 import { FormattedMessage, defineMessages } from 'react-intl';
 
 import { Tab, Tabs, TabList, TabPanel } from '~core/Tabs';
@@ -20,7 +20,11 @@ const MSG = defineMessages({
   },
 });
 
-const TokenActivationContent = (props: TokensTabProps) => {
+interface TokenActivationContentProps extends TokensTabProps {
+  setIsPopoverOpen: Dispatch<SetStateAction<boolean>>;
+}
+
+const TokenActivationContent = (props: TokenActivationContentProps) => {
   const [tabIndex, setTabIndex] = useState<number>(0);
   const { colony, walletAddress, setIsPopoverOpen } = props;
 

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/TokenActivationContent.tsx
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/TokenActivationContent.tsx
@@ -22,7 +22,7 @@ const MSG = defineMessages({
 
 const TokenActivationContent = (props: TokensTabProps) => {
   const [tabIndex, setTabIndex] = useState<number>(0);
-  const { colony, walletAddress } = props;
+  const { colony, walletAddress, setIsPopoverOpen } = props;
 
   const { data: unclaimedMotions, loading } = useClaimableStakedMotionsQuery({
     variables: {
@@ -72,6 +72,7 @@ const TokenActivationContent = (props: TokensTabProps) => {
                 ?.unclaimedMotionStakeEvents
             }
             isLoadingMotions={loading}
+            setIsPopoverOpen={setIsPopoverOpen}
           />
         </TabPanel>
       </Tabs>

--- a/src/modules/users/components/TokenActivation/TokenActivationPopover.tsx
+++ b/src/modules/users/components/TokenActivation/TokenActivationPopover.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useMemo, useState, useCallback } from 'react';
+import React, { ReactElement, useMemo, useState } from 'react';
 
 import Popover, { PopoverChildFn } from '~core/Popover';
 
@@ -32,18 +32,6 @@ const TokenActivationPopover = ({ children, ...otherProps }: Props) => {
     return [0, removeValueUnits(verticalOffset)];
   }, []);
 
-  const handleSetIsPopoverOpen3 = useCallback(() => {
-    setIsOpen(true);
-    setIsOpen(false);
-    console.log('handleSetIsPopoverOpen called');
-  }, []);
-
-  const handleSetIsPopoverOpen = () => {
-    setIsOpen(true);
-    setIsOpen(false);
-    console.log('handleSetIsPopoverOpen called');
-  };
-
   return (
     <Popover
       appearance={{ theme: 'grey' }}
@@ -52,10 +40,7 @@ const TokenActivationPopover = ({ children, ...otherProps }: Props) => {
       isOpen={isOpen}
       onClose={() => setIsOpen(false)}
       content={() => (
-        <TokenActivationContent
-          {...otherProps}
-          setIsPopoverOpen={handleSetIsPopoverOpen}
-        />
+        <TokenActivationContent {...otherProps} setIsPopoverOpen={setIsOpen} />
       )}
       popperProps={{
         modifiers: [

--- a/src/modules/users/components/TokenActivation/TokenActivationPopover.tsx
+++ b/src/modules/users/components/TokenActivation/TokenActivationPopover.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useMemo, useState } from 'react';
+import React, { ReactElement, useMemo, useState, useCallback } from 'react';
 
 import Popover, { PopoverChildFn } from '~core/Popover';
 
@@ -32,6 +32,18 @@ const TokenActivationPopover = ({ children, ...otherProps }: Props) => {
     return [0, removeValueUnits(verticalOffset)];
   }, []);
 
+  const handleSetIsPopoverOpen3 = useCallback(() => {
+    setIsOpen(true);
+    setIsOpen(false);
+    console.log('handleSetIsPopoverOpen called');
+  }, []);
+
+  const handleSetIsPopoverOpen = () => {
+    setIsOpen(true);
+    setIsOpen(false);
+    console.log('handleSetIsPopoverOpen called');
+  };
+
   return (
     <Popover
       appearance={{ theme: 'grey' }}
@@ -39,7 +51,12 @@ const TokenActivationPopover = ({ children, ...otherProps }: Props) => {
       placement="bottom"
       isOpen={isOpen}
       onClose={() => setIsOpen(false)}
-      content={() => <TokenActivationContent {...otherProps} />}
+      content={() => (
+        <TokenActivationContent
+          {...otherProps}
+          setIsPopoverOpen={handleSetIsPopoverOpen}
+        />
+      )}
       popperProps={{
         modifiers: [
           {

--- a/src/modules/users/components/TokenActivation/TokensTab/TokensTab.tsx
+++ b/src/modules/users/components/TokenActivation/TokensTab/TokensTab.tsx
@@ -1,4 +1,11 @@
-import React, { useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  Dispatch,
+  SetStateAction,
+} from 'react';
 import { FormattedMessage, defineMessages } from 'react-intl';
 import { BigNumber } from 'ethers/utils';
 
@@ -73,8 +80,7 @@ export interface TokensTabProps {
   token: UserToken;
   colony?: FullColonyFragment;
   walletAddress: Address;
-  // setIsPopoverOpen: React.Dispatch<React.SetStateAction<boolean>>;
-  setIsPopoverOpen: () => void;
+  setIsPopoverOpen: Dispatch<SetStateAction<boolean>>;
 }
 
 const TokensTab = ({

--- a/src/modules/users/components/TokenActivation/TokensTab/TokensTab.tsx
+++ b/src/modules/users/components/TokenActivation/TokensTab/TokensTab.tsx
@@ -73,6 +73,8 @@ export interface TokensTabProps {
   token: UserToken;
   colony?: FullColonyFragment;
   walletAddress: Address;
+  // setIsPopoverOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsPopoverOpen: () => void;
 }
 
 const TokensTab = ({

--- a/src/modules/users/components/TokenActivation/TokensTab/TokensTab.tsx
+++ b/src/modules/users/components/TokenActivation/TokensTab/TokensTab.tsx
@@ -1,11 +1,4 @@
-import React, {
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-  Dispatch,
-  SetStateAction,
-} from 'react';
+import React, { useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { FormattedMessage, defineMessages } from 'react-intl';
 import { BigNumber } from 'ethers/utils';
 
@@ -80,7 +73,6 @@ export interface TokensTabProps {
   token: UserToken;
   colony?: FullColonyFragment;
   walletAddress: Address;
-  setIsPopoverOpen: Dispatch<SetStateAction<boolean>>;
 }
 
 const TokensTab = ({


### PR DESCRIPTION
## Description

This PR retrieves the transaction hashes for an array of motionId's.

The tx hashes are used by `StakesTab` to create a link to the associated motions details page.

Resolves#3196
