### PR TITLE
Add new Tooltip to token balance of the TokenActivation component 

### DIFF
--- a/src/modules/users/components/UserTokenActivationButton/UserTokenActivationButton.css
+++ b/src/modules/users/components/UserTokenActivationButton/UserTokenActivationButton.css
@@ -38,7 +38,6 @@
 
 .tooltip {
   width: 237px;
-  font-size: var(--size-small);
-  font-weight: var(--weight-bold);
+  font-size: var(--size-tiny);
   text-align: left;
 }

--- a/src/modules/users/components/UserTokenActivationButton/UserTokenActivationButton.css
+++ b/src/modules/users/components/UserTokenActivationButton/UserTokenActivationButton.css
@@ -35,3 +35,10 @@
 .dotInactive {
   background-color: var(--pink);
 }
+
+.tooltip {
+  width: 237px;
+  font-size: var(--size-small);
+  font-weight: var(--weight-bold);
+  text-align: left;
+}

--- a/src/modules/users/components/UserTokenActivationButton/UserTokenActivationButton.css.d.ts
+++ b/src/modules/users/components/UserTokenActivationButton/UserTokenActivationButton.css.d.ts
@@ -2,3 +2,4 @@ export const tokens: string;
 export const tokensNumber: string;
 export const dot: string;
 export const dotInactive: string;
+export const tooltip: string;

--- a/src/modules/users/components/UserTokenActivationButton/UserTokenActivationButton.tsx
+++ b/src/modules/users/components/UserTokenActivationButton/UserTokenActivationButton.tsx
@@ -15,7 +15,7 @@ const displayName = 'users.UserTokenActivationButton';
 
 const MSG = defineMessages({
   tooltip: {
-    id: 'pages.NavigationWrapper.UserNavigation.tooltip',
+    id: 'users.UserTokenActivationButton.tooltip',
     defaultMessage:
       'View and activate tokens for staking or claim any unclaimed stakes.',
   },

--- a/src/modules/users/components/UserTokenActivationButton/UserTokenActivationButton.tsx
+++ b/src/modules/users/components/UserTokenActivationButton/UserTokenActivationButton.tsx
@@ -20,7 +20,6 @@ const MSG = defineMessages({
       'View and activate tokens for staking or claim any unclaimed stakes.',
   },
 });
-
 interface Props {
   userLock: UserLock;
   nativeToken: UserToken;
@@ -77,6 +76,16 @@ const UserTokenActivationButton = ({
                   <FormattedMessage {...MSG.tooltip} />
                 </div>
               }
+              popperProps={{
+                modifiers: [
+                  {
+                    name: 'offset',
+                    options: {
+                      offset: [120, 10],
+                    },
+                  },
+                ],
+              }}
             >
               <div>
                 <span

--- a/src/modules/users/components/UserTokenActivationButton/UserTokenActivationButton.tsx
+++ b/src/modules/users/components/UserTokenActivationButton/UserTokenActivationButton.tsx
@@ -1,17 +1,25 @@
 import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
 import { bigNumberify } from 'ethers/utils';
 
 import { TokenActivationPopover } from '~users/TokenActivation';
-
 import { getFormattedTokenValue } from '~utils/tokens';
+import { Tooltip } from '~core/Popover';
 import Numeral from '~core/Numeral';
-
 import { FullColonyFragment, UserLock, UserToken } from '~data/index';
 import { Address } from '~types/index';
 
 import styles from './UserTokenActivationButton.css';
 
 const displayName = 'users.UserTokenActivationButton';
+
+const MSG = defineMessages({
+  tooltip: {
+    id: 'pages.NavigationWrapper.UserNavigation.tooltip',
+    defaultMessage:
+      'View and activate tokens for staking or claim any unclaimed stakes.',
+  },
+});
 
 interface Props {
   userLock: UserLock;
@@ -51,7 +59,7 @@ const UserTokenActivationButton = ({
       walletAddress={walletAddress}
       isPendingBalanceZero={isPendingBalanceZero}
     >
-      {({ toggle, ref }) => (
+      {({ isOpen, toggle, ref }) => (
         <>
           <button
             type="button"
@@ -59,17 +67,30 @@ const UserTokenActivationButton = ({
             onClick={toggle}
             ref={ref}
           >
-            <span
-              className={`${styles.dot} ${
-                (inactiveBalance.gt(0) || totalBalance.isZero()) &&
-                styles.dotInactive
-              }`}
-            />
-            <Numeral
-              className={styles.tokensNumber}
-              suffix={` ${nativeToken?.symbol} `}
-              value={formattedTotalBalance}
-            />
+            <Tooltip
+              appearance={{ theme: 'dark', size: 'medium' }}
+              placement="bottom"
+              trigger={!isOpen ? 'hover' : 'disabled'}
+              showArrow
+              content={
+                <div className={styles.tooltip}>
+                  <FormattedMessage {...MSG.tooltip} />
+                </div>
+              }
+            >
+              <div>
+                <span
+                  className={`${styles.dot} ${
+                    (inactiveBalance.gt(0) || totalBalance.isZero()) &&
+                    styles.dotInactive
+                  }`}
+                />
+                <Numeral
+                  suffix={` ${nativeToken?.symbol} `}
+                  value={formattedTotalBalance}
+                />
+              </div>
+            </Tooltip>
           </button>
         </>
       )}


### PR DESCRIPTION
### Description

This PR adds a tooltip to the TokenActivationButton that provides an explanation of the functionality of the TokenActivation popover component.

To add clarity, the tooltip is displayed on hover, but is disabled when the TokenActivation popover component is displayed.

<img width="394" alt="Screenshot 2022-03-15 at 18 17 27" src="https://user-images.githubusercontent.com/582700/158366964-e590999e-dc39-4ec5-9df7-2c7c9a9a1eb5.png">

<img width="372" alt="Screenshot 2022-03-15 at 18 17 40" src="https://user-images.githubusercontent.com/582700/158366983-92820e02-689f-4f52-9771-90240dfd30b3.png">


Resolves #3231
