### PR TITLE
Fix old member rep being weird on motion page

### DIFF
--- a/src/modules/core/components/MemberReputation/MemberReputation.tsx
+++ b/src/modules/core/components/MemberReputation/MemberReputation.tsx
@@ -51,6 +51,7 @@ const MemberReputation = ({
       address: AddressZero,
       colonyAddress,
       domainId,
+      rootHash,
     },
     fetchPolicy: 'cache-and-network',
   });

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
@@ -300,6 +300,7 @@ const DefaultMotion = ({
             walletAddress={actionInitiator}
             colonyAddress={colony.colonyAddress}
             rootHash={rootHash || undefined}
+            domainId={motionDomain}
           />
         </div>
       </>


### PR DESCRIPTION
Fixed MemberReputation on the motion page not using the motion's root hash for the total domain reputation, and not using a dynamic domain id (It was always using the root domain id to get the rep).

Now the reputation shown on the motion page should be consistent with the rep that the users had at the time of the motion creation and not change percentages when the user gets more or less reputation.

Resolves #3249 
