### PR TITLE
Add action title for "New whitelisted addresses/address"

### DIFF
--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -1007,6 +1007,8 @@ export type ColonyAction = {
   motionDomain: Scalars['Int'];
   rootHash?: Maybe<Scalars['String']>;
   reputationChange: Scalars['String'];
+  isWhitelistActivated: Scalars['Boolean'];
+  verifiedAddresses: Array<Scalars['String']>;
 };
 
 export type NetworkContractsInput = {
@@ -1848,7 +1850,7 @@ export type ColonyActionQueryVariables = Exact<{
 
 
 export type ColonyActionQuery = { colonyAction: (
-    Pick<ColonyAction, 'hash' | 'actionInitiator' | 'fromDomain' | 'toDomain' | 'recipient' | 'status' | 'createdAt' | 'actionType' | 'amount' | 'tokenAddress' | 'annotationHash' | 'newVersion' | 'oldVersion' | 'colonyDisplayName' | 'colonyAvatarHash' | 'colonyTokens' | 'domainName' | 'domainPurpose' | 'domainColor' | 'motionState' | 'motionDomain' | 'blockNumber' | 'rootHash' | 'reputationChange'>
+    Pick<ColonyAction, 'hash' | 'actionInitiator' | 'fromDomain' | 'toDomain' | 'recipient' | 'status' | 'createdAt' | 'actionType' | 'amount' | 'tokenAddress' | 'annotationHash' | 'newVersion' | 'oldVersion' | 'colonyDisplayName' | 'colonyAvatarHash' | 'colonyTokens' | 'domainName' | 'domainPurpose' | 'domainColor' | 'motionState' | 'motionDomain' | 'blockNumber' | 'rootHash' | 'reputationChange' | 'isWhitelistActivated' | 'verifiedAddresses'>
     & { events: Array<Pick<ParsedEvent, 'type' | 'name' | 'values' | 'createdAt' | 'emmitedBy' | 'transactionHash'>>, roles: Array<Pick<ColonyActionRoles, 'id' | 'setTo'>> }
   ) };
 
@@ -4384,6 +4386,8 @@ export const ColonyActionDocument = gql`
     blockNumber
     rootHash
     reputationChange
+    isWhitelistActivated
+    verifiedAddresses
   }
 }
     `;

--- a/src/data/graphql/queries.graphql
+++ b/src/data/graphql/queries.graphql
@@ -239,6 +239,8 @@ query ColonyAction($transactionHash: String!, $colonyAddress: String!) {
     blockNumber
     rootHash
     reputationChange
+    isWhitelistActivated
+    verifiedAddresses
   }
 }
 

--- a/src/data/graphql/typeDefs.ts
+++ b/src/data/graphql/typeDefs.ts
@@ -124,6 +124,8 @@ export default gql`
     motionDomain: Int!
     rootHash: String
     reputationChange: String!
+    isWhitelistActivated: Boolean!
+    verifiedAddresses: [String!]!
   }
 
   input NetworkContractsInput {

--- a/src/data/resolvers/colonyActions.ts
+++ b/src/data/resolvers/colonyActions.ts
@@ -255,6 +255,8 @@ export const colonyActionsResolvers = ({
           motionState: null,
           motionDomain: null,
           rootHash: null,
+          isWhitelistActivated: false,
+          verifiedAddresses: [],
           ...actionValues,
         };
       }

--- a/src/i18n/en-actions.ts
+++ b/src/i18n/en-actions.ts
@@ -34,6 +34,7 @@ const actionsMessageDescriptors = {
   [`action.${ColonyMotions.SetUserRolesMotion}.remove`]: `Remove the {roles} in {fromDomain} from {recipient}`,
   [`action.${ColonyActions.SetUserRoles}.assignAndRemove`]: `{roles} in {fromDomain} to/from {recipient}`,
   [`action.${ColonyMotions.SetUserRolesMotion}.assignAndRemove`]: `{roles} in {fromDomain} to/from {recipient}`,
+  [`action.${ColonyActions.ColonyEdit}.verifiedAddresses`]: `Verified address list was updated`,
   'action.type': `{actionType, select,
       ${ColonyActions.WrongColony} {Not part of the Colony}
       ${ColonyActions.Payment} {Payment}

--- a/src/i18n/en-events.ts
+++ b/src/i18n/en-events.ts
@@ -28,6 +28,7 @@ const eventsMessageDescriptors = {
   [`event.${ColonyAndExtensionsEvents.ColonyMetadata}.name`]: `{initiator} changed this colony's name to {colonyName}`,
   [`event.${ColonyAndExtensionsEvents.ColonyMetadata}.logo`]: `{initiator} changed this colony's logo`,
   [`event.${ColonyAndExtensionsEvents.ColonyMetadata}.tokens`]: `{initiator} changed this colony's tokens`,
+  [`event.${ColonyAndExtensionsEvents.ColonyMetadata}.verifiedAddresses`]: `{initiator} updated this colony's verified addresses list`,
   [`event.${ColonyAndExtensionsEvents.ColonyMetadata}.fallback`]: `{initiator} changed this colony's metadata, but the values are the same`,
   [`event.${ColonyAndExtensionsEvents.DomainMetadata}.all`]: `{initiator} changed teams's name, description, color from {oldName}, {oldDescription}, {oldColor} to {domainName}, {domainPurpose}, {domainColor}`,
   [`event.${ColonyAndExtensionsEvents.DomainMetadata}.nameDescription`]: `{initiator} changed teams's name and description from {oldName}, {oldDescription} to {domainName}, {domainPurpose}`,

--- a/src/modules/core/components/ActionsList/ActionsListItem.tsx
+++ b/src/modules/core/components/ActionsList/ActionsListItem.tsx
@@ -16,7 +16,7 @@ import Icon from '~core/Icon';
 import FriendlyName from '~core/FriendlyName';
 import Tag, { Appearance as TagAppearance } from '~core/Tag';
 import CountDownTimer from '~dashboard/ActionsPage/CountDownTimer';
-import { useColonyMetadataChecks } from '~modules/dashboard/hooks/useColonyMetadataChecks';
+import useColonyMetadataChecks from '~modules/dashboard/hooks/useColonyMetadataChecks';
 
 import { getMainClasses, removeValueUnits } from '~utils/css';
 import {

--- a/src/modules/core/components/ActionsList/ActionsListItem.tsx
+++ b/src/modules/core/components/ActionsList/ActionsListItem.tsx
@@ -16,6 +16,7 @@ import Icon from '~core/Icon';
 import FriendlyName from '~core/FriendlyName';
 import Tag, { Appearance as TagAppearance } from '~core/Tag';
 import CountDownTimer from '~dashboard/ActionsPage/CountDownTimer';
+import { useColonyMetadataChecks } from '~modules/dashboard/hooks/useColonyMetadataChecks';
 
 import { getMainClasses, removeValueUnits } from '~utils/css';
 import {
@@ -32,7 +33,7 @@ import {
 import { createAddress } from '~utils/web3';
 import { FormattedAction, ColonyActions, ColonyMotions } from '~types/index';
 import { useDataFetcher } from '~utils/hooks';
-import { parseDomainMetadata } from '~utils/colonyActions';
+import { parseColonyMetadata, parseDomainMetadata } from '~utils/colonyActions';
 import { useFormatRolesTitle } from '~utils/hooks/useFormatRolesTitle';
 import { useEnabledExtensions } from '~utils/hooks/useEnabledExtensions';
 import {
@@ -128,6 +129,13 @@ const ActionsListItem = ({
 
   const [fetchTokenInfo, { data: tokenData }] = useTokenInfoLazyQuery();
 
+  const colonyObject = parseColonyMetadata(metadataJSON);
+  const colonyMetadataChecks = useColonyMetadataChecks(
+    actionType,
+    colony,
+    transactionHash,
+    { verifiedAddresses: colonyObject.verifiedAddresses || [] },
+  );
   useEffect(() => {
     if (transactionTokenAddress) {
       fetchTokenInfo({ variables: { address: transactionTokenAddress } });
@@ -284,7 +292,12 @@ const ActionsListItem = ({
           <div className={styles.titleWrapper}>
             <span className={styles.title}>
               <FormattedMessage
-                id={roleMessageDescriptorId || 'action.title'}
+                id={
+                  (colonyMetadataChecks.verifiedAddressesChanged &&
+                    `action.${ColonyActions.ColonyEdit}.verifiedAddresses`) ||
+                  roleMessageDescriptorId ||
+                  'action.title'
+                }
                 values={{
                   actionType,
                   initiator: (

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageEvent/ActionsPageEvent.tsx
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageEvent/ActionsPageEvent.tsx
@@ -32,7 +32,7 @@ import { getFormattedTokenValue } from '~utils/tokens';
 import { MotionVote } from '~utils/colonyMotions';
 
 import { ipfsDataFetcher } from '../../../../core/fetchers';
-import { useColonyMetadataChecks } from '../../../hooks/useColonyMetadataChecks';
+import useColonyMetadataChecks from '../../../hooks/useColonyMetadataChecks';
 import { EventValues } from '../ActionsPageFeed';
 import { STATUS } from '../../ActionsPage/types';
 import { EVENT_ROLES_MAP } from '../../ActionsPage/staticMaps';

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageEvent/ActionsPageEvent.tsx
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageEvent/ActionsPageEvent.tsx
@@ -14,7 +14,6 @@ import Numeral from '~core/Numeral';
 
 import {
   ColonyAction,
-  useSubgraphColonyMetadataQuery,
   useSubgraphDomainMetadataQuery,
   Colony,
   useUser,
@@ -22,8 +21,7 @@ import {
 import { ColonyAndExtensionsEvents } from '~types/index';
 import {
   getSpecificActionValuesCheck,
-  sortMetdataHistory,
-  parseColonyMetadata,
+  sortMetadataHistory,
   parseDomainMetadata,
   getColonyMetadataMessageDescriptorsIds,
   getDomainMetadataMessageDescriptorsIds,
@@ -34,12 +32,12 @@ import { getFormattedTokenValue } from '~utils/tokens';
 import { MotionVote } from '~utils/colonyMotions';
 
 import { ipfsDataFetcher } from '../../../../core/fetchers';
-
+import { useColonyMetadataChecks } from '../../../hooks/useColonyMetadataChecks';
 import { EventValues } from '../ActionsPageFeed';
 import { STATUS } from '../../ActionsPage/types';
 import { EVENT_ROLES_MAP } from '../../ActionsPage/staticMaps';
-import motionSpecificStyles from '../../ActionsPage/ActionsComponents/DefaultMotion.css';
 
+import motionSpecificStyles from '../../ActionsPage/ActionsComponents/DefaultMotion.css';
 import styles from './ActionsPageEvent.css';
 
 const displayName = 'dashboard.ActionsPageFeed.ActionsPageEvent';
@@ -144,12 +142,6 @@ const ActionsPageEvent = ({
     return eventsToIdsMap;
   });
 
-  const colonyMetadataHistory = useSubgraphColonyMetadataQuery({
-    variables: {
-      address: colonyAddress.toLowerCase(),
-    },
-  });
-
   const domainMetadataHistory = useSubgraphDomainMetadataQuery({
     variables: {
       colonyAddress: colonyAddress.toLowerCase(),
@@ -171,73 +163,13 @@ const ActionsPageEvent = ({
     // silent error
   }
 
-  /*
-   * Determine if the current medata is different from the previous one,
-   * and in what way
-   */
-  const getColonyMetadataChecks = useMemo(() => {
-    if (
-      eventName === ColonyAndExtensionsEvents.ColonyMetadata &&
-      !!colonyMetadataHistory?.data?.colony &&
-      !!actionData
-    ) {
-      const {
-        data: {
-          colony: { metadataHistory },
-        },
-      } = colonyMetadataHistory;
-      const sortedMetdataHistory = sortMetdataHistory(metadataHistory);
-      const currentMedataIndex = findLastIndex(
-        sortedMetdataHistory,
-        ({ transaction: { id: hash } }) => hash === actionData.hash,
-      );
-      /*
-       * We have a previous metadata entry
-       */
-      if (currentMedataIndex > 0) {
-        const prevMetdata = sortedMetdataHistory[currentMedataIndex - 1];
-        if (prevMetdata) {
-          setMetdataIpfsHash(prevMetdata.metadata);
-          if (metadataJSON) {
-            /*
-             * If we have a metadata json, parse into the expected values and then
-             * compare them agains the ones from the current action
-             *
-             * This should be the default case for a colony with metadata history
-             */
-            return getSpecificActionValuesCheck(
-              eventName as ColonyAndExtensionsEvents,
-              actionData,
-              parseColonyMetadata(metadataJSON),
-            );
-          }
-        }
-      }
-      /*
-       * We don't have a previous metadata entry, so fall back to the current
-       * action's values
-       */
-      const { colonyDisplayName, colonyAvatarHash, colonyTokens } = actionData;
-      return {
-        nameChanged: !!colonyDisplayName,
-        logoChanged: !!colonyAvatarHash,
-        tokensChanged: !!colonyTokens.length,
-      };
-    }
-    /*
-     * Default fallback, just use the current colony's values
-     */
-    const {
-      displayName: colonyDisplayName,
-      avatarHash,
-      tokenAddresses,
-    } = colony;
-    return {
-      nameChanged: !!colonyDisplayName,
-      logoChanged: !!avatarHash,
-      tokensChanged: !!tokenAddresses?.length,
-    };
-  }, [colonyMetadataHistory, actionData, metadataJSON, eventName, colony]);
+  const colonyMetadataChecks = useColonyMetadataChecks(
+    eventName,
+    colony,
+    actionData.hash,
+    actionData,
+  );
+
   const roleNameMessage = {
     id: `role.${
       values?.roles && values?.roles[eventIndex]
@@ -255,7 +187,7 @@ const ActionsPageEvent = ({
       !!actionData
     ) {
       const domain = domainMetadataHistory?.data?.domains[0];
-      const sortedMetdataHistory = sortMetdataHistory(domain?.metadataHistory);
+      const sortedMetdataHistory = sortMetadataHistory(domain?.metadataHistory);
       const currentMedataIndex = findLastIndex(
         sortedMetdataHistory,
         ({ transaction: { id: hash } }) => hash === actionData.hash,
@@ -292,7 +224,7 @@ const ActionsPageEvent = ({
       case ColonyAndExtensionsEvents.ColonyMetadata:
         return getColonyMetadataMessageDescriptorsIds(
           ColonyAndExtensionsEvents.ColonyMetadata,
-          getColonyMetadataChecks,
+          colonyMetadataChecks,
         );
       case ColonyAndExtensionsEvents.DomainMetadata:
         return getDomainMetadataMessageDescriptorsIds(
@@ -315,7 +247,7 @@ const ActionsPageEvent = ({
   }, [
     eventName,
     getDomainMetadataChecks,
-    getColonyMetadataChecks,
+    colonyMetadataChecks,
     eventIndex,
     values,
   ]);

--- a/src/modules/dashboard/hooks/useColonyMetadataChecks.ts
+++ b/src/modules/dashboard/hooks/useColonyMetadataChecks.ts
@@ -20,7 +20,7 @@ import { useDataFetcher } from '~utils/hooks';
  * Determine if the current medata is different from the previous one,
  * and in what way
  */
-export const useColonyMetadataChecks = (
+const useColonyMetadataChecks = (
   eventName: string,
   colony: Colony,
   transactionHash: string,
@@ -59,69 +59,70 @@ export const useColonyMetadataChecks = (
   }
   useEffect(() => {
     if (
-      (eventName === ColonyAndExtensionsEvents.ColonyMetadata ||
-        eventName === ColonyActions.ColonyEdit) &&
-      !!colonyMetadataHistory?.data?.colony
+      eventName === ColonyAndExtensionsEvents.ColonyMetadata ||
+      eventName === ColonyActions.ColonyEdit
     ) {
-      const {
-        data: {
-          colony: { metadataHistory },
-        },
-      } = colonyMetadataHistory;
-      const sortedMetadataHistory = sortMetadataHistory(metadataHistory);
-      const currentMetadataIndex = findLastIndex(
-        sortedMetadataHistory,
-        ({ transaction: { id: hash } }) => hash === transactionHash,
-      );
-      /*
-       * We have a previous metadata entry
-       */
-      if (currentMetadataIndex > 0) {
-        const prevMetadata = sortedMetadataHistory[currentMetadataIndex - 1];
-        if (prevMetadata) {
-          if (prevMetadata.metadata !== metadataIpfsHash) {
-            setMetadataIpfsHash(prevMetadata.metadata);
-          }
+      if (colonyMetadataHistory?.data?.colony) {
+        const {
+          data: {
+            colony: { metadataHistory },
+          },
+        } = colonyMetadataHistory;
+        const sortedMetadataHistory = sortMetadataHistory(metadataHistory);
+        const currentMetadataIndex = findLastIndex(
+          sortedMetadataHistory,
+          ({ transaction: { id: hash } }) => hash === transactionHash,
+        );
+        /*
+         * We have a previous metadata entry
+         */
+        if (currentMetadataIndex > 0) {
+          const prevMetadata = sortedMetadataHistory[currentMetadataIndex - 1];
+          if (prevMetadata) {
+            if (prevMetadata.metadata !== metadataIpfsHash) {
+              setMetadataIpfsHash(prevMetadata.metadata);
+            }
 
-          if (metadataJSON) {
-            const prevColonyMetadata = parseColonyMetadata(metadataJSON);
-            /*
-             * If we have a metadata json, parse into the expected values and then
-             * compare them agains the ones from the current action
-             *
-             * This should be the default case for a colony with metadata history
-             */
-            const newMetadataChecks = getSpecificActionValuesCheck(
-              ColonyAndExtensionsEvents.ColonyMetadata,
-              actionData,
-              prevColonyMetadata,
-            );
+            if (metadataJSON) {
+              const prevColonyMetadata = parseColonyMetadata(metadataJSON);
+              /*
+               * If we have a metadata json, parse into the expected values and then
+               * compare them agains the ones from the current action
+               *
+               * This should be the default case for a colony with metadata history
+               */
+              const newMetadataChecks = getSpecificActionValuesCheck(
+                ColonyAndExtensionsEvents.ColonyMetadata,
+                actionData,
+                prevColonyMetadata,
+              );
 
-            if (!isEqual(newMetadataChecks, metadataChecks)) {
-              setMetadataChecks(newMetadataChecks);
+              if (!isEqual(newMetadataChecks, metadataChecks)) {
+                setMetadataChecks(newMetadataChecks);
+              }
             }
           }
-        }
-      } else if (actionData) {
-        /*
-         * We don't have a previous metadata entry, so fall back to the current
-         * action's values if we can
-         */
-        const {
-          colonyDisplayName: actionColonyDisplayName,
-          colonyAvatarHash: actionColonyAvatarHash,
-          colonyTokens: actionColonyTokens,
-          verifiedAddresses: actionVerifiedAddresses,
-        } = actionData;
-        const newMetadataValues = {
-          nameChanged: !!actionColonyDisplayName,
-          logoChanged: !!actionColonyAvatarHash,
-          tokensChanged: !!actionColonyTokens?.length,
-          verifiedAddressesChanged: !!actionVerifiedAddresses?.length,
-        };
+        } else if (actionData) {
+          /*
+           * We don't have a previous metadata entry, so fall back to the current
+           * action's values if we can
+           */
+          const {
+            colonyDisplayName: actionColonyDisplayName,
+            colonyAvatarHash: actionColonyAvatarHash,
+            colonyTokens: actionColonyTokens,
+            verifiedAddresses: actionVerifiedAddresses,
+          } = actionData;
+          const newMetadataValues = {
+            nameChanged: !!actionColonyDisplayName,
+            logoChanged: !!actionColonyAvatarHash,
+            tokensChanged: !!actionColonyTokens?.length,
+            verifiedAddressesChanged: !!actionVerifiedAddresses?.length,
+          };
 
-        if (!isEqual(newMetadataValues, metadataChecks)) {
-          setMetadataChecks(newMetadataValues);
+          if (!isEqual(newMetadataValues, metadataChecks)) {
+            setMetadataChecks(newMetadataValues);
+          }
         }
       }
     }
@@ -129,6 +130,8 @@ export const useColonyMetadataChecks = (
     eventName,
     colonyMetadataHistory,
     transactionHash,
+    metadataChecks,
+    metadataIpfsHash,
     setMetadataIpfsHash,
     metadataJSON,
     actionData,
@@ -136,3 +139,5 @@ export const useColonyMetadataChecks = (
 
   return metadataChecks;
 };
+
+export default useColonyMetadataChecks;

--- a/src/modules/dashboard/hooks/useColonyMetadataChecks.ts
+++ b/src/modules/dashboard/hooks/useColonyMetadataChecks.ts
@@ -28,9 +28,6 @@ const useColonyMetadataChecks = (
 ) => {
   let metadataJSON: string | null = null;
   const [metadataIpfsHash, setMetadataIpfsHash] = useState<string>('');
-  /*
-   * Default fallback, just use the current colony's values
-   */
   const [metadataChecks, setMetadataChecks] = useState<{
     [key: string]: boolean;
   }>({

--- a/src/modules/dashboard/hooks/useColonyMetadataChecks.ts
+++ b/src/modules/dashboard/hooks/useColonyMetadataChecks.ts
@@ -1,0 +1,120 @@
+import findLastIndex from 'lodash/findLastIndex';
+import { useState } from 'react';
+
+import {
+  useSubgraphColonyMetadataQuery,
+  Colony,
+  ColonyAction,
+} from '~data/index';
+import { ipfsDataFetcher } from '~modules/core/fetchers';
+import { ColonyAndExtensionsEvents } from '~types/colonyActions';
+import {
+  getSpecificActionValuesCheck,
+  sortMetadataHistory,
+  parseColonyMetadata,
+} from '~utils/colonyActions';
+import { useDataFetcher } from '~utils/hooks';
+
+/*
+ * Determine if the current medata is different from the previous one,
+ * and in what way
+ */
+export const useColonyMetadataChecks = (
+  eventName: string,
+  colony: Colony,
+  transactionHash: string,
+  actionData: Partial<ColonyAction>,
+) => {
+  let metadataJSON: string | null = null;
+  const [metadataIpfsHash, setMetadataIpfsHash] = useState<string>('');
+
+  const colonyMetadataHistory = useSubgraphColonyMetadataQuery({
+    variables: {
+      address: colony.colonyAddress.toLowerCase(),
+    },
+  });
+
+  try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const { data: ipfsMetadata } = useDataFetcher(
+      ipfsDataFetcher,
+      [metadataIpfsHash as string],
+      [metadataIpfsHash],
+    );
+    metadataJSON = ipfsMetadata;
+  } catch (error) {
+    // silent error
+  }
+
+  if (
+    eventName === ColonyAndExtensionsEvents.ColonyMetadata &&
+    !!colonyMetadataHistory?.data?.colony
+  ) {
+    const {
+      data: {
+        colony: { metadataHistory },
+      },
+    } = colonyMetadataHistory;
+    const sortedMetadataHistory = sortMetadataHistory(metadataHistory);
+    const currentMetadataIndex = findLastIndex(
+      sortedMetadataHistory,
+      ({ transaction: { id: hash } }) => hash === transactionHash,
+    );
+    /*
+     * We have a previous metadata entry
+     */
+    if (currentMetadataIndex > 0) {
+      const prevMetadata = sortedMetadataHistory[currentMetadataIndex - 1];
+      if (prevMetadata) {
+        setMetadataIpfsHash(prevMetadata.metadata);
+        if (metadataJSON) {
+          const prevColonyMetadata = parseColonyMetadata(metadataJSON);
+          /*
+           * If we have a metadata json, parse into the expected values and then
+           * compare them agains the ones from the current action
+           *
+           * This should be the default case for a colony with metadata history
+           */
+          return getSpecificActionValuesCheck(
+            eventName as ColonyAndExtensionsEvents,
+            actionData,
+            prevColonyMetadata,
+          );
+        }
+      }
+    }
+    /*
+     * We don't have a previous metadata entry, so fall back to the current
+     * action's values if we can
+     */
+    if (actionData) {
+      const {
+        colonyDisplayName,
+        colonyAvatarHash,
+        colonyTokens,
+        verifiedAddresses,
+      } = actionData;
+      return {
+        nameChanged: !!colonyDisplayName,
+        logoChanged: !!colonyAvatarHash,
+        tokensChanged: !!colonyTokens?.length,
+        verifiedAddresses: !!verifiedAddresses?.length,
+      };
+    }
+  }
+  /*
+   * Default fallback, just use the current colony's values
+   */
+  const {
+    displayName: colonyDisplayName,
+    avatarHash,
+    tokenAddresses,
+    whitelistedAddresses,
+  } = colony;
+  return {
+    nameChanged: !!colonyDisplayName,
+    logoChanged: !!avatarHash,
+    tokensChanged: !!tokenAddresses?.length,
+    verifiedAddresses: !!whitelistedAddresses?.length,
+  };
+};

--- a/src/modules/dashboard/hooks/useColonyMetadataChecks.ts
+++ b/src/modules/dashboard/hooks/useColonyMetadataChecks.ts
@@ -1,5 +1,6 @@
+import isEqual from 'lodash/isEqual';
 import findLastIndex from 'lodash/findLastIndex';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 import {
   useSubgraphColonyMetadataQuery,
@@ -7,7 +8,7 @@ import {
   ColonyAction,
 } from '~data/index';
 import { ipfsDataFetcher } from '~modules/core/fetchers';
-import { ColonyAndExtensionsEvents } from '~types/colonyActions';
+import { ColonyAndExtensionsEvents, ColonyActions } from '~types/colonyActions';
 import {
   getSpecificActionValuesCheck,
   sortMetadataHistory,
@@ -27,6 +28,17 @@ export const useColonyMetadataChecks = (
 ) => {
   let metadataJSON: string | null = null;
   const [metadataIpfsHash, setMetadataIpfsHash] = useState<string>('');
+  /*
+   * Default fallback, just use the current colony's values
+   */
+  const [metadataChecks, setMetadataChecks] = useState<{
+    [key: string]: boolean;
+  }>({
+    nameChanged: false,
+    logoChanged: false,
+    tokensChanged: false,
+    verifiedAddressesChanged: false,
+  });
 
   const colonyMetadataHistory = useSubgraphColonyMetadataQuery({
     variables: {
@@ -45,76 +57,82 @@ export const useColonyMetadataChecks = (
   } catch (error) {
     // silent error
   }
+  useEffect(() => {
+    if (
+      (eventName === ColonyAndExtensionsEvents.ColonyMetadata ||
+        eventName === ColonyActions.ColonyEdit) &&
+      !!colonyMetadataHistory?.data?.colony
+    ) {
+      const {
+        data: {
+          colony: { metadataHistory },
+        },
+      } = colonyMetadataHistory;
+      const sortedMetadataHistory = sortMetadataHistory(metadataHistory);
+      const currentMetadataIndex = findLastIndex(
+        sortedMetadataHistory,
+        ({ transaction: { id: hash } }) => hash === transactionHash,
+      );
+      /*
+       * We have a previous metadata entry
+       */
+      if (currentMetadataIndex > 0) {
+        const prevMetadata = sortedMetadataHistory[currentMetadataIndex - 1];
+        if (prevMetadata) {
+          if (prevMetadata.metadata !== metadataIpfsHash) {
+            setMetadataIpfsHash(prevMetadata.metadata);
+          }
 
-  if (
-    eventName === ColonyAndExtensionsEvents.ColonyMetadata &&
-    !!colonyMetadataHistory?.data?.colony
-  ) {
-    const {
-      data: {
-        colony: { metadataHistory },
-      },
-    } = colonyMetadataHistory;
-    const sortedMetadataHistory = sortMetadataHistory(metadataHistory);
-    const currentMetadataIndex = findLastIndex(
-      sortedMetadataHistory,
-      ({ transaction: { id: hash } }) => hash === transactionHash,
-    );
-    /*
-     * We have a previous metadata entry
-     */
-    if (currentMetadataIndex > 0) {
-      const prevMetadata = sortedMetadataHistory[currentMetadataIndex - 1];
-      if (prevMetadata) {
-        setMetadataIpfsHash(prevMetadata.metadata);
-        if (metadataJSON) {
-          const prevColonyMetadata = parseColonyMetadata(metadataJSON);
-          /*
-           * If we have a metadata json, parse into the expected values and then
-           * compare them agains the ones from the current action
-           *
-           * This should be the default case for a colony with metadata history
-           */
-          return getSpecificActionValuesCheck(
-            eventName as ColonyAndExtensionsEvents,
-            actionData,
-            prevColonyMetadata,
-          );
+          if (metadataJSON) {
+            const prevColonyMetadata = parseColonyMetadata(metadataJSON);
+            /*
+             * If we have a metadata json, parse into the expected values and then
+             * compare them agains the ones from the current action
+             *
+             * This should be the default case for a colony with metadata history
+             */
+            const newMetadataChecks = getSpecificActionValuesCheck(
+              ColonyAndExtensionsEvents.ColonyMetadata,
+              actionData,
+              prevColonyMetadata,
+            );
+
+            if (!isEqual(newMetadataChecks, metadataChecks)) {
+              setMetadataChecks(newMetadataChecks);
+            }
+          }
+        }
+      } else if (actionData) {
+        /*
+         * We don't have a previous metadata entry, so fall back to the current
+         * action's values if we can
+         */
+        const {
+          colonyDisplayName: actionColonyDisplayName,
+          colonyAvatarHash: actionColonyAvatarHash,
+          colonyTokens: actionColonyTokens,
+          verifiedAddresses: actionVerifiedAddresses,
+        } = actionData;
+        const newMetadataValues = {
+          nameChanged: !!actionColonyDisplayName,
+          logoChanged: !!actionColonyAvatarHash,
+          tokensChanged: !!actionColonyTokens?.length,
+          verifiedAddressesChanged: !!actionVerifiedAddresses?.length,
+        };
+
+        if (!isEqual(newMetadataValues, metadataChecks)) {
+          setMetadataChecks(newMetadataValues);
         }
       }
     }
-    /*
-     * We don't have a previous metadata entry, so fall back to the current
-     * action's values if we can
-     */
-    if (actionData) {
-      const {
-        colonyDisplayName,
-        colonyAvatarHash,
-        colonyTokens,
-        verifiedAddresses,
-      } = actionData;
-      return {
-        nameChanged: !!colonyDisplayName,
-        logoChanged: !!colonyAvatarHash,
-        tokensChanged: !!colonyTokens?.length,
-        verifiedAddresses: !!verifiedAddresses?.length,
-      };
-    }
-  }
-  /*
-   * Default fallback, just use the current colony's values
-   */
-  const {
-    displayName: colonyDisplayName,
-    avatarHash,
-    tokenAddresses,
-    whitelistedAddresses,
-  } = colony;
-  return {
-    nameChanged: !!colonyDisplayName,
-    logoChanged: !!avatarHash,
-    tokensChanged: !!tokenAddresses?.length,
-    verifiedAddresses: !!whitelistedAddresses?.length,
-  };
+  }, [
+    eventName,
+    colonyMetadataHistory,
+    transactionHash,
+    setMetadataIpfsHash,
+    metadataJSON,
+    actionData,
+  ]);
+
+  return metadataChecks;
 };

--- a/src/utils/colonyActions.ts
+++ b/src/utils/colonyActions.ts
@@ -1,6 +1,6 @@
+import { ColonyRole } from '@colony/colony-js';
 import sortBy from 'lodash/sortBy';
 import isEqual from 'lodash/isEqual';
-import { ColonyRole } from '@colony/colony-js';
 
 import {
   ColonyActions,
@@ -319,8 +319,10 @@ export const getSpecificActionValuesCheck = (
     case ColonyAndExtensionsEvents.ColonyMetadata: {
       const nameChanged = prevColonyDisplayName !== currentColonyDisplayName;
       const logoChanged = prevColonyAvatarHash !== currentColonyAvatarHash;
-      const verifiedAddressesChanged =
-        prevVerifiedAddresses !== currentVerifiedAddresses;
+      const verifiedAddressesChanged = !isEqual(
+        prevVerifiedAddresses,
+        currentVerifiedAddresses,
+      );
       /*
        * Tokens arrays might come from a subgraph query, in which case
        * they're not really "arrays", so we have to create a new instace of

--- a/src/utils/events/index.ts
+++ b/src/utils/events/index.ts
@@ -449,10 +449,6 @@ const getVersionUpgradeActionValues = async (
 const getColonyEditActionValues = async (
   processedEvents: ProcessedEvent[],
 ): Promise<Partial<ActionValues>> => {
-  let colonyDisplayName = null;
-  let colonyAvatarHash = null;
-  let colonyTokens = [];
-
   const colonyMetadataEvent = processedEvents.find(
     ({ name }) => name === ColonyAndExtensionsEvents.ColonyMetadata,
   ) as ProcessedEvent;
@@ -461,6 +457,23 @@ const getColonyEditActionValues = async (
     address,
     values: { agent, metadata },
   } = colonyMetadataEvent;
+
+  const colonyEditValues: {
+    address: Address;
+    actionInitiator?: string;
+    colonyDisplayName: string | null;
+    colonyAvatarHash?: string | null;
+    colonyTokens?: string[];
+    isWhitelistActivated?: boolean;
+    verifiedAddresses?: string[];
+  } = {
+    address,
+    colonyDisplayName: null,
+    colonyAvatarHash: null,
+    colonyTokens: [],
+    isWhitelistActivated: false,
+    verifiedAddresses: [],
+  };
 
   /*
    * Fetch the colony's metadata
@@ -478,14 +491,18 @@ const getColonyEditActionValues = async (
   try {
     if (ipfsMetadata) {
       const {
-        colonyDisplayName: displayName,
-        colonyAvatarHash: avatarHash,
-        colonyTokens: tokenAddresses,
+        colonyDisplayName,
+        colonyAvatarHash,
+        colonyTokens,
+        isWhitelistActivated,
+        verifiedAddresses,
       } = JSON.parse(ipfsMetadata);
 
-      colonyDisplayName = displayName;
-      colonyAvatarHash = avatarHash;
-      colonyTokens = tokenAddresses;
+      colonyEditValues.colonyDisplayName = colonyDisplayName;
+      colonyEditValues.colonyAvatarHash = colonyAvatarHash;
+      colonyEditValues.colonyTokens = colonyTokens;
+      colonyEditValues.isWhitelistActivated = isWhitelistActivated;
+      colonyEditValues.verifiedAddresses = verifiedAddresses;
     }
   } catch (error) {
     log.verbose(
@@ -495,19 +512,6 @@ const getColonyEditActionValues = async (
       ipfsMetadata,
     );
   }
-
-  const colonyEditValues: {
-    address: Address;
-    actionInitiator?: string;
-    colonyDisplayName: string | null;
-    colonyAvatarHash?: string | null;
-    colonyTokens?: string[];
-  } = {
-    address,
-    colonyDisplayName,
-    colonyAvatarHash,
-    colonyTokens,
-  };
 
   if (agent) {
     colonyEditValues.actionInitiator = agent;


### PR DESCRIPTION
Added `useColonyMetadataChecks` hook for whenever we need to know what changed in an event or action. This is mostly used right now to change the action and event titles of the colony edit actions like adding an address to the whitelist.

The hook right is present and working in:
- The action page of the ColonyEdit action (Action page title, and event title in action's feed).
- The action list item displaying any ColonyMetadata/ColonyEdit event (item's title).

![FireShot Capture 585 - Colony details changed - Action - Colony - wonker - localhost](https://user-images.githubusercontent.com/18473896/165991822-4e39d028-ce58-4594-927c-5868b2222108.png)

![FireShot Capture 584 - Actions - Colony - wonker - localhost](https://user-images.githubusercontent.com/18473896/165991859-174c9134-49bd-4fde-b3a7-004f343aa741.png)

Resolves #3336 
