### PR TITLE
Fix agreement IPFS upload logic & disabled primary button css

### DIFF
--- a/src/data/staticData/extensionData.tsx
+++ b/src/data/staticData/extensionData.tsx
@@ -34,7 +34,7 @@ export interface ExtensionInitParams {
   title: string | MessageDescriptor;
   fieldName?: string | MessageDescriptor;
   description?: string | MessageDescriptor;
-  defaultValue: string | number;
+  defaultValue?: string | number;
   paramName: string;
   validation: object;
   type: ExtensionParamType;
@@ -726,7 +726,7 @@ const extensions: { [key: string]: ExtensionData } = {
           then: yup.string().required().min(100),
           otherwise: false,
         }),
-        defaultValue: '',
+        defaultValue: undefined,
         title: MSG.agreementTitle,
         description: MSG.agreementDescription,
         type: ExtensionParamType.Textarea,

--- a/src/modules/core/components/Button/Button.css
+++ b/src/modules/core/components/Button/Button.css
@@ -75,6 +75,11 @@
   cursor: default;
 }
 
+.main:disabled:hover {
+  border-color: disabledBackground;
+  background-color: disabledBackground;
+}
+
 /*
  * Arranging buttons relative to other elements
  */

--- a/src/modules/dashboard/sagas/whitelist/extensionEnable.ts
+++ b/src/modules/dashboard/sagas/whitelist/extensionEnable.ts
@@ -15,12 +15,13 @@ import { WhitelistPolicy } from '~types/index';
 
 import { getTxChannel } from '../../../core/sagas';
 
+import { ipfsUpload } from '../../../core/sagas/ipfs';
+
 import {
   refreshExtension,
   removeOldExtensionClients,
   setupEnablingGroupTransactions,
   Channel,
-  uploadIfpsAnnotation,
 } from '../utils';
 
 function* extensionEnable({
@@ -61,7 +62,10 @@ function* extensionEnable({
      */
     let agreementHash = '';
     if (payload.agreement) {
-      agreementHash = yield call(uploadIfpsAnnotation, payload.agreement);
+      agreementHash = yield call(
+        ipfsUpload,
+        JSON.stringify({ agreement: payload.agreement }),
+      );
     }
 
     const {

--- a/src/modules/dashboard/sagas/whitelist/extensionEnable.ts
+++ b/src/modules/dashboard/sagas/whitelist/extensionEnable.ts
@@ -15,13 +15,12 @@ import { WhitelistPolicy } from '~types/index';
 
 import { getTxChannel } from '../../../core/sagas';
 
-import { ipfsUpload } from '../../../core/sagas/ipfs';
-
 import {
   refreshExtension,
   removeOldExtensionClients,
   setupEnablingGroupTransactions,
   Channel,
+  uploadIfpsAnnotation,
 } from '../utils';
 
 function* extensionEnable({
@@ -60,12 +59,10 @@ function* extensionEnable({
     /*
      * Upload whitelist policy to IPFS
      */
-    const agreementHash = yield call(
-      ipfsUpload,
-      JSON.stringify({
-        agreement: payload.agreement,
-      }),
-    );
+    let agreementHash = '';
+    if (payload.agreement) {
+      agreementHash = yield call(uploadIfpsAnnotation, payload.agreement);
+    }
 
     const {
       address,


### PR DESCRIPTION
## Description

This PR fixes 2 issues:

- `Agreement` button appearing when there is no agreement in the Whitelist extension
- hover colour of a disabled button of the primary theme (present in all instances of primary button use in dialogs and also on the whitelist extension page where first noticed)

The third problem (below) noted in the issue is fixed by Dan in a different PR:

```
Validation message needs attention:
-whitelistAddress is a required field
```

**Changes** 🏗

- update whitelist `extensionEnable` saga
- update `Button` css
- update `extensionData` type & initial value for the agreement filed of the whitelist

resolves #3223 
