### PR TITLE
Verified recipients tick logic & Manage whitelist trigger

### DIFF
--- a/src/modules/core/components/MembersList/MembersListItem.tsx
+++ b/src/modules/core/components/MembersList/MembersListItem.tsx
@@ -29,7 +29,6 @@ interface Props<U> {
   showUserInfo: boolean;
   showUserReputation: boolean;
   domainId: number | undefined;
-  isWhiteListed?: boolean;
   user: U;
 }
 
@@ -53,12 +52,12 @@ const MembersListItem = <U extends AnyUser = AnyUser>(props: Props<U>) => {
     showUserInfo,
     showUserReputation,
     user,
-    isWhiteListed,
   } = props;
   const {
     profile: { walletAddress },
     banned = false,
-  } = user as AnyUser & { banned: boolean };
+    isWhitelisted = false,
+  } = user as AnyUser & { banned: boolean; isWhitelisted: boolean };
 
   const userProfile = useUser(createAddress(walletAddress || AddressZero));
 
@@ -142,7 +141,7 @@ const MembersListItem = <U extends AnyUser = AnyUser>(props: Props<U>) => {
             <InvisibleCopyableAddress address={walletAddress}>
               <MaskedAddress address={walletAddress} />
             </InvisibleCopyableAddress>
-            {isWhiteListed && (
+            {isWhitelisted && (
               <IconTooltip
                 icon="check-mark"
                 tooltipText={MSG.whitelistedTooltip}

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, MouseEventHandler } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useParams, Redirect } from 'react-router-dom';
 import { defineMessages } from 'react-intl';
 import { ColonyVersion, Extension } from '@colony/colony-js';
@@ -115,22 +115,12 @@ const ColonyMembers = () => {
 
   const openToggleManageWhitelistDialog = useDialog(ManageWhitelistDialog);
 
-  const handleToggleWhitelistDialog = useCallback<
-    MouseEventHandler<HTMLButtonElement>
-  >(
-    (evt) => {
-      evt.stopPropagation();
-      /*
-       * We don't have, and can't inject all the required props that the component
-       * is expecting when using it in a wizard
-       */
-      // @ts-ignore
-      return openToggleManageWhitelistDialog({
-        colony: colonyData?.processedColony as Colony,
-      });
-    },
-    [openToggleManageWhitelistDialog, colonyData],
-  );
+  const handleToggleWhitelistDialog = useCallback(() => {
+    // @ts-ignore
+    return openToggleManageWhitelistDialog({
+      colony: colonyData?.processedColony as Colony,
+    });
+  }, [openToggleManageWhitelistDialog, colonyData]);
 
   // eslint-disable-next-line max-len
   const oneTxPaymentExtension = colonyExtensions?.processedColony?.installedExtensions.find(
@@ -242,15 +232,13 @@ const ColonyMembers = () => {
                 </>
               )}
               {canManageWhitelist && (
-                <>
-                  <li>
-                    <Button
-                      appearance={{ theme: 'blue' }}
-                      text={MSG.manageWhitelist}
-                      onClick={handleToggleWhitelistDialog}
-                    />
-                  </li>
-                </>
+                <li>
+                  <Button
+                    appearance={{ theme: 'blue' }}
+                    text={MSG.manageWhitelist}
+                    onClick={handleToggleWhitelistDialog}
+                  />
+                </li>
               )}
             </ul>
           )}

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, MouseEventHandler } from 'react';
 import { useParams, Redirect } from 'react-router-dom';
 import { defineMessages } from 'react-intl';
 import { ColonyVersion, Extension } from '@colony/colony-js';
@@ -28,6 +28,7 @@ import { hasRoot, canAdminister } from '~modules/users/checks';
 import { oneTxMustBeUpgraded } from '~modules/dashboard/checks';
 
 import styles from './ColonyMembers.css';
+import ManageWhitelistDialog from '~dashboard/Dialogs/ManageWhitelistDialog';
 
 const displayName = 'dashboard.ColonyMembers';
 
@@ -43,6 +44,10 @@ const MSG = defineMessages({
   unbanAddress: {
     id: 'dashboard.ColonyMembers.unbanAddress',
     defaultMessage: 'Unban address',
+  },
+  manageWhitelist: {
+    id: 'dashboard.ColonyMembers.manageWhitelist',
+    defaultMessage: 'Manage whitelist',
   },
   loadingText: {
     id: 'dashboard.ColonyMembers.loadingText',
@@ -108,6 +113,25 @@ const ColonyMembers = () => {
     });
   }, [openPermissionManagementDialog, colonyData, isVotingExtensionEnabled]);
 
+  const openToggleManageWhitelistDialog = useDialog(ManageWhitelistDialog);
+
+  const handleToggleWhitelistDialog = useCallback<
+    MouseEventHandler<HTMLButtonElement>
+  >(
+    (evt) => {
+      evt.stopPropagation();
+      /*
+       * We don't have, and can't inject all the required props that the component
+       * is expecting when using it in a wizard
+       */
+      // @ts-ignore
+      return openToggleManageWhitelistDialog({
+        colony: colonyData?.processedColony as Colony,
+      });
+    },
+    [openToggleManageWhitelistDialog, colonyData],
+  );
+
   // eslint-disable-next-line max-len
   const oneTxPaymentExtension = colonyExtensions?.processedColony?.installedExtensions.find(
     ({
@@ -131,6 +155,7 @@ const ColonyMembers = () => {
   const canAdministerComments =
     hasRegisteredProfile &&
     (hasRoot(currentUserRoles) || canAdminister(currentUserRoles));
+  const canManageWhitelist = hasRegisteredProfile && hasRoot(currentUserRoles);
 
   const controlsDisabled =
     !isSupportedColonyVersion ||
@@ -212,6 +237,17 @@ const ColonyMembers = () => {
                             colonyData?.processedColony?.colonyAddress,
                         })
                       }
+                    />
+                  </li>
+                </>
+              )}
+              {canManageWhitelist && (
+                <>
+                  <li>
+                    <Button
+                      appearance={{ theme: 'blue' }}
+                      text={MSG.manageWhitelist}
+                      onClick={handleToggleWhitelistDialog}
                     />
                   </li>
                 </>

--- a/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/ManageWhitelistDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/ManageWhitelistDialog.tsx
@@ -34,7 +34,7 @@ export interface FormValues {
 }
 
 interface CustomWizardDialogProps {
-  prevStep: string;
+  prevStep?: string;
   colony: Colony;
 }
 
@@ -183,7 +183,7 @@ const ManageWhitelistDialog = ({
             {...formValues}
             colony={colony}
             whitelistedUsers={data?.verifiedUsers || []}
-            back={() => callStep(prevStep)}
+            back={prevStep ? () => callStep(prevStep) : cancel}
             showInput={showInput}
             toggleShowInput={handleToggleShowInput}
             formSuccess={formSuccess}

--- a/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/ManageWhitelistDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/ManageWhitelistDialog.tsx
@@ -190,6 +190,7 @@ const ManageWhitelistDialog = ({
             setFormSuccess={(isSuccess) => setFormSuccess(isSuccess)}
             tabIndex={tabIndex}
             setTabIndex={handleTabChange}
+            backButtonText={!prevStep ? 'button.cancel' : 'button.back'}
           />
         </Dialog>
       )}

--- a/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/ManageWhitelistDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/ManageWhitelistDialogForm.tsx
@@ -181,7 +181,12 @@ const ManageWhitelistDialogForm = ({
         <Button
           appearance={{ theme: 'secondary', size: 'large' }}
           onClick={back}
-          text={{ id: 'button.back' }}
+          text={{
+            id:
+              back.toString() === `() => callStep(prevStep)`
+                ? 'button.back'
+                : 'button.cancel',
+          }}
         />
         <Button
           appearance={{

--- a/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/ManageWhitelistDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/ManageWhitelistDialogForm.tsx
@@ -66,6 +66,7 @@ interface Props {
   setFormSuccess: (isSuccess: boolean) => void;
   tabIndex: TABS;
   setTabIndex: (index: TABS) => void;
+  backButtonText?: string;
 }
 
 const ManageWhitelistDialogForm = ({
@@ -85,6 +86,7 @@ const ManageWhitelistDialogForm = ({
   setTabIndex,
   resetForm,
   dirty,
+  backButtonText,
 }: Props & FormikProps<FormValues>) => {
   const { walletAddress, username, ethereal } = useLoggedInUser();
   const allUserRoles = useTransformer(getAllUserRoles, [colony, walletAddress]);
@@ -181,12 +183,7 @@ const ManageWhitelistDialogForm = ({
         <Button
           appearance={{ theme: 'secondary', size: 'large' }}
           onClick={back}
-          text={{
-            id:
-              back.toString() === `() => callStep(prevStep)`
-                ? 'button.back'
-                : 'button.cancel',
-          }}
+          text={{ id: backButtonText || 'button.back' }}
         />
         <Button
           appearance={{

--- a/src/modules/dashboard/components/Members/Members.tsx
+++ b/src/modules/dashboard/components/Members/Members.tsx
@@ -332,7 +332,10 @@ const Members = ({ colony: { colonyAddress }, colony, bannedUsers }: Props) => {
       roles: domainRole ? domainRole.roles : [],
       directRoles: domainRole ? domainRole.directRoles : [],
       banned: canAdministerComments ? !!isUserBanned : false,
-      isWhitelisted: isWhitelisted ? !!isWhitelisted : false,
+      isWhitelisted:
+        isWhitelisted && colonyData?.processedColony?.isWhitelistActivated
+          ? !!isWhitelisted
+          : false,
     };
   });
 

--- a/src/modules/dashboard/components/Members/Members.tsx
+++ b/src/modules/dashboard/components/Members/Members.tsx
@@ -19,6 +19,8 @@ import {
   useMembersSubscription,
   useLoggedInUser,
   BannedUsersQuery,
+  useColonyFromNameQuery,
+  useVerifiedUsersQuery,
 } from '~data/index';
 import {
   COLONY_TOTAL_BALANCE_DOMAIN_ID,
@@ -64,6 +66,7 @@ type Member = AnyUser & {
   roles: ColonyRole[];
   directRoles: ColonyRole[];
   banned: boolean;
+  isWhitelisted: boolean;
 };
 
 const displayName = 'dashboard.Members';
@@ -102,6 +105,28 @@ const Members = ({ colony: { colonyAddress }, colony, bannedUsers }: Props) => {
     ({ ethDomainId }) => ethDomainId === selectedDomainId,
   );
 
+  /*
+   * Identify users who are whitelisted
+   */
+
+  const { data: colonyData } = useColonyFromNameQuery({
+    variables: { name: colony.colonyName, address: colonyAddress },
+  });
+
+  const { data: verifiedAddresses } = useVerifiedUsersQuery({
+    variables: {
+      verifiedAddresses:
+        colonyData?.processedColony?.whitelistedAddresses || [],
+    },
+  });
+
+  const storedVerifiedRecipients = useMemo(
+    () =>
+      (verifiedAddresses?.verifiedUsers || []).map(
+        (user) => user?.profile.walletAddress,
+      ),
+    [verifiedAddresses],
+  );
   /*
    * NOTE If we can't find the domain based on the current selected doamain id,
    * it means that it doesn't exist.
@@ -297,11 +322,17 @@ const Members = ({ colony: { colonyAddress }, colony, bannedUsers }: Props) => {
       (rolesObject) =>
         createAddress(rolesObject.userAddress) === createAddress(walletAddress),
     );
+    const isWhitelisted = storedVerifiedRecipients.find(
+      (whitelistedUser) =>
+        whitelistedUser &&
+        createAddress(whitelistedUser) === createAddress(walletAddress),
+    );
     return {
       ...user,
       roles: domainRole ? domainRole.roles : [],
       directRoles: domainRole ? domainRole.directRoles : [],
       banned: canAdministerComments ? !!isUserBanned : false,
+      isWhitelisted: isWhitelisted ? !!isWhitelisted : false,
     };
   });
 


### PR DESCRIPTION
## Description

This adds the logic to show the tick for verified recipients on the Members page. I also took the opportunity to add the `Manage whitelist` dialog toggle on the members page.

**New stuff** ✨

* Verified recipient tick on members
* `Manage whitelist` dialog toggle

![87e28c78-e754-4852-bc78-a1bd9bcefcb2](https://user-images.githubusercontent.com/33682027/163132214-38041c1e-c8cf-4cb2-840a-94be7b3290a3.png)

### Testing
* Add some members to the whitelist and ensure it is activated
* Ensure the tick only appears only on the relevant addresses
* Try adding members to the whitelist by using the `Manage whitelist` link on the members page



Resolves #3301
