### PR TITLE
Correctly resize the Search icon in `ManageWhitelistDialog`

### DIFF
--- a/src/img/icons/search.svg
+++ b/src/img/icons/search.svg
@@ -1,8 +1,22 @@
-<svg version="1.1" viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg">
- <g transform="translate(-102.91 -146.4)">
-  <g transform="matrix(.33389 0 0 .33632 102.21 145.7)" fill="none" opacity=".65" stroke="#76748b" stroke-linecap="round" stroke-linejoin="round" stroke-width=".83333">
-   <path d="m9.1667 15.833c3.6819 0 6.6666-2.9847 6.6666-6.6666 0-3.6819-2.9847-6.6667-6.6666-6.6667-3.6819 0-6.6667 2.9848-6.6667 6.6667 0 3.6819 2.9848 6.6666 6.6667 6.6666z"/>
-   <path d="m17.5 17.5-3.625-3.625"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 0 30 30">
+  <g transform="matrix(5.6697746,0,0,5.6313974,-583.45866,-824.43653)">
+    <g
+       transform="matrix(0.33389,0,0,0.33632,102.21,145.7)"
+       fill="none"
+       opacity="0.65"
+       stroke="#76748b"
+       stroke-linecap="round"
+       stroke-linejoin="round"
+       stroke-width="0.83333">
+      <path
+        d="m 9.1667,15.833 c 3.6819,0 6.6666,-2.9847 6.6666,-6.6666 0,-3.6819 -2.9847,-6.6667 -6.6666,-6.6667 -3.6819,0 -6.6667,2.9848 -6.6667,6.6667 0,3.6819 2.9848,6.6666 6.6667,6.6666 z"
+      />
+      <path
+        d="M 17.5,17.5 13.875,13.875"
+      />
+    </g>
   </g>
- </g>
 </svg>

--- a/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/WhitelistedAddresses/WhitelistedAddresses.css
+++ b/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/WhitelistedAddresses/WhitelistedAddresses.css
@@ -22,6 +22,10 @@
   bottom: 7px;
 }
 
+.icon > svg > use {
+  transform: scale(5, 5);
+}
+
 .input {
   padding: 4px;
   height: 32px;

--- a/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/WhitelistedAddresses/WhitelistedAddresses.css
+++ b/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/WhitelistedAddresses/WhitelistedAddresses.css
@@ -22,10 +22,6 @@
   bottom: 7px;
 }
 
-.icon > svg > use {
-  transform: scale(5, 5);
-}
-
 .input {
   padding: 4px;
   height: 32px;


### PR DESCRIPTION
## Description

This PR resizes the Search icon in `ManageWhitelistDialog` to match the specs.

I do not understand why the SVG was not automatically scaling to fill the viewbox (If someone knows, i would be happy to hear the explanation??)

Hopefully my fix is an appropriate way to force the scaling.

<img width="660" alt="Screenshot 2022-03-27 at 20 14 59" src="https://user-images.githubusercontent.com/582700/160284193-56089bde-17bd-41c0-bee9-4a86f27ff3b4.png">

<img width="833" alt="Screenshot 2022-03-27 at 20 23 38" src="https://user-images.githubusercontent.com/582700/160284182-11c939b8-eef3-464f-958f-39d6214f9ba6.png">

Resolves #3263