### PR TITLE
Decimal issue with wallet balance within Create a Colony header

### DIFF
--- a/src/utils/numbers/numberFormatter.ts
+++ b/src/utils/numbers/numberFormatter.ts
@@ -1,7 +1,7 @@
 import numbro from 'numbro';
 import moveDecimal from 'move-decimal-point';
 
-import { BigNumber } from 'ethers/utils';
+import { BigNumber, formatUnits } from 'ethers/utils';
 
 import { numbroCustomLanguage } from './numbroCustomLanguage';
 
@@ -74,7 +74,10 @@ export const numberDisplayFormatter = ({
     thousandSeparated: useSeparator,
   };
 
-  const convertedNum = moveDecimal(value.toString(10), -(unit || 0));
+  const convertedNum =
+    typeof unit === 'string'
+      ? formatUnits(value, unit)
+      : moveDecimal(value.toString(10), -(unit || 0));
 
   // handle very small numbers
   if (useSmallNumberDefault && convertedNum < 0.00001 && convertedNum > 0) {


### PR DESCRIPTION
## Description

This PR fixes a bug in `numberFormatter` when attempting to convert a `BigNumber` where `unit` contains a string (such as `ether`). 
The fix should not effect other conversions.

Before fix:
<img width="317" alt="Screenshot 2022-04-05 at 15 07 22" src="https://user-images.githubusercontent.com/582700/161708479-7e86ac54-6a29-4083-87ad-4db3ef233fd3.png">


After fix:
<img width="373" alt="Screenshot 2022-04-05 at 15 06 39" src="https://user-images.githubusercontent.com/582700/161708502-07d659aa-53cf-471b-865b-24575fe17932.png">


Resolves #3286
