### PR TITLE
Remove unnecessary hover effect on DeleteComment comment

### DIFF
--- a/src/modules/core/components/Comment/Dialogs/DeleteComment/DeleteComment.tsx
+++ b/src/modules/core/components/Comment/Dialogs/DeleteComment/DeleteComment.tsx
@@ -82,7 +82,7 @@ const DeleteComment = ({ cancel, close, comment, undelete = false }: Props) => {
         </div>
         {comment && (
           <div className={styles.comment}>
-            <Comment {...comment} />
+            <Comment disableHover {...comment} />
           </div>
         )}
       </DialogSection>


### PR DESCRIPTION

![2022-04-28_17-46](https://user-images.githubusercontent.com/14034137/165750266-a72cedaf-cccd-4bd2-9e4c-123c40e30c1f.png)


Resolves #3342.


