### PR TITLE
Incorporate network fees in Create Payment

### DIFF
--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
@@ -46,6 +46,7 @@ import {
   useMotionStatusQuery,
   OneDomain,
   useColonyHistoricRolesQuery,
+  useNetworkContracts,
 } from '~data/index';
 
 import DetailsWidget from '../DetailsWidget';
@@ -266,7 +267,19 @@ const DefaultMotion = ({
     color: domainColor,
     description: domainPurpose,
   };
-  const decimalAmount = getFormattedTokenValue(amount, decimals);
+
+  const { feeInverse: networkFeeInverse } = useNetworkContracts();
+  const feePercentage = networkFeeInverse
+    ? bigNumberify(100).div(networkFeeInverse)
+    : null;
+
+  // In case it is a Payment Motion , calculate the payment the recipient gets, after network fees
+  const decimalAmount = getFormattedTokenValue(
+    feePercentage && actionType === ColonyMotions.PaymentMotion
+      ? bigNumberify(amount).mul(bigNumberify(100).sub(feePercentage)).div(100)
+      : amount,
+    decimals,
+  );
   const actionAndEventValues = {
     actionType,
     newVersion,

--- a/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.css
+++ b/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.css
@@ -24,7 +24,7 @@
   text-align: right;
 }
 
-.domainPotBalance {
+.domainPotBalance, .networkFee {
   font-size: var(--size-tiny);
   font-weight: var(--weight-bold);
   text-align: right;

--- a/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.css.d.ts
@@ -4,6 +4,7 @@ export const tokenAmountSelect: string;
 export const tokenAmountContainer: string;
 export const tokenAmountUsd: string;
 export const domainPotBalance: string;
+export const networkFee: string;
 export const domainSelects: string;
 export const tokenAmountInputContainer: string;
 export const singleUserContainer: string;

--- a/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
@@ -32,6 +32,7 @@ import {
   useLoggedInUser,
   useTokenBalancesForDomainsLazyQuery,
   AnyUser,
+  useNetworkContracts,
 } from '~data/index';
 import {
   getBalanceFromToken,
@@ -63,6 +64,10 @@ const MSG = defineMessages({
   amount: {
     id: 'dashboard.CreatePaymentDialog.CreatePaymentDialogForm.amount',
     defaultMessage: 'Amount',
+  },
+  fee: {
+    id: 'dashboard.CreatePaymentDialog.CreatePaymentDialogForm.fee',
+    defaultMessage: 'Network fee: {fee} {symbol}',
   },
   token: {
     id: 'dashboard.CreatePaymentDialog.CreatePaymentDialogForm.address',
@@ -113,6 +118,22 @@ const UserAvatar = HookedUserAvatar({ fetchUser: false });
 const supRenderAvatar = (address: Address, item: ItemDataType<AnyUser>) => (
   <UserAvatar address={address} user={item} size="xs" notSet={false} />
 );
+
+export const calculateFee = (
+  receivedAmount: string, // amount that the recipient finally receives
+  feeInverse: string,
+  decimals: number,
+): { feesInWei: string; totalToPay: string } => {
+  const amountInWei = moveDecimal(receivedAmount, decimals);
+  const totalToPay = bigNumberify(amountInWei)
+    .mul(feeInverse)
+    .div(bigNumberify(feeInverse).sub(1)); // this formula is easily derivable
+  const feesInWei = totalToPay.sub(amountInWei);
+  return {
+    feesInWei: feesInWei.toString(),
+    totalToPay: moveDecimal(totalToPay, -1 * decimals),
+  }; // NOTE: seems like moveDecimal does not have strict typing
+};
 
 const CreatePaymentDialogForm = ({
   back,
@@ -313,6 +334,8 @@ const CreatePaymentDialogForm = ({
 
   const inputDisabled = !canMakePayment || onlyForceAction || isSubmitting;
 
+  const { feeInverse: networkFeeInverse } = useNetworkContracts();
+
   return (
     <>
       <DialogSection appearance={{ theme: 'sidePadding' }}>
@@ -427,6 +450,41 @@ const CreatePaymentDialogForm = ({
                */
               forcedFieldError={customAmountError}
             />
+            {networkFeeInverse &&
+              values.amount &&
+              values.amount !== '0' &&
+              values.amount !== '0.' &&
+              values.amount !== '.' && (
+                <div className={styles.networkFee}>
+                  <FormattedMessage
+                    {...MSG.fee}
+                    values={{
+                      fee: (
+                        <Numeral
+                          appearance={{
+                            size: 'small',
+                            theme: 'grey',
+                          }}
+                          value={
+                            calculateFee(
+                              values.amount,
+                              networkFeeInverse,
+                              getTokenDecimalsWithFallback(
+                                selectedToken?.decimals,
+                              ),
+                            ).feesInWei
+                          }
+                          unit={getTokenDecimalsWithFallback(
+                            selectedToken && selectedToken.decimals,
+                          )}
+                          truncate={3}
+                        />
+                      ),
+                      symbol: (selectedToken && selectedToken.symbol) || '???',
+                    }}
+                  />
+                </div>
+              )}
           </div>
           <div className={styles.tokenAmountContainer}>
             <div className={styles.tokenAmountSelect}>


### PR DESCRIPTION
## Description

This PR 

- displays the network fee in Create Payment Dialog
- Calls the network contract with the total amount (amount to be received + fees) so that the recipient simply gets the amount typed in the form.

![Screenshot 2022-03-29 at 19-11-40 Actions Colony - Notun](https://user-images.githubusercontent.com/14034137/160626786-97fa980d-c02e-4e79-97a7-9474c1d0b48a.png)



Resolves #3266.
