### PR TITLE
Add tests for colony actions (REMIX)

### DIFF
--- a/cypress/e2e/3-actions.js
+++ b/cypress/e2e/3-actions.js
@@ -342,8 +342,6 @@ describe('User can create actions via UAC', () => {
     });
   });
   it('Can unlock the native token', () => {
-    const annotationText = 'Time to unlock the token';
-
     cy.login();
 
     cy.visit(`/colony/${Cypress.config().colony.name}`);
@@ -351,8 +349,6 @@ describe('User can create actions via UAC', () => {
     cy.getBySel('newActionButton', { timeout: 60000 }).click();
     cy.getBySel('indexModalItem').eq(1).click();
     cy.getBySel('indexModalItem').eq(5).click();
-
-    cy.getBySel('unlockTokenAnnotation').click().type(annotationText);
 
     cy.getBySel('unlockTokenConfirmButton').click();
 
@@ -368,14 +364,12 @@ describe('User can create actions via UAC', () => {
       }/tx/0x`,
     );
 
-    cy.getBySel('comment').should('have.text', annotationText);
-
     cy.getBySel('backButton').click();
 
     cy.getBySel('lockIconTooltip', { timeout: 15000 }).should('not.exist');
   });
   it.only('Can manage permissions', () => {
-    const annotationText = 'Time to unlock the token';
+    const annotationText = 'I am giving you the power to do things';
 
     cy.login();
 

--- a/cypress/e2e/3-actions.js
+++ b/cypress/e2e/3-actions.js
@@ -341,7 +341,7 @@ describe('User can create actions via UAC', () => {
       );
     });
   });
-  it.only('Can unlock the native token', () => {
+  it('Can unlock the native token', () => {
     const annotationText = 'Time to unlock the token';
 
     cy.login();
@@ -373,5 +373,39 @@ describe('User can create actions via UAC', () => {
     cy.getBySel('backButton').click();
 
     cy.getBySel('lockIconTooltip', { timeout: 15000 }).should('not.exist');
+  });
+  it.only('Can manage permissions', () => {
+    const annotationText = 'Time to unlock the token';
+
+    cy.login();
+
+    cy.visit(`/colony/${Cypress.config().colony.name}`);
+
+    cy.getBySel('new-action-button', { timeout: 70000 }).click();
+    cy.getBySel('index-modal-item').eq(4).click();
+    cy.getBySel('index-modal-item').eq(0).click();
+
+    cy.getBySel('permissionUserSelector').click({ force: true });
+    cy.getBySel('permissionUserSelectorItem').last().click();
+    cy.getBySel('permission').eq(1).click({force: true});
+    cy.getBySel('permission').eq(2).click({force: true});
+    cy.getBySel('permission').eq(3).click({force: true});
+    cy.getBySel('permissionAnnotation').click().type(annotationText);
+
+    cy.getBySel('permissionConfirmButton').click();
+
+    cy.getBySel('actionHeading', { timeout: 100000 }).should(
+      'contains',
+      `Assign the administration, funding, architecture permissions in Root to`,
+    );
+
+    cy.url().should(
+      'contains',
+      `${Cypress.config().baseUrl}/colony/${
+        Cypress.config().colony.name
+      }/tx/0x`,
+    );
+
+    cy.getBySel('comment').should('have.text', annotationText);
   });
 });

--- a/cypress/e2e/3-actions.js
+++ b/cypress/e2e/3-actions.js
@@ -341,4 +341,37 @@ describe('User can create actions via UAC', () => {
       );
     });
   });
+  it.only('Can unlock the native token', () => {
+    const annotationText = 'Time to unlock the token';
+
+    cy.login();
+
+    cy.visit(`/colony/${Cypress.config().colony.name}`);
+
+    cy.getBySel('new-action-button', { timeout: 60000 }).click();
+    cy.getBySel('index-modal-item').eq(1).click();
+    cy.getBySel('index-modal-item').eq(5).click();
+
+    cy.getBySel('unlockTokenAnnotation').click().type(annotationText);
+
+    cy.getBySel('unlockTokenConfirmButton').click();
+
+    cy.getBySel('actionHeading', { timeout: 100000 }).should(
+      'include.text',
+      `Unlock native token ${Cypress.config().colony.nativeToken}`,
+    );
+
+    cy.url().should(
+      'contains',
+      `${Cypress.config().baseUrl}/colony/${
+        Cypress.config().colony.name
+      }/tx/0x`,
+    );
+
+    cy.getBySel('comment').should('have.text', annotationText);
+
+    cy.getBySel('backButton').click();
+
+    cy.getBySel('lockIconTooltip', { timeout: 15000 }).should('not.exist');
+  });
 });

--- a/cypress/e2e/3-actions.js
+++ b/cypress/e2e/3-actions.js
@@ -283,7 +283,7 @@ describe('User can create actions via UAC', () => {
 
     cy.getBySel('comment').should('have.text', annotationText);
   });
-  it.only('Can transfer funds', () => {
+  it('Can transfer funds', () => {
     const amountToTransfer = 2;
     const annotationText = 'I want to transfer these funds just because';
     let prevColonyFunds;
@@ -347,8 +347,8 @@ describe('User can create actions via UAC', () => {
     cy.visit(`/colony/${Cypress.config().colony.name}`);
 
     cy.getBySel('newActionButton', { timeout: 60000 }).click();
-    cy.getBySel('indexModalItem').eq(1).click();
-    cy.getBySel('indexModalItem').eq(5).click();
+    cy.getBySel('fundsDialogIndexItem').click();
+    cy.getBySel('unlockTokenDialogIndexItem').click();
 
     cy.getBySel('unlockTokenConfirmButton').click();
 
@@ -368,7 +368,7 @@ describe('User can create actions via UAC', () => {
 
     cy.getBySel('lockIconTooltip', { timeout: 15000 }).should('not.exist');
   });
-  it.only('Can manage permissions', () => {
+  it('Can manage permissions', () => {
     const annotationText = 'I am giving you the power to do things';
 
     cy.login();
@@ -376,8 +376,8 @@ describe('User can create actions via UAC', () => {
     cy.visit(`/colony/${Cypress.config().colony.name}`);
 
     cy.getBySel('newActionButton', { timeout: 60000 }).click();
-    cy.getBySel('indexModalItem').eq(4).click();
-    cy.getBySel('indexModalItem').eq(0).click();
+    cy.getBySel('advancedDialogIndexItem').click();
+    cy.getBySel('managePermissionsDialogIndexItem').click();
 
     cy.getBySel('permissionUserSelector').click({ force: true });
     cy.getBySel('permissionUserSelectorItem').last().click();
@@ -412,8 +412,8 @@ describe('User can create actions via UAC', () => {
     cy.visit(`/colony/${Cypress.config().colony.name}`);
 
     cy.getBySel('newActionButton', { timeout: 70000 }).click();
-    cy.getBySel('indexModalItem').eq(4).click();
-    cy.getBySel('indexModalItem').eq(1).click();
+    cy.getBySel('advancedDialogIndexItem').click();
+    cy.getBySel('recoveryDialogIndexItem').click();
 
     cy.getBySel('recoveryAnnotation').click().type(annotationText);
 

--- a/cypress/e2e/3-actions.js
+++ b/cypress/e2e/3-actions.js
@@ -348,9 +348,9 @@ describe('User can create actions via UAC', () => {
 
     cy.visit(`/colony/${Cypress.config().colony.name}`);
 
-    cy.getBySel('new-action-button', { timeout: 60000 }).click();
-    cy.getBySel('index-modal-item').eq(1).click();
-    cy.getBySel('index-modal-item').eq(5).click();
+    cy.getBySel('newActionButton', { timeout: 60000 }).click();
+    cy.getBySel('indexModalItem').eq(1).click();
+    cy.getBySel('indexModalItem').eq(5).click();
 
     cy.getBySel('unlockTokenAnnotation').click().type(annotationText);
 
@@ -374,16 +374,16 @@ describe('User can create actions via UAC', () => {
 
     cy.getBySel('lockIconTooltip', { timeout: 15000 }).should('not.exist');
   });
-  it('Can manage permissions', () => {
+  it.only('Can manage permissions', () => {
     const annotationText = 'Time to unlock the token';
 
     cy.login();
 
     cy.visit(`/colony/${Cypress.config().colony.name}`);
 
-    cy.getBySel('new-action-button', { timeout: 60000 }).click();
-    cy.getBySel('index-modal-item').eq(4).click();
-    cy.getBySel('index-modal-item').eq(0).click();
+    cy.getBySel('newActionButton', { timeout: 60000 }).click();
+    cy.getBySel('indexModalItem').eq(4).click();
+    cy.getBySel('indexModalItem').eq(0).click();
 
     cy.getBySel('permissionUserSelector').click({ force: true });
     cy.getBySel('permissionUserSelectorItem').last().click();
@@ -394,9 +394,8 @@ describe('User can create actions via UAC', () => {
 
     cy.getBySel('permissionConfirmButton').click();
 
-    cy.getBySel('actionHeading', { timeout: 100000 }).should(
-      'contains',
-      `Assign the administration, funding, architecture permissions in Root to`,
+    cy.getBySel('actionHeading', { timeout: 100000 }).contains(
+      'Assign the administration, funding, architecture permissions in Root to',
     );
 
     cy.url().should(
@@ -418,9 +417,9 @@ describe('User can create actions via UAC', () => {
 
     cy.visit(`/colony/${Cypress.config().colony.name}`);
 
-    cy.getBySel('new-action-button', { timeout: 70000 }).click();
-    cy.getBySel('index-modal-item').eq(4).click();
-    cy.getBySel('index-modal-item').eq(1).click();
+    cy.getBySel('newActionButton', { timeout: 70000 }).click();
+    cy.getBySel('indexModalItem').eq(4).click();
+    cy.getBySel('indexModalItem').eq(1).click();
 
     cy.getBySel('recoveryAnnotation').click().type(annotationText);
 

--- a/cypress/e2e/3-actions.js
+++ b/cypress/e2e/3-actions.js
@@ -374,22 +374,22 @@ describe('User can create actions via UAC', () => {
 
     cy.getBySel('lockIconTooltip', { timeout: 15000 }).should('not.exist');
   });
-  it.only('Can manage permissions', () => {
+  it('Can manage permissions', () => {
     const annotationText = 'Time to unlock the token';
 
     cy.login();
 
     cy.visit(`/colony/${Cypress.config().colony.name}`);
 
-    cy.getBySel('new-action-button', { timeout: 70000 }).click();
+    cy.getBySel('new-action-button', { timeout: 60000 }).click();
     cy.getBySel('index-modal-item').eq(4).click();
     cy.getBySel('index-modal-item').eq(0).click();
 
     cy.getBySel('permissionUserSelector').click({ force: true });
     cy.getBySel('permissionUserSelectorItem').last().click();
-    cy.getBySel('permission').eq(1).click({force: true});
-    cy.getBySel('permission').eq(2).click({force: true});
-    cy.getBySel('permission').eq(3).click({force: true});
+    cy.getBySel('permission').eq(1).click({ force: true });
+    cy.getBySel('permission').eq(2).click({ force: true });
+    cy.getBySel('permission').eq(3).click({ force: true });
     cy.getBySel('permissionAnnotation').click().type(annotationText);
 
     cy.getBySel('permissionConfirmButton').click();
@@ -407,5 +407,55 @@ describe('User can create actions via UAC', () => {
     );
 
     cy.getBySel('comment').should('have.text', annotationText);
+  });
+  it('Can enable recovery mode', () => {
+    const storageSlot = '0x05';
+    const storageSlotValue =
+      '0x0000000000000000000000000000000000000000000000000000000000000002';
+    const annotationText = 'We have to recover what we have lost';
+
+    cy.login();
+
+    cy.visit(`/colony/${Cypress.config().colony.name}`);
+
+    cy.getBySel('new-action-button', { timeout: 70000 }).click();
+    cy.getBySel('index-modal-item').eq(4).click();
+    cy.getBySel('index-modal-item').eq(1).click();
+
+    cy.getBySel('recoveryAnnotation').click().type(annotationText);
+
+    cy.getBySel('recoveryConfirmButton').click();
+
+    cy.getBySel('actionHeading', { timeout: 100000 }).contains(
+      'Recovery mode activated by',
+    );
+
+    cy.url().should(
+      'contains',
+      `${Cypress.config().baseUrl}/colony/${
+        Cypress.config().colony.name
+      }/tx/0x`,
+    );
+
+    cy.getBySel('comment').should('have.text', annotationText);
+
+    cy.getBySel('storageSlotInput').click().type(storageSlot);
+    cy.getBySel('storageSlotValueInput').click().type(storageSlotValue);
+    cy.getBySel('storageSlotSubmitButton').click();
+
+    cy.getBySel('newSlotValueEvent', { timeout: 40000 }).should(
+      'have.text',
+      storageSlotValue,
+    );
+
+    cy.getBySel('approveExitButton').click();
+
+    cy.getBySel('closeGasStationButton').click();
+
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.getBySel('reactivateColonyButton', { timeout: 40000 })
+      .click()
+      .wait(20000)
+      .should('not.exist');
   });
 });

--- a/cypress/e2e/3-actions.js
+++ b/cypress/e2e/3-actions.js
@@ -283,7 +283,7 @@ describe('User can create actions via UAC', () => {
 
     cy.getBySel('comment').should('have.text', annotationText);
   });
-  it('Can transfer funds', () => {
+  it.only('Can transfer funds', () => {
     const amountToTransfer = 2;
     const annotationText = 'I want to transfer these funds just because';
     let prevColonyFunds;

--- a/src/modules/core/components/Fields/Checkbox/Checkbox.tsx
+++ b/src/modules/core/components/Fields/Checkbox/Checkbox.tsx
@@ -57,6 +57,7 @@ interface Props {
   push: (value: string) => void;
   /** @ignore injected by `asFieldArray` */
   remove: (value: string) => void;
+  dataTest?: string;
 }
 
 const displayName = 'Checkbox';
@@ -79,6 +80,7 @@ const Checkbox = ({
   value,
   tooltipText,
   tooltipPopperProps,
+  dataTest,
 }: Props) => {
   const [inputId] = useState<string>(nanoid());
 
@@ -116,6 +118,7 @@ const Checkbox = ({
           onChange={handleOnChange}
           aria-disabled={disabled}
           aria-checked={isChecked}
+          data-test={dataTest}
         />
         <span className={styles.checkbox}>
           <span className={styles.checkmark} />

--- a/src/modules/core/components/IconTooltip/IconTooltip.tsx
+++ b/src/modules/core/components/IconTooltip/IconTooltip.tsx
@@ -29,6 +29,7 @@ interface Props {
   className?: string;
   iconTitle?: string;
   showArrow?: boolean;
+  dataTest?: string;
 }
 
 const displayName = 'IconTooltip';
@@ -46,8 +47,12 @@ const IconTooltip = ({
   tooltipClassName = styles.tooltipWrapper,
   className,
   showArrow,
+  dataTest,
 }: Props) => (
-  <div className={cx(getMainClasses(appearance, styles), className)}>
+  <div
+    className={cx(getMainClasses(appearance, styles), className)}
+    data-test={dataTest}
+  >
     <Tooltip
       appearance={{
         theme: appearance.theme ? appearance.theme : 'dark',

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/RecoveryAction.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/RecoveryAction.tsx
@@ -206,7 +206,7 @@ const RecoveryAction = ({
            * @NOTE Can't use `Heading` here since it uses `formmatedMessage` internally
            * for message descriptors, and that doesn't support our complex text values
            */}
-          <h1 className={styles.heading}>
+          <h1 className={styles.heading} data-test="actionHeading">
             <FormattedMessage
               id="action.title"
               values={{
@@ -271,6 +271,7 @@ const RecoveryAction = ({
                       }}
                       emmitedBy={emmitedBy}
                       colony={colony}
+                      dataTest="recoveryActionEvent"
                     >
                       {name ===
                         ColonyAndExtensionsEvents.RecoveryStorageSlotSet && (
@@ -282,7 +283,10 @@ const RecoveryAction = ({
                               tagName="p"
                               {...MSG.newSlotValue}
                             />
-                            <div className={recoverySpecificStyles.slotValue}>
+                            <div
+                              className={recoverySpecificStyles.slotValue}
+                              data-test="newSlotValueEvent"
+                            >
                               {((eventValues as unknown) as EventValues)
                                 ?.toValue || fallbackStorageSlotValue}
                             </div>

--- a/src/modules/dashboard/components/ActionsPage/ApproveExitWidget/ApproveExitWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ApproveExitWidget/ApproveExitWidget.tsx
@@ -110,6 +110,7 @@ const ApproveExitWidget = ({
           success={ActionTypes.COLONY_ACTION_RECOVERY_EXIT_SUCCESS}
           transform={transform}
           text={MSG.reactivateButton}
+          data-test="reactivateColonyButton"
         />
       </div>
     </div>

--- a/src/modules/dashboard/components/ActionsPage/InputStorageWidget/InputStorageWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/InputStorageWidget/InputStorageWidget.tsx
@@ -234,6 +234,7 @@ const InputStorageWidget = ({
                 colorSchema: 'grey',
               }}
               disabled={!hasRegisteredProfile || isSubmitting}
+              dataTest="storageSlotInput"
             />
             {storageSlotLocationError && (
               <span className={styles.inputValidationError}>
@@ -276,6 +277,7 @@ const InputStorageWidget = ({
               disabled={
                 !hasRegisteredProfile || !userHasPermission || isSubmitting
               }
+              dataTest="storageSlotValueInput"
             />
             {newStorageSlotValueError && (
               <span className={styles.inputValidationError}>
@@ -295,6 +297,7 @@ const InputStorageWidget = ({
                     !newStorageSlotValue ||
                     isSubmitting
                   }
+                  data-test="storageSlotSubmitButton"
                 />
               </div>
             )}

--- a/src/modules/dashboard/components/ActionsPage/MultisigWidget/MultisigWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/MultisigWidget/MultisigWidget.tsx
@@ -226,6 +226,7 @@ const MultisigWidget = ({
                 transform={transform}
                 text={{ id: 'button.approve' }}
                 disabled={hasAlreadyApproved}
+                data-test="approveExitButton"
               />
             </div>
           </Tooltip>

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageEvent/ActionsPageEvent.tsx
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageEvent/ActionsPageEvent.tsx
@@ -84,6 +84,7 @@ interface Props {
   colony: Colony;
   children?: ReactNode;
   rootHash?: string;
+  dataTest?: string;
 }
 
 interface DomainMetadata {
@@ -104,6 +105,7 @@ const ActionsPageEvent = ({
   colony,
   children,
   rootHash,
+  dataTest,
 }: Props) => {
   let metadataJSON;
   const [metdataIpfsHash, setMetdataIpfsHash] = useState<string | undefined>(
@@ -328,7 +330,7 @@ const ActionsPageEvent = ({
     colonyNativeToken?.decimals,
   );
   return (
-    <div className={styles.main}>
+    <div className={styles.main} data-test={dataTest}>
       <div className={styles.wrapper}>
         <div className={styles.status}>
           <TransactionStatus status={STATUS.Succeeded} showTooltip={false} />

--- a/src/modules/dashboard/components/ColonyHome/ColonyFunding/TokenItem.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyFunding/TokenItem.tsx
@@ -46,6 +46,7 @@ const TokenItem = ({
             tooltipText={{ id: 'tooltip.lockedToken' }}
             className={styles.tokenLockWrapper}
             appearance={{ size: 'small' }}
+            dataTest="lockIconTooltip"
           />
         )}
       </span>

--- a/src/modules/dashboard/components/Dialogs/AdvancedDialog/AdvancedDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/AdvancedDialog/AdvancedDialog.tsx
@@ -141,6 +141,7 @@ const AdvancedDialog = ({
           <FormattedMessage {...MSG.managePermissionsPermissionList} />
         ),
       },
+      dataTest: 'managePermissionsDialogIndexItem',
     },
     {
       title: MSG.recoveryTitle,
@@ -155,6 +156,7 @@ const AdvancedDialog = ({
         permissionsList: <FormattedMessage {...MSG.recoveryPermissionsList} />,
       },
       disabled: !isSupportedColonyVersion,
+      dataTest: 'recoveryDialogIndexItem',
     },
     {
       title: MSG.upgradeTitle,

--- a/src/modules/dashboard/components/Dialogs/ManageFundsDialog/ManageFundsDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/ManageFundsDialog/ManageFundsDialog.tsx
@@ -184,6 +184,7 @@ const ManageFundsDialog = ({
           <FormattedMessage {...MSG.manageTokensPermissionsList} />
         ),
       },
+      dataTest: 'unlockTokenDialogIndexItem',
     },
   ];
   const filteredItems = useMemo(() => {

--- a/src/modules/dashboard/components/Dialogs/PermissionManagementDialog/PermissionManagementCheckbox.tsx
+++ b/src/modules/dashboard/components/Dialogs/PermissionManagementDialog/PermissionManagementCheckbox.tsx
@@ -52,6 +52,7 @@ interface Props {
   disabled: boolean;
   role: ColonyRole;
   domainId: number;
+  dataTest: string;
 }
 
 const displayName =
@@ -62,6 +63,7 @@ const PermissionManagementCheckbox = ({
   disabled,
   role,
   domainId,
+  dataTest,
 }: Props) => {
   const roleNameMessage = { id: `role.${role}` };
   const roleDescriptionMessage = useMemo(
@@ -109,6 +111,7 @@ const PermissionManagementCheckbox = ({
           },
         ],
       }}
+      dataTest={dataTest}
     >
       <span className={styles.permissionChoiceDescription}>
         <PermissionsLabel

--- a/src/modules/dashboard/components/Dialogs/PermissionManagementDialog/PermissionManagementDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/PermissionManagementDialog/PermissionManagementDialog.tsx
@@ -285,6 +285,7 @@ const PermissionManagementDialog = ({
                       ) ||
                       isSubmitting
                     }
+                    data-test="permissionConfirmButton"
                   />
                 </DialogSection>
               </div>

--- a/src/modules/dashboard/components/Dialogs/PermissionManagementDialog/PermissionManagementForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/PermissionManagementDialog/PermissionManagementForm.tsx
@@ -286,6 +286,8 @@ const PermissionManagementForm = ({
             renderAvatar={supRenderAvatar}
             disabled={inputDisabled}
             placeholder={MSG.userPickerPlaceholder}
+            dataTest="permissionUserSelector"
+            itemDataTest="permissionUserSelectorItem"
           />
         </div>
       </DialogSection>
@@ -317,6 +319,7 @@ const PermissionManagementForm = ({
                 role={role}
                 asterisk={roleIsInherited}
                 domainId={domainId}
+                dataTest="permission"
               />
             );
           })}
@@ -325,6 +328,7 @@ const PermissionManagementForm = ({
           label={MSG.annotation}
           name="annotationMessage"
           disabled={inputDisabled}
+          dataTest="permissionAnnotation"
         />
       </DialogSection>
     </>

--- a/src/modules/dashboard/components/Dialogs/RecoveryModeDialog/RecoveryModeDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/RecoveryModeDialog/RecoveryModeDialogForm.tsx
@@ -118,6 +118,7 @@ const RecoveryModeDialogForm = ({
           label={MSG.annotation}
           name="annotation"
           disabled={!userHasPermission || isSubmitting}
+          dataTest="recoveryAnnotation"
         />
       </DialogSection>
       {!userHasPermission && (
@@ -151,6 +152,7 @@ const RecoveryModeDialogForm = ({
           onClick={() => handleSubmit()}
           loading={isSubmitting}
           disabled={!userHasPermission || isSubmitting}
+          data-test="recoveryConfirmButton"
         />
       </DialogSection>
     </>

--- a/src/modules/dashboard/components/Dialogs/UnlockTokenDialog/UnlockTokenForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/UnlockTokenDialog/UnlockTokenForm.tsx
@@ -147,6 +147,7 @@ const UnlockTokenForm = ({
             label={MSG.annotation}
             name="annotationMessage"
             disabled={inputDisabled}
+            dataTest="unlockTokenAnnotation"
           />
         </DialogSection>
       )}
@@ -184,6 +185,7 @@ const UnlockTokenForm = ({
           text={{ id: 'button.confirm' }}
           loading={isSubmitting}
           disabled={!isValid || inputDisabled}
+          data-test="unlockTokenConfirmButton"
         />
       </DialogSection>
     </>


### PR DESCRIPTION
Added tests for the following actions:

- Unlock native token
- Permission management
- Recovery mode

For the permission management, make sure to have at least 2 members in the colony.

Resolves #3250 
