### PR TITLE
Display user feedback when IPFS fails to provide annotations

### DIFF
--- a/src/modules/core/components/CalloutCard/CalloutCard.css
+++ b/src/modules/core/components/CalloutCard/CalloutCard.css
@@ -1,5 +1,5 @@
 .main {
-  padding: 9px 9px 10px 15px;
+  padding: 20px 14px 20px 14px;
   width: 100%;
   position: relative;
   border-radius: var(--radius-normal);

--- a/src/modules/core/components/CalloutCard/CalloutCard.css
+++ b/src/modules/core/components/CalloutCard/CalloutCard.css
@@ -1,5 +1,5 @@
 .main {
-  padding: 20px 14px 20px 14px;
+  padding: 20px 14px;
   width: 100%;
   position: relative;
   border-radius: var(--radius-normal);

--- a/src/modules/core/components/CalloutCard/CalloutCard.css
+++ b/src/modules/core/components/CalloutCard/CalloutCard.css
@@ -1,0 +1,34 @@
+.main {
+  padding: 9px 9px 10px 15px;
+  width: 100%;
+  position: relative;
+  border-radius: var(--radius-normal);
+  background-color: var(--colony-white);
+  font-size: var(--size-smallish);
+  font-weight: var(--weight-bold);
+}
+
+/* Theme */
+.themePrimary {
+  composes: main;
+  background-color: var(--primary);
+  color: var(--colony-white);
+}
+
+.themeInfo {
+  composes: main;
+  background-color: newInfoBlue;
+  color: var(--colony-white);
+}
+
+.themeDanger {
+  composes: main;
+  background-color: var(--danger);
+  color: var(--colony-white);
+}
+
+.themePinky {
+  composes: main;
+  background-color: color-mod(var(--pink) alpha(15%));
+  color: var(--dark);
+}

--- a/src/modules/core/components/CalloutCard/CalloutCard.css.d.ts
+++ b/src/modules/core/components/CalloutCard/CalloutCard.css.d.ts
@@ -1,0 +1,5 @@
+export const main: string;
+export const themePrimary: string;
+export const themeInfo: string;
+export const themeDanger: string;
+export const themePinky: string;

--- a/src/modules/core/components/CalloutCard/CalloutCard.md
+++ b/src/modules/core/components/CalloutCard/CalloutCard.md
@@ -1,0 +1,61 @@
+**Description**
+The CalloutCard component provides a standardsed way to display user information such as warnings.
+The CalloutCard's appearance can be customized through `theme`s. The content should be provided through the appropriate props.
+
+### Example
+
+Here's a super simple implementation of an CalloutCard, and different examples of customisation of the content:
+
+```jsx
+import CalloutCard from '~core/CalloutCard';
+import Link from '~core/Link';
+import ExternalLink from '~core/ExternalLink';
+
+const MSG = defineMessages({
+warningTitle: {
+  id: 'dashboard.ActionsPageFeed.ActionsPageFeedItemWithIPFS.warningTitle',
+  defaultMessage: `<span>Attention.</span> `,
+},
+warningTextExternal: {
+  id: 'dashboard.ActionsPageFeed.ActionsPageFeedItemWithIPFS.warningText',
+  defaultMessage: `Unable to connect to IPFS gateway, annotations not loaded. <a>Reload to try again</a>`,
+},
+warningTextInternal: {
+    id: 'dashboard.ActionsPageFeed.ActionsPageFeedItemWithIPFS.internalLink',
+    defaultMessage: `Unable to connect to IPFS gateway, annotations not loaded. {link}`,
+  },
+});
+
+ <CalloutCard
+  label={...MSG.warningTitle}
+  labelValues={{
+    span: (chunks) => (
+      <span className={styles.noIPFSLabel}>{chunks}</span>
+    ),
+  }}
+  description={...MSG.warningTextInternal}
+  descriptionValues={{
+    link: (
+      <Link
+        to={location.pathname}
+        text={MSG.internalLink}
+        className={styles.link}
+        onClick={() => window.location.reload(false)}
+      />
+    ),
+  }}
+/>
+
+<CalloutCard
+  label={...MSG.warningTitle}
+  labelValues={{
+    span: (chunks) => (
+      <span className={styles.noIPFSLabel}>{chunks}</span>
+    ),
+  }}
+  description={...MSG.warningTextExternal}
+  descriptionValues={{
+    a: (chunks) => <ExternalLink href="/url">{chunks}</ExternalLink>,
+  }}
+/>
+```

--- a/src/modules/core/components/CalloutCard/CalloutCard.tsx
+++ b/src/modules/core/components/CalloutCard/CalloutCard.tsx
@@ -17,13 +17,13 @@ interface Props {
   appearance?: Appearance;
 
   /** label text */
-  label: MessageDescriptor | string;
+  label: MessageDescriptor;
 
   /** Values for context text (react-intl interpolation) */
   labelValues?: ComplexMessageValues;
 
   /** A string or a `messageDescriptor` that make up the cards's content */
-  description?: MessageDescriptor | string;
+  description?: MessageDescriptor;
 
   /** Values for context text (react-intl interpolation) */
   descriptionValues?: ComplexMessageValues;

--- a/src/modules/core/components/CalloutCard/CalloutCard.tsx
+++ b/src/modules/core/components/CalloutCard/CalloutCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FormattedMessage, MessageDescriptor } from 'react-intl';
 
-import { SimpleMessageValues } from '~types/index';
+import { ComplexMessageValues } from '~types/index';
 
 import { getMainClasses } from '~utils/css';
 import styles from './CalloutCard.css';
@@ -20,13 +20,13 @@ interface Props {
   label: MessageDescriptor | string;
 
   /** Values for context text (react-intl interpolation) */
-  labelValues?: SimpleMessageValues;
+  labelValues?: ComplexMessageValues;
 
   /** A string or a `messageDescriptor` that make up the cards's content */
   description?: MessageDescriptor | string;
 
   /** Values for context text (react-intl interpolation) */
-  descriptionValues?: SimpleMessageValues;
+  descriptionValues?: ComplexMessageValues;
 }
 
 const CalloutCard = ({

--- a/src/modules/core/components/CalloutCard/CalloutCard.tsx
+++ b/src/modules/core/components/CalloutCard/CalloutCard.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { FormattedMessage, MessageDescriptor } from 'react-intl';
+
+import { SimpleMessageValues } from '~types/index';
+
+import { getMainClasses } from '~utils/css';
+import styles from './CalloutCard.css';
+
+const displayName = 'CalloutCard';
+
+interface Appearance {
+  theme?: 'primary' | 'info' | 'danger' | 'pinky';
+}
+
+interface Props {
+  /** Appearance object */
+  appearance?: Appearance;
+
+  /** label text */
+  label: MessageDescriptor | string;
+
+  /** Values for context text (react-intl interpolation) */
+  labelValues?: SimpleMessageValues;
+
+  /** A string or a `messageDescriptor` that make up the cards's content */
+  description?: MessageDescriptor | string;
+
+  /** Values for context text (react-intl interpolation) */
+  descriptionValues?: SimpleMessageValues;
+}
+
+const CalloutCard = ({
+  appearance = { theme: 'pinky' },
+  label,
+  labelValues,
+  description,
+  descriptionValues,
+}: Props) => {
+  return (
+    <div className={getMainClasses(appearance, styles)}>
+      <FormattedMessage {...label} values={labelValues} />
+      <FormattedMessage {...description} values={descriptionValues} />
+    </div>
+  );
+};
+
+CalloutCard.displayName = displayName;
+
+export default CalloutCard;

--- a/src/modules/core/components/CalloutCard/CalloutCard.tsx
+++ b/src/modules/core/components/CalloutCard/CalloutCard.tsx
@@ -23,7 +23,7 @@ interface Props {
   labelValues?: ComplexMessageValues;
 
   /** A string or a `messageDescriptor` that make up the cards's content */
-  description?: MessageDescriptor;
+  description: MessageDescriptor;
 
   /** Values for context text (react-intl interpolation) */
   descriptionValues?: ComplexMessageValues;

--- a/src/modules/core/components/CalloutCard/index.ts
+++ b/src/modules/core/components/CalloutCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CalloutCard';

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeedItemWithIPFS/ActionsPageFeedItemWithIPFS.css
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeedItemWithIPFS/ActionsPageFeedItemWithIPFS.css
@@ -1,0 +1,14 @@
+.link {
+  font-weight: var(--weight-bold);
+  color: var(--sky-blue);
+}
+
+.link:hover {
+  text-decoration: underline;
+}
+
+.noIPFSLabel {
+  font-size: var(--size-smallish);
+  font-weight: var(--weight-bold);
+  color: var(--pink);
+}

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeedItemWithIPFS/ActionsPageFeedItemWithIPFS.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeedItemWithIPFS/ActionsPageFeedItemWithIPFS.css.d.ts
@@ -1,0 +1,3 @@
+export const link: string;
+export const noIPFSLabel: string;
+export const noIpfsLabel: string;

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeedItemWithIPFS/ActionsPageFeedItemWithIPFS.tsx
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeedItemWithIPFS/ActionsPageFeedItemWithIPFS.tsx
@@ -59,13 +59,13 @@ const ActionsPageFeedItemWithIPFS = ({
   if (!ipfsDataJSON) {
     return (
       <CalloutCard
-        label={...MSG.warningTitle}
+        label={MSG.warningTitle}
         labelValues={{
           span: (chunks) => (
             <span className={styles.noIPFSLabel}>{chunks}</span>
           ),
         }}
-        description={...MSG.warningText}
+        description={MSG.warningText}
         descriptionValues={{
           link: (
             <Link

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeedItemWithIPFS/ActionsPageFeedItemWithIPFS.tsx
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeedItemWithIPFS/ActionsPageFeedItemWithIPFS.tsx
@@ -72,7 +72,7 @@ const ActionsPageFeedItemWithIPFS = ({
               to={location.pathname}
               text={MSG.reloadLink}
               className={styles.link}
-              onClick={() => window.location.reload(false)}
+              onClick={() => window.location.reload()}
             />
           ),
         }}

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeedItemWithIPFS/ActionsPageFeedItemWithIPFS.tsx
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeedItemWithIPFS/ActionsPageFeedItemWithIPFS.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import { defineMessages } from 'react-intl';
 
@@ -43,8 +43,8 @@ const ActionsPageFeedItemWithIPFS = ({
     [hash],
   );
 
-  const getAnnotationMessage = useCallback(() => {
-    if (!annotation) {
+  const annotationMessage = useMemo(() => {
+    if (!annotation || !ipfsDataJSON) {
       return undefined;
     }
     const annotationObject = JSON.parse(ipfsDataJSON);
@@ -80,7 +80,6 @@ const ActionsPageFeedItemWithIPFS = ({
     );
   }
 
-  const annotationMessage = getAnnotationMessage();
   /*
    * This means that the annotation object is in a format we don't recognize
    */

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeedItemWithIPFS/ActionsPageFeedItemWithIPFS.tsx
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeedItemWithIPFS/ActionsPageFeedItemWithIPFS.tsx
@@ -1,12 +1,32 @@
 import React, { useCallback } from 'react';
+import { useLocation } from 'react-router-dom';
+import { defineMessages } from 'react-intl';
 
 import Comment, { Props as CommentProps } from '~core/Comment';
+import CalloutCard from '~core/CalloutCard';
+import Link from '~core/Link';
 
 import { useDataFetcher } from '~utils/hooks';
 import { ipfsDataFetcher } from '../../../../core/fetchers';
 
+import styles from './ActionsPageFeedItemWithIPFS.css';
+
 const displayName = 'dashboard.ActionsPageFeed.ActionsPageFeedItemWithIPFS';
 
+const MSG = defineMessages({
+  warningTitle: {
+    id: 'dashboard.ActionsPageFeed.ActionsPageFeedItemWithIPFS.warningTitle',
+    defaultMessage: `<span>Attention.</span> `,
+  },
+  warningText: {
+    id: 'dashboard.ActionsPageFeed.ActionsPageFeedItemWithIPFS.internalLink',
+    defaultMessage: `Unable to connect to IPFS gateway, annotations not loaded. {link}`,
+  },
+  reloadLink: {
+    id: 'dashboard.ActionsPageFeed.ActionsPageFeedItemWithIPFS.internalLink',
+    defaultMessage: `Reload to try again`,
+  },
+});
 interface Props extends CommentProps {
   hash: string;
 }
@@ -24,7 +44,7 @@ const ActionsPageFeedItemWithIPFS = ({
   );
 
   const getAnnotationMessage = useCallback(() => {
-    if (!annotation || !ipfsDataJSON) {
+    if (!annotation) {
       return undefined;
     }
     const annotationObject = JSON.parse(ipfsDataJSON);
@@ -34,8 +54,33 @@ const ActionsPageFeedItemWithIPFS = ({
     return undefined;
   }, [annotation, ipfsDataJSON]);
 
-  const annotationMessage = getAnnotationMessage();
+  const location = useLocation();
+  // trouble connecting to IPFS
+  if (!ipfsDataJSON) {
+    return (
+      <CalloutCard
+        label={...MSG.warningTitle}
+        labelValues={{
+          span: (chunks) => (
+            <span className={styles.noIPFSLabel}>{chunks}</span>
+          ),
+        }}
+        description={...MSG.warningText}
+        descriptionValues={{
+          link: (
+            <Link
+              to={location.pathname}
+              text={MSG.reloadLink}
+              className={styles.link}
+              onClick={() => window.location.reload(false)}
+            />
+          ),
+        }}
+      />
+    );
+  }
 
+  const annotationMessage = getAnnotationMessage();
   /*
    * This means that the annotation object is in a format we don't recognize
    */


### PR DESCRIPTION
## Description

This PR displays a warning to update the user when IPFS is uncontactable and does not return annotations for the annotation hash provided.

No IPFS connection:
<img width="564" alt="Screenshot 2022-05-15 at 17 46 25" src="https://user-images.githubusercontent.com/582700/168485354-119c562b-2fbb-477d-b6dd-1c047d50325d.png">

With IPFS connection:
<img width="594" alt="Screenshot 2022-05-15 at 17 47 09" src="https://user-images.githubusercontent.com/582700/168485360-ca5f3d60-7d77-4811-8133-b6d0556eb753.png">



To promote simplification and standardisation, I have created a CalloutCard component to display the message. This new generic component is very configurable and can be used in exiting situations, such as Confusable warnings ( i will create a new issue to search & replace), and should be considered for use in new dev. 

Resolves #3237
