### PR TITLE
Add "Total reputation in team" section

### DIFF
--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css
@@ -40,6 +40,11 @@
   margin-bottom: 50px;
 }
 
+.teamReputationPointsContainer h4 {
+  font-size: var(--size-smallish);
+  line-height: 18px;
+}
+
 .reputationPoints {
   line-height: 18px;
   color: var(--dark);

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css
@@ -16,7 +16,8 @@
 
 .rightAside {
   display: flex;
-  padding: 200px 0 20px 100px;
+  flex-direction: column;
+  padding: 153px 0 20px 85px;
   width: 26.5%;
 }
 
@@ -33,4 +34,13 @@
 
 .controls li + li {
   margin: 18px 0 0;
+}
+
+.teamReputationPointsContainer {
+  margin-bottom: 50px;
+}
+
+.reputationPoints {
+  line-height: 18px;
+  color: var(--dark);
 }

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css.d.ts
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css.d.ts
@@ -4,3 +4,5 @@ export const mainContent: string;
 export const rightAside: string;
 export const loadingWrapper: string;
 export const controls: string;
+export const teamReputationPointsContainer: string;
+export const reputationPoints: string;

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -2,9 +2,9 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useParams, Redirect } from 'react-router-dom';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { ColonyVersion, Extension } from '@colony/colony-js';
-
 import Decimal from 'decimal.js';
 import { AddressZero } from 'ethers/constants';
+
 import Button from '~core/Button';
 import { useDialog } from '~core/Dialog';
 import { BanUserDialog } from '~core/Comment';

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useParams, Redirect } from 'react-router-dom';
-import { defineMessages, FormattedMessage } from 'react-intl';
+import { defineMessages } from 'react-intl';
 import { ColonyVersion, Extension } from '@colony/colony-js';
 import Decimal from 'decimal.js';
 import { AddressZero } from 'ethers/constants';
@@ -9,6 +9,7 @@ import Button from '~core/Button';
 import { useDialog } from '~core/Dialog';
 import { BanUserDialog } from '~core/Comment';
 import Heading from '~core/Heading';
+import Numeral from '~core/Numeral';
 import {
   COLONY_TOTAL_BALANCE_DOMAIN_ID,
   DEFAULT_TOKEN_DECIMALS,
@@ -61,10 +62,6 @@ const MSG = defineMessages({
   totalReputationTitle: {
     id: 'dashboard.ColonyMembers.totalReputationTitle',
     defaultMessage: 'Total reputation in team',
-  },
-  reputationPoints: {
-    id: 'dashboard.ColonyMembers.reputationPoints',
-    defaultMessage: '{teamReputationPoints} reputation points',
   },
 });
 
@@ -153,12 +150,13 @@ const ColonyMembers = () => {
     });
   }, [openPermissionManagementDialog, colonyData, isVotingExtensionEnabled]);
 
