### PR TITLE
Fix CreateDomainButton icon going out of bounds

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyDomainSelector/CreateDomainButton.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyDomainSelector/CreateDomainButton.css
@@ -9,10 +9,11 @@
 .main {
   composes: button from "~styles/reset.css";
   display: flex;
-  align-items: center;
   justify-content: center;
+  align-items: center;
   height: 38px;
   width: 199px;
+  position: relative;
   border-radius: 15px;
   font-size: var(--size-small);
   font-weight: var(--weight-bold);
@@ -32,6 +33,5 @@
 
 .buttonIcon {
   position: absolute;
-  bottom: 10px;
-  left: 66px;
+  left: 0;
 }


### PR DESCRIPTION
This was just a classic case of an `absolute` element not being inside a `relative` container.

![FireShot Capture 590 - Actions - Colony - wonker - localhost](https://user-images.githubusercontent.com/18473896/167505228-c68d09bc-f71d-4eaf-be0b-9708eccfc510.png)

Resolves #3373 
