### PR TITLE
Fetch whitelisted addresses and filter out users dropdown in Payment modal

### DIFF
--- a/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialog.tsx
@@ -11,12 +11,7 @@ import { ActionForm } from '~core/Fields';
 
 import { Address } from '~types/index';
 import { ActionTypes } from '~redux/index';
-import {
-  useVerifiedUsersQuery,
-  useColonyFromNameQuery,
-  AnyUser,
-  useMembersSubscription,
-} from '~data/index';
+import { AnyUser, useMembersSubscription } from '~data/index';
 import { getTokenDecimalsWithFallback } from '~utils/tokens';
 import { pipe, withMeta, mapPayload } from '~utils/actions';
 import { WizardDialogType } from '~utils/hooks';
@@ -53,7 +48,13 @@ type Props = Required<DialogProps> &
 const displayName = 'dashboard.CreatePaymentDialog';
 
 const CreatePaymentDialog = ({
-  colony: { tokens = [], colonyAddress, nativeTokenAddress, colonyName },
+  colony: {
+    tokens = [],
+    colonyAddress,
+    nativeTokenAddress,
+    colonyName,
+    isWhitelistActivated,
+  },
   colony,
   isVotingExtensionEnabled,
   callStep,
@@ -98,37 +99,20 @@ const CreatePaymentDialog = ({
     variables: { colonyAddress },
   });
 
-  const { data: colonyData } = useColonyFromNameQuery({
-    variables: { name: colonyName, address: colonyAddress },
-  });
-  const isWhiteListActive = colonyData?.processedColony?.isWhitelistActivated;
+  const filteredVerifiedRecipients = useMemo(() => {
+    return isWhitelistActivated
+      ? (colonyMembers?.subscribedUsers || []).filter((member) =>
+          colony?.whitelistedAddresses.some(
+            (el) => el.toLowerCase() === member.id.toLowerCase(),
+          ),
+        )
+      : colonyMembers?.subscribedUsers || [];
+  }, [colonyMembers, colony, isWhitelistActivated]);
 
-  const { data } = useVerifiedUsersQuery({
-    variables: {
-      verifiedAddresses:
-        colonyData?.processedColony?.whitelistedAddresses || [],
-    },
-    fetchPolicy: 'network-only',
-  });
-
-  const storedVerifiedRecipients = useMemo(
-    () =>
-      (data?.verifiedUsers || []).map((user) => user?.profile.walletAddress),
-    [data],
-  );
-
-  const filteredVerifiedRecipients = isWhiteListActive
-    ? (colonyMembers?.subscribedUsers || []).filter((member) =>
-        storedVerifiedRecipients.some(
-          (el) => el.toLowerCase() === member.id.toLowerCase(),
-        ),
-      )
-    : colonyMembers?.subscribedUsers || [];
-
-  const getIsUnverifiedRecipient = (walletAddress) => {
+  const showWarningForAddress = (walletAddress) => {
     if (!walletAddress) return false;
-    return isWhiteListActive
-      ? !storedVerifiedRecipients.some(
+    return isWhitelistActivated
+      ? !colony?.whitelistedAddresses.some(
           (el) => el.toLowerCase() === walletAddress.toLowerCase(),
         )
       : false;
@@ -212,7 +196,7 @@ const CreatePaymentDialog = ({
               back={() => callStep(prevStep)}
               subscribedUsers={filteredVerifiedRecipients}
               ethDomainId={ethDomainId}
-              showWhitelistWarning={getIsUnverifiedRecipient(
+              showWhitelistWarning={showWarningForAddress(
                 formValues.values?.recipient?.profile?.walletAddress,
               )}
             />

--- a/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.css
+++ b/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.css
@@ -80,3 +80,21 @@
 .motionVoteDomain {
   margin: 6px 0;
 }
+
+.warningContainer {
+  margin-top: 20px;
+  padding: 20px 15px;
+  border-radius: var(--radius-normal);
+  background-color: color-mod(var(--danger) alpha(15%));
+}
+
+.warningText {
+  font-size: var(--size-smallish);
+  font-weight: var(--weight-bold);
+  line-height: 18px;
+  color: var(--dark);
+}
+
+.warningLabel {
+  color: var(--danger);
+}

--- a/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.css.d.ts
@@ -11,3 +11,6 @@ export const noPermissionFromMessage: string;
 export const modalHeading: string;
 export const headingContainer: string;
 export const motionVoteDomain: string;
+export const warningContainer: string;
+export const warningText: string;
+export const warningLabel: string;

--- a/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
@@ -106,7 +106,7 @@ const MSG = defineMessages({
   },
   warningText: {
     id: `dashboard.CreatePaymentDialog.CreatePaymentDialogForm.warningText`,
-    defaultMessage: `<span>Warning.</span> Warning. You are about to make a payment to an address not on the whitelist. Are you sure the address is correct?`,
+    defaultMessage: `<span>Warning.</span> You are about to make a payment to an address not on the whitelist. Are you sure the address is correct?`,
   },
 });
 interface Props extends ActionDialogProps {

--- a/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
@@ -101,12 +101,17 @@ const MSG = defineMessages({
     payment.`,
   },
   userPickerPlaceholder: {
-    id: 'SingleUserPicker.userPickerPlaceholder',
+    id: `dashboard.CreatePaymentDialog.CreatePaymentDialogForm.userPickerPlaceholder`,
     defaultMessage: 'Search for a user or paste wallet address',
+  },
+  warningText: {
+    id: `dashboard.CreatePaymentDialog.CreatePaymentDialogForm.warningText`,
+    defaultMessage: `<span>Warning.</span> Warning. You are about to make a payment to an address not on the whitelist. Are you sure the address is correct?`,
   },
 });
 interface Props extends ActionDialogProps {
   subscribedUsers: AnyUser[];
+  showWhitelistWarning: boolean;
   ethDomainId?: number;
 }
 
@@ -128,6 +133,7 @@ const CreatePaymentDialogForm = ({
   isValid,
   values,
   ethDomainId: preselectedDomainId,
+  showWhitelistWarning,
 }: Props & FormikProps<FormValues>) => {
   const selectedDomain =
     preselectedDomainId === 0 || preselectedDomainId === undefined
@@ -404,6 +410,20 @@ const CreatePaymentDialogForm = ({
             placeholder={MSG.userPickerPlaceholder}
           />
         </div>
+        {showWhitelistWarning && (
+          <div className={styles.warningContainer}>
+            <p className={styles.warningText}>
+              <FormattedMessage
+                {...MSG.warningText}
+                values={{
+                  span: (chunks) => (
+                    <span className={styles.warningLabel}>{chunks}</span>
+                  ),
+                }}
+              />
+            </p>
+          </div>
+        )}
         {values.recipient &&
           isConfusing(
             values.recipient.profile.username ||


### PR DESCRIPTION
## Description

This PR updates the payment modal. Whitelisted addresses are retrieved from IPFS and used to filter recipient addresses from the dropdown.

- If the whitelist is active - only show addresses that are both in colonyMembers subscribedUsers & in verified recipients list
- If the whitelist is inactive - show colonyMembers subscribedUsers (as before update)

If an address is manually entered and whitelist is active, then a warning will be shown:
-`Warning. You are about to make a payment to an address not on the whitelist. Are you sure the address is correct?`

<img width="529" alt="Screenshot 2022-04-19 at 11 10 35" src="https://user-images.githubusercontent.com/582700/163981657-d8e51b8c-515f-4c5c-921a-085598384b97.png">


Resolves #3182 
