### PR TITLE
Fix dapp sometimes crashing on extension tests

### DIFF
--- a/src/modules/dashboard/components/ColonyFundingMenu/ColonyFundingMenu.tsx
+++ b/src/modules/dashboard/components/ColonyFundingMenu/ColonyFundingMenu.tsx
@@ -100,12 +100,9 @@ const ColonyFundingMenu = ({
   );
 
   const oneTxPaymentExtension = data?.processedColony?.installedExtensions.find(
-    ({
-      details: { initialized, missingPermissions },
-      extensionId: extensionName,
-    }) =>
-      initialized &&
-      !missingPermissions.length &&
+    ({ details, extensionId: extensionName }) =>
+      details?.initialized &&
+      !details?.missingPermissions.length &&
       extensionName === Extension.OneTxPayment,
   );
   const mustUpgradeOneTx = oneTxMustBeUpgraded(oneTxPaymentExtension);

--- a/src/modules/dashboard/components/ColonyHome/ColonyDomainSelector/ColonyDomainSelector.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyDomainSelector/ColonyDomainSelector.tsx
@@ -88,12 +88,9 @@ const ColonyDomainSelector = ({
     [getDomainColor],
   );
   const oneTxPaymentExtension = data?.processedColony?.installedExtensions.find(
-    ({
-      details: { initialized, missingPermissions },
-      extensionId: extensionName,
-    }) =>
-      initialized &&
-      !missingPermissions.length &&
+    ({ details, extensionId: extensionName }) =>
+      details?.initialized &&
+      !details?.missingPermissions.length &&
       extensionName === Extension.OneTxPayment,
   );
   const mustUpgradeOneTx = oneTxMustBeUpgraded(oneTxPaymentExtension);

--- a/src/modules/dashboard/components/ColonyHome/ColonyExtensions/ColonyExtensions.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyExtensions/ColonyExtensions.tsx
@@ -51,8 +51,8 @@ const ColonyExtensions = ({ colony: { colonyName, colonyAddress } }: Props) => {
         {data.processedColony.installedExtensions
           .filter(
             (extension) =>
-              extension.details.initialized &&
-              !extension.details.missingPermissions.length,
+              extension.details?.initialized &&
+              !extension.details?.missingPermissions.length,
           )
           .map((extension) => {
             const { address, extensionId } = extension;

--- a/src/modules/dashboard/components/ColonyHome/ExtensionUpgrade/ExtensionUpgrade.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ExtensionUpgrade/ExtensionUpgrade.tsx
@@ -41,12 +41,9 @@ const ExtensionUpgrade = ({ colony: { colonyName, colonyAddress } }: Props) => {
     colonyNameEntry === colonyName && extensionId === Extension.OneTxPayment;
 
   const oneTxPaymentExtension = data?.processedColony?.installedExtensions.find(
-    ({
-      details: { initialized, missingPermissions },
-      extensionId: extensionName,
-    }) =>
-      initialized &&
-      !missingPermissions.length &&
+    ({ details, extensionId: extensionName }) =>
+      details?.initialized &&
+      !details?.missingPermissions.length &&
       extensionName === Extension.OneTxPayment,
   );
   const mustUpgrade = oneTxMustBeUpgraded(oneTxPaymentExtension);

--- a/src/modules/dashboard/components/ColonyHomeActions/ColonyHomeActions.tsx
+++ b/src/modules/dashboard/components/ColonyHomeActions/ColonyHomeActions.tsx
@@ -253,12 +253,9 @@ const ColonyHomeActions = ({ colony, ethDomainId }: Props) => {
   ]);
 
   const oneTxPaymentExtension = data?.processedColony?.installedExtensions.find(
-    ({
-      details: { initialized, missingPermissions },
-      extensionId: extensionName,
-    }) =>
-      initialized &&
-      !missingPermissions.length &&
+    ({ details, extensionId: extensionName }) =>
+      details?.initialized &&
+      !details?.missingPermissions.length &&
       extensionName === Extension.OneTxPayment,
   );
   const mustUpgradeOneTx = oneTxMustBeUpgraded(oneTxPaymentExtension);

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -110,12 +110,9 @@ const ColonyMembers = () => {
 
   // eslint-disable-next-line max-len
   const oneTxPaymentExtension = colonyExtensions?.processedColony?.installedExtensions.find(
-    ({
-      details: { initialized, missingPermissions },
-      extensionId: extensionName,
-    }) =>
-      initialized &&
-      !missingPermissions.length &&
+    ({ details, extensionId: extensionName }) =>
+      details?.initialized &&
+      !details?.missingPermissions.length &&
       extensionName === Extension.OneTxPayment,
   );
   const mustUpgradeOneTx = oneTxMustBeUpgraded(oneTxPaymentExtension);

--- a/src/modules/dashboard/components/Extensions/ExtensionActionButton.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionActionButton.tsx
@@ -69,11 +69,11 @@ const ExtensionActionButton = ({
     );
   }
 
-  if (installedExtension.details.deprecated) {
+  if (installedExtension.details?.deprecated) {
     return null;
   }
 
-  if (!installedExtension.details.initialized) {
+  if (!installedExtension.details?.initialized) {
     return (
       <Button
         appearance={{ theme: 'primary', size: 'medium' }}
@@ -84,7 +84,7 @@ const ExtensionActionButton = ({
       />
     );
   }
-  if (installedExtension.details.missingPermissions.length) {
+  if (installedExtension.details?.missingPermissions.length) {
     return (
       <ActionButton
         button={IconButton}

--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
@@ -224,7 +224,7 @@ const ExtensionDetails = ({
     installedExtension &&
     !installedExtension?.details?.deprecated;
   const extesionCanBeUninstalled =
-    extensionUninstallable && installedExtension?.details.deprecated;
+    extensionUninstallable && installedExtension?.details?.deprecated;
   const extensionCanBeUpgraded =
     hasRegisteredProfile &&
     !(extesionCanBeInstalled || extesionCanBeEnabled) &&
@@ -232,8 +232,8 @@ const ExtensionDetails = ({
 
   const extensionEnabled =
     installedExtension &&
-    installedExtension.details.initialized &&
-    !installedExtension.details.deprecated;
+    installedExtension.details?.initialized &&
+    !installedExtension.details?.deprecated;
 
   const extensionCompatible = extension?.currentVersion
     ? !extensionsIncompatibilityMap[extensionId][extension.currentVersion].find(
@@ -255,14 +255,16 @@ const ExtensionDetails = ({
           <span className={styles.installedBy}>
             <DetailsWidgetUser
               colony={colony}
-              walletAddress={installedExtension.details.installedBy}
+              walletAddress={installedExtension.details?.installedBy}
             />
           </span>
         ),
       },
       {
         label: MSG.dateInstalled,
-        value: <FormattedDate value={installedExtension.details.installedAt} />,
+        value: (
+          <FormattedDate value={installedExtension.details?.installedAt} />
+        ),
       },
       {
         label: MSG.versionInstalled,
@@ -396,8 +398,8 @@ const ExtensionDetails = ({
               component={() => {
                 if (
                   !canInstall ||
-                  (installedExtension?.details.initialized &&
-                    !installedExtension?.details.missingPermissions.length)
+                  (installedExtension?.details?.initialized &&
+                    !installedExtension?.details?.missingPermissions.length)
                 ) {
                   return <Redirect to={extensionUrl} />;
                 }

--- a/src/modules/dashboard/components/Extensions/ExtensionSetup.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionSetup.tsx
@@ -311,9 +311,9 @@ const ExtensionSetup = ({
   );
 
   if (
-    installedExtension.details.deprecated ||
-    (installedExtension.details.initialized &&
-      !installedExtension.details.missingPermissions.length)
+    installedExtension.details?.deprecated ||
+    (installedExtension.details?.initialized &&
+      !installedExtension.details?.missingPermissions.length)
   ) {
     return <Redirect to={`/colony/${colonyName}/extensions/${extensionId}`} />;
   }
@@ -321,8 +321,8 @@ const ExtensionSetup = ({
   // This is a special case that should not happen. Used to recover the
   // missing permission transactions
   if (
-    installedExtension.details.initialized &&
-    installedExtension.details.missingPermissions.length
+    installedExtension.details?.initialized &&
+    installedExtension.details?.missingPermissions.length
   ) {
     return (
       <div className={styles.main}>

--- a/src/modules/dashboard/components/Extensions/ExtensionStatus.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionStatus.tsx
@@ -49,13 +49,13 @@ const ExtensionStatus = ({
 
   if (!installedExtension) {
     status = MSG.notInstalled;
-  } else if (!installedExtension.details.initialized) {
+  } else if (!installedExtension.details?.initialized) {
     status = MSG.notEnabled;
     theme = 'golden';
-  } else if (installedExtension.details.missingPermissions.length) {
+  } else if (installedExtension.details?.missingPermissions.length) {
     status = MSG.missingPermissions;
     theme = 'danger';
-  } else if (installedExtension.details.initialized) {
+  } else if (installedExtension.details?.initialized) {
     status = MSG.enabled;
     theme = 'primary';
   } else {
@@ -70,7 +70,7 @@ const ExtensionStatus = ({
           data-test={`${camelCase(status.defaultMessage)}StatusTag`}
         />
       ) : null}
-      {installedExtension && installedExtension.details.deprecated ? (
+      {installedExtension && installedExtension.details?.deprecated ? (
         <Tag
           appearance={{ theme: 'danger' }}
           text={MSG.deprecated}

--- a/src/modules/dashboard/sagas/coinMachine/extensionEnable.ts
+++ b/src/modules/dashboard/sagas/coinMachine/extensionEnable.ts
@@ -61,12 +61,9 @@ function* extensionEnable({
       throw new Error('Extension not installed');
     }
 
-    const {
-      address,
-      details: { initialized, missingPermissions },
-    } = data.colonyExtension;
+    const { address, details } = data.colonyExtension;
 
-    if (!initialized && extension.initializationParams) {
+    if (!details?.initialized && extension.initializationParams) {
       let shouldSetNewTokenAuthority = false;
       let initParams = [] as any[];
 
@@ -93,8 +90,8 @@ function* extensionEnable({
         deployTokenAuthority?: Channel;
         makeArbitraryTransaction?: Channel;
       } = {};
-      if (missingPermissions.length) {
-        const bytes32Roles = intArrayToBytes32(missingPermissions);
+      if (details?.missingPermissions.length) {
+        const bytes32Roles = intArrayToBytes32(details.missingPermissions);
         additionalChannels.setUserRolesWithProofs = {
           context: ClientType.ColonyClient,
           params: [address, ROOT_DOMAIN_ID, bytes32Roles],

--- a/src/modules/dashboard/sagas/extensions/colonyExtensionEnable.ts
+++ b/src/modules/dashboard/sagas/extensions/colonyExtensionEnable.ts
@@ -56,19 +56,16 @@ function* colonyExtensionEnable({
       throw new Error('Extension not installed');
     }
 
-    const {
-      address,
-      details: { initialized, missingPermissions },
-    } = data.colonyExtension;
+    const { address, details } = data.colonyExtension;
 
-    if (!initialized && extension.initializationParams) {
+    if (!details?.initialized && extension.initializationParams) {
       const initParams = modifyParams(extension.initializationParams, payload);
 
       const additionalChannels: {
         setUserRolesWithProofs?: Channel;
       } = {};
-      if (missingPermissions.length) {
-        const bytes32Roles = intArrayToBytes32(missingPermissions);
+      if (details?.missingPermissions.length) {
+        const bytes32Roles = intArrayToBytes32(details.missingPermissions);
         additionalChannels.setUserRolesWithProofs = {
           context: ClientType.ColonyClient,
           params: [address, ROOT_DOMAIN_ID, bytes32Roles],

--- a/src/modules/dashboard/sagas/whitelist/extensionEnable.ts
+++ b/src/modules/dashboard/sagas/whitelist/extensionEnable.ts
@@ -67,12 +67,9 @@ function* extensionEnable({
       }),
     );
 
-    const {
-      address,
-      details: { initialized, missingPermissions },
-    } = data.colonyExtension;
+    const { address, details } = data.colonyExtension;
 
-    if (!initialized && extension.initializationParams) {
+    if (!details?.initialized && extension.initializationParams) {
       const initParams = [
         payload?.policy !== WhitelistPolicy.AgreementOnly,
         agreementHash,
@@ -81,8 +78,8 @@ function* extensionEnable({
       const additionalChannels: {
         setUserRolesWithProofs?: Channel;
       } = {};
-      if (missingPermissions.length) {
-        const bytes32Roles = intArrayToBytes32(missingPermissions);
+      if (details?.missingPermissions.length) {
+        const bytes32Roles = intArrayToBytes32(details.missingPermissions);
         additionalChannels.setUserRolesWithProofs = {
           context: ClientType.ColonyClient,
           params: [address, ROOT_DOMAIN_ID, bytes32Roles],

--- a/src/utils/hooks/useEnabledExtensions.tsx
+++ b/src/utils/hooks/useEnabledExtensions.tsx
@@ -26,13 +26,13 @@ export const useEnabledExtensions = ({ colonyAddress }: Props) => {
 
   const isVotingExtensionEnabled = !!(
     installedVotingExtension &&
-    installedVotingExtension.details.initialized &&
-    !installedVotingExtension.details.deprecated
+    installedVotingExtension.details?.initialized &&
+    !installedVotingExtension.details?.deprecated
   );
   const isOneTxPaymentExtensionEnabled = !!(
     installedOneTxPaymentExtension &&
-    installedOneTxPaymentExtension.details.initialized &&
-    !installedOneTxPaymentExtension.details.deprecated
+    installedOneTxPaymentExtension.details?.initialized &&
+    !installedOneTxPaymentExtension.details?.deprecated
   );
 
   const installedExtensionsAddresses = installedExtensions.map((extension) =>
@@ -40,8 +40,8 @@ export const useEnabledExtensions = ({ colonyAddress }: Props) => {
   );
   const isWhitelistExtensionEnabled = !!(
     installedWhitelistExtension &&
-    installedWhitelistExtension.details.initialized &&
-    !installedWhitelistExtension.details.deprecated
+    installedWhitelistExtension.details?.initialized &&
+    !installedWhitelistExtension.details?.deprecated
   );
 
   return {


### PR DESCRIPTION
Added optional chaining operator to `details` prop.

Sometimes the prop can be `null/undefined` by the time the code tries to access it, causing the dapp to crash, notably when running the extension tests. I guess that would be because the dapp when you run the test runs slower than in the dev env, for example?

**To test**: Run the extension tests and check that the dapp doesn't crash during the tests or a bit after finishing the tests due to the `initialized` prop being inaccessible
