### PR TITLE
Fix & consolidate the whole set of cypress tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,60 @@
+version: 2.1
+orbs:
+  browser-tools: circleci/browser-tools@1.2.5
+jobs:
+  build:
+    docker:
+      - image: cimg/node:14.18.2-browsers
+    resource_class: xlarge
+    steps:
+      - browser-tools/install-chrome
+      - checkout
+      - run: 
+          command: wget https://github.com/ipfs/go-ipfs/releases/download/v0.4.23/go-ipfs_v0.4.23_linux-amd64.tar.gz
+      - run:
+          command: tar zxf go-ipfs_v0.4.23_linux-amd64.tar.gz
+      - run: 
+          command: cd go-ipfs && sudo ./install.sh
+      - run:
+          command: ipfs init && ipfs daemon
+          background: true
+      - run:
+          command: sudo npm install -g npm@8.2.0
+      - run:  
+          command: sudo apt-get update && sudo apt-get install python postgresql-12 cargo clang libpq-dev libssl-dev pkg-config
+      - run:
+          command: yarn --pure-lockfile
+      - run:
+          command: yarn provision
+      - run:
+          command: cp .env.example .env
+      - run: 
+          command: sudo chown -R circleci:circleci /var/run/postgresql
+      - run: 
+          command: /usr/lib/postgresql/12/bin/initdb -D .postgres
+      - run:
+          command: /usr/lib/postgresql/12/bin/pg_ctl -D .postgres -l logfile start
+      - run: 
+          command: createdb graph-node
+      - run: 
+          command: cd src/lib/graph-node && cargo update -p lexical-core && cargo build
+      - run:
+          command: yarn ganache
+          background: true
+      - run:
+          command: cd src/lib/graph-node && cargo run -p graph-node --release -- --postgres-url postgresql://circleci@localhost:5432/graph-node --ethereum-rpc mainnet:http://127.0.0.1:8545 --ipfs 127.0.0.1:5001
+          background: true
+      - run:
+          command: sed -i s/300000/600000/g ./scripts/start_all.js 
+      - run:
+          command: yarn run dev:heavy --skip-graph-node --skip-ganache
+          background: true
+      - run:
+          command: wget --retry-connrefused --waitretry=10 --read-timeout=20 --timeout=15 -t 100 http://localhost:9090/landing
+      - run:
+          command: |
+            sed -i 's/"skipInitTests": true/"skipInitTests": false/g' ./cypress.json
+      - run:
+          command: yarn cy:run
+      - store_artifacts:
+          path: cypress/videos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,8 @@ jobs:
       - run:
           command: |
             sed -i 's/"skipInitTests": true/"skipInitTests": false/g' ./cypress.json
+      - run: 
+          command: wget http://127.0.0.1:3001/reputation/monitor/toggle 
       - run:
           command: yarn cy:run
       - store_artifacts:

--- a/cypress.json
+++ b/cypress.json
@@ -9,8 +9,5 @@
         "name": "jaya",
         "nativeToken": "JAY"
     },
-    "colony2": {
-        "name": "sirius"
-    },
     "skipInitTests": true
 }

