### PR TITLE
Add motion tests - part 2

### DIFF
--- a/cypress/e2e/2-createColony.js
+++ b/cypress/e2e/2-createColony.js
@@ -22,6 +22,7 @@ describe('Create a new colony', () => {
       } = Cypress.config().colony;
       const { name } = Cypress.config().colony2;
 
+      cy.login();
       cy.getColonyTokenAddress(existingColony);
 
       cy.createColony(Cypress.config().colony2, false);

--- a/cypress/e2e/3-actions.js
+++ b/cypress/e2e/3-actions.js
@@ -5,7 +5,7 @@ import { createAddress } from '~utils/web3';
 
 describe('User can create actions via UAC', () => {
   it('Can mint native tokens', () => {
-    const amountToMint = 10;
+    const amountToMint = 10000;
     cy.mintTokens(amountToMint, false);
 
     cy.getBySel('backButton').click();

--- a/cypress/e2e/3-actions.js
+++ b/cypress/e2e/3-actions.js
@@ -116,38 +116,30 @@ describe('User can create actions via UAC', () => {
     cy.getBySel('lockIconTooltip', { timeout: 15000 }).should('not.exist');
   });
   it('Can manage permissions', () => {
-    const annotationText = 'I am giving you the power to do things';
-
-    cy.login();
-
-    cy.visit(`/colony/${Cypress.config().colony.name}`);
-
-    cy.getBySel('newActionButton', { timeout: 60000 }).click();
-    cy.getBySel('advancedDialogIndexItem').click();
-    cy.getBySel('managePermissionsDialogIndexItem').click();
-
-    cy.getBySel('permissionUserSelector').click({ force: true });
-    cy.getBySel('permissionUserSelectorItem').last().click();
-    cy.getBySel('permission').eq(1).click({ force: true });
-    cy.getBySel('permission').eq(2).click({ force: true });
-    cy.getBySel('permission').eq(3).click({ force: true });
-    cy.getBySel('permissionAnnotation').click().type(annotationText);
-
-    cy.getBySel('permissionConfirmButton').click();
-
-    cy.getBySel('actionHeading', { timeout: 100000 }).contains(
-      'Assign the administration, funding, architecture permissions in Root to',
-    );
-
-    cy.url().should(
-      'contains',
-      `${Cypress.config().baseUrl}/colony/${
-        Cypress.config().colony.name
-      }/tx/0x`,
-    );
-
-    cy.getBySel('comment').should('have.text', annotationText);
+    const { colony } = Cypress.config();
+    cy.managePermissions(colony.name);
   });
+
+  it('Can award users', () => {
+    const amountToAward = 100;
+    cy.awardRep(amountToAward, false);
+  });
+
+  it('Can smite users', () => {
+    const amountToSmite = 10;
+
+    cy.smiteUser(amountToSmite, false);
+  });
+
+  it('Make payment from a subdomain', () => {
+    const amountToPay = 10;
+    const accounts = Object.entries(ganacheAccounts.private_keys).map(
+      ([address]) => address,
+    );
+
+    cy.makePayment(amountToPay, createAddress(accounts[1]), false, true);
+  });
+
   it('Can enable recovery mode', () => {
     const storageSlot = '0x05';
     const storageSlotValue =
@@ -197,25 +189,5 @@ describe('User can create actions via UAC', () => {
       .click()
       .wait(20000)
       .should('not.exist');
-  });
-
-  it('Can award users', () => {
-    const amountToAward = 100;
-    cy.awardRep(amountToAward, false);
-  });
-
-  it('Can smite users', () => {
-    const amountToSmite = 10;
-
-    cy.smiteUser(amountToSmite, false);
-  });
-
-  it('Make payment from a subdomain', () => {
-    const amountToPay = 10;
-    const accounts = Object.entries(ganacheAccounts.private_keys).map(
-      ([address]) => address,
-    );
-
-    cy.makePayment(amountToPay, createAddress(accounts[1]), false, true);
   });
 });

--- a/cypress/e2e/3-actions.js
+++ b/cypress/e2e/3-actions.js
@@ -101,28 +101,15 @@ describe('User can create actions via UAC', () => {
       );
     });
   });
-  it('Can unlock the native token', () => {
+  it.only('Can unlock the native token', () => {
+    const colony = { name: 'haha', nativeToken: 'HAH' };
     cy.login();
+    cy.createColony(colony, true);
+    cy.url().should('eq', `${Cypress.config().baseUrl}/colony/${colony.name}`, {
+      timeout: 90000,
+    });
 
-    cy.visit(`/colony/${Cypress.config().colony.name}`);
-
-    cy.getBySel('newActionButton', { timeout: 60000 }).click();
-    cy.getBySel('fundsDialogIndexItem').click();
-    cy.getBySel('unlockTokenDialogIndexItem').click();
-
-    cy.getBySel('unlockTokenConfirmButton').click();
-
-    cy.getBySel('actionHeading', { timeout: 100000 }).should(
-      'include.text',
-      `Unlock native token ${Cypress.config().colony.nativeToken}`,
-    );
-
-    cy.url().should(
-      'contains',
-      `${Cypress.config().baseUrl}/colony/${
-        Cypress.config().colony.name
-      }/tx/0x`,
-    );
+    cy.unlockToken(colony, false);
 
     cy.getBySel('backButton').click();
 

--- a/cypress/e2e/3-actions.js
+++ b/cypress/e2e/3-actions.js
@@ -101,15 +101,15 @@ describe('User can create actions via UAC', () => {
       );
     });
   });
-  it.only('Can unlock the native token', () => {
-    const colony = { name: 'haha', nativeToken: 'HAH' };
+  it('Can unlock the native token', () => {
+    const colony = { name: 'sirius', nativeToken: 'SIRS' };
     cy.login();
     cy.createColony(colony, true);
     cy.url().should('eq', `${Cypress.config().baseUrl}/colony/${colony.name}`, {
       timeout: 90000,
     });
 
-    cy.unlockToken(colony, false);
+    cy.unlockToken(colony);
 
     cy.getBySel('backButton').click();
 

--- a/cypress/e2e/5-extensions.js
+++ b/cypress/e2e/5-extensions.js
@@ -1,29 +1,18 @@
 import { Extension } from '@colony/colony-js';
 
 const testExtensionManagementFlow = (extensionId) => {
-  // Can install extension
   cy.installExtension();
 
-  // Can enable extension
   cy.enableExtension(extensionId);
 
-  // Can deprecate extension
-  cy.getBySel('deprecateExtensionButton').click();
-  cy.getBySel('confirmButton').click();
-  cy.getBySel('deprecatedStatusTag', { timeout: 30000 }).should('exist');
+  cy.deprecateExtension();
 
   // Can re-enable extension
   cy.getBySel('reenableExtensionButton').click();
   cy.getBySel('confirmButton').click();
   cy.getBySel('enabledStatusTag', { timeout: 30000 }).should('exist');
 
-  // Can uninstall extension
-  cy.getBySel('deprecateExtensionButton').click();
-  cy.getBySel('confirmButton').click();
-  cy.getBySel('uninstallExtensionButton', { timeout: 20000 }).click();
-  cy.getBySel('uninstallWarningInput').click().type('I UNDERSTAND');
-  cy.getBySel('uninstallConfirmButton').click();
-  cy.getBySel('notInstalledStatusTag', { timeout: 30000 }).should('exist');
+  cy.uninstallExtension();
 };
 
 describe('Colony extensions', () => {

--- a/cypress/e2e/6-updateColony.js
+++ b/cypress/e2e/6-updateColony.js
@@ -1,5 +1,7 @@
+import newColony from '../fixtures/colony.json';
+
 describe('Colony can be updated', () => {
-  it.only('can update colony details', () => {
+  it('can update colony details', () => {
     const newName = 'plushka';
 
     cy.editColonyDetails(newName, false);
@@ -10,11 +12,19 @@ describe('Colony can be updated', () => {
 
   it('can update colony tokens', () => {
     const {
-      name: existingColony,
+      name: existingColonyName,
       nativeToken: existingToken,
     } = Cypress.config().colony;
 
-    cy.updateTokens(existingColony);
+    cy.login();
+    cy.createColony(newColony, true);
+    cy.url().should(
+      'eq',
+      `${Cypress.config().baseUrl}/colony/${newColony.name}`,
+      { timeout: 90000 },
+    );
+
+    cy.updateTokens(newColony.name, existingColonyName, false);
 
     cy.getBySel('backButton').click();
 

--- a/cypress/e2e/6-updateColony.js
+++ b/cypress/e2e/6-updateColony.js
@@ -1,24 +1,8 @@
 describe('Colony can be updated', () => {
-  it('can update colony details', () => {
-    const annotationText = 'Test annotation';
-    const colonyName = Cypress.config().colony.name;
+  it.only('can update colony details', () => {
     const newName = 'plushka';
 
-    cy.login();
-    cy.visit(`/colony/${colonyName}`);
-    cy.changeColonyname(colonyName, newName);
-
-    const filePath = 'cypress/fixtures/images/jaya-the-beast.png';
-    cy.get('input[type="file"]').selectFile(filePath, { force: true });
-
-    cy.get('textarea').click().type(annotationText);
-    cy.getBySel('confirmButton').click();
-
-    cy.getBySel('actionHeading', { timeout: 60000 }).should(
-      'have.text',
-      `Colony details changed`,
-    );
-    cy.checkUrlAfterAction(colonyName);
+    cy.editColonyDetails(newName, false);
     cy.getBySel('backButton').click();
 
     cy.checkColonyName(newName);

--- a/cypress/e2e/6-updateColony.js
+++ b/cypress/e2e/6-updateColony.js
@@ -13,26 +13,8 @@ describe('Colony can be updated', () => {
       name: existingColony,
       nativeToken: existingToken,
     } = Cypress.config().colony;
-    cy.getColonyTokenAddress(existingColony);
 
-    const colony = { name: 'feola', nativeToken: 'FEOL' };
-
-    cy.createColony(colony, true);
-
-    cy.getBySel('manageFunds', { timeout: 60000 }).click();
-    cy.getBySel('manageTokens', { timeout: 30000 }).click();
-
-    cy.get('@existingTokenAddress').then((address) => {
-      cy.get('input').last().click().type(address);
-    });
-    cy.getBySel('confirm').click();
-
-    cy.getBySel('actionHeading', { timeout: 60000 }).should(
-      'have.text',
-      `Colony details changed`,
-    );
-
-    cy.checkUrlAfterAction(colony.name);
+    cy.updateTokens(existingColony);
 
     cy.getBySel('backButton').click();
 

--- a/cypress/e2e/8-motions.js
+++ b/cypress/e2e/8-motions.js
@@ -95,7 +95,8 @@ describe('User can create motions via UAC', () => {
 
     cy.checkMotion();
   });
-  it.only('Can unlock the native token', () => {
+
+  it('Can unlock the native token', () => {
     const { colony } = Cypress.config();
     cy.login();
 
@@ -106,5 +107,26 @@ describe('User can create motions via UAC', () => {
     cy.getBySel('backButton').click();
 
     cy.getBySel('lockIconTooltip', { timeout: 15000 }).should('not.exist');
+  });
+
+  it('Can manage permissions', () => {
+    const { colony } = Cypress.config();
+
+    cy.managePermissions(colony.name, true);
+
+    cy.checkMotion();
+  });
+
+  it.only('Disables & deprecates voting extensions', () => {
+    cy.login();
+    cy.visit(`/colony/${Cypress.config().colony.name}`);
+
+    // deprecate & unistall voting reputaiton extension
+    cy.getBySel('extensionsNavigationButton', { timeout: 60000 }).click({
+      force: true,
+    });
+    cy.getBySel('votingReputationExtensionCard', { timeout: 80000 }).click();
+
+    cy.uninstallExtension();
   });
 });

--- a/cypress/e2e/8-motions.js
+++ b/cypress/e2e/8-motions.js
@@ -3,6 +3,8 @@ import { Extension } from '@colony/colony-js';
 import ganacheAccounts from '~lib/colonyNetwork/ganache-accounts.json';
 import { createAddress } from '~utils/web3';
 
+import createdColony from '../fixtures/colony.json';
+
 describe('User can create motions via UAC', () => {
   it('Installs & enables voting extensions', () => {
     cy.login();
@@ -73,6 +75,23 @@ describe('User can create motions via UAC', () => {
     const amountToSmite = 10;
 
     cy.smiteUser(amountToSmite, true);
+
+    cy.checkMotion();
+  });
+
+  it('Can edit colony details', () => {
+    const newName = 'solntse';
+
+    cy.editColonyDetails(newName, true);
+
+    cy.checkMotion();
+  });
+
+  it.only('Can update tokens', () => {
+    const { name: existingColonyName } = Cypress.config().colony;
+    cy.login();
+
+    cy.updateTokens(existingColonyName, createdColony.name, true);
 
     cy.checkMotion();
   });

--- a/cypress/e2e/8-motions.js
+++ b/cypress/e2e/8-motions.js
@@ -117,7 +117,7 @@ describe('User can create motions via UAC', () => {
     cy.checkMotion();
   });
 
-  it.only('Disables & deprecates voting extensions', () => {
+  it('Disables & deprecates voting extensions', () => {
     cy.login();
     cy.visit(`/colony/${Cypress.config().colony.name}`);
 

--- a/cypress/e2e/8-motions.js
+++ b/cypress/e2e/8-motions.js
@@ -87,12 +87,24 @@ describe('User can create motions via UAC', () => {
     cy.checkMotion();
   });
 
-  it.only('Can update tokens', () => {
+  it('Can update tokens', () => {
     const { name: existingColonyName } = Cypress.config().colony;
     cy.login();
 
     cy.updateTokens(existingColonyName, createdColony.name, true);
 
     cy.checkMotion();
+  });
+  it.only('Can unlock the native token', () => {
+    const { colony } = Cypress.config();
+    cy.login();
+
+    cy.visit(`/colony/${colony.name}`);
+
+    cy.unlockToken(colony);
+
+    cy.getBySel('backButton').click();
+
+    cy.getBySel('lockIconTooltip', { timeout: 15000 }).should('not.exist');
   });
 });

--- a/cypress/fixtures/colony.json
+++ b/cypress/fixtures/colony.json
@@ -1,4 +1,4 @@
 {
-  "name": "a",
-  "nativeToken": "A"
+  "name": "feola",
+  "nativeToken": "FEOL"
 }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -84,6 +84,7 @@ Cypress.Commands.add('claimNewUserName', (numberFromList) => {
 });
 
 Cypress.Commands.add('createColony', (colony, useNewToken) => {
+  cy.visit('/landing');
   cy.getBySel('createColony').click();
 
   cy.get('input').first().click().type(colony.name);
@@ -107,7 +108,6 @@ Cypress.Commands.add('createColony', (colony, useNewToken) => {
 });
 
 Cypress.Commands.add('getColonyTokenAddress', (colonyName) => {
-  cy.login();
   cy.visit(`/colony/${colonyName}`);
   cy.getBySel('colonyMenu', { timeout: 60000 }).click();
   cy.getBySel('nativeTokenAddress').invoke('text').as('existingTokenAddress');
@@ -480,25 +480,27 @@ Cypress.Commands.add('editColonyDetails', (newName, isMotion) => {
   cy.checkUrlAfterAction(colonyName);
 });
 
-Cypress.Commands.add('updateTokens', (existingColony) => {
-  cy.getColonyTokenAddress(existingColony);
+Cypress.Commands.add(
+  'updateTokens',
+  (updatedColonyName, tokenProviderColonyName, isMotion) => {
+    cy.getColonyTokenAddress(tokenProviderColonyName);
 
-  const colony = { name: 'feola', nativeToken: 'FEOL' };
+    cy.visit(`/colony/${updatedColonyName}`);
 
-  cy.createColony(colony, true);
+    cy.getBySel('newActionButton', { timeout: 90000 }).click();
+    cy.getBySel('fundsDialogIndexItem').click();
+    cy.getBySel('manageTokensDialogItem').click();
 
-  cy.getBySel('manageFunds', { timeout: 60000 }).click();
-  cy.getBySel('manageTokens', { timeout: 30000 }).click();
+    cy.get('@existingTokenAddress').then((address) => {
+      cy.get('input').last().click().type(address);
+    });
+    cy.getBySel('confirm').click();
 
-  cy.get('@existingTokenAddress').then((address) => {
-    cy.get('input').last().click().type(address);
-  });
-  cy.getBySel('confirm').click();
+    cy.getBySel('actionHeading', { timeout: 60000 }).should(
+      'have.text',
+      isMotion ? 'Change colony details' : `Colony details changed`,
+    );
 
-  cy.getBySel('actionHeading', { timeout: 60000 }).should(
-    'have.text',
-    `Colony details changed`,
-  );
-
-  cy.checkUrlAfterAction(colony.name);
-});
+    cy.checkUrlAfterAction(updatedColonyName);
+  },
+);

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -479,3 +479,26 @@ Cypress.Commands.add('editColonyDetails', (newName, isMotion) => {
   );
   cy.checkUrlAfterAction(colonyName);
 });
+
+Cypress.Commands.add('updateTokens', (existingColony) => {
+  cy.getColonyTokenAddress(existingColony);
+
+  const colony = { name: 'feola', nativeToken: 'FEOL' };
+
+  cy.createColony(colony, true);
+
+  cy.getBySel('manageFunds', { timeout: 60000 }).click();
+  cy.getBySel('manageTokens', { timeout: 30000 }).click();
+
+  cy.get('@existingTokenAddress').then((address) => {
+    cy.get('input').last().click().type(address);
+  });
+  cy.getBySel('confirm').click();
+
+  cy.getBySel('actionHeading', { timeout: 60000 }).should(
+    'have.text',
+    `Colony details changed`,
+  );
+
+  cy.checkUrlAfterAction(colony.name);
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -121,6 +121,12 @@ Cypress.Commands.add('checkUrlAfterAction', (colonyName) => {
   );
 });
 
+Cypress.Commands.add('checkColonyName', (colonyName) => {
+  cy.getBySel('colonyTitle', { timeout: 60000 }).then((name) => {
+    expect(name.text()).to.equal(colonyName);
+  });
+});
+
 Cypress.Commands.add('changeColonyname', (colonyName, newName) => {
   cy.getBySel('newActionButton', { timeout: 60000 }).click();
   cy.getBySel('advancedDialogIndexItem').click();
@@ -449,4 +455,27 @@ Cypress.Commands.add('smiteUser', (amountToSmite, isMotion) => {
   );
 
   cy.getBySel('comment').should('have.text', annotationText);
+});
+
+Cypress.Commands.add('editColonyDetails', (newName, isMotion) => {
+  const annotationText = isMotion
+    ? 'Test motion annotation'
+    : 'Test annotation';
+  const colonyName = Cypress.config().colony.name;
+
+  cy.login();
+  cy.visit(`/colony/${colonyName}`);
+  cy.changeColonyname(colonyName, newName);
+
+  const filePath = 'cypress/fixtures/images/jaya-the-beast.png';
+  cy.get('input[type="file"]').selectFile(filePath, { force: true });
+
+  cy.get('textarea').click().type(annotationText);
+  cy.getBySel('confirmButton').click();
+
+  cy.getBySel('actionHeading', { timeout: 60000 }).should(
+    'have.text',
+    isMotion ? 'Change colony details' : 'Colony details changed',
+  );
+  cy.checkUrlAfterAction(colonyName);
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -143,13 +143,11 @@ Cypress.Commands.add('checkMotion', () => {
 });
 
 Cypress.Commands.add('installExtension', () => {
-  // Can install extension
   cy.getBySel('installExtensionButton').click();
   cy.getBySel('disabledStatusTag', { timeout: 30000 }).should('exist');
 });
 
 Cypress.Commands.add('enableExtension', (extensionId) => {
-  // Can enable extension
   cy.getBySel('closeGasStationButton').click();
   cy.getBySel('enableExtensionButton').click();
   if (extensionId === Extension.Whitelist) {
@@ -157,6 +155,21 @@ Cypress.Commands.add('enableExtension', (extensionId) => {
   }
   cy.getBySel('setupExtensionConfirmButton').click();
   cy.getBySel('enabledStatusTag', { timeout: 30000 }).should('exist');
+});
+
+Cypress.Commands.add('deprecateExtension', () => {
+  cy.getBySel('deprecateExtensionButton').click();
+  cy.getBySel('confirmButton').click();
+  cy.getBySel('deprecatedStatusTag', { timeout: 30000 }).should('exist');
+});
+
+Cypress.Commands.add('uninstallExtension', () => {
+  cy.getBySel('deprecateExtensionButton').click();
+  cy.getBySel('confirmButton').click();
+  cy.getBySel('uninstallExtensionButton', { timeout: 20000 }).click();
+  cy.getBySel('uninstallWarningInput').click().type('I UNDERSTAND');
+  cy.getBySel('uninstallConfirmButton').click();
+  cy.getBySel('notInstalledStatusTag', { timeout: 30000 }).should('exist');
 });
 
 Cypress.Commands.add('mintTokens', (amountToMint, isMotion) => {
@@ -505,7 +518,7 @@ Cypress.Commands.add(
   },
 );
 
-Cypress.Commands.add('unlockToken', (colony, isMotion) => {
+Cypress.Commands.add('unlockToken', (colony) => {
   cy.getBySel('newActionButton', { timeout: 60000 }).click();
   cy.getBySel('fundsDialogIndexItem').click();
   cy.getBySel('unlockTokenDialogIndexItem').click();
@@ -521,4 +534,40 @@ Cypress.Commands.add('unlockToken', (colony, isMotion) => {
     'contains',
     `${Cypress.config().baseUrl}/colony/${colony.name}/tx/0x`,
   );
+});
+
+Cypress.Commands.add('managePermissions', (colonyName, isMotion) => {
+  const annotationText = 'I am giving you the power to do things';
+
+  cy.login();
+
+  cy.visit(`/colony/${colonyName}`);
+
+  cy.getBySel('newActionButton', { timeout: 60000 }).click();
+  cy.getBySel('advancedDialogIndexItem').click();
+  cy.getBySel('managePermissionsDialogIndexItem').click();
+
+  if (!isMotion) {
+    cy.getBySel('permissionUserSelector').click({ force: true });
+    cy.getBySel('permissionUserSelectorItem').last().click();
+  }
+  cy.getBySel('permission').eq(1).click({ force: true });
+  cy.getBySel('permission').eq(2).click({ force: true });
+  cy.getBySel('permission').eq(3).click({ force: true });
+  cy.getBySel('permissionAnnotation').click().type(annotationText);
+
+  cy.getBySel('permissionConfirmButton').click();
+
+  cy.getBySel('actionHeading', { timeout: 100000 }).contains(
+    isMotion
+      ? 'Remove the administration, architecture, funding permissions'
+      : `Assign the administration, funding, architecture permissions in Root to`,
+  );
+
+  cy.url().should(
+    'contains',
+    `${Cypress.config().baseUrl}/colony/${Cypress.config().colony.name}/tx/0x`,
+  );
+
+  cy.getBySel('comment').should('have.text', annotationText);
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -504,3 +504,21 @@ Cypress.Commands.add(
     cy.checkUrlAfterAction(updatedColonyName);
   },
 );
+
+Cypress.Commands.add('unlockToken', (colony, isMotion) => {
+  cy.getBySel('newActionButton', { timeout: 60000 }).click();
+  cy.getBySel('fundsDialogIndexItem').click();
+  cy.getBySel('unlockTokenDialogIndexItem').click();
+
+  cy.getBySel('unlockTokenConfirmButton').click();
+
+  cy.getBySel('actionHeading', { timeout: 100000 }).should(
+    'include.text',
+    `Unlock native token ${colony.nativeToken}`,
+  );
+
+  cy.url().should(
+    'contains',
+    `${Cypress.config().baseUrl}/colony/${colony.name}/tx/0x`,
+  );
+});

--- a/src/modules/dashboard/components/Dialogs/ManageFundsDialog/ManageFundsDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/ManageFundsDialog/ManageFundsDialog.tsx
@@ -160,6 +160,7 @@ const ManageFundsDialog = ({
         ),
       },
       onClick: () => callStep(nextStepManageTokens),
+      dataTest: 'manageTokensDialogItem',
     },
     {
       title: MSG.rewardPayoutTitle,

--- a/src/modules/dashboard/components/Extensions/Extensions.tsx
+++ b/src/modules/dashboard/components/Extensions/Extensions.tsx
@@ -131,6 +131,7 @@ const Extensions = ({ colonyAddress }: Props) => {
                   key={extension.extensionId}
                   extension={extension}
                   installedExtension={installedExtensions[idx]}
+                  dataTest={`${camelCase(extension.extensionId)}ExtensionCard`}
                 />
               ))}
             </div>


### PR DESCRIPTION
## Description

This is part 2 of motions tests PR.

You need to make sure that the reputation miner is on before running the tests.

To test I would recommend to run the actions tests first in a headless mode. If you don't have the colony with the given name already installed then you can change the cypress variable skipInitTests to false and run the create colony tests before as well. This way a subdomain will be created, funds transferred, payments made and there will be reputation in the root and necessary subdomain as well.

You also need to have at least 2 members in the colony where the tests are running or skip the permissions test in actions file.

resolves #3251 