### PR TITLE
Remove new line symbols from `span` in `Numeral` component

### DIFF
--- a/src/modules/core/components/Fields/Checkbox/Checkbox.tsx
+++ b/src/modules/core/components/Fields/Checkbox/Checkbox.tsx
@@ -125,7 +125,7 @@ const Checkbox = ({
         </span>
       </>
     ),
-    [disabled, handleOnChange, inputId, isChecked, name],
+    [disabled, handleOnChange, inputId, isChecked, name, dataTest],
   );
 
   return (

--- a/src/modules/core/components/Numeral/Numeral.tsx
+++ b/src/modules/core/components/Numeral/Numeral.tsx
@@ -60,9 +60,9 @@ const Numeral = ({
 
   useEffect(() => {
     if (outputRef.current) {
-      outputRef.current.innerHTML = `${prefix ? `${prefix} ` : ''}
-        ${formattedNumber}
-        ${suffix ? ` ${suffix}` : ''}`;
+      const prefixStr = prefix ? `${prefix} ` : '';
+      const suffixStr = suffix ? ` ${suffix}` : '';
+      outputRef.current.innerHTML = `${prefixStr}${formattedNumber}${suffixStr}`;
     }
   }, [outputRef, formattedNumber, prefix, suffix]);
 


### PR DESCRIPTION
The way the innerHtml of the span element was created in `Numeral` component, it was adding `\n` around the number.

This was not seen because span is a single line element. Without this change if you change span to div on another element that can be multi line you will see that the number and token is split in several lines.

resolves #3303 