-  const selectedDomain = colonyData?.processedColony.domains.find(
+  const selectedDomain = colonyData?.processedColony?.domains?.find(
     ({ ethDomainId }) => ethDomainId === selectedDomainId,
   );
 
-  const nativeToken = colonyData?.processedColony.tokens.find(
-    ({ address }) => address === colonyData?.processedColony.nativeTokenAddress,
+  const nativeToken = colonyData?.processedColony?.tokens.find(
+    ({ address }) =>
+      address === colonyData?.processedColony?.nativeTokenAddress,
   );
 
   const formattedTotalDomainRep = getFormattedTokenValue(
@@ -234,11 +232,9 @@ const ColonyMembers = () => {
               appearance={{ size: 'normal', theme: 'dark' }}
             />
             <p className={styles.reputationPoints}>
-              <FormattedMessage
-                {...MSG.reputationPoints}
-                values={{
-                  teamReputationPoints: formattedTotalDomainRep,
-                }}
+              <Numeral
+                value={formattedTotalDomainRep}
+                suffix="reputation points"
               />
             </p>
           </div>

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -1,11 +1,18 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useParams, Redirect } from 'react-router-dom';
-import { defineMessages } from 'react-intl';
+import { defineMessages, FormattedMessage } from 'react-intl';
 import { ColonyVersion, Extension } from '@colony/colony-js';
 
+import Decimal from 'decimal.js';
+import { AddressZero } from 'ethers/constants';
 import Button from '~core/Button';
 import { useDialog } from '~core/Dialog';
 import { BanUserDialog } from '~core/Comment';
+import Heading from '~core/Heading';
+import {
+  COLONY_TOTAL_BALANCE_DOMAIN_ID,
+  DEFAULT_TOKEN_DECIMALS,
+} from '~constants';
 
 import LoadingTemplate from '~pages/LoadingTemplate';
 import Members from '~dashboard/Members';
@@ -19,8 +26,10 @@ import {
   useColonyExtensionsQuery,
   useBannedUsersQuery,
   useLoggedInUser,
+  useUserReputationQuery,
 } from '~data/index';
 import { useTransformer } from '~utils/hooks';
+import { getFormattedTokenValue } from '~utils/tokens';
 import { useEnabledExtensions } from '~utils/hooks/useEnabledExtensions';
 import { NOT_FOUND_ROUTE } from '~routes/index';
 import { checkIfNetworkIsAllowed } from '~utils/networks';
@@ -49,6 +58,14 @@ const MSG = defineMessages({
     id: 'dashboard.ColonyMembers.loadingText',
     defaultMessage: 'Loading Colony',
   },
+  totalReputationTitle: {
+    id: 'dashboard.ColonyMembers.totalReputationTitle',
+    defaultMessage: 'Total reputation in team',
+  },
+  reputationPoints: {
+    id: 'dashboard.ColonyMembers.reputationPoints',
+    defaultMessage: '{teamReputationPoints} reputation points',
+  },
 });
 
 const ColonyMembers = () => {
@@ -58,6 +75,9 @@ const ColonyMembers = () => {
     ethereal,
     walletAddress: currentUserWalletAddress,
   } = useLoggedInUser();
+  const { domainId } = useParams<{
+    domainId: string;
+  }>();
   const isNetworkAllowed = checkIfNetworkIsAllowed(networkId);
   const hasRegisteredProfile = !!username && !ethereal;
 
@@ -100,6 +120,30 @@ const ColonyMembers = () => {
     },
   });
 
+  const [selectedDomainId, setSelectedDomainId] = useState<number>(
+    /*
+     * @NOTE DomainId param sanitization
+     *
+     * We don't actually need to worry about sanitizing the domainId that's
+     * coming in from the params.
+     * The value that reaches us through the hook is being processes by `react-router`
+     * and will always be a string.
+     *
+     * So if we can change that string into a number, we use it as domain, otherwise
+     * we fall back to the "All Domains" selection
+     */
+    parseInt(domainId, 10) || COLONY_TOTAL_BALANCE_DOMAIN_ID,
+  );
+
+  const { data: totalReputation } = useUserReputationQuery({
+    variables: {
+      address: AddressZero,
+      colonyAddress,
+      domainId: selectedDomainId,
+    },
+    fetchPolicy: 'cache-and-network',
+  });
+
   const openPermissionManagementDialog = useDialog(PermissionManagementDialog);
 
   const handlePermissionManagementDialog = useCallback(() => {
@@ -108,6 +152,19 @@ const ColonyMembers = () => {
       isVotingExtensionEnabled,
     });
   }, [openPermissionManagementDialog, colonyData, isVotingExtensionEnabled]);
+
+  const selectedDomain = colonyData?.processedColony.domains.find(
+    ({ ethDomainId }) => ethDomainId === selectedDomainId,
+  );
+
+  const nativeToken = colonyData?.processedColony.tokens.find(
+    ({ address }) => address === colonyData?.processedColony.nativeTokenAddress,
+  );
+
+  const formattedTotalDomainRep = getFormattedTokenValue(
+    new Decimal(totalReputation?.userReputation || '0').abs().toString(),
+    nativeToken?.decimals || DEFAULT_TOKEN_DECIMALS,
+  );
 
   // eslint-disable-next-line max-len
   const oneTxPaymentExtension = colonyExtensions?.processedColony?.installedExtensions.find(
@@ -165,10 +222,26 @@ const ColonyMembers = () => {
             <Members
               colony={colonyData.processedColony}
               bannedUsers={bannedMembers?.bannedUsers || []}
+              selectedDomain={selectedDomain}
+              handleDomainChange={setSelectedDomainId}
             />
           )}
         </div>
         <aside className={styles.rightAside}>
