### PR TITLE
Fix `ActionsListItem` decimals logic

### DIFF
--- a/src/modules/core/components/ActionsList/ActionsListItem.tsx
+++ b/src/modules/core/components/ActionsList/ActionsListItem.tsx
@@ -193,7 +193,8 @@ const ActionsListItem = ({
         MotionState.Invalid
     ];
 
-  const decimals = tokenData?.tokenInfo?.decimals || colonyTokenDecimals;
+  const decimals =
+    tokenData?.tokenInfo?.decimals || Number(colonyTokenDecimals);
   const symbol = tokenData?.tokenInfo?.symbol || colonyTokenSymbol;
   const formattedReputationChange = getFormattedTokenValue(
     new Decimal(reputationChange || '0').abs().toString(),


### PR DESCRIPTION
## Description

This PR fixes the logic for decimals in `ActionsListItem`. The problem was that the data coming from the subgraph subscription gave decimals as string - in the case of USDC "6".  The check in `getTokenDecimalsWithFallback` then gave false and provided a fallback value of 18.

After the update:

<img width="767" alt="Screenshot 2022-05-09 at 13 59 21" src="https://user-images.githubusercontent.com/34057551/167406134-243d8ee2-3786-4800-ae95-2494a306b297.png">

Before the update:

<img width="754" alt="Screenshot 2022-05-09 at 13 59 44" src="https://user-images.githubusercontent.com/34057551/167406152-30d3165e-6da1-4df4-af3d-ae5fc9cac0ca.png">

To test and fix the bug I took the actual production data for the Shapeshift colony. To test it yourself you just need to put the below object instead of `useSubgraphOneTxSubscription` (line 104 in `ColonyActions` file):

```
const { data: oneTxActions, loading: oneTxActionsLoading } = {
  loading: false,
  data: {
    oneTxPayments: [
      {
        id: '0x725cdb48f0ea078e46e96b0b6cd2027b97b99b83_oneTxPayment_1_752',
        agent: '0xf42d88b0b95a6495af8d5044a64a6fdd67bcbffb',
        transaction: {
          hash:
            '0x63d59dce2c49ba6646093727fb056ee170f5967aae9bf30dafdcf690590889db',
          block: {
            id: 'block_21942060',
            timestamp: '1651527420',
          },
        },
        payment: {
          to: '0x322c6ac38abdc6a868268b830f8b8c03f5dd204f',
          domain: {
            ethDomainId: '6',
            name: 'Team #6',
          },
          fundingPot: {
            fundingPotPayouts: [
              {
                id:
                  '0x725cdb48f0ea078e46e96b0b6cd2027b97b99b83_fundingpot_766_0xddafbb505ad214d7b80b1f830fccc89b60fb7a83',
                token: {
                  address: '0xddafbb505ad214d7b80b1f830fccc89b60fb7a83',
                  symbol: 'USDC',
                  decimals: '6',
                },
                amount: '59500000000',
              },
            ],
          },
        },
        timestamp: '1651527420',
      },
    ],
  },
};
```


**Changes** 🏗

- update `ActionsListItem` file
 
resolves #3368 
