### PR TITLE
Fix the finalize motion error condition

### DIFF
--- a/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
@@ -204,7 +204,7 @@ const FinalizeMotionAndClaimWidget = ({
     }
 
     return true;
-  }, [domainBalanceData, motionAmount, fromDomain]);
+  }, [domainBalanceData, motionAmount, fromDomain, actionType]);
 
   const nativeToken = tokens.find(
     ({ address }) => address === nativeTokenAddress,

--- a/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
@@ -194,6 +194,7 @@ const FinalizeMotionAndClaimWidget = ({
     const domainBalance = bigNumberify(domainBalanceData?.domainBalance || '0');
 
     if (
+      actionType !== ColonyMotions.MintTokensMotion &&
       domainBalanceData !== undefined &&
       fromDomain !== undefined &&
       motionAmount !== undefined &&


### PR DESCRIPTION
## Description

Update the condition that prevents finalising motion.

To test you need to mint an mount that is more than the current colony token balance

Before

<img width="1034" alt="Screenshot 2022-04-13 at 17 09 12" src="https://user-images.githubusercontent.com/34057551/163199692-fad00082-33e6-4168-9f15-cc1cadae718f.png">

After

<img width="1014" alt="Screenshot 2022-04-13 at 17 07 50" src="https://user-images.githubusercontent.com/34057551/163199725-c5e82988-bb93-4075-922d-39a86fe71b12.png">


resolves #3307 
