### PR TITLE
Prevent extra margin in DefaultMotion tags

### DIFF
--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
@@ -134,7 +134,9 @@ const DefaultMotion = ({
     return Object.values(MOTION_TAG_MAP).reduce((acc, object) => {
       const { theme, colorSchema } = object as TagAppearance;
       acc[object.tagName] = (
-        <Tag text={object.name} appearance={{ theme, colorSchema }} />
+        <span>
+          <Tag text={object.name} appearance={{ theme, colorSchema }} />
+        </span>
       );
       return acc;
     }, {} as any);


### PR DESCRIPTION
## Description

I the cause of the issue is https://github.com/joincolony/colonyDapp/blob/f09568540a45c9a29aea6fb49061ca796344ddc7/src/modules/core/components/Tag/Tag.css#L11

- the sibling selector kicks in when there are two tags in the same line - even if there is text in between them.

In DefaultMotion wrapping the Tag component in a `span` prevents that from happening.

![Screenshot 2022-03-21 at 11-10-59 Pay halum 199 TOK Motion Colony - Notun](https://user-images.githubusercontent.com/14034137/159210800-a21134e5-373f-43f6-990d-d0319ec86ec3.png)


Resolves  #3253