+          <div className={styles.teamReputationPointsContainer}>
+            <Heading
+              text={MSG.totalReputationTitle}
+              appearance={{ size: 'normal', theme: 'dark' }}
+            />
+            <p className={styles.reputationPoints}>
+              <FormattedMessage
+                {...MSG.reputationPoints}
+                values={{
+                  teamReputationPoints: formattedTotalDomainRep,
+                }}
+              />
+            </p>
+          </div>
           <ul className={styles.controls}>
             <li>
               <InviteLinkButton

--- a/src/modules/dashboard/components/Members/Members.css
+++ b/src/modules/dashboard/components/Members/Members.css
@@ -92,3 +92,8 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+.reputationPoints {
+  line-height: 18px;
+  color: var(--dark);
+}

--- a/src/modules/dashboard/components/Members/Members.css
+++ b/src/modules/dashboard/components/Members/Members.css
@@ -1,3 +1,7 @@
+.membersContainer {
+  display: flex;
+}
+
 .main {
   margin-top: 20px;
 }
@@ -93,7 +97,6 @@
   white-space: nowrap;
 }
 
-.reputationPoints {
-  line-height: 18px;
-  color: var(--dark);
+.asideBar {
+  margin-left: 80px;
 }

--- a/src/modules/dashboard/components/Members/Members.css.d.ts
+++ b/src/modules/dashboard/components/Members/Members.css.d.ts
@@ -6,3 +6,4 @@ export const subscribeButton: string;
 export const subscribedIcon: string;
 export const unsubscribedIcon: string;
 export const titleContainer: string;
+export const reputationPoints: string;

--- a/src/modules/dashboard/components/Members/Members.css.d.ts
+++ b/src/modules/dashboard/components/Members/Members.css.d.ts
@@ -1,3 +1,4 @@
+export const membersContainer: string;
 export const main: string;
 export const tableBody: string;
 export const communityRole: string;
@@ -6,4 +7,4 @@ export const subscribeButton: string;
 export const subscribedIcon: string;
 export const unsubscribedIcon: string;
 export const titleContainer: string;
-export const reputationPoints: string;
+export const asideBar: string;

--- a/src/modules/dashboard/components/Members/Members.tsx
+++ b/src/modules/dashboard/components/Members/Members.tsx
@@ -1,8 +1,7 @@
-import React, { FC, useState, useCallback } from 'react';
+import React, { FC, useCallback } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { ROOT_DOMAIN_ID } from '@colony/colony-js';
 import sortBy from 'lodash/sortBy';
-import { useParams } from 'react-router';
 
 import MembersSection from './MembersSection';
 
@@ -19,6 +18,7 @@ import {
   useContributorsAndWatchersQuery,
   ColonyContributor,
   ColonyWatcher,
+  DomainFieldsFragment,
 } from '~data/index';
 import {
   COLONY_TOTAL_BALANCE_DOMAIN_ID,
@@ -54,40 +54,24 @@ const MSG = defineMessages({
 interface Props {
   colony: Colony;
   bannedUsers: BannedUsersQuery['bannedUsers'];
+  selectedDomain: DomainFieldsFragment | undefined;
+  handleDomainChange: React.Dispatch<React.SetStateAction<number>>;
 }
 
 const displayName = 'dashboard.Members';
 
-const Members = ({ colony: { colonyAddress, colonyName }, colony }: Props) => {
-  const { domainId } = useParams<{
-    domainId: string;
-  }>();
-
+const Members = ({
+  colony: { colonyAddress, colonyName },
+  colony,
+  selectedDomain,
+  handleDomainChange,
+}: Props) => {
   const {
     walletAddress: currentUserWalletAddress,
     username,
     ethereal,
   } = useLoggedInUser();
   const hasRegisteredProfile = !!username && !ethereal;
-
-  const [selectedDomainId, setSelectedDomainId] = useState<number>(
-    /*
-     * @NOTE DomainId param sanitization
-     *
-     * We don't actually need to worry about sanitizing the domainId that's
-     * coming in from the params.
-     * The value that reaches us through the hook is being processes by `react-router`
-     * and will always be a string.
-     *
-     * So if we can change that string into a number, we use it as domain, otherwise
-     * we fall back to the "All Domains" selection
-     */
-    parseInt(domainId, 10) || COLONY_TOTAL_BALANCE_DOMAIN_ID,
-  );
-
-  const selectedDomain = colony.domains.find(
-    ({ ethDomainId }) => ethDomainId === selectedDomainId,
-  );
 
   /*
    * NOTE If we can't find the domain based on the current selected doamain id,
@@ -134,8 +118,8 @@ const Members = ({ colony: { colonyAddress, colonyName }, colony }: Props) => {
   );
 
   const setFieldValue = useCallback(
-    (value) => setSelectedDomainId(parseInt(value, 10)),
-    [setSelectedDomainId],
+    (value) => handleDomainChange(parseInt(value, 10)),
+    [handleDomainChange],
   );
 
   if (loadingMembers) {

--- a/src/modules/dashboard/components/Members/Members.tsx
+++ b/src/modules/dashboard/components/Members/Members.tsx
@@ -2,9 +2,7 @@ import React, { FC, useState, useCallback } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { ROOT_DOMAIN_ID } from '@colony/colony-js';
 import sortBy from 'lodash/sortBy';
-import { useParams } from 'react-router-dom';
-import { AddressZero } from 'ethers/constants';
-import Decimal from 'decimal.js';
+import { useParams } from 'react-router';
 
 import MembersSection from './MembersSection';
 
@@ -14,7 +12,6 @@ import { SpinnerLoader } from '~core/Preloaders';
 import Heading from '~core/Heading';
 import { Select, Form } from '~core/Fields';
 import { useTransformer } from '~utils/hooks';
-import { getFormattedTokenValue } from '~utils/tokens';
 import {
   Colony,
   useLoggedInUser,
@@ -26,7 +23,6 @@ import {
 import {
   COLONY_TOTAL_BALANCE_DOMAIN_ID,
   ALLDOMAINS_DOMAIN_SELECTION,
-  DEFAULT_TOKEN_DECIMALS,
 } from '~constants';
 import { getAllUserRoles } from '~modules/transformers';
 import { hasRoot, canAdminister } from '~modules/users/checks';
@@ -52,14 +48,6 @@ const MSG = defineMessages({
   failedToFetch: {
     id: 'dashboard.Members.failedToFetch',
     defaultMessage: "Could not fetch the colony's members",
-  },
-  totalReputationTitle: {
-    id: 'dashboard.Members.totalReputationTitle',
-    defaultMessage: 'Total reputation in team',
-  },
-  reputationPoints: {
-    id: 'dashboard.Members.reputationPoints',
-    defaultMessage: '{teamReputationPoints} reputation points',
   },
 });
 
@@ -97,26 +85,8 @@ const Members = ({ colony: { colonyAddress, colonyName }, colony }: Props) => {
     parseInt(domainId, 10) || COLONY_TOTAL_BALANCE_DOMAIN_ID,
   );
 
-  const { data: totalReputation } = useUserReputationQuery({
-    variables: {
-      address: AddressZero,
-      colonyAddress,
-      domainId: selectedDomainId,
-    },
-    fetchPolicy: 'cache-and-network',
-  });
-
   const selectedDomain = colony.domains.find(
     ({ ethDomainId }) => ethDomainId === selectedDomainId,
-  );
-
-  const nativeToken = tokens.find(
-    ({ address }) => address === nativeTokenAddress,
-  );
-
-  const formattedTotalDomainRep = getFormattedTokenValue(
-    new Decimal(totalReputation?.userReputation || '0').abs().toString(),
-    nativeToken?.decimals || DEFAULT_TOKEN_DECIMALS,
   );
 
   /*


### PR DESCRIPTION
Added section in the sidebar of the colony members page that shows the total reputation points in the domain selected. The amount should change depending on what team is selected by the current domain selector in the page's header.

![FireShot Capture 591 - Members - Colony - wonker - localhost](https://user-images.githubusercontent.com/18473896/168344092-ce2f14bb-7b64-4f9b-a3f3-1182b8018588.png)
![FireShot Capture 592 - Members - Colony - wonker - localhost](https://user-images.githubusercontent.com/18473896/168344103-4a1a8f62-6e9e-48f9-aaab-fd55f07296c9.png)

Resolves #3384 
