### PR TITLE
Added IconTooltip sizing + copy update

### DIFF
--- a/src/modules/core/components/MembersList/MembersListItem.tsx
+++ b/src/modules/core/components/MembersList/MembersListItem.tsx
@@ -35,7 +35,7 @@ interface Props<U> {
 const MSG = defineMessages({
   whitelistedTooltip: {
     id: 'core.MembersList.MembersListItem.whitelistedTooltip',
-    defaultMessage: `Address added to whitelist`,
+    defaultMessage: `Added to verified address list`,
   },
 });
 
@@ -150,6 +150,7 @@ const MembersListItem = <U extends AnyUser = AnyUser>(props: Props<U>) => {
                   placement: 'top',
                   strategy: 'fixed',
                 }}
+                appearance={{ size: 'medium' }}
                 className={styles.whitelistedIcon}
               />
             )}


### PR DESCRIPTION
## Description

Adds appearance size prop to `IconTooltip` component, which was affected by the rebase of the parent branch and the refactor of the IconTooltip on master.

Plus also a copy update in the tooltip.

![1dceeccf-4946-40f9-bde2-62bc7861e631](https://user-images.githubusercontent.com/33682027/166454012-fbf9bfad-521b-43ff-ae1a-b3ac863d11d8.png)


Resolves #3332
