### PR TITLE
Display important copy to warn about Award Reputation

### DIFF
--- a/src/modules/dashboard/components/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.css
+++ b/src/modules/dashboard/components/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.css
@@ -84,3 +84,38 @@
   font-size: var(--size-medium);
   color: var(--dark);
 }
+
+.warningContainer {
+  margin: 20px 0 8px 0;
+}
+
+.warningTitle {
+  font-size: var(--size-smallish);
+  font-weight: var(--weight-bold);
+  color: var(--pink);
+}
+
+.warningText {
+  margin-top: 2px;
+  font-size: var(--size-normal);
+  font-weight: var(--weight-normal);
+  color: var(--dark);
+}
+
+.divider {
+  margin: 0px 0 6px 0;
+  height: 1px;
+  width: 100%;
+  background-color: color-mod(var(--temp-grey-blue-7) alpha(15%));
+}
+
+.link {
+  font-size: var(--size-small);
+  font-weight: var(--weight-bold);
+  color: var(--sky-blue);
+
+  &:hover {
+    text-decoration: underline;
+    color: var(--dark-blue);
+  }
+}

--- a/src/modules/dashboard/components/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.css.d.ts
@@ -9,3 +9,8 @@ export const inputText: string;
 export const activeItem: string;
 export const motionVoteDomain: string;
 export const percentageSign: string;
+export const warningContainer: string;
+export const warningTitle: string;
+export const warningText: string;
+export const divider: string;
+export const link: string;

--- a/src/modules/dashboard/components/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.tsx
@@ -19,6 +19,8 @@ import PermissionRequiredInfo from '~core/PermissionRequiredInfo';
 import NotEnoughReputation from '~dashboard/NotEnoughReputation';
 import PermissionsLabel from '~core/PermissionsLabel';
 import Numeral from '~core/Numeral';
+import ExternalLink from '~core/ExternalLink';
+import { REPUTATION_LEARN_MORE } from '~externalUrls';
 
 import { Address } from '~types/index';
 import HookedUserAvatar from '~users/HookedUserAvatar';
@@ -46,8 +48,8 @@ const MSG = defineMessages({
   title: {
     id: 'dashboard.ManageReputationContainer.ManageReputationDialogForm.title',
     defaultMessage: `{isSmiteAction, select,
-      true {Smite}
-      false {Award}
+      true {Smite Reputation}
+      false {Award Reputation}
     }`,
   },
   team: {
@@ -92,6 +94,14 @@ const MSG = defineMessages({
       one {pt}
       other {pts}
     } ({userPercentageReputation}%)`,
+  },
+  warningTitle: {
+    id: `dashboard.ManageReputationContainer.ManageReputationDialogForm.warningTitle`,
+    defaultMessage: `Caution!`,
+  },
+  warningText: {
+    id: `dashboard.ManageReputationContainer.ManageReputationDialogForm.noPermission`,
+    defaultMessage: `Improper use of this feature can break your colony. <a>Learn more</a>`,
   },
 });
 
@@ -305,8 +315,31 @@ const ManageReputationDialogForm = ({
               />
             )}
           </div>
+          {!isSmiteAction && (
+            <div className={styles.warningContainer}>
+              <p className={styles.warningTitle}>
+                <FormattedMessage {...MSG.warningTitle} />
+              </p>
+              <p className={styles.warningText}>
+                <FormattedMessage
+                  {...MSG.warningText}
+                  values={{
+                    a: (chunks) => (
+                      <ExternalLink
+                        href={REPUTATION_LEARN_MORE}
+                        className={styles.link}
+                      >
+                        {chunks}
+                      </ExternalLink>
+                    ),
+                  }}
+                />
+              </p>
+            </div>
+          )}
         </div>
       </DialogSection>
+      {!isSmiteAction && <hr className={styles.divider} />}
       {!userHasPermission && (
         <DialogSection>
           <PermissionRequiredInfo requiredRoles={[ColonyRole.Arbitration]} />

--- a/src/modules/dashboard/components/Dialogs/ManageReputationDialog/ManageReputationDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/ManageReputationDialog/ManageReputationDialog.tsx
@@ -18,7 +18,7 @@ const MSG = defineMessages({
   },
   awardReputationTitle: {
     id: 'dashboard.ManageReputationDialog.awardReputationTitle',
-    defaultMessage: 'Award reputation',
+    defaultMessage: 'Award Reputation',
   },
   awardReputationDescription: {
     id: 'dashboard.ManageReputationDialog.awardReputationDescription',
@@ -31,12 +31,12 @@ const MSG = defineMessages({
   },
   smiteReputationTitle: {
     id: 'dashboard.ManageReputationDialog.smiteReputationTitle',
-    defaultMessage: 'Smite',
+    defaultMessage: 'Smite Reputation',
   },
   smiteReputationDescription: {
     id: 'dashboard.ManageReputationDialog.smiteReputationDescription',
     defaultMessage:
-      'Punish undesirable behaviour by deducting Reputation points.',
+      'Punish undesirable behaviour by deducting reputation points.',
   },
 });
 

--- a/src/modules/externalUrls.ts
+++ b/src/modules/externalUrls.ts
@@ -44,3 +44,8 @@ export const WALLET_CONNECT_XDAI = `https://colony.gitbook.io/colony/get-started
  * Recovery Mode
  */
 export const RECOVERY_HELP = `https://colony.gitbook.io/colony/advanced-features/recovery-mode`;
+
+/*
+ * Reputation & Smite
+ */
+export const REPUTATION_LEARN_MORE = `https://colony.gitbook.io/colony/key-concepts/reputation`;

--- a/src/modules/externalUrls.ts
+++ b/src/modules/externalUrls.ts
@@ -48,4 +48,4 @@ export const RECOVERY_HELP = `https://colony.gitbook.io/colony/advanced-features
 /*
  * Reputation & Smite
  */
-export const REPUTATION_LEARN_MORE = `https://colony.gitbook.io/colony/key-concepts/reputation`;
+export const REPUTATION_LEARN_MORE = `https://colony.gitbook.io/colony/key-concepts/reputation/award-reputation`;


### PR DESCRIPTION
## Description

This PR displays copy to warn about exercising caution when using Award Reputation (not shown on Smite dialog).


<img width="619" alt="Screenshot 2022-05-03 at 19 05 03" src="https://user-images.githubusercontent.com/582700/166503519-925e7f26-99cf-4a47-97dc-a41f13f17908.png">


I added a few extra minor fixes that were bothering me as i frequently navigated to the dialog. These include:

1- (Award) reputation should be capitalised
2- Smite should be 'Smite Reputation'
3- Within the descriptions capitalisation of 'reputation' should consistent
4-(in Smite dialog) Title currently 'Smite' should be 'Smite Reputation'

<img width="524" alt="Screenshot 2022-05-03 at 17 06 52" src="https://user-images.githubusercontent.com/582700/166503315-6f3b6d5c-b988-40ac-a158-56600b742ba9.png">



Resolves #3337
