### PR TITLE
Update COLONY_CLAIM_TOKEN saga

### DIFF
--- a/src/data/resolvers/transactions.ts
+++ b/src/data/resolvers/transactions.ts
@@ -131,6 +131,7 @@ export const getColonyUnclaimedTransfers = async (
     variables: {
       colonyAddress: colonyClient.address.toLowerCase(),
     },
+    fetchPolicy: 'network-only',
   });
   const colonyFundsClaimedEvents =
     colonyFundsClaimedEventsData?.colonyFundsClaimedEvents || [];

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -153,6 +153,8 @@
     "transaction.ColonyClient.upgrade.description": "Colony Version Upgrade",
     "transaction.group.upgrade.title": "Colony Version Upgrade",
     "transaction.group.upgrade.description": "Colony Version Upgrade",
+    "transaction.group.claimIncomingFunds.title": "Claim Incoming Funds",
+    "transaction.group.claimIncomingFunds.description": "Claim Incoming Funds",
     "transaction.ColonyClient.claimColonyFunds.title": "Claim Pending Transactions",
     "transaction.ColonyClient.claimColonyFunds.description": "Claim Pending Transactions",
     "transaction.ColonyClient.moveFundsBetweenPotsWithProofs.title": "Move Funds Between Pots",

--- a/src/modules/dashboard/components/ColonyHome/ColonyUnclaimedTransfers/ColonyUnclaimedTransfers.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyUnclaimedTransfers/ColonyUnclaimedTransfers.tsx
@@ -63,13 +63,17 @@ const ColonyUnclaimedTransfers = ({
   const isNetworkAllowed = checkIfNetworkIsAllowed(networkId);
 
   const firstItem = data?.processedColony.unclaimedTransfers[0];
+  const tokenAddresses =
+    data?.processedColony.unclaimedTransfers.map(
+      (unclaimedTransfer) => unclaimedTransfer.token,
+    ) || [];
 
   const { data: tokenData } = useTokenQuery({
     variables: { address: firstItem?.token || '' },
   });
 
   const transform = useCallback(
-    mergePayload({ colonyAddress, tokenAddress: firstItem?.token || '' }),
+    mergePayload({ colonyAddress, tokenAddresses }),
     [colonyAddress, firstItem],
   );
 

--- a/src/modules/dashboard/components/UnclaimedTransfers/UnclaimedTransfersItem.tsx
+++ b/src/modules/dashboard/components/UnclaimedTransfers/UnclaimedTransfersItem.tsx
@@ -46,10 +46,10 @@ const UnclaimedTransfersItem = ({
     variables: { address: tokenAddress },
   });
 
-  const transform = useCallback(mergePayload({ colonyAddress, tokenAddresses: [tokenAddress] }), [
-    colonyAddress,
-    tokenAddress,
-  ]);
+  const transform = useCallback(
+    mergePayload({ colonyAddress, tokenAddresses: [tokenAddress] }),
+    [colonyAddress, tokenAddress],
+  );
 
   const isNetworkAllowed = checkIfNetworkIsAllowed(networkId);
 

--- a/src/modules/dashboard/components/UnclaimedTransfers/UnclaimedTransfersItem.tsx
+++ b/src/modules/dashboard/components/UnclaimedTransfers/UnclaimedTransfersItem.tsx
@@ -46,7 +46,7 @@ const UnclaimedTransfersItem = ({
     variables: { address: tokenAddress },
   });
 
-  const transform = useCallback(mergePayload({ colonyAddress, tokenAddress }), [
+  const transform = useCallback(mergePayload({ colonyAddress, tokenAddresses: [tokenAddress] }), [
     colonyAddress,
     tokenAddress,
   ]);

--- a/src/modules/dashboard/sagas/colony.ts
+++ b/src/modules/dashboard/sagas/colony.ts
@@ -1,5 +1,7 @@
-import { call, fork, put, takeEvery } from 'redux-saga/effects';
+import { all, call, fork, put, takeEvery } from 'redux-saga/effects';
 import { ClientType } from '@colony/colony-js';
+import { $Values } from 'utility-types';
+import isEmpty from 'lodash/isEmpty';
 
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom } from '~utils/saga/effects';
@@ -12,11 +14,17 @@ import {
   TokenBalancesForDomainsDocument,
 } from '~data/index';
 import { ContextModule, TEMP_getContext } from '~context/index';
+import { TxConfig } from '~types/index';
 
-import { createTransaction, getTxChannel } from '../../core/sagas';
+import {
+  ChannelDefinition,
+  createTransaction,
+  getTxChannel,
+  createTransactionChannels,
+} from '../../core/sagas';
 
 function* colonyClaimToken({
-  payload: { colonyAddress, tokenAddress },
+  payload: { colonyAddress, tokenAddresses },
   meta,
 }: Action<ActionTypes.COLONY_CLAIM_TOKEN>) {
   let txChannel;
@@ -24,23 +32,58 @@ function* colonyClaimToken({
     const apolloClient = TEMP_getContext(ContextModule.ApolloClient);
 
     txChannel = yield call(getTxChannel, meta.id);
-    yield fork(createTransaction, meta.id, {
-      context: ClientType.ColonyClient,
-      methodName: 'claimColonyFunds',
-      identifier: colonyAddress,
-      params: [tokenAddress],
-    });
 
-    const { payload } = yield takeFrom(
-      txChannel,
-      ActionTypes.TRANSACTION_SUCCEEDED,
+    if (isEmpty(tokenAddresses)) {
+      throw new Error('Token addresses need to be provided');
+    }
+
+    const channelNames: string[] = [];
+
+    for (let index = 0; index < tokenAddresses.length; index += 1) {
+      channelNames.push(String(index));
+    }
+
+    const channels: { [id: string]: ChannelDefinition } = yield call(
+      createTransactionChannels,
+      meta.id,
+      channelNames,
     );
 
-    yield put<AllActions>({
-      type: ActionTypes.COLONY_CLAIM_TOKEN_SUCCESS,
-      payload,
-      meta,
-    });
+    const createGroupTransaction = (
+      { id, index }: $Values<typeof channels>,
+      config: TxConfig,
+    ) =>
+      fork(createTransaction, id, {
+        ...config,
+        group: {
+          key: 'claimIncomingFunds',
+          id: meta.id,
+          index,
+        },
+      });
+
+    yield all(
+      Object.keys(channels).map((id) =>
+        createGroupTransaction(channels[id], {
+          context: ClientType.ColonyClient,
+          methodName: 'claimColonyFunds',
+          identifier: colonyAddress,
+          params: [tokenAddresses[id]],
+        }),
+      ),
+    );
+
+    yield all(
+      Object.keys(channels).map((id) =>
+        takeFrom(channels[id].channel, ActionTypes.TRANSACTION_CREATED),
+      ),
+    );
+
+    yield all(
+      Object.keys(channels).map((id) =>
+        takeFrom(channels[id].channel, ActionTypes.TRANSACTION_SUCCEEDED),
+      ),
+    );
 
     // Refresh relevant values
     yield apolloClient.query<
@@ -51,13 +94,20 @@ function* colonyClaimToken({
       variables: { address: colonyAddress },
       fetchPolicy: 'network-only',
     });
+
     yield apolloClient.query<
       TokenBalancesForDomainsQuery,
       TokenBalancesForDomainsQueryVariables
     >({
       query: TokenBalancesForDomainsDocument,
-      variables: { colonyAddress, tokenAddresses: [tokenAddress] },
+      variables: { colonyAddress, tokenAddresses },
       fetchPolicy: 'network-only',
+    });
+
+    yield put<AllActions>({
+      type: ActionTypes.COLONY_CLAIM_TOKEN_SUCCESS,
+      payload: { params: { tokenAddresses } },
+      meta,
     });
   } catch (error) {
     return yield putError(ActionTypes.COLONY_CLAIM_TOKEN_ERROR, error, meta);

--- a/src/redux/types/actions/colony.ts
+++ b/src/redux/types/actions/colony.ts
@@ -10,13 +10,13 @@ import {
 export type ColonyActionTypes =
   | UniqueActionType<
       ActionTypes.COLONY_CLAIM_TOKEN,
-      { tokenAddress: Address; colonyAddress: Address },
+      { tokenAddresses: Address[]; colonyAddress: Address },
       object
     >
   | ErrorActionType<ActionTypes.COLONY_CLAIM_TOKEN_ERROR, object>
   | UniqueActionType<
       ActionTypes.COLONY_CLAIM_TOKEN_SUCCESS,
-      { params: { token: Address } },
+      { params: { tokenAddresses: Address[] } },
       object
     >
   | UniqueActionType<


### PR DESCRIPTION
Updated `COLONY_CLAIM_TOKEN` saga so that it supports claiming multiple tokens, this update is necessary in order to fully implement the `Claim` button shown in the new "Incoming funds" aside (#3316)

### TODO

- [x] Connect new `Claim` button with updated `COLONY_CLAIM_TOKEN` saga

Resolves #3318 
