### PR TITLE
Members list update: contributors vs. watchers

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.tsx
@@ -25,7 +25,7 @@ import styles from './ColonyMembers.css';
 const MSG = defineMessages({
   title: {
     id: 'dashboard.ColonyHome.ColonyMembers.title',
-    defaultMessage: `Members{hasCounter, select,
+    defaultMessage: `Contributors{hasCounter, select,
       true { ({count})}
       false {}
     }`,


### PR DESCRIPTION
### **Story**

As a colony owner, I would like to recognize who is the admin of a team, so I can find quickly who is accountable for administrative decisions. 

As a colony admin, I would like to find someone new I can assign to an onboarding task, so this person could earn reputation.

As a new community member, I would like to watch what is happening within a colony, so if interesting task appears I could contribute. 

### **Description**

There is no distinction of users who hold permissions and reputation and those who do not. By introducing a separation of members and watchers, we make it easier to recognize who is team member and who is just watching a colony.

Which, can also make it easier to find users to perform actions and tasks.

Core elements: