### PR TITLE
Update members list's items in the Members page

### DIFF
--- a/src/modules/core/components/MemberReputation/MemberReputation.css
+++ b/src/modules/core/components/MemberReputation/MemberReputation.css
@@ -14,6 +14,16 @@
   color: reputationColor;
 }
 
+.reputationPointsContainer {
+  margin-left: 3px;
+  height: 23px;
+}
+
+.reputationPoints {
+  composes: reputation;
+  font-weight: var(--weight-normal);
+}
+
 .icon {
   height: 11px;
   width: 11px;

--- a/src/modules/core/components/MemberReputation/MemberReputation.css.d.ts
+++ b/src/modules/core/components/MemberReputation/MemberReputation.css.d.ts
@@ -1,4 +1,6 @@
 export const reputationColor: string;
 export const reputationWrapper: string;
 export const reputation: string;
+export const reputationPointsContainer: string;
+export const reputationPoints: string;
 export const icon: string;

--- a/src/modules/core/components/MemberReputation/MemberReputation.tsx
+++ b/src/modules/core/components/MemberReputation/MemberReputation.tsx
@@ -4,6 +4,7 @@ import { ROOT_DOMAIN_ID } from '@colony/colony-js';
 import { AddressZero } from 'ethers/constants';
 import Decimal from 'decimal.js';
 
+import { DEFAULT_TOKEN_DECIMALS } from '~constants';
 import { useUserReputationQuery } from '~data/index';
 import { Address } from '~types/index';
 import Numeral from '~core/Numeral';
@@ -32,6 +33,7 @@ interface Props {
   onReputationLoaded?: (reputationLoaded: boolean) => void;
   showIconTitle?: boolean;
   showReputationPoints?: boolean;
+  nativeTokenDecimals?: number;
 }
 
 const displayName = 'MemberReputation';
@@ -44,6 +46,7 @@ const MemberReputation = ({
   onReputationLoaded = () => null,
   showIconTitle = true,
   showReputationPoints = false,
+  nativeTokenDecimals = DEFAULT_TOKEN_DECIMALS,
 }: Props) => {
   const { data: userReputationData } = useUserReputationQuery({
     variables: { address: walletAddress, colonyAddress, domainId, rootHash },
@@ -66,7 +69,7 @@ const MemberReputation = ({
   );
   const formattedReputationPoints = getFormattedTokenValue(
     new Decimal(userReputationData?.userReputation || 0).toString(),
-    18,
+    nativeTokenDecimals,
   );
 
   useEffect(() => {

--- a/src/modules/core/components/MemberReputation/MemberReputation.tsx
+++ b/src/modules/core/components/MemberReputation/MemberReputation.tsx
@@ -2,16 +2,16 @@ import React, { useEffect } from 'react';
 import { defineMessages } from 'react-intl';
 import { ROOT_DOMAIN_ID } from '@colony/colony-js';
 import { AddressZero } from 'ethers/constants';
-
 import Decimal from 'decimal.js';
+
 import { useUserReputationQuery } from '~data/index';
 import { Address } from '~types/index';
 import Numeral from '~core/Numeral';
 import Icon from '~core/Icon';
 import { calculatePercentageReputation, ZeroValue } from '~utils/reputation';
+import { getFormattedTokenValue } from '~utils/tokens';
 
 import styles from './MemberReputation.css';
-import { getFormattedTokenValue } from '~utils/tokens';
 
 const MSG = defineMessages({
   starReputationTitle: {

--- a/src/modules/core/components/MemberReputation/MemberReputation.tsx
+++ b/src/modules/core/components/MemberReputation/MemberReputation.tsx
@@ -3,6 +3,7 @@ import { defineMessages } from 'react-intl';
 import { ROOT_DOMAIN_ID } from '@colony/colony-js';
 import { AddressZero } from 'ethers/constants';
 
+import Decimal from 'decimal.js';
 import { useUserReputationQuery } from '~data/index';
 import { Address } from '~types/index';
 import Numeral from '~core/Numeral';
@@ -10,6 +11,7 @@ import Icon from '~core/Icon';
 import { calculatePercentageReputation, ZeroValue } from '~utils/reputation';
 
 import styles from './MemberReputation.css';
+import { getFormattedTokenValue } from '~utils/tokens';
 
 const MSG = defineMessages({
   starReputationTitle: {
@@ -29,6 +31,7 @@ interface Props {
   rootHash?: string;
   onReputationLoaded?: (reputationLoaded: boolean) => void;
   showIconTitle?: boolean;
+  showReputationPoints?: boolean;
 }
 
 const displayName = 'MemberReputation';
@@ -40,6 +43,7 @@ const MemberReputation = ({
   rootHash,
   onReputationLoaded = () => null,
   showIconTitle = true,
+  showReputationPoints = false,
 }: Props) => {
   const { data: userReputationData } = useUserReputationQuery({
     variables: { address: walletAddress, colonyAddress, domainId, rootHash },
@@ -59,6 +63,10 @@ const MemberReputation = ({
   const userPercentageReputation = calculatePercentageReputation(
     userReputationData?.userReputation,
     totalReputation?.userReputation,
+  );
+  const formattedReputationPoints = getFormattedTokenValue(
+    new Decimal(userReputationData?.userReputation || 0).toString(),
+    18,
   );
 
   useEffect(() => {
@@ -92,6 +100,17 @@ const MemberReputation = ({
             suffix="%"
           />
         )}
+      {showReputationPoints && (
+        <div className={styles.reputationPointsContainer}>
+          <span className={styles.reputationPoints}>(</span>
+          <Numeral
+            className={styles.reputationPoints}
+            appearance={{ theme: 'primary' }}
+            value={formattedReputationPoints}
+            suffix="pts)"
+          />
+        </div>
+      )}
       <Icon
         name="star"
         appearance={{ size: 'extraTiny' }}

--- a/src/modules/core/components/MembersList/Actions/MemberActions.css
+++ b/src/modules/core/components/MembersList/Actions/MemberActions.css
@@ -1,0 +1,40 @@
+.actionsButton {
+  padding: 0;
+  height: 18px;
+  width: 8px;
+  position: relative;
+  border: 1px solid transparent;
+  border-radius: var(--radius-small);
+  background: transparent;
+  cursor: pointer;
+}
+
+.actionsButton:focus {
+  outline: 0;
+}
+
+.activeDropdown,
+.actionsButton:hover {
+  border-color: var(--action-secondary);
+}
+
+.actionsIcon {
+  height: 10px;
+  width: 10px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  fill: var(--temp-grey-blue-7);
+}
+
+.actionsIcon svg {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.activeDropdown .actionsIcon,
+.actionsButton:hover .actionsIcon {
+  fill: var(--action-secondary);
+}

--- a/src/modules/core/components/MembersList/Actions/MemberActions.css.d.ts
+++ b/src/modules/core/components/MembersList/Actions/MemberActions.css.d.ts
@@ -1,0 +1,3 @@
+export const actionsButton: string;
+export const activeDropdown: string;
+export const actionsIcon: string;

--- a/src/modules/core/components/MembersList/Actions/MemberActions.tsx
+++ b/src/modules/core/components/MembersList/Actions/MemberActions.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import { defineMessages } from 'react-intl';
+import classnames from 'classnames';
+
+import Icon from '~core/Icon';
+import Popover from '~core/Popover';
+
+import MemberActionsPopover from './MemberActionsPopover';
+
+import styles from './MemberActions.css';
+
+const MSG = defineMessages({
+  memberActionsTitle: {
+    id: 'core.MemberList.MemberActions.MemberActionTitle',
+    defaultMessage: 'Member Actions',
+  },
+});
+
+interface Props {
+  currentUserPermission: string;
+  colonyAddress: string;
+  userAddress: string;
+}
+
+const displayName = 'core.MemberList.MemberActions';
+
+const MemberActions = ({
+  currentUserPermission,
+  colonyAddress,
+  userAddress,
+}: Props) => {
+  const [isOpen, setOpen] = useState(false);
+  return (
+    <Popover
+      content={({ close }) => (
+        <MemberActionsPopover
+          closePopover={close}
+          currentUserPermission={currentUserPermission}
+          colonyAddress={colonyAddress}
+          userAddress={userAddress}
+        />
+      )}
+      trigger="click"
+      showArrow={false}
+      placement="right"
+      isOpen={isOpen}
+      onClose={() => setOpen(false)}
+      popperOptions={{
+        modifiers: [
+          {
+            name: 'offset',
+            options: {
+              offset: [40, 15],
+            },
+          },
+        ],
+      }}
+    >
+      {({ ref, id }) => (
+        <button
+          id={id}
+          ref={ref}
+          className={classnames(styles.actionsButton, {
+            [styles.activeDropdown]: isOpen,
+          })}
+          onClick={() => setOpen(true)}
+          type="button"
+        >
+          <Icon
+            className={styles.actionsIcon}
+            name="three-dots-row"
+            title={MSG.memberActionsTitle}
+          />
+        </button>
+      )}
+    </Popover>
+  );
+};
+
+MemberActions.displayName = displayName;
+
+export default MemberActions;

--- a/src/modules/core/components/MembersList/Actions/MemberActions.tsx
+++ b/src/modules/core/components/MembersList/Actions/MemberActions.tsx
@@ -17,15 +17,15 @@ const MSG = defineMessages({
 });
 
 interface Props {
-  currentUserPermission: string;
   colonyAddress: string;
   userAddress: string;
+  canAdministerComments?: boolean;
 }
 
 const displayName = 'core.MemberList.MemberActions';
 
 const MemberActions = ({
-  currentUserPermission,
+  canAdministerComments,
   colonyAddress,
   userAddress,
 }: Props) => {
@@ -35,7 +35,7 @@ const MemberActions = ({
       content={({ close }) => (
         <MemberActionsPopover
           closePopover={close}
-          currentUserPermission={currentUserPermission}
+          canAdministerComments={canAdministerComments}
           colonyAddress={colonyAddress}
           userAddress={userAddress}
         />

--- a/src/modules/core/components/MembersList/Actions/MemberActions.tsx
+++ b/src/modules/core/components/MembersList/Actions/MemberActions.tsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 
 import Icon from '~core/Icon';
 import Popover from '~core/Popover';
+import { Colony } from '~data/index';
 
 import MemberActionsPopover from './MemberActionsPopover';
 
@@ -17,8 +18,10 @@ const MSG = defineMessages({
 });
 
 interface Props {
-  colonyAddress: string;
   userAddress: string;
+  colony: Colony;
+  isWhitelisted: boolean;
+  isBanned: boolean;
   canAdministerComments?: boolean;
 }
 
@@ -26,8 +29,10 @@ const displayName = 'core.MemberList.MemberActions';
 
 const MemberActions = ({
   canAdministerComments,
-  colonyAddress,
+  colony,
   userAddress,
+  isWhitelisted,
+  isBanned,
 }: Props) => {
   const [isOpen, setOpen] = useState(false);
   return (
@@ -36,7 +41,9 @@ const MemberActions = ({
         <MemberActionsPopover
           closePopover={close}
           canAdministerComments={canAdministerComments}
-          colonyAddress={colonyAddress}
+          colony={colony}
+          isWhitelisted={isWhitelisted}
+          isBanned={isBanned}
           userAddress={userAddress}
         />
       )}

--- a/src/modules/core/components/MembersList/Actions/MemberActionsPopover.css
+++ b/src/modules/core/components/MembersList/Actions/MemberActionsPopover.css
@@ -1,0 +1,14 @@
+.actionButton {
+  composes: flexContainerRow flexAlignCenter from '~styles/layout.css';
+  color: var(--dark);
+  letter-spacing: var(--spacing-medium);
+}
+
+.actionButton i {
+  margin-right: 12px;
+}
+
+.actionButton i svg {
+  fill: var(--temp-grey-blue-7);
+  stroke: none;
+}

--- a/src/modules/core/components/MembersList/Actions/MemberActionsPopover.css
+++ b/src/modules/core/components/MembersList/Actions/MemberActionsPopover.css
@@ -1,5 +1,6 @@
 .actionButton {
   composes: flexContainerRow flexAlignCenter from '~styles/layout.css';
+  font-size: var(--size-normal);
   color: var(--dark);
   letter-spacing: var(--spacing-medium);
 }

--- a/src/modules/core/components/MembersList/Actions/MemberActionsPopover.css.d.ts
+++ b/src/modules/core/components/MembersList/Actions/MemberActionsPopover.css.d.ts
@@ -1,0 +1,1 @@
+export const actionButton: string;

--- a/src/modules/core/components/MembersList/Actions/MemberActionsPopover.tsx
+++ b/src/modules/core/components/MembersList/Actions/MemberActionsPopover.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback } from 'react';
 import { FormattedMessage, defineMessages } from 'react-intl';
 
-import { COMMENT_MODERATION } from '~immutable/index';
 import DropdownMenu, {
   DropdownMenuSection,
   DropdownMenuItem,
@@ -33,16 +32,16 @@ const MSG = defineMessages({
 
 interface Props {
   closePopover: () => void;
-  currentUserPermission: string;
   colonyAddress: string;
   userAddress: string;
+  canAdministerComments?: boolean;
 }
 
 const displayName = 'core.MembersList.MemberActionsPopover';
 
 const MemberActionsPopover = ({
   closePopover,
-  currentUserPermission,
+  canAdministerComments,
   colonyAddress,
   userAddress,
 }: Props) => {
@@ -100,7 +99,7 @@ const MemberActionsPopover = ({
 
   return (
     <DropdownMenu onClick={closePopover}>
-      {currentUserPermission === COMMENT_MODERATION.CAN_MODERATE && (
+      {canAdministerComments && (
         <>{renderModeratorOptions()}</>
       )}
       <>{renderUserActions()}</>

--- a/src/modules/core/components/MembersList/Actions/MemberActionsPopover.tsx
+++ b/src/modules/core/components/MembersList/Actions/MemberActionsPopover.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 import { FormattedMessage, defineMessages } from 'react-intl';
 
+import { getBlockscoutUserURL } from '~externalUrls';
 import { Colony } from '~data/index';
 import DropdownMenu, {
   DropdownMenuSection,
@@ -61,18 +62,15 @@ const MemberActionsPopover = ({
   );
   const openManageWhitelistDialog = useDialog(ManageWhitelistDialog);
   const handleManageWhitelist = useCallback(
-    () =>
-      // @ts-ignore
-      openManageWhitelistDialog({ userAddress, colony }),
+    () => openManageWhitelistDialog({ userAddress, colony }),
     [openManageWhitelistDialog, userAddress, colony],
   );
 
-  const BLOCKSCOUT_URL = `https://blockscout.com/xdai/mainnet/address/${userAddress}/transactions`;
   const renderUserActions = () => (
     <DropdownMenuItem>
       <Button appearance={{ theme: 'no-style' }}>
         <ExternalLink
-          href={BLOCKSCOUT_URL}
+          href={getBlockscoutUserURL(userAddress)}
           className={styles.actionButton}
           text={MSG.viewOnBlockscout}
         />

--- a/src/modules/core/components/MembersList/Actions/MemberActionsPopover.tsx
+++ b/src/modules/core/components/MembersList/Actions/MemberActionsPopover.tsx
@@ -1,0 +1,113 @@
+import React, { useCallback } from 'react';
+import { FormattedMessage, defineMessages } from 'react-intl';
+
+import { COMMENT_MODERATION } from '~immutable/index';
+import DropdownMenu, {
+  DropdownMenuSection,
+  DropdownMenuItem,
+} from '~core/DropdownMenu';
+import Button from '~core/Button';
+import { useDialog } from '~core/Dialog';
+import { BanUserDialog } from '~core/Comment';
+import ExternalLink from '~core/ExternalLink';
+
+import styles from './MemberActionsPopover.css';
+
+const MSG = defineMessages({
+  addToAddressBook: {
+    id: 'core.MembersList.MemberActionsPopover.addToAddressBook',
+    defaultMessage: `Add to address book`,
+  },
+  banUser: {
+    id: 'core.MembersList.MemberActionsPopover.banUser',
+    defaultMessage: `{unban, select,
+      true {Unban}
+      other {Ban}
+    } user`,
+  },
+  viewOnBlockscout: {
+    id: 'core.MembersList.MemberActionsPopover.viewOnBlockscout',
+    defaultMessage: 'View on Blockscout',
+  },
+});
+
+interface Props {
+  closePopover: () => void;
+  currentUserPermission: string;
+  colonyAddress: string;
+  userAddress: string;
+}
+
+const displayName = 'core.MembersList.MemberActionsPopover';
+
+const MemberActionsPopover = ({
+  closePopover,
+  currentUserPermission,
+  colonyAddress,
+  userAddress,
+}: Props) => {
+  const openBanUserDialog = useDialog(BanUserDialog);
+  const handleBanUser = useCallback(
+    () =>
+      openBanUserDialog({
+        colonyAddress,
+      }),
+    [openBanUserDialog, colonyAddress],
+  );
+
+  const BLOCKSCOUT_URL = `https://blockscout.com/xdai/mainnet/address/${userAddress}/transactions`;
+  const renderUserActions = () => (
+    <DropdownMenuSection>
+      <DropdownMenuItem>
+        <Button appearance={{ theme: 'no-style' }}>
+          <ExternalLink
+            href={BLOCKSCOUT_URL}
+            className={styles.actionButton}
+            text={MSG.viewOnBlockscout}
+          />
+        </Button>
+      </DropdownMenuItem>
+    </DropdownMenuSection>
+  );
+
+  const renderModeratorOptions = () => {
+    const userBanned = false;
+    return (
+      <DropdownMenuSection>
+        <DropdownMenuItem>
+          <Button appearance={{ theme: 'no-style' }}>
+            <div className={styles.actionButton}>
+              <FormattedMessage {...MSG.addToAddressBook} />
+            </div>
+          </Button>
+        </DropdownMenuItem>
+        <DropdownMenuItem>
+          <Button
+            appearance={{ theme: 'no-style' }}
+            onClick={() => handleBanUser()}
+          >
+            <div className={styles.actionButton}>
+              <FormattedMessage
+                {...MSG.banUser}
+                values={{ unban: userBanned }}
+              />
+            </div>
+          </Button>
+        </DropdownMenuItem>
+      </DropdownMenuSection>
+    );
+  };
+
+  return (
+    <DropdownMenu onClick={closePopover}>
+      {currentUserPermission === COMMENT_MODERATION.CAN_MODERATE && (
+        <>{renderModeratorOptions()}</>
+      )}
+      <>{renderUserActions()}</>
+    </DropdownMenu>
+  );
+};
+
+MemberActionsPopover.displayName = displayName;
+
+export default MemberActionsPopover;

--- a/src/modules/core/components/MembersList/Actions/MemberActionsPopover.tsx
+++ b/src/modules/core/components/MembersList/Actions/MemberActionsPopover.tsx
@@ -69,17 +69,15 @@ const MemberActionsPopover = ({
 
   const BLOCKSCOUT_URL = `https://blockscout.com/xdai/mainnet/address/${userAddress}/transactions`;
   const renderUserActions = () => (
-    <>
-      <DropdownMenuItem>
-        <Button appearance={{ theme: 'no-style' }}>
-          <ExternalLink
-            href={BLOCKSCOUT_URL}
-            className={styles.actionButton}
-            text={MSG.viewOnBlockscout}
-          />
-        </Button>
-      </DropdownMenuItem>
-    </>
+    <DropdownMenuItem>
+      <Button appearance={{ theme: 'no-style' }}>
+        <ExternalLink
+          href={BLOCKSCOUT_URL}
+          className={styles.actionButton}
+          text={MSG.viewOnBlockscout}
+        />
+      </Button>
+    </DropdownMenuItem>
   );
 
   const renderModeratorOptions = () => {

--- a/src/modules/core/components/MembersList/Actions/index.ts
+++ b/src/modules/core/components/MembersList/Actions/index.ts
@@ -1,0 +1,1 @@
+export { default } from './MemberActions';

--- a/src/modules/core/components/MembersList/MembersList.tsx
+++ b/src/modules/core/components/MembersList/MembersList.tsx
@@ -4,6 +4,7 @@ import ListGroup, { ListGroupAppearance } from '~core/ListGroup';
 import { AnyUser, Colony } from '~data/index';
 
 import MembersListItem from './MembersListItem';
+import SortingRow from './SortingRow';
 
 interface Props<U> {
   colony: Colony;
@@ -30,21 +31,24 @@ const MembersList = <U extends AnyUser = AnyUser>({
   listGroupAppearance,
   canAdministerComments,
 }: Props<U>) => (
-  <ListGroup appearance={listGroupAppearance}>
-    {users.map((user) => (
-      <MembersListItem<U>
-        colony={colony}
-        extraItemContent={extraItemContent}
-        key={user.id}
-        onRowClick={onRowClick}
-        showUserInfo={showUserInfo}
-        showUserReputation={showUserReputation}
-        domainId={domainId}
-        user={user}
-        canAdministerComments={canAdministerComments}
-      />
-    ))}
-  </ListGroup>
+  <div>
+    <SortingRow />
+    <ListGroup appearance={listGroupAppearance}>
+      {users.map((user) => (
+        <MembersListItem<U>
+          colony={colony}
+          extraItemContent={extraItemContent}
+          key={user.id}
+          onRowClick={onRowClick}
+          showUserInfo={showUserInfo}
+          showUserReputation={showUserReputation}
+          domainId={domainId}
+          user={user}
+          canAdministerComments={canAdministerComments}
+        />
+      ))}
+    </ListGroup>
+  </div>
 );
 
 MembersList.displayName = displayName;

--- a/src/modules/core/components/MembersList/MembersList.tsx
+++ b/src/modules/core/components/MembersList/MembersList.tsx
@@ -4,7 +4,6 @@ import ListGroup, { ListGroupAppearance } from '~core/ListGroup';
 import { AnyUser, Colony } from '~data/index';
 
 import MembersListItem from './MembersListItem';
-import SortingRow from './SortingRow';
 
 interface Props<U> {
   colony: Colony;
@@ -31,24 +30,21 @@ const MembersList = <U extends AnyUser = AnyUser>({
   listGroupAppearance,
   canAdministerComments,
 }: Props<U>) => (
-  <div>
-    <SortingRow />
-    <ListGroup appearance={listGroupAppearance}>
-      {users.map((user) => (
-        <MembersListItem<U>
-          colony={colony}
-          extraItemContent={extraItemContent}
-          key={user.id}
-          onRowClick={onRowClick}
-          showUserInfo={showUserInfo}
-          showUserReputation={showUserReputation}
-          domainId={domainId}
-          user={user}
-          canAdministerComments={canAdministerComments}
-        />
-      ))}
-    </ListGroup>
-  </div>
+  <ListGroup appearance={listGroupAppearance}>
+    {users.map((user) => (
+      <MembersListItem<U>
+        colony={colony}
+        extraItemContent={extraItemContent}
+        key={user.id}
+        onRowClick={onRowClick}
+        showUserInfo={showUserInfo}
+        showUserReputation={showUserReputation}
+        domainId={domainId}
+        user={user}
+        canAdministerComments={canAdministerComments}
+      />
+    ))}
+  </ListGroup>
 );
 
 MembersList.displayName = displayName;

--- a/src/modules/core/components/MembersList/MembersListItem.css
+++ b/src/modules/core/components/MembersList/MembersListItem.css
@@ -1,7 +1,7 @@
 .main {
   display: flex;
   align-items: center;
-  overflow-y: auto;
+  padding-right: 15px;
 }
 
 .section {
@@ -15,7 +15,8 @@
 .usernameSection {
   composes: section;
   composes: inlineEllipsis from '~styles/text.css';
-  flex-grow: 1;
+  flex-grow: 0.5;
+  margin-right: auto;
 }
 
 .displayName {
@@ -34,6 +35,7 @@
 }
 
 .address span {
+  font-size: var(--size-normal);
   font-weight: 500;
 }
 
@@ -41,8 +43,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-left: 26px;
-  width: 69px;
+  margin-right: 20px;
 }
 
 .stateHasReputation {

--- a/src/modules/core/components/MembersList/MembersListItem.css
+++ b/src/modules/core/components/MembersList/MembersListItem.css
@@ -44,7 +44,7 @@
   align-items: center;
   justify-content: flex-end;
   margin-right: 20px;
-  width: 150px;
+  width: 170px;
 }
 
 .stateHasReputation {

--- a/src/modules/core/components/MembersList/MembersListItem.css
+++ b/src/modules/core/components/MembersList/MembersListItem.css
@@ -17,6 +17,7 @@
   composes: inlineEllipsis from '~styles/text.css';
   flex-grow: 0.5;
   margin-right: auto;
+  max-width: 200px;
 }
 
 .displayName {

--- a/src/modules/core/components/MembersList/MembersListItem.css
+++ b/src/modules/core/components/MembersList/MembersListItem.css
@@ -42,8 +42,9 @@
 .reputationSection {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-end;
   margin-right: 20px;
+  width: 150px;
 }
 
 .stateHasReputation {

--- a/src/modules/core/components/MembersList/MembersListItem.tsx
+++ b/src/modules/core/components/MembersList/MembersListItem.tsx
@@ -11,11 +11,13 @@ import { defineMessages } from 'react-intl';
 import { createAddress } from '~utils/web3';
 import UserMention from '~core/UserMention';
 import { ListGroupItem } from '~core/ListGroup';
+import MemberReputation from '~core/MemberReputation';
 import { AnyUser, Colony, useUser } from '~data/index';
 import { ENTER } from '~types/index';
 import HookedUserAvatar from '~users/HookedUserAvatar';
 import { getMainClasses } from '~utils/css';
-import MemberReputation from '~core/MemberReputation';
+
+import MemberActions from './Actions';
 
 import styles from './MembersListItem.css';
 import InvisibleCopyableAddress from '~core/InvisibleCopyableAddress';
@@ -113,16 +115,6 @@ const MembersListItem = <U extends AnyUser = AnyUser>({
         // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
         tabIndex={onRowClick ? 0 : undefined}
       >
-        {showUserReputation && (
-          <div className={styles.reputationSection}>
-            <MemberReputation
-              walletAddress={walletAddress}
-              colonyAddress={colony.colonyAddress}
-              domainId={domainId}
-              onReputationLoaded={setReputationLoaded}
-            />
-          </div>
-        )}
         <div className={styles.section}>
           <UserAvatar
             size="s"
@@ -162,6 +154,22 @@ const MembersListItem = <U extends AnyUser = AnyUser>({
           </div>
         </div>
         {renderedExtraItemContent && <div>{renderedExtraItemContent}</div>}
+        {showUserReputation && (
+          <div className={styles.reputationSection}>
+            <MemberReputation
+              walletAddress={walletAddress}
+              colonyAddress={colony.colonyAddress}
+              domainId={domainId}
+              onReputationLoaded={setReputationLoaded}
+              showReputationPoints
+            />
+          </div>
+        )}
+        <MemberActions
+          canAdministerComments={canAdministerComments}
+          colonyAddress={colony.colonyAddress}
+          userAddress={walletAddress}
+        />
       </div>
     </ListGroupItem>
   );

--- a/src/modules/core/components/MembersList/MembersListItem.tsx
+++ b/src/modules/core/components/MembersList/MembersListItem.tsx
@@ -167,8 +167,10 @@ const MembersListItem = <U extends AnyUser = AnyUser>({
         )}
         <MemberActions
           canAdministerComments={canAdministerComments}
-          colonyAddress={colony.colonyAddress}
+          colony={colony}
           userAddress={walletAddress}
+          isWhitelisted={isWhitelisted}
+          isBanned={isUserBanned}
         />
       </div>
     </ListGroupItem>

--- a/src/modules/core/components/MembersList/MembersListItem.tsx
+++ b/src/modules/core/components/MembersList/MembersListItem.tsx
@@ -98,6 +98,10 @@ const MembersListItem = <U extends AnyUser = AnyUser>({
     profile: { displayName, username },
   } = userProfile;
 
+  const nativeToken = colony.tokens.find(
+    (token) => token.address === colony.nativeTokenAddress,
+  );
+
   return (
     <ListGroupItem>
       {/* Disable, as `role` is conditional */}
@@ -162,6 +166,7 @@ const MembersListItem = <U extends AnyUser = AnyUser>({
               domainId={domainId}
               onReputationLoaded={setReputationLoaded}
               showReputationPoints
+              nativeTokenDecimals={nativeToken?.decimals}
             />
           </div>
         )}

--- a/src/modules/core/components/MembersList/SortingRow/SortingRow.css
+++ b/src/modules/core/components/MembersList/SortingRow/SortingRow.css
@@ -1,7 +1,6 @@
 .container {
   display: flex;
   justify-content: flex-end;
-  margin-bottom: 15px;
   padding-right: 34px;
   gap: 94px;
 }

--- a/src/modules/core/components/MembersList/SortingRow/SortingRow.css
+++ b/src/modules/core/components/MembersList/SortingRow/SortingRow.css
@@ -3,7 +3,7 @@
   justify-content: flex-end;
   margin-bottom: 15px;
   padding-right: 34px;
-  gap: 75px;
+  gap: 94px;
 }
 
 .sortingButton {

--- a/src/modules/core/components/MembersList/SortingRow/SortingRow.css
+++ b/src/modules/core/components/MembersList/SortingRow/SortingRow.css
@@ -1,0 +1,26 @@
+.container {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 15px;
+  padding-right: 34px;
+  gap: 75px;
+}
+
+.sortingButton {
+  display: flex;
+  align-items: center;
+  padding: 0;
+  border: none;
+  background-color: transparent;
+  font-weight: var(--weight-bold);
+  color: var(--temp-grey-blue-7);
+  cursor: pointer;
+}
+
+.sortingIcon {
+  height: 15px;
+  width: 30px;
+  position: relative;
+  top: -6px;
+  fill: var(--temp-grey-blue-7);
+}

--- a/src/modules/core/components/MembersList/SortingRow/SortingRow.css.d.ts
+++ b/src/modules/core/components/MembersList/SortingRow/SortingRow.css.d.ts
@@ -1,0 +1,3 @@
+export const container: string;
+export const sortingButton: string;
+export const sortingIcon: string;

--- a/src/modules/core/components/MembersList/SortingRow/SortingRow.tsx
+++ b/src/modules/core/components/MembersList/SortingRow/SortingRow.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import Button from '~core/Button';
+import Icon from '~core/Icon';
+
+import styles from './SortingRow.css';
+
+const displayName = 'dashboard.MembersList.SortingRow';
+
+const MSG = defineMessages({
+  permissions: {
+    id: 'dashboard.MembersList.SortingRow.permissions',
+    defaultMessage: 'Permissions',
+  },
+  reputation: {
+    id: 'dashboard.MembersList.SortingRow.reputation',
+    defaultMessage: 'Reputation',
+  },
+});
+
+const SortingRow = () => {
+  return (
+    <div className={styles.container}>
+      <Button className={styles.sortingButton}>
+        <FormattedMessage {...MSG.permissions} />
+        <Icon
+          className={styles.sortingIcon}
+          name="caret-down-small"
+          title={MSG.permissions}
+        />
+      </Button>
+      <Button className={styles.sortingButton}>
+        <FormattedMessage {...MSG.reputation} />
+        <Icon
+          className={styles.sortingIcon}
+          name="caret-down-small"
+          title={MSG.reputation}
+        />
+      </Button>
+    </div>
+  );
+};
+
+SortingRow.displayName = displayName;
+
+export default SortingRow;

--- a/src/modules/core/components/MembersList/SortingRow/index.ts
+++ b/src/modules/core/components/MembersList/SortingRow/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SortingRow';

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -158,7 +158,6 @@ const ColonyMembers = () => {
   const openToggleManageWhitelistDialog = useDialog(ManageWhitelistDialog);
 
   const handleToggleWhitelistDialog = useCallback(() => {
-    // @ts-ignore
     return openToggleManageWhitelistDialog({
       colony: colonyData?.processedColony as Colony,
     });

--- a/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/ManageWhitelistDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/ManageWhitelistDialog.tsx
@@ -37,10 +37,11 @@ export interface FormValues {
 interface CustomWizardDialogProps {
   colony: Colony;
   userAddress?: string;
-  prevStep?: string;
 }
 
-type Props = DialogProps & WizardDialogType<object> & CustomWizardDialogProps;
+type Props = DialogProps &
+  Partial<WizardDialogType<object>> &
+  CustomWizardDialogProps;
 
 const displayName = 'dashboard.ManageWhitelistDialog';
 
@@ -187,7 +188,7 @@ const ManageWhitelistDialog = ({
             {...formValues}
             colony={colony}
             whitelistedUsers={data?.verifiedUsers || []}
-            back={prevStep ? () => callStep(prevStep) : cancel}
+            back={prevStep && callStep ? () => callStep(prevStep) : cancel}
             showInput={showInput}
             toggleShowInput={handleToggleShowInput}
             formSuccess={formSuccess}

--- a/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/ManageWhitelistDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/ManageWhitelistDialog.tsx
@@ -31,11 +31,13 @@ export interface FormValues {
   annotation: string;
   isWhitelistActivated: boolean;
   whitelistedAddresses: Address[];
+  whitelistAddress?: Address;
 }
 
 interface CustomWizardDialogProps {
-  prevStep?: string;
   colony: Colony;
+  userAddress?: string;
+  prevStep?: string;
 }
 
 type Props = DialogProps & WizardDialogType<object> & CustomWizardDialogProps;
@@ -54,6 +56,7 @@ const ManageWhitelistDialog = ({
     tokenAddresses,
     nativeTokenAddress,
   },
+  userAddress,
 }: Props) => {
   const [showInput, setShowInput] = useState<boolean>(true);
   const [formSuccess, setFormSuccess] = useState<boolean>(false);
@@ -164,6 +167,7 @@ const ManageWhitelistDialog = ({
         isWhitelistActivated: colonyData?.processedColony?.isWhitelistActivated,
         whitelistedAddresses: storedVerifiedRecipients,
         isSubmitting: false,
+        whitelistAddress: userAddress,
       }}
       submit={ActionTypes.COLONY_VERIFIED_RECIPIENTS_MANAGE}
       error={ActionTypes.COLONY_VERIFIED_RECIPIENTS_MANAGE_ERROR}

--- a/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/ManageWhitelistDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/ManageWhitelistDialogForm.tsx
@@ -197,7 +197,12 @@ const ManageWhitelistDialogForm = ({
           }}
           text={{ id: 'button.confirm' }}
           style={{ width: styles.wideButton }}
-          disabled={!dirty || !userHasPermission || !isValid || isSubmitting}
+          disabled={
+            (tabIndex === 0 ? !values.whitelistAddress : !dirty) ||
+            !userHasPermission ||
+            !isValid ||
+            isSubmitting
+          }
           type="submit"
           loading={isSubmitting}
           onClick={() => handleSubmit()}

--- a/src/modules/dashboard/components/Members/MembersSection.css
+++ b/src/modules/dashboard/components/Members/MembersSection.css
@@ -11,6 +11,13 @@
   color: var(--dark);
 }
 
+.contributorsTitle {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
 .description {
   margin-left: 9px;
   font-size: var(--size-tiny);

--- a/src/modules/dashboard/components/Members/MembersSection.css.d.ts
+++ b/src/modules/dashboard/components/Members/MembersSection.css.d.ts
@@ -1,5 +1,6 @@
 export const bar: string;
 export const title: string;
+export const contributorsTitle: string;
 export const description: string;
 export const noResults: string;
 export const membersList: string;

--- a/src/modules/dashboard/components/Members/MembersSection.tsx
+++ b/src/modules/dashboard/components/Members/MembersSection.tsx
@@ -1,12 +1,14 @@
 import React, { useState, useCallback, ReactNode } from 'react';
-
+import classnames from 'classnames';
 import { FormattedMessage, defineMessages } from 'react-intl';
-import styles from './MembersSection.css';
 
 import MembersList from '~core/MembersList';
 import { Colony, ColonyWatcher, ColonyContributor } from '~data/index';
 
 import LoadMoreButton from '~core/LoadMoreButton';
+import SortingRow from '~core/MembersList/SortingRow';
+
+import styles from './MembersSection.css';
 
 const displayName = 'dashboard.MembersSection';
 
@@ -58,12 +60,17 @@ Props<U>) => {
   return (
     <>
       <div className={styles.bar}>
-        <div className={styles.title}>
+        <div
+          className={classnames(styles.title, {
+            [styles.contributorsTitle]: isContributorsSection,
+          })}
+        >
           <FormattedMessage
             {...(isContributorsSection
               ? MSG.contributorsTitle
               : MSG.watchersTitle)}
           />
+          {isContributorsSection && <SortingRow />}
         </div>
         {!isContributorsSection && (
           <div className={styles.description}>
@@ -79,6 +86,7 @@ Props<U>) => {
             domainId={currentDomainId}
             users={paginatedMembers}
             canAdministerComments={canAdministerComments}
+            showUserReputation={isContributorsSection}
           />
         </div>
       ) : (

--- a/src/modules/dashboard/components/UserPermissions/UserPermissions.css
+++ b/src/modules/dashboard/components/UserPermissions/UserPermissions.css
@@ -1,6 +1,6 @@
 
 .main {
-  padding: 0 30px;
+  padding: 0 25px;
   font-size: var(--size-tiny);
   font-weight: var(--weight-bold);
   white-space: nowrap;

--- a/src/modules/externalUrls.ts
+++ b/src/modules/externalUrls.ts
@@ -13,6 +13,8 @@ export const NETWORK_RELEASES = `https://github.com/JoinColony/colonyNetwork/rel
 export const ETHERSCAN_CONVERSION_RATE = `https://api.etherscan.io/api?module=stats&action=ethprice`;
 export const ETH_GAS_STATION = `https://ethgasstation.info/json/ethgasAPI.json`;
 export const XDAI_GAS_STATION = `https://blockscout.com/xdai/mainnet/api/v1/gas-price-oracle`;
+export const getBlockscoutUserURL = (userAddress: string) =>
+  `https://blockscout.com/xdai/mainnet/address/${userAddress}/transactions`;
 
 /*
  * Coin Machine


### PR DESCRIPTION
Updated styles of mainly `MembersListItem` and added new things to it like reputation points display along with the percentage and a members action popover that can be used to ban, view the user on blockscout, and add them to the address book. The logic related to the sorting row will be done in a separate PR.

![FireShot Capture 629 - Members - Colony - wonker - localhost](https://user-images.githubusercontent.com/18473896/174191164-1d62976e-9872-4b10-97f5-30ab57c2b882.png)

#### TODO

- [x] Connect `Add to address book` member action to the verified recipient's dialog

Resolves #3385 
