### PR TITLE
Update Verified Recipients labels and copy

### DIFF
--- a/src/modules/core/components/UploadAddresses/UploadAddresses.tsx
+++ b/src/modules/core/components/UploadAddresses/UploadAddresses.tsx
@@ -36,6 +36,7 @@ interface Props {
   toggleShowInput: () => void;
   formSuccess?: boolean;
   setFormSuccess?: (isSuccess: boolean) => void;
+  inputLabelMsg?: MessageDescriptor | undefined;
   inputSuccessMsg?: MessageDescriptor | undefined;
   fileSuccessMsg?: MessageDescriptor | undefined;
 }
@@ -48,6 +49,7 @@ const UploadAddresses = ({
   toggleShowInput,
   formSuccess,
   setFormSuccess,
+  inputLabelMsg = MSG.inputLabel,
   inputSuccessMsg,
   fileSuccessMsg,
 }: Props) => {
@@ -93,7 +95,7 @@ const UploadAddresses = ({
     <>
       <div className={styles.actionsContainer}>
         <InputLabel
-          label={showInput ? MSG.inputLabel : MSG.uploadLabel}
+          label={showInput ? inputLabelMsg : MSG.uploadLabel}
           appearance={{ colorSchema: 'grey' }}
         />
         <div className={styles.actionsSubContainer}>

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -47,7 +47,7 @@ const MSG = defineMessages({
   },
   manageWhitelist: {
     id: 'dashboard.ColonyMembers.manageWhitelist',
-    defaultMessage: 'Manage whitelist',
+    defaultMessage: 'Manage verified addresses',
   },
   loadingText: {
     id: 'dashboard.ColonyMembers.loadingText',

--- a/src/modules/dashboard/components/Dialogs/AdvancedDialog/AdvancedDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/AdvancedDialog/AdvancedDialog.tsx
@@ -85,12 +85,12 @@ const MSG = defineMessages({
   },
   manageWhitelistTitle: {
     id: 'dashboard.AdvancedDialog.manageWhitelistTitle',
-    defaultMessage: 'Manage whitelist',
+    defaultMessage: 'Manage verified addresses',
   },
   manageWhitelistDescription: {
     id: 'dashboard.AdvancedDialog.manageWhitelistDescription',
     defaultMessage:
-      'Get warned when taking an action to addresses not on the whitelist.',
+      'Get warned when taking an action to addresses not on the verified list.',
   },
 });
 

--- a/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/ManageWhitelistActiveToggle.tsx
+++ b/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/ManageWhitelistActiveToggle.tsx
@@ -18,11 +18,11 @@ const MSG = defineMessages({
   },
   headerTitle: {
     id: `dashboard.ManageWhitelistDialog.ManageWhitelistDialogForm.ManageWhitelistActiveToggle.headerTitle`,
-    defaultMessage: 'Whitelisted addresses',
+    defaultMessage: 'Verified addresses',
   },
   tooltipText: {
     id: `dashboard.ManageWhitelistDialog.ManageWhitelistDialogForm.ManageWhitelistActiveToggle.tooltipText`,
-    defaultMessage: `Whitelist is active by default once at least one address is added to the list. You can turn this feature “Off” to deactivate the whitelist. Use with caution.`,
+    defaultMessage: `Verified addresses is active by default once at least one address is added to the list. You can turn this feature “Off” to deactivate. Use with caution.`,
   },
   warningText: {
     id: `dashboard.ManageWhitelistDialog.ManageWhitelistDialogForm.ManageWhitelistActiveToggle.warningText`,

--- a/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/ManageWhitelistDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/ManageWhitelistDialogForm.tsx
@@ -26,7 +26,7 @@ import styles from './ManageWhitelistDialogForm.css';
 const MSG = defineMessages({
   title: {
     id: 'dashboard.ManageWhitelistDialog.ManageWhitelistDialogForm.title',
-    defaultMessage: 'Manage whitelist',
+    defaultMessage: 'Manage verified addresses',
   },
   annotation: {
     id: `dashboard.ManageWhitelistDialog.ManageWhitelistDialogForm.annotation`,
@@ -44,11 +44,15 @@ const MSG = defineMessages({
   },
   whitelisted: {
     id: 'dashboard.ManageWhitelistDialog.ManageWhitelistDialogForm.whitelisted',
-    defaultMessage: 'Whitelisted',
+    defaultMessage: 'Verified addresses',
+  },
+  inputLabel: {
+    id: `dashboard.ManageWhitelistDialog.ManageWhitelistDialogForm.inputLabel`,
+    defaultMessage: `Add wallet address to verified address list.`,
   },
   inputSuccess: {
     id: `dashboard.ManageWhitelistDialog.ManageWhitelistDialogForm.inputSuccess`,
-    defaultMessage: `Address is whitelisted now. You can add another one or close modal.`,
+    defaultMessage: `Address is verified now. You can add another one or close modal.`,
   },
   fileSuccess: {
     id: `dashboard.ManageWhitelistDialog.ManageWhitelistDialogForm.fileSuccess`,
@@ -134,6 +138,7 @@ const ManageWhitelistDialogForm = ({
               toggleShowInput={toggleShowInput}
               formSuccess={formSuccess}
               setFormSuccess={(isSuccess) => setFormSuccess(isSuccess)}
+              inputLabelMsg={MSG.inputLabel}
               inputSuccessMsg={MSG.inputSuccess}
               fileSuccessMsg={MSG.fileSuccess}
             />

--- a/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/NoWhitelistedAddressesState/NoWhitelistedAddressesState.tsx
+++ b/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/NoWhitelistedAddressesState/NoWhitelistedAddressesState.tsx
@@ -6,7 +6,7 @@ import styles from './NoWhitelistedAddressesState.css';
 const MSG = defineMessages({
   title: {
     id: `dashboard.ManageWhitelistDialog.NoWhitelistedAddressesState.title`,
-    defaultMessage: 'There are no whitelisted addresses yet.',
+    defaultMessage: 'There are no verified addresses yet.',
   },
   desc: {
     id: `dashboard.ManageWhitelistDialog.NoWhitelistedAddressesState.desc`,

--- a/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/WhitelistedAddresses/WhitelistedAddresses.tsx
+++ b/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/WhitelistedAddresses/WhitelistedAddresses.tsx
@@ -20,11 +20,11 @@ const MSG = defineMessages({
   },
   checkedTooltipText: {
     id: `dashboard.ManageWhitelistDialog.WhitelistedAddresses.checkedTooltipText`,
-    defaultMessage: `User is added to the whitelist. Uncheck if you wish to remove this user`,
+    defaultMessage: `User is added to the verified address list. Uncheck to remove.`,
   },
   unCheckedTooltipText: {
     id: `dashboard.ManageWhitelistDialog.WhitelistedAddresses.unCheckedTooltipText`,
-    defaultMessage: `User will be removed from the whitelist`,
+    defaultMessage: `User will be removed from the verified address list.`,
   },
 });
 


### PR DESCRIPTION
## Description

It has been identified during QA that there is confusion between the Whitelist feature and the Whitelist Extension. Therefore, new copy has been suggested for each of the labels and the copy used within this feature.

Spec is located here - [Figma Link](https://www.figma.com/file/Phby7kEYihhvGgQn69A314/Verified-Recipients?node-id=670%3A15354)

**Changes** 🏗

* Copy changes in various locations for Verified Recipients feature
* Added new prop to allow input label change on Upload Addresses component

Resolves #3338
