### PR TITLE
Add Standard Number display formatting to StakesListItem

### DIFF
--- a/src/modules/users/components/TokenActivation/StakesTab/StakesListItem.tsx
+++ b/src/modules/users/components/TokenActivation/StakesTab/StakesListItem.tsx
@@ -2,6 +2,7 @@ import React, { Dispatch, SetStateAction } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
 import Link from '~core/Link';
+import Numeral from '~core/Numeral';
 
 import styles from './StakesTab.css';
 
@@ -36,9 +37,7 @@ const StakesListItem = ({
           onKeyPress={setIsPopoverOpen as any}
           tabIndex={0}
         >
-          <div>
-            {stakedAmount} {tokenSymbol}
-          </div>
+          <Numeral value={stakedAmount} unit={tokenSymbol} />
           <div className={styles.falseLink}>
             <FormattedMessage {...MSG.motionUrl} />
           </div>

--- a/src/modules/users/components/TokenActivation/StakesTab/StakesListItem.tsx
+++ b/src/modules/users/components/TokenActivation/StakesTab/StakesListItem.tsx
@@ -37,7 +37,9 @@ const StakesListItem = ({
           onKeyPress={setIsPopoverOpen as any}
           tabIndex={0}
         >
-          <Numeral value={stakedAmount} suffix={tokenSymbol} />
+          <div>
+            <Numeral value={stakedAmount} suffix={tokenSymbol} />
+          </div>
           <div className={styles.falseLink}>
             <FormattedMessage {...MSG.motionUrl} />
           </div>

--- a/src/modules/users/components/TokenActivation/StakesTab/StakesListItem.tsx
+++ b/src/modules/users/components/TokenActivation/StakesTab/StakesListItem.tsx
@@ -37,7 +37,7 @@ const StakesListItem = ({
           onKeyPress={setIsPopoverOpen as any}
           tabIndex={0}
         >
-          <Numeral value={stakedAmount} unit={tokenSymbol} />
+          <Numeral value={stakedAmount} suffix={tokenSymbol} />
           <div className={styles.falseLink}>
             <FormattedMessage {...MSG.motionUrl} />
           </div>


### PR DESCRIPTION
## Description

This PR adds Standard Number display formatting to StakesListItem.

To test:
1. Create a motion
2. Let it fail or pass & finalise
3. Check entry in StakesTab - value should be formatted.

Resolves #3276

Before:
<img width="273" alt="Screenshot 2022-03-30 at 11 22 40" src="https://user-images.githubusercontent.com/582700/160763241-df441ecf-b838-4672-869f-875c8e681c06.png">

After:
<img width="268" alt="Screenshot 2022-03-30 at 12 58 12" src="https://user-images.githubusercontent.com/582700/160763292-f794b935-6a3b-488d-8667-6b82aa33b4d7.png">

