### PR TITLE
Fix the `UserCheckbox` default values

### DIFF
--- a/src/modules/core/components/UserCheckbox/UserCheckbox.tsx
+++ b/src/modules/core/components/UserCheckbox/UserCheckbox.tsx
@@ -34,7 +34,7 @@ const UserCheckbox = ({
   showDisplayName = true,
 }: Props) => {
   const userProfile = useUser(createAddress(walletAddress || AddressZero));
-  const [isChecked, setIsChecked] = useState<boolean>(false);
+  const [isChecked, setIsChecked] = useState<boolean>(true);
 
   const {
     getArrowProps,
@@ -57,7 +57,6 @@ const UserCheckbox = ({
             value={walletAddress}
             className={styles.checkbox}
             onChange={(props) => setIsChecked(props.isChecked)}
-            getDefaultValue={(checked) => setIsChecked(checked)}
           />
           {visible && (
             <div


### PR DESCRIPTION
## Description

This PR fixes removes the red background every time the whitelisted addresses list in the dialog is updated (removed or added). The red background is caused by the `isChecked` boolean value of `false`. When we update the list, the value used to default to false, hence the red background  on any updates.

Resolves #3309 