### PR TITLE
Align ColorTag in create team modal's Select component

### DIFF
--- a/src/modules/core/components/Fields/Select/Select.css
+++ b/src/modules/core/components/Fields/Select/Select.css
@@ -128,10 +128,6 @@
   }
 }
 
-.themeGrid > div {
-  align-items: flex-start;
-}
-
 .widthContent {
   width: min-content;
 }


### PR DESCRIPTION
## Description

![2022-04-27_21-31](https://user-images.githubusercontent.com/14034137/165563075-24d8936b-6ad3-4bc1-af6e-d0e475a67071.png)


This is caused by commit 2b91811f7 in which I edited the Select component in order to avoid a (very) deeply nested and fragile CSS selector in the ColonyActions filter component.
AFAIU, this PR should not cause issues anywhere else (grid is not used much) but if you think otherwise please let me know - I will revert 2b91811f7 and figure something out about that.

Resolves #3340.