--- a/cypress/e2e/2-createColony.js
+++ b/cypress/e2e/2-createColony.js
@@ -3,9 +3,10 @@ describe('Create a new colony', () => {
     colony,
     colony: { name: colonyName, nativeToken },
     baseUrl,
+    skipInitTests,
   } = Cypress.config();
 
-  if (!Cypress.config().skipInitTests) {
+  if (!skipInitTests) {
     it('creates a new colony with new token', () => {
       cy.login();
 

--- a/cypress/e2e/2-createColony.js
+++ b/cypress/e2e/2-createColony.js
@@ -36,7 +36,7 @@ describe('Create a new colony', () => {
     });
 
     it('creates a new colony with existing token', () => {
-      const newColony = { name: 'feola' };
+      const newColony = { name: 'maya' };
 
       cy.login();
       cy.getColonyTokenAddress(colonyName);

--- a/cypress/e2e/2-createColony.js
+++ b/cypress/e2e/2-createColony.js
@@ -1,23 +1,22 @@
 describe('Create a new colony', () => {
   const {
-    colony: { name: colonyName },
+    colony,
+    colony: { name: colonyName, nativeToken },
     baseUrl,
   } = Cypress.config();
 
   if (!Cypress.config().skipInitTests) {
     it('creates a new colony with new token', () => {
-      const { name, nativeToken } = Cypress.config().colony;
-
       cy.login();
 
-      cy.createColony(Cypress.config().colony, true);
+      cy.createColony(colony, true);
 
       cy.getBySel('colonyTokenSymbol', { timeout: 120000 }).should(
         'have.text',
         nativeToken,
       );
 
-      cy.url().should('eq', `${baseUrl}/colony/${name}`);
+      cy.url().should('eq', `${baseUrl}/colony/${colonyName}`);
     });
 
     it('New user is created which joins the colony', () => {
@@ -37,23 +36,19 @@ describe('Create a new colony', () => {
     });
 
     it('creates a new colony with existing token', () => {
-      const {
-        nativeToken: existingToken,
-        name: existingColony,
-      } = Cypress.config().colony;
-      const { name } = Cypress.config().colony2;
+      const newColony = { name: 'feola' };
 
       cy.login();
-      cy.getColonyTokenAddress(existingColony);
+      cy.getColonyTokenAddress(colonyName);
 
-      cy.createColony(Cypress.config().colony2, false);
+      cy.createColony(newColony, false);
 
       cy.getBySel('colonyTokenSymbol', { timeout: 120000 }).should(
         'have.text',
-        existingToken,
+        nativeToken,
       );
 
-      cy.url().should('eq', `${baseUrl}/colony/${name}`);
+      cy.url().should('eq', `${baseUrl}/colony/${newColony.name}`);
     });
   }
 });

--- a/cypress/e2e/3-actions.js
+++ b/cypress/e2e/3-actions.js
@@ -1,8 +1,5 @@
 import Decimal from 'decimal.js';
 
-import ganacheAccounts from '~lib/colonyNetwork/ganache-accounts.json';
-import { createAddress } from '~utils/web3';
-
 describe('User can create actions via UAC', () => {
   const {
     colony: { name: colonyName },
@@ -144,11 +141,8 @@ describe('User can create actions via UAC', () => {
 
   it('Make payment from a subdomain', () => {
     const amountToPay = 10;
-    const accounts = Object.entries(ganacheAccounts.private_keys).map(
-      ([address]) => address,
-    );
 
-    cy.makePayment(amountToPay, createAddress(accounts[15]), false, true);
+    cy.makePayment(amountToPay, undefined, false, true);
   });
 
   it('Can enable recovery mode', () => {

--- a/cypress/e2e/3-actions.js
+++ b/cypress/e2e/3-actions.js
@@ -1,4 +1,4 @@
-import { bigNumberify } from 'ethers/utils';
+import Decimal from 'decimal.js';
 
 import ganacheAccounts from '~lib/colonyNetwork/ganache-accounts.json';
 import { createAddress } from '~utils/web3';
@@ -10,13 +10,13 @@ describe('User can create actions via UAC', () => {
   } = Cypress.config();
 
   it('Can mint native tokens', () => {
-    const amountToMint = 10000;
+    const amountToMint = 10;
     cy.mintTokens(amountToMint, false);
 
     cy.getBySel('backButton').click();
 
     cy.get('@totalFunds').then(($totalFunds) => {
-      const totalFunds = bigNumberify($totalFunds.split(',').join(''))
+      const totalFunds = new Decimal($totalFunds.split(',').join(''))
         .add(amountToMint)
         .toString();
 
@@ -29,17 +29,22 @@ describe('User can create actions via UAC', () => {
 
   it('Can make payment', () => {
     const amountToPay = 10;
+    const paidAmount = new Decimal(amountToPay).add(
+      new Decimal(1.0101).div(100).mul(amountToPay),
+    );
+
     const accounts = Object.entries(ganacheAccounts.private_keys).map(
       ([address]) => address,
     );
 
-    cy.makePayment(amountToPay, createAddress(accounts[1]), false);
+    cy.makePayment(amountToPay, createAddress(accounts[15]), false);
 
     cy.getBySel('backButton').click();
 
     cy.get('@totalFunds').then(($totalFunds) => {
-      const totalFunds = bigNumberify($totalFunds.split(',').join(''))
-        .sub(amountToPay)
+      const totalFunds = new Decimal($totalFunds.split(',').join(''))
+        .sub(paidAmount)
+        .toDecimalPlaces(3)
         .toString();
 
       cy.getBySel('colonyTotalFunds', { timeout: 15000 }).then(($text) => {
@@ -84,7 +89,7 @@ describe('User can create actions via UAC', () => {
   });
 
   it('Can transfer funds', () => {
-    const amountToTransfer = 1000;
+    const amountToTransfer = 100;
 
     cy.transferFunds(amountToTransfer, false);
 
@@ -94,7 +99,7 @@ describe('User can create actions via UAC', () => {
     cy.getBySel('colonyDomainSelectorItem').last().click();
 
     cy.get('@teamFunds').then(($teamFunds) => {
-      const teamFunds = bigNumberify($teamFunds.split(',').join(''))
+      const teamFunds = new Decimal($teamFunds.split(',').join(''))
         .add(amountToTransfer)
         .toString();
 
@@ -141,7 +146,7 @@ describe('User can create actions via UAC', () => {
       ([address]) => address,
     );
 
-    cy.makePayment(amountToPay, createAddress(accounts[1]), false, true);
+    cy.makePayment(amountToPay, createAddress(accounts[15]), false, true);
   });
 
   it('Can enable recovery mode', () => {

--- a/cypress/e2e/3-actions.js
+++ b/cypress/e2e/3-actions.js
@@ -111,20 +111,25 @@ describe('User can create actions via UAC', () => {
       );
     });
   });
-  it('Can unlock the native token', () => {
-    const colony = { name: 'sirius', nativeToken: 'SIRS' };
-    cy.login();
-    cy.createColony(colony, true);
-    cy.url().should('eq', `${baseUrl}/colony/${colony.name}`, {
-      timeout: 90000,
+
+  /* needs to only work once */
+  if (!Cypress.config().skipInitTests) {
+    it('Can unlock the native token', () => {
+      const colony = { name: 'sirius', nativeToken: 'SIRS' };
+      cy.login();
+      cy.createColony(colony, true);
+      cy.url().should('eq', `${baseUrl}/colony/${colony.name}`, {
+        timeout: 90000,
+      });
+
+      cy.unlockToken(colony);
+
+      cy.getBySel('backButton').click();
+
+      cy.getBySel('lockIconTooltip', { timeout: 15000 }).should('not.exist');
     });
+  }
 
-    cy.unlockToken(colony);
-
-    cy.getBySel('backButton').click();
-
-    cy.getBySel('lockIconTooltip', { timeout: 15000 }).should('not.exist');
-  });
   it('Can manage permissions', () => {
     cy.managePermissions();
   });

--- a/cypress/e2e/3-actions.js
+++ b/cypress/e2e/3-actions.js
@@ -139,12 +139,6 @@ describe('User can create actions via UAC', () => {
     cy.smiteUser(amountToSmite, false);
   });
 
-  it('Make payment from a subdomain', () => {
-    const amountToPay = 10;
-
-    cy.makePayment(amountToPay, undefined, false, true);
-  });
-
   it('Can enable recovery mode', () => {
     const storageSlot = '0x05';
     const storageSlotValue =
@@ -188,5 +182,11 @@ describe('User can create actions via UAC', () => {
       .click()
       .wait(20000)
       .should('not.exist');
+  });
+
+  it('Make payment from a subdomain', () => {
+    const amountToPay = 10;
+
+    cy.makePayment(amountToPay, undefined, false, true);
   });
 });

--- a/cypress/e2e/3-actions.js
+++ b/cypress/e2e/3-actions.js
@@ -10,7 +10,7 @@ describe('User can create actions via UAC', () => {
   } = Cypress.config();
 
   it('Can mint native tokens', () => {
-    const amountToMint = 10;
+    const amountToMint = 400;
     cy.mintTokens(amountToMint, false);
 
     cy.getBySel('backButton').click();

--- a/cypress/e2e/3-actions.js
+++ b/cypress/e2e/3-actions.js
@@ -33,11 +33,7 @@ describe('User can create actions via UAC', () => {
       new Decimal(1.0101).div(100).mul(amountToPay),
     );
 
-    const accounts = Object.entries(ganacheAccounts.private_keys).map(
-      ([address]) => address,
-    );
-
-    cy.makePayment(amountToPay, createAddress(accounts[15]), false);
+    cy.makePayment(amountToPay, undefined, false);
 
     cy.getBySel('backButton').click();
 
@@ -116,6 +112,7 @@ describe('User can create actions via UAC', () => {
   if (!Cypress.config().skipInitTests) {
     it('Can unlock the native token', () => {
       const colony = { name: 'sirius', nativeToken: 'SIRS' };
+
       cy.login();
       cy.createColony(colony, true);
       cy.url().should('eq', `${baseUrl}/colony/${colony.name}`, {

--- a/cypress/e2e/3-actions.js
+++ b/cypress/e2e/3-actions.js
@@ -4,6 +4,7 @@ describe('User can create actions via UAC', () => {
   const {
     colony: { name: colonyName },
     baseUrl,
+    skipInitTests,
   } = Cypress.config();
 
   it('Can mint native tokens', () => {
@@ -106,7 +107,7 @@ describe('User can create actions via UAC', () => {
   });
 
   /* needs to only work once */
-  if (!Cypress.config().skipInitTests) {
+  if (!skipInitTests) {
     it('Can unlock the native token', () => {
       const colony = { name: 'sirius', nativeToken: 'SIRS' };
 

--- a/cypress/e2e/6-updateColony.js
+++ b/cypress/e2e/6-updateColony.js
@@ -12,24 +12,29 @@ describe('Colony can be updated', () => {
     cy.checkColonyName(newName);
   });
 
-  it('can update colony tokens', () => {
-    const {
-      name: existingColonyName,
-      nativeToken: existingToken,
-    } = Cypress.config().colony;
+  // Will run only once as we create a new colony
+  if (!Cypress.config().skipInitTests) {
+    it('can update colony tokens', () => {
+      const {
+        name: existingColonyName,
+        nativeToken: existingToken,
+      } = Cypress.config().colony;
 
-    cy.login();
-    cy.createColony(newColony, true);
-    cy.url().should('eq', `${baseUrl}/colony/${newColony.name}`, {
-      timeout: 90000,
+      cy.login();
+      cy.createColony(newColony, true);
+      cy.url().should('eq', `${baseUrl}/colony/${newColony.name}`, {
+        timeout: 90000,
+      });
+
+      cy.updateTokens(newColony.name, existingColonyName, false);
+
+      cy.getBySel('backButton').click();
+
+      cy.getBySel('availableFunds', { timeout: 60000 }).then(
+        (availableFunds) => {
+          expect(availableFunds.text()).to.contains(existingToken);
+        },
+      );
     });
-
-    cy.updateTokens(newColony.name, existingColonyName, false);
-
-    cy.getBySel('backButton').click();
-
-    cy.getBySel('availableFunds', { timeout: 60000 }).then((availableFunds) => {
-      expect(availableFunds.text()).to.contains(existingToken);
-    });
-  });
+  }
 });

--- a/cypress/e2e/6-updateColony.js
+++ b/cypress/e2e/6-updateColony.js
@@ -1,8 +1,12 @@
 import newColony from '../fixtures/colony.json';
 
-const { baseUrl } = Cypress.config();
-
 describe('Colony can be updated', () => {
+  const {
+    baseUrl,
+    skipInitTests,
+    colony: { name: colonyName, nativeToken },
+  } = Cypress.config();
+
   it('can update colony details', () => {
     const newName = 'plushka';
 
@@ -13,26 +17,21 @@ describe('Colony can be updated', () => {
   });
 
   // Will run only once as we create a new colony
-  if (!Cypress.config().skipInitTests) {
+  if (!skipInitTests) {
     it('can update colony tokens', () => {
-      const {
-        name: existingColonyName,
-        nativeToken: existingToken,
-      } = Cypress.config().colony;
-
       cy.login();
       cy.createColony(newColony, true);
       cy.url().should('eq', `${baseUrl}/colony/${newColony.name}`, {
         timeout: 90000,
       });
 
-      cy.updateTokens(newColony.name, existingColonyName, false);
+      cy.updateTokens(newColony.name, colonyName, false);
 
       cy.getBySel('backButton').click();
 
       cy.getBySel('availableFunds', { timeout: 60000 }).then(
         (availableFunds) => {
-          expect(availableFunds.text()).to.contains(existingToken);
+          expect(availableFunds.text()).to.contains(nativeToken);
         },
       );
     });

--- a/cypress/e2e/8-motions.js
+++ b/cypress/e2e/8-motions.js
@@ -1,6 +1,6 @@
-import Decimal from 'decimal.js';
 import { Extension } from '@colony/colony-js';
 import numbro from 'numbro';
+import Decimal from 'decimal.js';
 
 import ganacheAccounts from '~lib/colonyNetwork/ganache-accounts.json';
 import { createAddress } from '~utils/web3';
@@ -169,12 +169,15 @@ describe('User can create motions via UAC', () => {
     // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.getBySel('claimForColonyButton', { timeout: 100000 }).click().wait(5000);
 
+    cy.reload();
+
     cy.get('@totalFunds').then(($totalFunds) => {
       const totalFunds = new Decimal($totalFunds.split(',').join(''))
         .add(amountToMint)
+        .toDecimalPlaces(3)
         .toString();
 
-      cy.getBySel('colonyTotalFunds', { timeout: 15000 }).then(($text) => {
+      cy.getBySel('colonyTotalFunds', { timeout: 150000 }).then(($text) => {
         const text = $text.text().split(',').join('');
         expect(text).to.eq(totalFunds);
       });

--- a/cypress/e2e/8-motions.js
+++ b/cypress/e2e/8-motions.js
@@ -146,7 +146,7 @@ describe('User can create motions via UAC', () => {
     // to close the gas station
     cy.getBySel('actionHeading').click();
 
-    cy.get('input[type="radio"]').first().click({ force: true });
+    cy.getBySel('yesVoteButton', { timeout: 30000 }).click({ force: true });
     cy.getBySel('voteButton').click();
 
     cy.getBySel('revealButton').click();

--- a/cypress/e2e/8-motions.js
+++ b/cypress/e2e/8-motions.js
@@ -147,10 +147,14 @@ describe('User can create motions via UAC', () => {
     cy.getBySel('actionHeading').click();
 
     cy.getBySel('yesVoteButton', { timeout: 30000 }).click({ force: true });
-    cy.getBySel('voteButton').click();
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.getBySel('voteButton').click().wait(7000);
 
-    cy.getBySel('revealButton').click();
-    cy.getBySel('motionStatusTag', { timeout: 20000 }).should(
+    // to close the gas station
+    cy.getBySel('actionHeading').click();
+
+    cy.getBySel('revealButton', { timeout: 120000 }).click();
+    cy.getBySel('motionStatusTag', { timeout: 30000 }).should(
       'have.text',
       'Passed',
     );

--- a/cypress/e2e/8-motions.js
+++ b/cypress/e2e/8-motions.js
@@ -11,6 +11,7 @@ import { numbroCustomLanguage } from '../../src/utils/numbers/numbroCustomLangua
 describe('User can create motions via UAC', () => {
   const {
     colony: { name: colonyName },
+    colony,
   } = Cypress.config();
   numbro.registerLanguage(numbroCustomLanguage);
   numbro.setLanguage('en-GB');
@@ -97,19 +98,17 @@ describe('User can create motions via UAC', () => {
   });
 
   it('Can update tokens', () => {
-    const { name: existingColonyName } = Cypress.config().colony;
     cy.login();
 
-    cy.updateTokens(existingColonyName, createdColony.name, true);
+    cy.updateTokens(colonyName, createdColony.name, true);
 
     cy.checkMotion();
   });
 
   it('Can unlock the native token', () => {
-    const { colony } = Cypress.config();
     cy.login();
 
-    cy.visit(`/colony/${colony.name}`);
+    cy.visit(`/colony/${colonyName}`);
 
     cy.unlockToken(colony);
 

--- a/cypress/e2e/8-motions.js
+++ b/cypress/e2e/8-motions.js
@@ -187,7 +187,7 @@ describe('User can create motions via UAC', () => {
     });
   });
 
-  it.only('User can claim their stake', () => {
+  it('User can claim their stake', () => {
     cy.login();
     cy.visit(`/colony/${colonyName}`);
 

--- a/cypress/e2e/8-motions.js
+++ b/cypress/e2e/8-motions.js
@@ -166,9 +166,7 @@ describe('User can create motions via UAC', () => {
 
     cy.getBySel('backButton').click();
 
-    cy.getBySel('eventsNavigationButton').click({
-      force: true,
-    });
+    cy.getBySel('transactionsLog').click();
     // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.getBySel('claimForColonyButton', { timeout: 100000 }).click().wait(5000);
 

--- a/cypress/e2e/8-motions.js
+++ b/cypress/e2e/8-motions.js
@@ -42,7 +42,7 @@ describe('User can create motions via UAC', () => {
       ([address]) => address,
     );
 
-    cy.makePayment(amountToPay, createAddress(accounts[1]), true);
+    cy.makePayment(amountToPay, createAddress(accounts[15]), true);
     cy.checkMotion();
   });
 

--- a/cypress/e2e/8-tokenActivation.js
+++ b/cypress/e2e/8-tokenActivation.js
@@ -14,6 +14,31 @@ describe('Token Activation & Deactivation', () => {
     cy.visit(`/colony/${colonyName}`);
   });
 
+  it(`User can activate tokens`, () => {
+    // Open Token Activation popover
+    const amountToActivate = 10;
+
+    // Activate tokens - wait required for reliability
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.activateTokens(amountToActivate).wait(20000);
+
+    // Check that the active tokens are correct
+    cy.get('@activatedTokens').then(($activatedTokens) => {
+      const [activatedTokensElement] = $activatedTokens.split(' ');
+      const parsedActivatedTokens = numbro.unformat(activatedTokensElement);
+      const activatedTokens = new Decimal(parsedActivatedTokens)
+        .add(amountToActivate)
+        .toFixed(0);
+
+      cy.getBySel('activeTokens', { timeout: 60000 }).then(($tokens) => {
+        const [activeTokensElement] = $tokens.text().split(' ');
+        const parsedActiveTokens = numbro.unformat(activeTokensElement);
+        const fixActiveTokens = new Decimal(parsedActiveTokens).toFixed(0);
+        expect(fixActiveTokens).to.eq(activatedTokens);
+      });
+    });
+  });
+
   it(`User can deactivate tokens`, () => {
     // Open Token Activation popover
     const amountToDeactivate = 10;
@@ -43,31 +68,6 @@ describe('Token Activation & Deactivation', () => {
         const parsedInactiveTokens = numbro.unformat(inactiveTokensElement);
         const fixInactiveTokens = new Decimal(parsedInactiveTokens).toFixed(0);
         expect(fixInactiveTokens).to.eq(deactivatedTokens);
-      });
-    });
-  });
-
-  it(`User can activate tokens`, () => {
-    // Open Token Activation popover
-    const amountToActivate = 10;
-
-    // Activate tokens - wait required for reliability
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.activateTokens(amountToActivate).wait(20000);
-
-    // Check that the active tokens are correct
-    cy.get('@activatedTokens').then(($activatedTokens) => {
-      const [activatedTokensElement] = $activatedTokens.split(' ');
-      const parsedActivatedTokens = numbro.unformat(activatedTokensElement);
-      const activatedTokens = new Decimal(parsedActivatedTokens)
-        .add(amountToActivate)
-        .toFixed(0);
-
-      cy.getBySel('activeTokens', { timeout: 60000 }).then(($tokens) => {
-        const [activeTokensElement] = $tokens.text().split(' ');
-        const parsedActiveTokens = numbro.unformat(activeTokensElement);
-        const fixActiveTokens = new Decimal(parsedActiveTokens).toFixed(0);
-        expect(fixActiveTokens).to.eq(activatedTokens);
       });
     });
   });

--- a/cypress/e2e/9-motions.js
+++ b/cypress/e2e/9-motions.js
@@ -8,7 +8,7 @@ import { createAddress } from '~utils/web3';
 import createdColony from '../fixtures/colony.json';
 import { numbroCustomLanguage } from '../../src/utils/numbers/numbroCustomLanguage';
 
-describe.only('User can create motions via UAC', () => {
+describe('User can create motions via UAC', () => {
   const {
     colony: { name: colonyName },
     colony,
@@ -114,7 +114,7 @@ describe.only('User can create motions via UAC', () => {
     cy.checkMotion();
   });
 
-  it.only('Disables reputation monitor', () => {
+  it('Disables reputation monitor', () => {
     // turn off the reputation monitor to avoid race conditions
     cy.request('http://127.0.0.1:3001/reputation/monitor/toggle');
   });

--- a/cypress/e2e/9-motions.js
+++ b/cypress/e2e/9-motions.js
@@ -8,7 +8,7 @@ import { createAddress } from '~utils/web3';
 import createdColony from '../fixtures/colony.json';
 import { numbroCustomLanguage } from '../../src/utils/numbers/numbroCustomLanguage';
 
-describe('User can create motions via UAC', () => {
+describe.only('User can create motions via UAC', () => {
   const {
     colony: { name: colonyName },
     colony,
@@ -52,15 +52,6 @@ describe('User can create motions via UAC', () => {
     const domainPurpose = 'Only cats allowed';
 
     cy.createTeam(domainName, domainPurpose, true);
-
-    cy.checkMotion();
-  });
-
-  it('Can edit teams - motion', () => {
-    const domainName = 'Dolphins';
-    const domainPurpose = 'This team has been taken over by dolphins';
-
-    cy.editTeam(domainName, domainPurpose, true);
 
     cy.checkMotion();
   });
@@ -119,6 +110,20 @@ describe('User can create motions via UAC', () => {
 
   it('Can manage permissions', () => {
     cy.managePermissions(true);
+
+    cy.checkMotion();
+  });
+
+  it.only('Disables reputation monitor', () => {
+    // turn off the reputation monitor to avoid race conditions
+    cy.request('http://127.0.0.1:3001/reputation/monitor/toggle');
+  });
+
+  it('Can edit teams - motion', () => {
+    const domainName = 'Dolphins';
+    const domainPurpose = 'This team has been taken over by dolphins';
+
+    cy.editTeam(domainName, domainPurpose, true);
 
     cy.checkMotion();
   });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -348,14 +348,12 @@ Cypress.Commands.add('editTeam', (domainName, domainPurpose, isMotion) => {
 
   cy.getBySel('editDomainConfirmButton').click();
 
-  cy.get('@domaniName').then((oldName) => {
-    cy.getBySel('actionHeading', { timeout: 100000 }).should(
-      'have.text',
-      isMotion
-        ? `Edit ${domainName} team details`
-        : `${domainName} team details edited`,
-    );
-  });
+  cy.getBySel('actionHeading', { timeout: 100000 }).should(
+    'have.text',
+    isMotion
+      ? `Edit ${domainName} team details`
+      : `${domainName} team details edited`,
+  );
 
   cy.url().should('contains', `${baseUrl}/colony/${colonyName}/tx/0x`);
 
@@ -420,7 +418,7 @@ Cypress.Commands.add('awardRep', (amountToAward, isMotion) => {
   cy.getBySel('awardReputationDialogIndexItem').click();
 
   cy.getBySel('reputationRecipientSelector').click({ force: true });
-  cy.getBySel('reputationRecipientSelectorItem').last().click();
+  cy.getBySel('reputationRecipientSelectorItem').first().click();
 
   cy.getBySel('reputationRecipientName').then(($value) => {
     rewardedUser = $value.text();
@@ -457,7 +455,7 @@ Cypress.Commands.add('smiteUser', (amountToSmite, isMotion) => {
   cy.getBySel('smiteReputationDialogIndexItem').click();
 
   cy.getBySel('reputationRecipientSelector').click({ force: true });
-  cy.getBySel('reputationRecipientSelectorItem').last().click();
+  cy.getBySel('reputationRecipientSelectorItem').first().click();
   cy.getBySel('reputationRecipientName').then(($value) => {
     smoteUser = $value.text();
   });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -25,7 +25,6 @@
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 
 import { Extension } from '@colony/colony-js';
-import Decimal from 'decimal.js';
 
 import { splitAddress } from '~utils/strings';
 
@@ -38,7 +37,7 @@ const {
 
 Cypress.Commands.add('login', () => {
   cy.visit('/landing');
-  cy.findByText(/connect wallet/i).click();
+  cy.findByText(/connect wallet/i, { timeout: 30000 }).click();
   cy.contains(/ganache/i).click();
   // eslint-disable-next-line cypress/no-unnecessary-waiting
   cy.findByText(/continue/i)
@@ -233,11 +232,6 @@ Cypress.Commands.add(
       : 'Test annotation';
 
     const cutAddress = splitAddress(address);
-    const paidAmount = isMotion
-      ? amountToPay
-      : new Decimal(amountToPay).sub(
-          new Decimal(1.0001).div(100).mul(amountToPay),
-        );
 
     cy.login();
     cy.visit(`/colony/${colonyName}`);
@@ -267,7 +261,7 @@ Cypress.Commands.add(
       'have.text',
       `Pay ${cutAddress.header}${cutAddress.start}...${
         cutAddress.end
-      } ${paidAmount.toString()} ${Cypress.config().colony.nativeToken}`,
+      } ${amountToPay.toString()} ${Cypress.config().colony.nativeToken}`,
     );
     cy.getBySel('comment').should('have.text', annotationText);
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -31,7 +31,7 @@ import { splitAddress } from '~utils/strings';
 import { buildUser } from './generate';
 
 const {
-  colony: { name: colonyName },
+  colony: { name: colonyName, nativeToken },
   baseUrl,
 } = Cypress.config();
 
@@ -217,7 +217,7 @@ Cypress.Commands.add('mintTokens', (amountToMint, isMotion) => {
 
   cy.getBySel('actionHeading', { timeout: 60000 }).should(
     'have.text',
-    `Mint ${amountToMint} ${Cypress.config().colony.nativeToken}`,
+    `Mint ${amountToMint} ${nativeToken}`,
   );
 
   if (isMotion !== undefined) {
@@ -233,10 +233,6 @@ Cypress.Commands.add(
     const annotationText = isMotion
       ? 'Test motion annotation'
       : 'Test annotation';
-
-    const {
-      colony: { nativeToken },
-    } = Cypress.config();
 
     let recipient;
 
@@ -393,9 +389,7 @@ Cypress.Commands.add('transferFunds', (amountToTransfer, isMotion) => {
 
   cy.getBySel('actionHeading', { timeout: 100000 }).should(
     'include.text',
-    `Move ${amountToTransfer} ${
-      Cypress.config().colony.nativeToken
-    } from Root to `,
+    `Move ${amountToTransfer} ${nativeToken} from Root to `,
   );
 
   cy.url().should('contains', `${baseUrl}/colony/${colonyName}/tx/0x`);

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -327,7 +327,7 @@ Cypress.Commands.add('editTeam', (domainName, domainPurpose, isMotion) => {
     cy.getBySel('actionHeading', { timeout: 100000 }).should(
       'have.text',
       isMotion
-        ? `Edit ${oldName} team details`
+        ? `Edit ${domainName} team details`
         : `${domainName} team details edited`,
     );
   });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -130,7 +130,7 @@ Cypress.Commands.add('createColony', (colony, useNewToken) => {
 
 Cypress.Commands.add('getColonyTokenAddress', (setColonyName) => {
   cy.visit(`/colony/${setColonyName}`);
-  cy.getBySel('colonyMenu', { timeout: 60000 }).click();
+  cy.getBySel('colonyMenuPopover', { timeout: 60000 }).click();
   cy.getBySel('nativeTokenAddress').invoke('text').as('existingTokenAddress');
 });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -37,8 +37,9 @@ const {
 
 Cypress.Commands.add('login', () => {
   cy.visit('/landing');
-  cy.findByText(/connect wallet/i, { timeout: 30000 }).click({
+  cy.findByText(/connect wallet/i, { timeout: 60000 }).click({
     timeout: 30000,
+    force: true,
   });
   cy.contains(/ganache/i).click();
   // eslint-disable-next-line cypress/no-unnecessary-waiting

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -37,7 +37,9 @@ const {
 
 Cypress.Commands.add('login', () => {
   cy.visit('/landing');
-  cy.findByText(/connect wallet/i, { timeout: 30000 }).click();
+  cy.findByText(/connect wallet/i, { timeout: 30000 }).click({
+    timeout: 30000,
+  });
   cy.contains(/ganache/i).click();
   // eslint-disable-next-line cypress/no-unnecessary-waiting
   cy.findByText(/continue/i)

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -171,8 +171,11 @@ Cypress.Commands.add('enableExtension', (extensionId) => {
   cy.getBySel('enableExtensionButton').click();
   if (extensionId === Extension.Whitelist) {
     cy.getBySel('policySelector').eq(1).click({ force: true });
+    cy.getBySel('policySelector').eq(1).click({ force: true });
   }
-  cy.getBySel('setupExtensionConfirmButton').click();
+  // eslint-disable-next-line cypress/no-unnecessary-waiting
+  cy.getBySel('setupExtensionConfirmButton').click().wait(7000);
+  cy.getBySel('closeGasStationButton').click();
   cy.getBySel('enabledStatusTag', { timeout: 30000 }).should('exist');
 });
 

--- a/src/i18n/en-motions.ts
+++ b/src/i18n/en-motions.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import { ColonyMotions } from '~types/index';
 
 const motionsMessageDescriptors = {
@@ -12,17 +13,9 @@ const motionsMessageDescriptors = {
       ${ColonyMotions.MoveFundsMotion}
         {Move {amount} {tokenSymbol} from {fromDomainName} to {toDomainName}}
       ${ColonyMotions.EmitDomainReputationPenaltyMotion}
-        {Smite {recipient} with a {reputationChangeNumeral}
-        {reputationChange, plural,
-          one {pt}
-          other {pts}
-        } reputation penalty}
+        {Smite {recipient} with a {reputationChangeNumeral} {reputationChange, plural, one {pt} other {pts}} reputation penalty}
       ${ColonyMotions.EmitDomainReputationRewardMotion}
-        {Award {recipient} with a {reputationChangeNumeral}
-        {reputationChange, plural,
-          one {pt}
-          other {pts}
-        } reputation reward}
+        {Award {recipient} with a {reputationChangeNumeral} {reputationChange, plural, one {pt} other {pts}} reputation reward}
       ${ColonyMotions.UnlockTokenMotion} {Unlock native token {tokenSymbol}}
       other {Generic motion we don't have information about}
     }`,

--- a/src/modules/core/components/Fields/RadioGroup/CustomRadioGroup.tsx
+++ b/src/modules/core/components/Fields/RadioGroup/CustomRadioGroup.tsx
@@ -49,6 +49,7 @@ const CustomRadioGroup = ({
           checked,
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           name: optionName,
+          dataTest: optionDataTest,
           ...rest
         }) => (
           <CustomRadio
@@ -59,7 +60,7 @@ const CustomRadioGroup = ({
             key={value}
             appearance={{ ...optionApperance, direction: appearance.direction }}
             disabled={disabled}
-            dataTest={dataTest}
+            dataTest={optionDataTest || dataTest}
             {...rest}
           />
         ),

--- a/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteWidget.tsx
@@ -127,6 +127,7 @@ const VoteWidget = ({
       icon: inputDisabled
         ? 'circle-thumbs-up-grey'
         : `circle-thumbs-up${checkedValue === '1' ? '' : '-outlined'}`,
+      dataTest: 'yesVoteButton',
     },
     {
       value: '0',

--- a/src/modules/dashboard/components/ColonyActions/ColonyActions.tsx
+++ b/src/modules/dashboard/components/ColonyActions/ColonyActions.tsx
@@ -296,7 +296,11 @@ const ColonyActions = ({
               </div>
             </Form>
 
-            <Link className={styles.link} to={`/colony/${colonyName}/events`}>
+            <Link
+              className={styles.link}
+              to={`/colony/${colonyName}/events`}
+              data-test="transactionsLog"
+            >
               <FormattedMessage {...MSG.transactionsLogLink} />
             </Link>
           </div>

--- a/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
@@ -439,6 +439,7 @@ const CreatePaymentDialogForm = ({
             placeholder={MSG.userPickerPlaceholder}
             dataTest="paymentRecipientPicker"
             itemDataTest="paymentRecipientItem"
+            valueDataTest="paymentRecipientName"
           />
         </div>
       </DialogSection>


### PR DESCRIPTION
## Description

This consolidates all the tests. To run it properly, you need to do it first thing after you start the dev environment.

Remember to have the reputation monitor on.

This needs to be run in a headless mode with `npm run cy:run` command. You also  need to change a cypress variable `skipInitTests` to false.

Sometimes annotations don't get through and this causes a test to fail although it all worked fine. Not sure how to deal with it yet...

## TODO

Refactor restructuring of the config variables where they are used.

resolves #3299 