### PR TITLE
Whitelist filtering in payment modal not updating

### DIFF
--- a/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialog.tsx
@@ -102,11 +102,11 @@ const CreatePaymentDialog = ({
 
   /*
    * @NOTE This (extravagant) query retrieves the latest whitelist data.
-   * Whitelist data from colony obj can be stale.
+   * Whitelist data from colony prop can be stale.
    *
    * Add/remove to whitelist then navigating to payment dialog
    * without closing the modal will cause the whitelist data in
-   * colony obj to be out of date.
+   * colony prop to be outdated.
    */
   const { data: colonyData } = useColonyFromNameQuery({
     variables: { name: colonyName, address: colonyAddress },


### PR DESCRIPTION
## Description

This PR fixes a bug in `CreatePaymentDialog` where the colony prop containing whitelist data is stale. To resolve this issue, a query is made in `CreatePaymentDialog` to retrieve fresh whitelist data, instead of using the outdated data from colony prop.

The bug was caused by adding/removing an entry to whitelist (made via manage whitelist dialog) and then navigating to payment dialog without closing the modal. The filtered dropdown used outdated whitelist data so may have shown inappropriate results.

Resolves  #3324
