### PR TITLE
Fix number overflow on motion page

### DIFF
--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
@@ -243,27 +243,23 @@ const DefaultMotion = ({
 
   const threshold = bigNumberify(
     votingStateData?.votingState?.thresholdValue || 0,
-  )
-    .div(bigNumberify(10).pow(18))
-    .toNumber();
+  ).div(bigNumberify(10).pow(18));
 
   const totalVotedReputationValue = bigNumberify(
     votingStateData?.votingState?.totalVotedReputation || 0,
-  )
-    .div(bigNumberify(10).pow(18))
-    .toNumber();
+  ).div(bigNumberify(10).pow(18));
 
   const skillRepValue = bigNumberify(
     votingStateData?.votingState?.skillRep || 0,
-  )
-    .div(bigNumberify(10).pow(18))
-    .toNumber();
-
-  const currentReputationPercent =
-    (totalVotedReputationValue > 0 &&
-      Math.round((totalVotedReputationValue / skillRepValue) * 100)) ||
-    0;
-  const thresholdPercent = Math.round((threshold / skillRepValue) * 100);
+  ).div(bigNumberify(10).pow(18));
+  const currentReputationPercent = !totalVotedReputationValue.isZero()
+    ? Math.round(
+        totalVotedReputationValue.div(skillRepValue).mul(100).toNumber(),
+      )
+    : 0;
+  const thresholdPercent = !skillRepValue.isZero()
+    ? Math.round(threshold.div(skillRepValue).mul(100).toNumber())
+    : 0;
   const domainMetadata = {
     name: domainName,
     color: domainColor,


### PR DESCRIPTION
Fixed BigNumbers overflowing on `.toNumber()` in the motion page. I also checked all of the other places where we use `.toNumber()` and it may overflow, however, the only places that gave problems was this one in the motion page.

In order to test:

- Mint a lot of tokens (for example, `100x10^18` or `^20` or even more).
- Make a large payment to yourself with the rep miner ON, with a similar amount as the one minted so that a lot of reputation points are generated.
- With rep, now install the voting extension and make any motion.
- If the dapp doesn't crash when on the motion page, the fix works.

Resolves #3262 
