### PR TITLE
Separate number formatting from display, update Standard Number display format rules

### DIFF
--- a/src/modules/core/components/EthUsd/EthUsd.tsx
+++ b/src/modules/core/components/EthUsd/EthUsd.tsx
@@ -30,9 +30,6 @@ interface Props extends NumeralProps {
   /** Should the suffix be visible? */
   showSuffix?: boolean;
 
-  /** Number of decimals to show */
-  truncate?: number;
-
   /** Ether unit the number is notated in (e.g. 'ether' = 10^18 wei) */
   unit?: string;
 
@@ -46,7 +43,6 @@ const EthUsd = ({
   appearance,
   showPrefix = true,
   showSuffix = true,
-  truncate = 2,
   unit = 'ether',
   value,
   ...rest
@@ -101,7 +97,6 @@ const EthUsd = ({
       appearance={appearance}
       prefix={showPrefix && valueUsd ? '~ ' : ''}
       suffix={showSuffix ? ` ${suffixText}` : ''}
-      truncate={truncate}
       value={valueUsd || '-'}
       {...rest}
     />

--- a/src/modules/core/components/InfoPopover/MemberInfoPopover/UserTokens.tsx
+++ b/src/modules/core/components/InfoPopover/MemberInfoPopover/UserTokens.tsx
@@ -43,10 +43,7 @@ const UserTokens = ({ totalBalance, nativeToken }: Props) => {
       />
       <div className={styles.tokenAmount}>
         <TokenIcon token={nativeToken} name={nativeToken.name} size="xxs" />
-        <Numeral
-          suffix={` ${nativeToken.symbol} `}
-          value={formattedTotalBalance}
-        />
+        <Numeral value={formattedTotalBalance} suffix={nativeToken.symbol} />
       </div>
     </div>
   );

--- a/src/modules/core/components/Numeral/Numeral.tsx
+++ b/src/modules/core/components/Numeral/Numeral.tsx
@@ -1,8 +1,8 @@
-import React, { HTMLAttributes } from 'react';
+import React, { HTMLAttributes, useEffect, useRef } from 'react';
 import { BigNumber } from 'ethers/utils';
 
 import { getMainClasses } from '~utils/css';
-import { numberFormatter } from '~utils/numbers';
+import { numberDisplayFormatter } from '~utils/numbers';
 
 import styles from './Numeral.css';
 
@@ -11,7 +11,6 @@ interface Appearance {
   size?: 'medium' | 'large' | 'small';
   weight?: 'medium';
 }
-
 export interface Props extends HTMLAttributes<HTMLSpanElement> {
   /** Appearance object */
   appearance?: Appearance;
@@ -25,17 +24,17 @@ export interface Props extends HTMLAttributes<HTMLSpanElement> {
   /** Suffix the value with this string */
   suffix?: string;
 
-  /** Number of decimals to show after comma */
-  truncate?: number;
+  /** Number of mantissa digits to show */
+  mantissa?: number;
+
+  /** Total length of number to show */
+  totalLength?: number;
 
   /** Number of decimals to format the number with, or unit from which to determine this (ether, gwei, etc.) */
   unit?: number | string;
 
   /** Actual value */
-  value: number | string | BigNumber;
-
-  /** Should large number be truncate to 5 figures */
-  reducedOutput?: boolean;
+  value: string | BigNumber | number;
 }
 
 const Numeral = ({
@@ -43,28 +42,36 @@ const Numeral = ({
   className,
   prefix,
   suffix,
-  truncate,
+  mantissa,
+  totalLength,
   unit,
   value,
-  reducedOutput = true,
   ...props
 }: Props) => {
-  const formattedNumber = numberFormatter({
+  // formattedNumber could contain HTML,
+  // use outputRef to reference as an html object
+  const outputRef = useRef<HTMLSpanElement>(null);
+  const formattedNumber = numberDisplayFormatter({
     unit,
     value,
-    prefix,
-    suffix,
-    truncate,
-    reducedOutput,
+    mantissa,
+    totalLength,
   });
+
+  useEffect(() => {
+    if (outputRef.current) {
+      outputRef.current.innerHTML = `${prefix ? `${prefix} ` : ''}
+        ${formattedNumber}
+        ${suffix ? ` ${suffix}` : ''}`;
+    }
+  }, [outputRef, formattedNumber, prefix, suffix]);
 
   return (
     <span
       className={className || getMainClasses(appearance, styles)}
       {...props}
-    >
-      {formattedNumber}
-    </span>
+      ref={outputRef}
+    />
   );
 };
 

--- a/src/modules/core/components/PayoutsList/PayoutsList.tsx
+++ b/src/modules/core/components/PayoutsList/PayoutsList.tsx
@@ -76,7 +76,7 @@ const PayoutsList = ({
                   className={cx(styles.payoutNumber, {
                     [styles.native]: token.address === nativeTokenAddress,
                   })}
-                  suffix={` ${token.symbol} `}
+                  suffix={token.symbol}
                   unit={getTokenDecimalsWithFallback(token.decimals)}
                   value={bigNumberify(
                     moveDecimal(
@@ -107,7 +107,7 @@ const PayoutsList = ({
                     ),
                   )}
                   unit={getTokenDecimalsWithFallback(token.decimals)}
-                  suffix={` ${token.symbol} `}
+                  suffix={token.symbol}
                 />
               ))}
             </div>

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultAction.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultAction.tsx
@@ -6,6 +6,7 @@ import Tag, { Appearance as TagAppareance } from '~core/Tag';
 import FriendlyName from '~core/FriendlyName';
 import { EventValue } from '~data/resolvers/colonyActions';
 import { parseDomainMetadata } from '~utils/colonyActions';
+import Numeral from '~core/Numeral';
 
 import ActionsPageFeed, {
   ActionsPageFeedItemWithIPFS,
@@ -104,7 +105,6 @@ const DefaultAction = ({
       ethDomainId: fromDomain,
     };
   }
-
   /*
    * There's a weird edge case where Apollo's caches screws with us and doesn't
    * fetch the latest domain (maybe network lag?)
@@ -127,6 +127,7 @@ const DefaultAction = ({
   });
 
   const decimalAmount = getFormattedTokenValue(amount, decimals);
+
   /*
    * @NOTE We need to convert the action type name into a forced camel-case string
    *
@@ -145,7 +146,7 @@ const DefaultAction = ({
         <FriendlyName user={recipient} autoShrinkAddress colony={colony} />
       </span>
     ),
-    amount: decimalAmount,
+    amount: <Numeral value={decimalAmount} />,
     token,
     tokenSymbol: <span>{symbol || '???'}</span>,
     decimals: getTokenDecimalsWithFallback(decimals),

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
@@ -6,6 +6,7 @@ import Decimal from 'decimal.js';
 
 import { ROOT_DOMAIN_ID, ColonyRoles } from '@colony/colony-js';
 
+import Numeral from '~core/Numeral';
 import { CommentInput } from '~core/Comment';
 import Heading from '~core/Heading';
 import Tag, { Appearance as TagAppearance } from '~core/Tag';
@@ -265,6 +266,7 @@ const DefaultMotion = ({
     description: domainPurpose,
   };
   const decimalAmount = getFormattedTokenValue(amount, decimals);
+
   const actionAndEventValues = {
     actionType,
     newVersion,
@@ -285,7 +287,7 @@ const DefaultMotion = ({
         <FriendlyName user={recipient} autoShrinkAddress colony={colony} />
       </span>
     ),
-    amount: decimalAmount,
+    amount: <Numeral value={decimalAmount} />,
     token,
     tokenSymbol: <span>{symbol || '???'}</span>,
     initiator: (
@@ -327,6 +329,7 @@ const DefaultMotion = ({
       </div>
     ),
     spaceBreak: <br />,
+
     reputationChange: getFormattedTokenValue(
       new Decimal(reputationChange).abs().toString(),
       decimals,
@@ -348,7 +351,6 @@ const DefaultMotion = ({
       initiator.profile?.username ??
       initiator.profile?.walletAddress,
     reputationChange: actionAndEventValues.reputationChange,
-
     fromDomain: actionAndEventValues.fromDomain?.name,
     toDomain: actionAndEventValues.toDomain?.name,
     roles: roleTitle,

--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.tsx
@@ -5,7 +5,7 @@ import Decimal from 'decimal.js';
 import Icon from '~core/Icon';
 import DetailsWidgetUser from '~core/DetailsWidgetUser';
 import TransactionLink from '~core/TransactionLink';
-
+import Numeral from '~core/Numeral';
 import TokenIcon from '~dashboard/HookedTokenIcon';
 import { AnyUser, Colony } from '~data/index';
 import { ColonyActions, ColonyMotions } from '~types/index';
@@ -105,9 +105,11 @@ const DetailsWidget = ({
   /*
    * @NOTE These were already being passed along as React Components, all we
    * are doing here is wrapping them in a function call so we can render them
+   * Amount should have already been passed through <Numeral>
    */
   const Amount = () => values?.amount as ReactElement;
   const Symbol = () => values?.tokenSymbol as ReactElement;
+
   const detailsForAction = getDetailsForAction(actionType);
 
   return (
@@ -185,7 +187,7 @@ const DetailsWidget = ({
             <FormattedMessage {...MSG.value} />
           </div>
           <div className={styles.tokenContainer}>
-            {values.token && (
+            {values?.token && (
               <TokenIcon
                 token={values.token}
                 name={values.token.name || undefined}
@@ -219,7 +221,7 @@ const DetailsWidget = ({
             />
           </div>
           <div className={styles.value}>
-            {values?.reputationChange}{' '}
+            <Numeral value={values?.reputationChange || '0'} />{' '}
             {new Decimal(values?.reputationChange || '0').eq(1) ? 'pt' : 'pts'}
           </div>
         </div>

--- a/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
@@ -393,7 +393,6 @@ const FinalizeMotionAndClaimWidget = ({
                       <Numeral
                         value={userStake}
                         suffix={` ${nativeToken?.symbol}`}
-                        truncate={5}
                       />
                     </div>
                   </div>
@@ -410,7 +409,6 @@ const FinalizeMotionAndClaimWidget = ({
                       <Numeral
                         value={userWinnings}
                         suffix={` ${nativeToken?.symbol}`}
-                        truncate={5}
                       />
                     </div>
                   </div>
@@ -424,7 +422,6 @@ const FinalizeMotionAndClaimWidget = ({
                       <Numeral
                         value={userTotals}
                         suffix={` ${nativeToken?.symbol}`}
-                        truncate={5}
                       />
                     </div>
                   </div>

--- a/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
@@ -390,10 +390,7 @@ const FinalizeMotionAndClaimWidget = ({
                       </div>
                     </div>
                     <div className={styles.value}>
-                      <Numeral
-                        value={userStake}
-                        suffix={` ${nativeToken?.symbol}`}
-                      />
+                      <Numeral value={userStake} suffix={nativeToken?.symbol} />
                     </div>
                   </div>
                   <div className={styles.item}>
@@ -408,7 +405,7 @@ const FinalizeMotionAndClaimWidget = ({
                     <div className={styles.value}>
                       <Numeral
                         value={userWinnings}
-                        suffix={` ${nativeToken?.symbol}`}
+                        suffix={nativeToken?.symbol}
                       />
                     </div>
                   </div>
@@ -421,7 +418,7 @@ const FinalizeMotionAndClaimWidget = ({
                     <div className={styles.value}>
                       <Numeral
                         value={userTotals}
-                        suffix={` ${nativeToken?.symbol}`}
+                        suffix={nativeToken?.symbol}
                       />
                     </div>
                   </div>

--- a/src/modules/dashboard/components/ActionsPage/StakingValidationError/StakingValidationError.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingValidationError/StakingValidationError.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { defineMessage, FormattedMessage } from 'react-intl';
 
-import { SimpleMessageValues } from '~types/index';
+import { UniversalMessageValues } from '~types/index';
 
 import styles from './StakingValidationError.css';
 
@@ -12,7 +12,7 @@ interface Props {
     | 'stakeMoreTokens'
     | 'cantStakeMore'
     | 'stakeMoreReputation';
-  errorValues?: SimpleMessageValues;
+  errorValues?: UniversalMessageValues;
 }
 
 const stakeValidationMSG = defineMessage({

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
@@ -5,12 +5,14 @@ import { bigNumberify } from 'ethers/utils';
 
 import Heading from '~core/Heading';
 import Slider, { Appearance } from '~core/Slider';
+import Numeral from '~core/Numeral';
 import StakingValidationError from '~dashboard/ActionsPage/StakingValidationError';
 
 import { Colony, useLoggedInUser } from '~data/index';
 import { getFormattedTokenValue } from '~utils/tokens';
 
 import styles from './StakingWidget.css';
+import validationErrorStyles from '~dashboard/ActionsPage/StakingValidationError/StakingValidationError.css';
 
 export interface StakingAmounts {
   remainingToFullyYayStaked: string;
@@ -153,9 +155,7 @@ const StakingSlider = ({
           {...(isObjection ? MSG.descriptionObject : MSG.descriptionStake)}
         />
       </p>
-      <span
-        className={styles.amount}
-      >{`${displayStake} ${nativeToken?.symbol}`}</span>
+      <Numeral value={displayStake} suffix={nativeToken?.symbol} />
       <div className={styles.sliderContainer}>
         <Slider
           name="amount"
@@ -173,19 +173,41 @@ const StakingSlider = ({
         <StakingValidationError
           stakeType={errorStakeType}
           errorValues={{
-            minimumStake: `${displayStake} ${nativeToken?.symbol}`,
-            userActiveTokens: `${getFormattedTokenValue(
-              userActivatedTokens.toString(),
-              nativeToken?.decimals,
-            )} ${nativeToken?.symbol}`,
-            minimumReputation: `${getFormattedTokenValue(
-              minUserStake.toString(),
-              nativeToken?.decimals,
-            )}`,
-            userReputation: `${getFormattedTokenValue(
-              maxUserStake.toString(),
-              nativeToken?.decimals,
-            )}`,
+            minimumStake: (
+              <Numeral
+                className={validationErrorStyles.validationError}
+                value={displayStake}
+                suffix={nativeToken?.symbol}
+              />
+            ),
+            userActiveTokens: (
+              <Numeral
+                className={validationErrorStyles.validationError}
+                value={getFormattedTokenValue(
+                  userActivatedTokens.toString(),
+                  nativeToken?.decimals,
+                )}
+                suffix={nativeToken?.symbol}
+              />
+            ),
+            minimumReputation: (
+              <Numeral
+                className={validationErrorStyles.validationError}
+                value={getFormattedTokenValue(
+                  minUserStake.toString(),
+                  nativeToken?.decimals,
+                )}
+              />
+            ),
+            userReputation: (
+              <Numeral
+                className={validationErrorStyles.validationError}
+                value={getFormattedTokenValue(
+                  maxUserStake.toString(),
+                  nativeToken?.decimals,
+                )}
+              />
+            ),
           }}
         />
       )}

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/GroupedTotalStake.tsx
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/GroupedTotalStake.tsx
@@ -126,7 +126,7 @@ const GroupedTotalStake = ({
                 requiredStake: (
                   <Numeral
                     value={formattedRequiredStake}
-                    suffix={` ${tokenSymbol}`}
+                    suffix={tokenSymbol}
                   />
                 ),
               }}
@@ -153,7 +153,7 @@ const GroupedTotalStake = ({
                 requiredStake: (
                   <Numeral
                     value={formattedRequiredStake}
-                    suffix={` ${tokenSymbol}`}
+                    suffix={tokenSymbol}
                   />
                 ),
               }}

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/SingleTotalStake.tsx
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/SingleTotalStake.tsx
@@ -5,6 +5,7 @@ import { bigNumberify } from 'ethers/utils';
 
 import Heading from '~core/Heading';
 import ProgressBar from '~core/ProgressBar';
+import Numeral from '~core/Numeral';
 import { getFormattedTokenValue } from '~utils/tokens';
 
 import styles from './TotalStakeWidget.css';
@@ -83,7 +84,9 @@ const SingleTotalStake = ({
             {...MSG.stakeProgress}
             values={{
               totalPercentage: formattedTotalPercentage,
-              requiredStake: `${requiredStakeDisplay} ${tokenSymbol}`,
+              requiredStake: (
+                <Numeral value={requiredStakeDisplay} suffix={tokenSymbol} />
+              ),
             }}
           />
         </span>
@@ -102,7 +105,9 @@ const SingleTotalStake = ({
             {...MSG.userStake}
             values={{
               userPercentage: formattedUserStakePercentage,
-              userStake: `${userStakeDisplay} ${tokenSymbol}`,
+              userStake: (
+                <Numeral value={userStakeDisplay} suffix={tokenSymbol} />
+              ),
             }}
           />
         </p>

--- a/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteDetails.tsx
+++ b/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteDetails.tsx
@@ -188,7 +188,7 @@ const VoteDetails = ({
                             nativeToken?.decimals,
                           )}
                           appearance={{ theme: 'dark', size: 'small' }}
-                          suffix={` ${nativeToken?.symbol}`}
+                          suffix={nativeToken?.symbol}
                         />
                       ) : (
                         <>
@@ -206,7 +206,7 @@ const VoteDetails = ({
                               nativeToken?.decimals,
                             )}
                             appearance={{ theme: 'dark', size: 'small' }}
-                            suffix={` ${nativeToken?.symbol}`}
+                            suffix={nativeToken?.symbol}
                           />
                         </>
                       )}
@@ -225,7 +225,7 @@ const VoteDetails = ({
                           voterReward.motionVoterReward.reward,
                           nativeToken?.decimals,
                         )}
-                        suffix={` ${nativeToken?.symbol}`}
+                        suffix={nativeToken?.symbol}
                         appearance={{ theme: 'dark', size: 'small' }}
                       />
                     </>

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageEvent/ActionsPageEvent.tsx
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageEvent/ActionsPageEvent.tsx
@@ -390,7 +390,7 @@ const ActionsPageEvent = ({
                     >
                       <Numeral
                         value={decimalStakeAmount}
-                        suffix={` ${colonyNativeToken?.symbol}`}
+                        suffix={colonyNativeToken?.symbol}
                       />
                     </Tag>
                   </div>

--- a/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
+++ b/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
@@ -419,7 +419,7 @@ const BuyTokens = ({
                               amount: (
                                 <Numeral
                                   value={userPurchaseTokenBalance}
-                                  suffix={` ${purchaseToken?.symbol}`}
+                                  suffix={purchaseToken?.symbol}
                                 />
                               ),
                             }}

--- a/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
+++ b/src/modules/dashboard/components/CoinMachine/BuyTokens/BuyTokens.tsx
@@ -419,7 +419,6 @@ const BuyTokens = ({
                               amount: (
                                 <Numeral
                                   value={userPurchaseTokenBalance}
-                                  truncate={2}
                                   suffix={` ${purchaseToken?.symbol}`}
                                 />
                               ),

--- a/src/modules/dashboard/components/CoinMachine/SaleStateWidget/SaleStateWidget.tsx
+++ b/src/modules/dashboard/components/CoinMachine/SaleStateWidget/SaleStateWidget.tsx
@@ -4,6 +4,7 @@ import { bigNumberify } from 'ethers/utils';
 import { Share } from 'react-twitter-widgets';
 
 import Decimal from 'decimal.js';
+import Numeral from '~core/Numeral';
 import Heading from '~core/Heading';
 import TransactionLink from '~core/TransactionLink';
 import Button from '~core/Button';
@@ -304,7 +305,10 @@ const SaleStateWidget = ({
             <FormattedMessage {...MSG[`${state}AmountLabel`]} />
           </div>
           <div className={styles.value}>
-            {decimalAmount} {sellableToken?.symbol || '???'}
+            <Numeral
+              value={decimalAmount}
+              suffix={sellableToken?.symbol || '???'}
+            />
           </div>
         </div>
         <div className={styles.item}>
@@ -312,7 +316,7 @@ const SaleStateWidget = ({
             <FormattedMessage {...MSG.for} />
           </div>
           <div className={styles.value}>
-            {cost} {purchaseToken?.symbol || '???'}
+            <Numeral value={cost} suffix={purchaseToken?.symbol || '???'} />
           </div>
         </div>
       </div>

--- a/src/modules/dashboard/components/CoinMachine/TokenSalesTable/SoldTokensWidget.tsx
+++ b/src/modules/dashboard/components/CoinMachine/TokenSalesTable/SoldTokensWidget.tsx
@@ -4,6 +4,7 @@ import { bigNumberify } from 'ethers/utils';
 
 import { AnyToken } from '~data/index';
 import { getFormattedTokenValue } from '~utils/tokens';
+import Numeral from '~core/Numeral';
 
 import styles from './SoldTokensWidget.css';
 
@@ -54,11 +55,14 @@ const SoldTokensWidget = ({
     <FormattedMessage
       {...MSG.periodTokens}
       values={{
-        tokensBought: getFormattedTokenValue(
-          bigNumberify(tokensBought),
-          decimals,
+        tokensBought: (
+          <Numeral
+            value={getFormattedTokenValue(bigNumberify(tokensBought), decimals)}
+          />
         ),
-        tokensAvailable: getFormattedTokenValue(lowestUpperLimit, decimals),
+        tokensAvailable: (
+          <Numeral value={getFormattedTokenValue(lowestUpperLimit, decimals)} />
+        ),
       }}
     />
   );

--- a/src/modules/dashboard/components/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.tsx
@@ -18,6 +18,7 @@ import Toggle from '~core/Fields/Toggle';
 import PermissionRequiredInfo from '~core/PermissionRequiredInfo';
 import NotEnoughReputation from '~dashboard/NotEnoughReputation';
 import PermissionsLabel from '~core/PermissionsLabel';
+import Numeral from '~core/Numeral';
 
 import { Address } from '~types/index';
 import HookedUserAvatar from '~users/HookedUserAvatar';
@@ -44,14 +45,14 @@ import styles from './ManageReputationDialogForm.css';
 const MSG = defineMessages({
   title: {
     id: 'dashboard.ManageReputationContainer.ManageReputationDialogForm.title',
-    defaultMessage: `{isSmiteAction, select, 
+    defaultMessage: `{isSmiteAction, select,
       true {Smite}
-      false {Award} 
+      false {Award}
     }`,
   },
   team: {
     id: `dashboard.ManageReputationContainer.ManageReputationDialogForm.team`,
-    defaultMessage: `Team in which Reputation should be {isSmiteAction, select, 
+    defaultMessage: `Team in which Reputation should be {isSmiteAction, select,
       true {deducted}
       false {awarded}
     }`,
@@ -62,7 +63,7 @@ const MSG = defineMessages({
   },
   amount: {
     id: 'dashboard.ManageReputationContainer.ManageReputationDialogForm.amount',
-    defaultMessage: `Amount of reputation points to {isSmiteAction, select, 
+    defaultMessage: `Amount of reputation points to {isSmiteAction, select,
       true {deduct}
       false {award}
     }`,
@@ -376,7 +377,9 @@ const ManageReputationDialogForm = ({
               {...MSG.maxReputation}
               values={{
                 isSmiteAction,
-                userReputationAmount: formattedUserReputationAmount,
+                userReputationAmount: (
+                  <Numeral value={formattedUserReputationAmount} />
+                ),
                 userPercentageReputation:
                   userPercentageReputation === null
                     ? 0

--- a/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
@@ -378,7 +378,6 @@ const CreatePaymentDialogForm = ({
                         unit={getTokenDecimalsWithFallback(
                           selectedToken && selectedToken.decimals,
                         )}
-                        truncate={3}
                       />
                     ),
                     symbol: (selectedToken && selectedToken.symbol) || '???',

--- a/src/modules/dashboard/components/Dialogs/TransferFundsDialog/TransferFundsDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/TransferFundsDialog/TransferFundsDialogForm.tsx
@@ -301,7 +301,6 @@ const TransferFundsDialogForm = ({
                         unit={getTokenDecimalsWithFallback(
                           selectedToken && selectedToken.decimals,
                         )}
-                        truncate={3}
                       />
                     ),
                     symbol: (selectedToken && selectedToken.symbol) || '???',
@@ -340,7 +339,6 @@ const TransferFundsDialogForm = ({
                         unit={getTokenDecimalsWithFallback(
                           selectedToken && selectedToken.decimals,
                         )}
-                        truncate={3}
                       />
                     ),
                     symbol: (selectedToken && selectedToken.symbol) || '???',

--- a/src/modules/dashboard/components/UnclaimedTransfers/UnclaimedTransfersItem.tsx
+++ b/src/modules/dashboard/components/UnclaimedTransfers/UnclaimedTransfersItem.tsx
@@ -116,7 +116,7 @@ const UnclaimedTransfersItem = ({
           <Numeral
             value={amount}
             unit={getTokenDecimalsWithFallback(token.decimals)}
-            suffix={` ${token.symbol}`}
+            suffix={token.symbol}
             className={styles.amount}
           />
           {tokenIsETH(token) && <EthUsd value={amount} unit="wei" />}

--- a/src/modules/pages/components/WizardTemplateColony/WizardTemplateColony.tsx
+++ b/src/modules/pages/components/WizardTemplateColony/WizardTemplateColony.tsx
@@ -61,7 +61,7 @@ const WizardTemplateColony = ({
               {ethBalance.isZero() ? (
                 <div className={styles.noMoney}>
                   <Numeral
-                    suffix={` ${DEFAULT_NETWORK_TOKEN.symbol}`}
+                    suffix={DEFAULT_NETWORK_TOKEN.symbol}
                     unit="ether"
                     value={ethBalance}
                   />
@@ -69,7 +69,7 @@ const WizardTemplateColony = ({
               ) : (
                 <div className={styles.yeihMoney}>
                   <Numeral
-                    suffix={` ${DEFAULT_NETWORK_TOKEN.symbol}`}
+                    suffix={DEFAULT_NETWORK_TOKEN.symbol}
                     unit="ether"
                     value={ethBalance}
                   />

--- a/src/modules/users/components/GasStation/GasStationHeader/GasStationHeader.tsx
+++ b/src/modules/users/components/GasStation/GasStationHeader/GasStationHeader.tsx
@@ -40,10 +40,7 @@ const GasStationHeader = ({ close }: Props) => {
           <CopyableAddress>{walletAddress}</CopyableAddress>
         </div>
         <div>
-          <Numeral
-            value={balance}
-            suffix={` ${DEFAULT_NETWORK_TOKEN.symbol}`}
-          />
+          <Numeral value={balance} suffix={DEFAULT_NETWORK_TOKEN.symbol} />
         </div>
       </div>
       <div className={styles.actionsContainer}>

--- a/src/modules/users/components/Inbox/InboxItem/InboxItem.tsx
+++ b/src/modules/users/components/Inbox/InboxItem/InboxItem.tsx
@@ -196,7 +196,7 @@ const InboxItem = ({
                 values={{
                   amount: makeInboxDetail(amount, (value) => (
                     <Numeral
-                      suffix={` ${token ? token.symbol : ''}`}
+                      suffix={token ? token.symbol : ''}
                       value={value || '-'}
                     />
                   )),

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/ChangeTokenStateForm.tsx
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/ChangeTokenStateForm.tsx
@@ -207,7 +207,7 @@ const ChangeTokenStateForm = ({
                     tokenBalance: (
                       <Numeral
                         value={tokenBalance}
-                        suffix={` ${token?.symbol}`}
+                        suffix={token?.symbol}
                         className={styles.balanceAmount}
                       />
                     ),
@@ -232,7 +232,7 @@ const ChangeTokenStateForm = ({
                       lockedTokens: (
                         <Numeral
                           value={formattedLockedTokens}
-                          suffix={` ${token?.symbol}`}
+                          suffix={token?.symbol}
                           className={styles.balanceAmount}
                         />
                       ),

--- a/src/modules/users/components/TokenActivation/TokenActivationContent/TokensTab.tsx
+++ b/src/modules/users/components/TokenActivation/TokenActivationContent/TokensTab.tsx
@@ -6,6 +6,7 @@ import { SMALL_TOKEN_AMOUNT_FORMAT } from '~constants';
 import Icon from '~core/Icon';
 import InfoPopover from '~core/InfoPopover';
 import TokenIcon from '~dashboard/HookedTokenIcon';
+import Numeral from '~core/Numeral';
 
 import { UserToken } from '~data/generated';
 import { Address } from '~types/index';
@@ -142,7 +143,7 @@ const TokensTab = ({
                 : styles.totalTokensSmall
             }
           >
-            {formattedTotalAmount} <span>{token?.symbol}</span>
+            <Numeral value={formattedTotalAmount} suffix={token.symbol} />
           </p>
         </div>
       </InfoPopover>
@@ -158,9 +159,7 @@ const TokensTab = ({
               />
             </TokenTooltip>
             <div className={styles.tokenNumbers}>
-              <span>
-                {formattedActiveTokens} {token.symbol}
-              </span>
+              <Numeral value={formattedActiveTokens} suffix={token.symbol} />
               {formattedActiveTokens === SMALL_TOKEN_AMOUNT_FORMAT && (
                 <SmallTokenAmountMessage />
               )}
@@ -174,9 +173,7 @@ const TokensTab = ({
           </li>
           <li>
             <div className={styles.tokenNumbersLocked}>
-              <span>
-                {formattedLockedTokens} {token.symbol}
-              </span>
+              <Numeral value={formattedLockedTokens} suffix={token.symbol} />
             </div>
           </li>
           <li>
@@ -187,9 +184,7 @@ const TokensTab = ({
               <FormattedMessage {...MSG.inactive} />
             </TokenTooltip>
             <div className={styles.tokenNumbersInactive}>
-              <span>
-                {formattedInactiveTokens} {token.symbol}
-              </span>
+              <Numeral value={formattedInactiveTokens} suffix={token.symbol} />
               {formattedInactiveTokens === SMALL_TOKEN_AMOUNT_FORMAT && (
                 <SmallTokenAmountMessage />
               )}

--- a/src/modules/users/components/UserTokenActivationButton/UserTokenActivationButton.tsx
+++ b/src/modules/users/components/UserTokenActivationButton/UserTokenActivationButton.tsx
@@ -2,10 +2,8 @@ import React from 'react';
 import { bigNumberify } from 'ethers/utils';
 
 import { TokenActivationPopover } from '~users/TokenActivation';
-
 import { getFormattedTokenValue } from '~utils/tokens';
 import Numeral from '~core/Numeral';
-
 import { UserLock, UserToken } from '~data/index';
 import { Address } from '~types/index';
 
@@ -63,8 +61,8 @@ const UserTokenActivationButton = ({
               }`}
             />
             <Numeral
-              suffix={` ${nativeToken?.symbol} `}
               value={formattedTotalBalance}
+              suffix={nativeToken?.symbol}
             />
           </button>
         </>

--- a/src/utils/numbers/index.ts
+++ b/src/utils/numbers/index.ts
@@ -1,7 +1,7 @@
 import { BigNumberish, bigNumberify } from 'ethers/utils';
 
-export { numberFormatter } from './numberFormatter';
-
+export { numberDisplayFormatter } from './numberFormatter';
+export { minimalFormatter } from './numberFormatter';
 /**
  * Return whether `a` is less than `b` where each are number-like values.
  */

--- a/src/utils/numbers/numberFormatter.ts
+++ b/src/utils/numbers/numberFormatter.ts
@@ -86,6 +86,11 @@ export const numberDisplayFormatter = ({
       ? aboveMillionFormat
       : defaultFormat;
 
+  // protect against Numbro's use of averages & abbreviation
+  // when totalLength is set. Example: 400,000 is formatted to 400k.
+  formatType.totalLength =
+    formatType === defaultFormat && convertedNum.length <= 6 ? 0 : totalLength;
+
   if (!numbro.validate(convertedNum, formatType)) {
     return value.toString();
   }

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -1,7 +1,7 @@
 import { bigNumberify, BigNumberish } from 'ethers/utils';
 import Decimal from 'decimal.js';
 
-import { numberFormatter } from '~utils/numbers';
+import { minimalFormatter } from '~utils/numbers';
 import { TokenWithBalances } from '~data/index';
 import { DEFAULT_TOKEN_DECIMALS, SMALL_TOKEN_AMOUNT_FORMAT } from '~constants';
 
@@ -66,9 +66,7 @@ export const getFormattedTokenValue = (
     return SMALL_TOKEN_AMOUNT_FORMAT;
   }
 
-  return numberFormatter({
-    abreviateOverMillion: false,
-    suffix: '',
+  return minimalFormatter({
     value: decimalValue.toString(),
   });
 };


### PR DESCRIPTION
## Description

This PR implements the outcome of discussions on standard number display. The notable changes include a max length = 6, and handle very large numbers >= 1000000000000000.

https://www.notion.so/colony/Standardized-Number-Display-Format-334f22de4c824d5dbb49fdcdc730d1b7
https://stackblitz.com/edit/number-format-playground-yfjmhc?file=numberFormatter.ts

<img width="408" alt="Screenshot 2022-03-11 at 14 55 13" src="https://user-images.githubusercontent.com/582700/158201305-e5b14931-3b13-4a82-ba59-6cdf50ae356b.png">


<img width="278" alt="Screenshot 2022-03-11 at 15 55 37" src="https://user-images.githubusercontent.com/582700/158201199-74f76c82-51e0-48fb-b667-cb2a571ae96e.png">


## Explanation
When formatting very large numbers engineering (standard scientific) notation will be used.  The exponent will be superscripted.... (this small requirement caused many changes)

Previously, getFormattedTokenValue or the numberFormatter returned a string with the (decimal) formatted value. This output could be displayed directly (like in most situations) or passed to <Numeral> to be displayed.

When handling very large numbers, the returned formatted number string will contain HTML tags that superscript the exponent. Therefore, the string needs to be interpreted, and cannot simply be displayed.

This prompted the separation of responsibilities into 2 aspects.

1. Accessing (formatted) token value
2. Displaying numbers using Standard Number Display formatting rules (via <Numeral>)

I've tried to provide the same underlining functionality of being able to access the value in standard form. Where the number undergoes minimal formatting. 
Whenever a number is to be displayed, it should be passed to <Numeral> that will format the number (depending on large or small), average, reduce mantissa, etc..... and finally add pre/suf-fixes. 

To handle the potential that the formatted number string might contain HTML, <Numeral> then adds the output to a reference of an html object useRef<HTMLSpanElement>.

Almost all numerical displays now <Numeral>. There are several edge cases that need consideration, like:

-Coin machine - Numbers & prices. Some values are in ETH, so are less than < than 0.00000.... 
-Slider for motions  - i saw the issue from Shapeshift that suggest that some 'rounding' may be causing their 99% problems.. <Numeral> is not used in the slider.

When testing with very large numbers (325.363×10^39) protection must also be given to protect fields that have a 'max' button.

##Observations
Numbro: Complexities of competing formatting rules can cause unexpected outputs.

Setting `totalLength`:  seems to effect the formatting, with the number being averaged, despite being less than 6 digits, and average=false.
example:
```
 { num: 18785.68144 },
 { num: 235255 },
 { num: 400000 },

average:false
totalLength:  6

//output
18.7857K ETH
235.255K ETH
400K ETH

Without 
average:false
//totalLength:  6,

//output
18,785.68144 ETH
235,255 ETH
400,000 ETH
```

##Testing
This PR touches many parts of the Dapp, so should be tested rigorously. 
It is also a good candidate for making use of Cypress and our new testing infrastructure. This will certainly be beneficial today, and also in the future, should we need to refine the formatting rules further.

For testing and to identify fields as being Numeral'ified, i used:

Numeral.tsx: Line 63
``outputRef.current.innerHTML  =  `NUMERAL ${prefix  ?  `${prefix} `  :  ''}``

Resolves #3236
