### PR TITLE
Change Numbro abbreviations and number formatting

### DIFF
--- a/src/utils/numbers/numberFormatter.ts
+++ b/src/utils/numbers/numberFormatter.ts
@@ -46,6 +46,73 @@ export const numberFormatter = ({
   abreviateOverMillion = true,
   useSmallNumberDefault = true,
 }: FunctionArgs): string => {
+  numbro.registerLanguage({
+    languageTag: 'en-GB',
+    delimiters: {
+      thousands: ',',
+      decimal: '.',
+    },
+    abbreviations: {
+      thousand: 'K',
+      million: 'M',
+      billion: 'B',
+      trillion: 'T',
+    },
+    ordinal: (number) => {
+      const b = number % 10;
+      if (Math.round((number % 100) / 10) === 1) {
+        return 'th';
+      }
+      if (b === 1) {
+        return 'st';
+      }
+      if (b === 2) {
+        return 'st';
+      }
+      if (b === 3) {
+        return 'rd';
+      }
+      return 'th';
+    },
+    currency: {
+      symbol: '',
+      position: 'prefix',
+      code: '',
+    },
+    currencyFormat: {
+      thousandSeparated: true,
+      totalLength: 4,
+      spaceSeparated: false,
+      spaceSeparatedCurrency: false,
+      average: true,
+    },
+    formats: {
+      fourDigits: {
+        totalLength: 4,
+        spaceSeparated: false,
+        average: true,
+      },
+      fullWithTwoDecimals: {
+        output: 'currency',
+        thousandSeparated: true,
+        spaceSeparated: false,
+        mantissa: 2,
+      },
+      fullWithTwoDecimalsNoCurrency: {
+        mantissa: 2,
+        thousandSeparated: true,
+      },
+      fullWithNoDecimals: {
+        output: 'currency',
+        thousandSeparated: true,
+        spaceSeparated: false,
+        mantissa: 0,
+      },
+    },
+  });
+
+  numbro.setLanguage('en-GB');
+
   const defaultFormat = {
     // totalLength: reducedOutput ? 5 : 0,
     trimMantissa: true,
@@ -57,12 +124,13 @@ export const numberFormatter = ({
   };
 
   const aboveMillionFormat = {
-    mantissa: 1,
-    optionalMantissa: true,
+    mantissa: 5,
+    trimMantissa: true,
     average: true,
     lowPrecision: true,
-    totalLength: 2,
+    totalLength: 6,
     spaceSeparated: false,
+    thousandSeparated: useSeparator,
   };
 
   const convertedNum =

--- a/src/utils/numbers/numberFormatter.ts
+++ b/src/utils/numbers/numberFormatter.ts
@@ -4,6 +4,7 @@ import moveDecimal from 'move-decimal-point';
 
 import { BigNumber, formatUnits } from 'ethers/utils';
 import { SMALL_TOKEN_AMOUNT_FORMAT } from '~constants';
+import { numbroCustomLanguage } from './numbroCustomLanguage';
 
 export interface FunctionArgs {
   /** Should use separator (e.g. for thousands ',') */
@@ -46,71 +47,7 @@ export const numberFormatter = ({
   abreviateOverMillion = true,
   useSmallNumberDefault = true,
 }: FunctionArgs): string => {
-  numbro.registerLanguage({
-    languageTag: 'en-GB',
-    delimiters: {
-      thousands: ',',
-      decimal: '.',
-    },
-    abbreviations: {
-      thousand: 'K',
-      million: 'M',
-      billion: 'B',
-      trillion: 'T',
-    },
-    ordinal: (number) => {
-      const b = number % 10;
-      if (Math.round((number % 100) / 10) === 1) {
-        return 'th';
-      }
-      if (b === 1) {
-        return 'st';
-      }
-      if (b === 2) {
-        return 'st';
-      }
-      if (b === 3) {
-        return 'rd';
-      }
-      return 'th';
-    },
-    currency: {
-      symbol: '',
-      position: 'prefix',
-      code: '',
-    },
-    currencyFormat: {
-      thousandSeparated: true,
-      totalLength: 4,
-      spaceSeparated: false,
-      spaceSeparatedCurrency: false,
-      average: true,
-    },
-    formats: {
-      fourDigits: {
-        totalLength: 4,
-        spaceSeparated: false,
-        average: true,
-      },
-      fullWithTwoDecimals: {
-        output: 'currency',
-        thousandSeparated: true,
-        spaceSeparated: false,
-        mantissa: 2,
-      },
-      fullWithTwoDecimalsNoCurrency: {
-        mantissa: 2,
-        thousandSeparated: true,
-      },
-      fullWithNoDecimals: {
-        output: 'currency',
-        thousandSeparated: true,
-        spaceSeparated: false,
-        mantissa: 0,
-      },
-    },
-  });
-
+  numbro.registerLanguage(numbroCustomLanguage);
   numbro.setLanguage('en-GB');
 
   const defaultFormat = {

--- a/src/utils/numbers/numbroCustomLanguage.ts
+++ b/src/utils/numbers/numbroCustomLanguage.ts
@@ -1,0 +1,62 @@
+export const numbroCustomLanguage = {
+  languageTag: 'en-GB',
+  delimiters: {
+    thousands: ',',
+    decimal: '.',
+  },
+  abbreviations: {
+    thousand: 'K',
+    million: 'M',
+    billion: 'B',
+    trillion: 'T',
+  },
+  ordinal: (number) => {
+    const b = number % 10;
+    if (Math.round((number % 100) / 10) === 1) {
+      return 'th';
+    }
+    if (b === 1) {
+      return 'st';
+    }
+    if (b === 2) {
+      return 'st';
+    }
+    if (b === 3) {
+      return 'rd';
+    }
+    return 'th';
+  },
+  currency: {
+    symbol: '',
+    position: 'prefix',
+    code: '',
+  },
+  currencyFormat: {
+    thousandSeparated: true,
+    totalLength: 4,
+    spaceSeparated: false,
+    spaceSeparatedCurrency: false,
+    average: true,
+  },
+  formats: {
+    fourDigits: {
+      totalLength: 4,
+      spaceSeparated: false,
+      average: true,
+    },
+    fullWithTwoDecimals: {
+      thousandSeparated: true,
+      spaceSeparated: false,
+      mantissa: 2,
+    },
+    fullWithTwoDecimalsNoCurrency: {
+      mantissa: 2,
+      thousandSeparated: true,
+    },
+    fullWithNoDecimals: {
+      thousandSeparated: true,
+      spaceSeparated: false,
+      mantissa: 0,
+    },
+  },
+};


### PR DESCRIPTION
## Description

This PR adds some number formatting changes and a custom language file for Numbro, which is the only way to change the abbreviation, it seems.

I put the language file alongside the `numberFormatter.ts` file for lack of a better location, and I don't see many reasons to have multiple language files for this purpose. I did try to utilise the existing `react-intl`, however, this seems like it will require quite a bit of refactoring (unless someone has an idea here)

![number_formatting](https://user-images.githubusercontent.com/33682027/155590682-e71f5ed0-a82b-4d17-ac0f-0dd8f2bcc774.png)


**Expected number format**
- Abbreviation starts at 1 million
- All numbers are to have 6 max digits, so, abbreviated numbers will have 5 significant decimal places.
- Abbreviation has a thousand separator
- With a capital letter for abbreviation 
- With no space between the abbreviation and the number

**New stuff** ✨

* Adds language file for Numbro
* Registers the newly added language file

**Changes** 🏗

* Changes number formatting to 5 decimal places
* Adds comma separation on numbers larger then a 1 quadrillion.

Resolves #3168
