### PR TITLE
Add contributors & watchers data

### DIFF
--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -245,6 +245,7 @@ export type Query = {
   colony: SubgraphColony;
   colonyAction: ColonyAction;
   colonyAddress: Scalars['String'];
+  colonyContributors: Array<ColonyContributor>;
   colonyDomain: ProcessedDomain;
   colonyExtension?: Maybe<ColonyExtension>;
   colonyMembersWithReputation?: Maybe<Array<Scalars['String']>>;
@@ -405,6 +406,12 @@ export type QueryColonyActionArgs = {
 
 export type QueryColonyAddressArgs = {
   name: Scalars['String'];
+};
+
+
+export type QueryColonyContributorsArgs = {
+  colonyAddress: Scalars['String'];
+  domainId?: Maybe<Scalars['Int']>;
 };
 
 
@@ -1105,6 +1112,13 @@ export type ActionThatNeedsAttention = {
 export type UserDomainReputation = {
   domainId: Scalars['Int'];
   reputationPercentage: Scalars['String'];
+};
+
+export type ColonyContributor = {
+  id: Scalars['String'];
+  directRoles: Array<Scalars['Int']>;
+  roles: Array<Scalars['Int']>;
+  profile: UserProfile;
 };
 
 export type ByColonyFilter = {
@@ -2021,6 +2035,17 @@ export type ColonyMembersWithReputationQueryVariables = Exact<{
 
 
 export type ColonyMembersWithReputationQuery = Pick<Query, 'colonyMembersWithReputation'>;
+
+export type ColonyContributorsQueryVariables = Exact<{
+  colonyAddress: Scalars['String'];
+  domainId?: Maybe<Scalars['Int']>;
+}>;
+
+
+export type ColonyContributorsQuery = { colonyContributors: Array<(
+    Pick<ColonyContributor, 'id' | 'directRoles' | 'roles'>
+    & { profile: Pick<UserProfile, 'avatarHash' | 'displayName' | 'username' | 'walletAddress'> }
+  )> };
 
 export type ColonyReputationQueryVariables = Exact<{
   address: Scalars['String'];
@@ -5100,6 +5125,48 @@ export function useColonyMembersWithReputationLazyQuery(baseOptions?: Apollo.Laz
 export type ColonyMembersWithReputationQueryHookResult = ReturnType<typeof useColonyMembersWithReputationQuery>;
 export type ColonyMembersWithReputationLazyQueryHookResult = ReturnType<typeof useColonyMembersWithReputationLazyQuery>;
 export type ColonyMembersWithReputationQueryResult = Apollo.QueryResult<ColonyMembersWithReputationQuery, ColonyMembersWithReputationQueryVariables>;
+export const ColonyContributorsDocument = gql`
+    query ColonyContributors($colonyAddress: String!, $domainId: Int) {
+  colonyContributors(colonyAddress: $colonyAddress, domainId: $domainId) @client {
+    id
+    directRoles
+    roles
+    profile {
+      avatarHash
+      displayName
+      username
+      walletAddress
+    }
+  }
+}
+    `;
+
+/**
+ * __useColonyContributorsQuery__
+ *
+ * To run a query within a React component, call `useColonyContributorsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useColonyContributorsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useColonyContributorsQuery({
+ *   variables: {
+ *      colonyAddress: // value for 'colonyAddress'
+ *      domainId: // value for 'domainId'
+ *   },
+ * });
+ */
+export function useColonyContributorsQuery(baseOptions?: Apollo.QueryHookOptions<ColonyContributorsQuery, ColonyContributorsQueryVariables>) {
+        return Apollo.useQuery<ColonyContributorsQuery, ColonyContributorsQueryVariables>(ColonyContributorsDocument, baseOptions);
+      }
+export function useColonyContributorsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ColonyContributorsQuery, ColonyContributorsQueryVariables>) {
+          return Apollo.useLazyQuery<ColonyContributorsQuery, ColonyContributorsQueryVariables>(ColonyContributorsDocument, baseOptions);
+        }
+export type ColonyContributorsQueryHookResult = ReturnType<typeof useColonyContributorsQuery>;
+export type ColonyContributorsLazyQueryHookResult = ReturnType<typeof useColonyContributorsLazyQuery>;
+export type ColonyContributorsQueryResult = Apollo.QueryResult<ColonyContributorsQuery, ColonyContributorsQueryVariables>;
 export const ColonyReputationDocument = gql`
     query ColonyReputation($address: String!, $domainId: Int) {
   colonyReputation(address: $address, domainId: $domainId) @client

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -2038,6 +2038,7 @@ export type ColonyMembersWithReputationQuery = Pick<Query, 'colonyMembersWithRep
 
 export type ColonyContributorsQueryVariables = Exact<{
   colonyAddress: Scalars['String'];
+  colonyName?: Maybe<ColonyName>;
   domainId?: Maybe<Scalars['Int']>;
 }>;
 
@@ -5126,8 +5127,8 @@ export type ColonyMembersWithReputationQueryHookResult = ReturnType<typeof useCo
 export type ColonyMembersWithReputationLazyQueryHookResult = ReturnType<typeof useColonyMembersWithReputationLazyQuery>;
 export type ColonyMembersWithReputationQueryResult = Apollo.QueryResult<ColonyMembersWithReputationQuery, ColonyMembersWithReputationQueryVariables>;
 export const ColonyContributorsDocument = gql`
-    query ColonyContributors($colonyAddress: String!, $domainId: Int) {
-  colonyContributors(colonyAddress: $colonyAddress, domainId: $domainId) @client {
+    query ColonyContributors($colonyAddress: String!, $colonyName: colonyName, $domainId: Int) {
+  colonyContributors(colonyAddress: $colonyAddress, colonyName: $colonyName, domainId: $domainId) @client {
     id
     directRoles
     roles
@@ -5154,6 +5155,7 @@ export const ColonyContributorsDocument = gql`
  * const { data, loading, error } = useColonyContributorsQuery({
  *   variables: {
  *      colonyAddress: // value for 'colonyAddress'
+ *      colonyName: // value for 'colonyName'
  *      domainId: // value for 'domainId'
  *   },
  * });

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -1123,7 +1123,7 @@ export type ColonyContributor = {
   profile: UserProfile;
 };
 
-export type Watcher = {
+export type ColonyWatcher = {
   id: Scalars['String'];
   profile: UserProfile;
   banned: Scalars['Boolean'];
@@ -1131,7 +1131,7 @@ export type Watcher = {
 
 export type ContributorsAndWatchers = {
   contributors: Array<ColonyContributor>;
-  watchers: Array<Watcher>;
+  watchers: Array<ColonyWatcher>;
 };
 
 export type ByColonyFilter = {
@@ -2057,10 +2057,10 @@ export type ContributorsAndWatchersQueryVariables = Exact<{
 
 
 export type ContributorsAndWatchersQuery = { contributorsAndWatchers?: Maybe<{ contributors: Array<(
-      Pick<ColonyContributor, 'id' | 'directRoles' | 'roles'>
+      Pick<ColonyContributor, 'id' | 'directRoles' | 'roles' | 'banned'>
       & { profile: Pick<UserProfile, 'avatarHash' | 'displayName' | 'username' | 'walletAddress'> }
     )>, watchers: Array<(
-      Pick<Watcher, 'id'>
+      Pick<ColonyWatcher, 'id' | 'banned'>
       & { profile: Pick<UserProfile, 'avatarHash' | 'displayName' | 'username' | 'walletAddress'> }
     )> }> };
 
@@ -5149,6 +5149,7 @@ export const ContributorsAndWatchersDocument = gql`
       id
       directRoles
       roles
+      banned
       profile {
         avatarHash
         displayName
@@ -5158,6 +5159,7 @@ export const ContributorsAndWatchersDocument = gql`
     }
     watchers {
       id
+      banned
       profile {
         avatarHash
         displayName

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -245,12 +245,12 @@ export type Query = {
   colony: SubgraphColony;
   colonyAction: ColonyAction;
   colonyAddress: Scalars['String'];
-  colonyContributors: Array<ColonyContributor>;
   colonyDomain: ProcessedDomain;
   colonyExtension?: Maybe<ColonyExtension>;
   colonyMembersWithReputation?: Maybe<Array<Scalars['String']>>;
   colonyName: Scalars['String'];
   colonyReputation?: Maybe<Scalars['String']>;
+  contributorsAndWatchers?: Maybe<ContributorsAndWatchers>;
   currentPeriodTokens: CurrentPeriodTokens;
   domain: SubgraphUnusedDomain;
   domainBalance: Scalars['String'];
@@ -409,12 +409,6 @@ export type QueryColonyAddressArgs = {
 };
 
 
-export type QueryColonyContributorsArgs = {
-  colonyAddress: Scalars['String'];
-  domainId?: Maybe<Scalars['Int']>;
-};
-
-
 export type QueryColonyDomainArgs = {
   colonyAddress: Scalars['String'];
   domainId: Scalars['Int'];
@@ -440,6 +434,13 @@ export type QueryColonyNameArgs = {
 
 export type QueryColonyReputationArgs = {
   address: Scalars['String'];
+  domainId?: Maybe<Scalars['Int']>;
+};
+
+
+export type QueryContributorsAndWatchersArgs = {
+  colonyAddress: Scalars['String'];
+  colonyName: Scalars['String'];
   domainId?: Maybe<Scalars['Int']>;
 };
 
@@ -1118,7 +1119,19 @@ export type ColonyContributor = {
   id: Scalars['String'];
   directRoles: Array<Scalars['Int']>;
   roles: Array<Scalars['Int']>;
+  banned: Scalars['Boolean'];
   profile: UserProfile;
+};
+
+export type Watcher = {
+  id: Scalars['String'];
+  profile: UserProfile;
+  banned: Scalars['Boolean'];
+};
+
+export type ContributorsAndWatchers = {
+  contributors: Array<ColonyContributor>;
+  watchers: Array<Watcher>;
 };
 
 export type ByColonyFilter = {
@@ -2036,17 +2049,20 @@ export type ColonyMembersWithReputationQueryVariables = Exact<{
 
 export type ColonyMembersWithReputationQuery = Pick<Query, 'colonyMembersWithReputation'>;
 
-export type ColonyContributorsQueryVariables = Exact<{
+export type ContributorsAndWatchersQueryVariables = Exact<{
   colonyAddress: Scalars['String'];
   colonyName?: Maybe<ColonyName>;
   domainId?: Maybe<Scalars['Int']>;
 }>;
 
 
-export type ColonyContributorsQuery = { colonyContributors: Array<(
-    Pick<ColonyContributor, 'id' | 'directRoles' | 'roles'>
-    & { profile: Pick<UserProfile, 'avatarHash' | 'displayName' | 'username' | 'walletAddress'> }
-  )> };
+export type ContributorsAndWatchersQuery = { contributorsAndWatchers?: Maybe<{ contributors: Array<(
+      Pick<ColonyContributor, 'id' | 'directRoles' | 'roles'>
+      & { profile: Pick<UserProfile, 'avatarHash' | 'displayName' | 'username' | 'walletAddress'> }
+    )>, watchers: Array<(
+      Pick<Watcher, 'id'>
+      & { profile: Pick<UserProfile, 'avatarHash' | 'displayName' | 'username' | 'walletAddress'> }
+    )> }> };
 
 export type ColonyReputationQueryVariables = Exact<{
   address: Scalars['String'];
@@ -5126,33 +5142,44 @@ export function useColonyMembersWithReputationLazyQuery(baseOptions?: Apollo.Laz
 export type ColonyMembersWithReputationQueryHookResult = ReturnType<typeof useColonyMembersWithReputationQuery>;
 export type ColonyMembersWithReputationLazyQueryHookResult = ReturnType<typeof useColonyMembersWithReputationLazyQuery>;
 export type ColonyMembersWithReputationQueryResult = Apollo.QueryResult<ColonyMembersWithReputationQuery, ColonyMembersWithReputationQueryVariables>;
-export const ColonyContributorsDocument = gql`
-    query ColonyContributors($colonyAddress: String!, $colonyName: colonyName, $domainId: Int) {
-  colonyContributors(colonyAddress: $colonyAddress, colonyName: $colonyName, domainId: $domainId) @client {
-    id
-    directRoles
-    roles
-    profile {
-      avatarHash
-      displayName
-      username
-      walletAddress
+export const ContributorsAndWatchersDocument = gql`
+    query ContributorsAndWatchers($colonyAddress: String!, $colonyName: colonyName, $domainId: Int) {
+  contributorsAndWatchers(colonyAddress: $colonyAddress, colonyName: $colonyName, domainId: $domainId) @client {
+    contributors {
+      id
+      directRoles
+      roles
+      profile {
+        avatarHash
+        displayName
+        username
+        walletAddress
+      }
+    }
+    watchers {
+      id
+      profile {
+        avatarHash
+        displayName
+        username
+        walletAddress
+      }
     }
   }
 }
     `;
 
 /**
- * __useColonyContributorsQuery__
+ * __useContributorsAndWatchersQuery__
  *
- * To run a query within a React component, call `useColonyContributorsQuery` and pass it any options that fit your needs.
- * When your component renders, `useColonyContributorsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useContributorsAndWatchersQuery` and pass it any options that fit your needs.
+ * When your component renders, `useContributorsAndWatchersQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useColonyContributorsQuery({
+ * const { data, loading, error } = useContributorsAndWatchersQuery({
  *   variables: {
  *      colonyAddress: // value for 'colonyAddress'
  *      colonyName: // value for 'colonyName'
@@ -5160,15 +5187,15 @@ export const ColonyContributorsDocument = gql`
  *   },
  * });
  */
-export function useColonyContributorsQuery(baseOptions?: Apollo.QueryHookOptions<ColonyContributorsQuery, ColonyContributorsQueryVariables>) {
-        return Apollo.useQuery<ColonyContributorsQuery, ColonyContributorsQueryVariables>(ColonyContributorsDocument, baseOptions);
+export function useContributorsAndWatchersQuery(baseOptions?: Apollo.QueryHookOptions<ContributorsAndWatchersQuery, ContributorsAndWatchersQueryVariables>) {
+        return Apollo.useQuery<ContributorsAndWatchersQuery, ContributorsAndWatchersQueryVariables>(ContributorsAndWatchersDocument, baseOptions);
       }
-export function useColonyContributorsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ColonyContributorsQuery, ColonyContributorsQueryVariables>) {
-          return Apollo.useLazyQuery<ColonyContributorsQuery, ColonyContributorsQueryVariables>(ColonyContributorsDocument, baseOptions);
+export function useContributorsAndWatchersLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ContributorsAndWatchersQuery, ContributorsAndWatchersQueryVariables>) {
+          return Apollo.useLazyQuery<ContributorsAndWatchersQuery, ContributorsAndWatchersQueryVariables>(ContributorsAndWatchersDocument, baseOptions);
         }
-export type ColonyContributorsQueryHookResult = ReturnType<typeof useColonyContributorsQuery>;
-export type ColonyContributorsLazyQueryHookResult = ReturnType<typeof useColonyContributorsLazyQuery>;
-export type ColonyContributorsQueryResult = Apollo.QueryResult<ColonyContributorsQuery, ColonyContributorsQueryVariables>;
+export type ContributorsAndWatchersQueryHookResult = ReturnType<typeof useContributorsAndWatchersQuery>;
+export type ContributorsAndWatchersLazyQueryHookResult = ReturnType<typeof useContributorsAndWatchersLazyQuery>;
+export type ContributorsAndWatchersQueryResult = Apollo.QueryResult<ContributorsAndWatchersQuery, ContributorsAndWatchersQueryVariables>;
 export const ColonyReputationDocument = gql`
     query ColonyReputation($address: String!, $domainId: Int) {
   colonyReputation(address: $address, domainId: $domainId) @client

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -2051,7 +2051,7 @@ export type ColonyMembersWithReputationQuery = Pick<Query, 'colonyMembersWithRep
 
 export type ContributorsAndWatchersQueryVariables = Exact<{
   colonyAddress: Scalars['String'];
-  colonyName?: Maybe<ColonyName>;
+  colonyName: Scalars['String'];
   domainId?: Maybe<Scalars['Int']>;
 }>;
 
@@ -5143,7 +5143,7 @@ export type ColonyMembersWithReputationQueryHookResult = ReturnType<typeof useCo
 export type ColonyMembersWithReputationLazyQueryHookResult = ReturnType<typeof useColonyMembersWithReputationLazyQuery>;
 export type ColonyMembersWithReputationQueryResult = Apollo.QueryResult<ColonyMembersWithReputationQuery, ColonyMembersWithReputationQueryVariables>;
 export const ContributorsAndWatchersDocument = gql`
-    query ContributorsAndWatchers($colonyAddress: String!, $colonyName: colonyName, $domainId: Int) {
+    query ContributorsAndWatchers($colonyAddress: String!, $colonyName: String!, $domainId: Int) {
   contributorsAndWatchers(colonyAddress: $colonyAddress, colonyName: $colonyName, domainId: $domainId) @client {
     contributors {
       id

--- a/src/data/graphql/queries.graphql
+++ b/src/data/graphql/queries.graphql
@@ -466,6 +466,20 @@ query ColonyMembersWithReputation($colonyAddress: String!, $domainId: Int) {
   colonyMembersWithReputation(colonyAddress: $colonyAddress, domainId: $domainId) @client
 }
 
+query ColonyContributors($colonyAddress: String!, $domainId: Int) {
+  colonyContributors(colonyAddress: $colonyAddress, domainId: $domainId) @client {
+    id
+    directRoles
+    roles
+    profile {
+      avatarHash
+      displayName
+      username
+      walletAddress
+    }
+  }
+}
+
 query ColonyReputation($address: String!, $domainId: Int) {
   colonyReputation(address: $address, domainId: $domainId) @client
 }

--- a/src/data/graphql/queries.graphql
+++ b/src/data/graphql/queries.graphql
@@ -466,8 +466,8 @@ query ColonyMembersWithReputation($colonyAddress: String!, $domainId: Int) {
   colonyMembersWithReputation(colonyAddress: $colonyAddress, domainId: $domainId) @client
 }
 
-query ColonyContributors($colonyAddress: String!, $domainId: Int) {
-  colonyContributors(colonyAddress: $colonyAddress, domainId: $domainId) @client {
+query ColonyContributors($colonyAddress: String!, $colonyName: colonyName, $domainId: Int) {
+  colonyContributors(colonyAddress: $colonyAddress, colonyName: $colonyName, domainId: $domainId) @client {
     id
     directRoles
     roles

--- a/src/data/graphql/queries.graphql
+++ b/src/data/graphql/queries.graphql
@@ -466,7 +466,7 @@ query ColonyMembersWithReputation($colonyAddress: String!, $domainId: Int) {
   colonyMembersWithReputation(colonyAddress: $colonyAddress, domainId: $domainId) @client
 }
 
-query ContributorsAndWatchers($colonyAddress: String!, $colonyName: colonyName, $domainId: Int) {
+query ContributorsAndWatchers($colonyAddress: String!, $colonyName: String!, $domainId: Int) {
   contributorsAndWatchers(colonyAddress: $colonyAddress, colonyName: $colonyName, domainId: $domainId) @client {
     contributors {
       id

--- a/src/data/graphql/queries.graphql
+++ b/src/data/graphql/queries.graphql
@@ -466,16 +466,27 @@ query ColonyMembersWithReputation($colonyAddress: String!, $domainId: Int) {
   colonyMembersWithReputation(colonyAddress: $colonyAddress, domainId: $domainId) @client
 }
 
-query ColonyContributors($colonyAddress: String!, $colonyName: colonyName, $domainId: Int) {
-  colonyContributors(colonyAddress: $colonyAddress, colonyName: $colonyName, domainId: $domainId) @client {
-    id
-    directRoles
-    roles
-    profile {
-      avatarHash
-      displayName
-      username
-      walletAddress
+query ContributorsAndWatchers($colonyAddress: String!, $colonyName: colonyName, $domainId: Int) {
+  contributorsAndWatchers(colonyAddress: $colonyAddress, colonyName: $colonyName, domainId: $domainId) @client {
+    contributors {
+      id
+      directRoles
+      roles
+      profile {
+        avatarHash
+        displayName
+        username
+        walletAddress
+      }
+    }
+    watchers {
+      id
+      profile {
+        avatarHash
+        displayName
+        username
+        walletAddress
+      }
     }
   }
 }

--- a/src/data/graphql/queries.graphql
+++ b/src/data/graphql/queries.graphql
@@ -472,6 +472,7 @@ query ContributorsAndWatchers($colonyAddress: String!, $colonyName: String!, $do
       id
       directRoles
       roles
+      banned
       profile {
         avatarHash
         displayName
@@ -481,6 +482,7 @@ query ContributorsAndWatchers($colonyAddress: String!, $colonyName: String!, $do
     }
     watchers {
       id
+      banned
       profile {
         avatarHash
         displayName

--- a/src/data/graphql/typeDefs.ts
+++ b/src/data/graphql/typeDefs.ts
@@ -252,7 +252,19 @@ export default gql`
     id: String!
     directRoles: [Int!]!
     roles: [Int!]!
+    banned: Boolean!
     profile: UserProfile!
+  }
+
+  type Watcher {
+    id: String!
+    profile: UserProfile!
+    banned: Boolean!
+  }
+
+  type ContributorsAndWatchers {
+    contributors: [ColonyContributor!]!
+    watchers: [Watcher!]!
   }
 
   extend type Query {
@@ -260,10 +272,11 @@ export default gql`
     colonyAddress(name: String!): String!
     colonyName(address: String!): String!
     colonyReputation(address: String!, domainId: Int): String
-    colonyContributors(
+    contributorsAndWatchers(
       colonyAddress: String!
+      colonyName: String!
       domainId: Int
-    ): [ColonyContributor!]!
+    ): ContributorsAndWatchers
     colonyMembersWithReputation(
       colonyAddress: String!
       domainId: Int

--- a/src/data/graphql/typeDefs.ts
+++ b/src/data/graphql/typeDefs.ts
@@ -248,11 +248,22 @@ export default gql`
     reputationPercentage: String!
   }
 
+  type ColonyContributor {
+    id: String!
+    directRoles: [Int!]!
+    roles: [Int!]!
+    profile: UserProfile!
+  }
+
   extend type Query {
     loggedInUser: LoggedInUser!
     colonyAddress(name: String!): String!
     colonyName(address: String!): String!
     colonyReputation(address: String!, domainId: Int): String
+    colonyContributors(
+      colonyAddress: String!
+      domainId: Int
+    ): [ColonyContributor!]!
     colonyMembersWithReputation(
       colonyAddress: String!
       domainId: Int

--- a/src/data/graphql/typeDefs.ts
+++ b/src/data/graphql/typeDefs.ts
@@ -256,7 +256,7 @@ export default gql`
     profile: UserProfile!
   }
 
-  type Watcher {
+  type ColonyWatcher {
     id: String!
     profile: UserProfile!
     banned: Boolean!
@@ -264,7 +264,7 @@ export default gql`
 
   type ContributorsAndWatchers {
     contributors: [ColonyContributor!]!
-    watchers: [Watcher!]!
+    watchers: [ColonyWatcher!]!
   }
 
   extend type Query {

--- a/src/data/resolvers/colony.ts
+++ b/src/data/resolvers/colony.ts
@@ -417,7 +417,7 @@ export const colonyResolvers = ({
       >({
         query: BannedUsersDocument,
         variables: {
-          colonyAddress: colonyAddress.toLowerCase(),
+          colonyAddress,
         },
         fetchPolicy: 'network-only',
       });

--- a/src/data/resolvers/colony.ts
+++ b/src/data/resolvers/colony.ts
@@ -11,6 +11,7 @@ import {
   ROOT_DOMAIN_ID,
   getHistoricColonyRoles,
   formatColonyRoles,
+  ColonyRole,
 } from '@colony/colony-js';
 
 import { Color } from '~core/ColorTag';
@@ -34,6 +35,18 @@ import {
   SubgraphLatestSyncedBlockQuery,
   SubgraphLatestSyncedBlockQueryVariables,
   SubgraphLatestSyncedBlockDocument,
+  ColonyMembersWithReputationQuery,
+  ColonyMembersWithReputationQueryVariables,
+  ColonyMembersWithReputationDocument,
+  ColonyFromNameQuery,
+  ColonyFromNameQueryVariables,
+  ColonyFromNameDocument,
+  ColonyMembersQuery,
+  ColonyMembersQueryVariables,
+  ColonyMembersDocument,
+  BannedUsersQuery,
+  BannedUsersQueryVariables,
+  BannedUsersDocument,
 } from '~data/index';
 
 import { createAddress } from '~utils/web3';
@@ -42,6 +55,7 @@ import { parseSubgraphEvent } from '~utils/events';
 import { Address } from '~types/index';
 
 import { COLONY_TOTAL_BALANCE_DOMAIN_ID } from '~constants';
+import { getAllUserRolesForDomain } from '~modules/transformers';
 
 import { getToken } from './token';
 import {
@@ -310,6 +324,177 @@ export const colonyResolvers = ({
       const { skillId } = await colonyClient.getDomain(domainId);
       const { addresses } = await colonyClient.getMembersReputation(skillId);
       return addresses || [];
+    },
+    async contributorsAndWatchers(
+      _,
+      {
+        colonyAddress,
+        colonyName,
+        domainId = COLONY_TOTAL_BALANCE_DOMAIN_ID,
+      }: { colonyAddress: Address; colonyName: string; domainId: number },
+    ) {
+      const { data: colony } = await apolloClient.query<
+        ColonyFromNameQuery,
+        ColonyFromNameQueryVariables
+      >({
+        query: ColonyFromNameDocument,
+        variables: {
+          name: colonyName,
+          address: colonyAddress.toLowerCase(),
+        },
+        fetchPolicy: 'network-only',
+      });
+
+      const domainRoles = getAllUserRolesForDomain(
+        colony?.processedColony,
+        domainId === COLONY_TOTAL_BALANCE_DOMAIN_ID ? ROOT_DOMAIN_ID : domainId,
+      );
+      const directDomainRoles = getAllUserRolesForDomain(
+        colony?.processedColony,
+        domainId === COLONY_TOTAL_BALANCE_DOMAIN_ID ? ROOT_DOMAIN_ID : domainId,
+        true,
+      );
+
+      const inheritedDomainRoles = getAllUserRolesForDomain(
+        colony?.processedColony,
+        ROOT_DOMAIN_ID,
+        true,
+      );
+
+      const domainRolesArray = domainRoles
+        .sort(({ roles }) => (roles.includes(ColonyRole.Root) ? -1 : 1))
+        .filter(({ roles }) => !!roles.length)
+        .map(({ address, roles }) => {
+          const directUserRoles = directDomainRoles.find(
+            ({ address: userAddress }) => userAddress === address,
+          );
+          const rootRoles = inheritedDomainRoles.find(
+            ({ address: userAddress }) => userAddress === address,
+          );
+          const allUserRoles = [
+            ...new Set([
+              ...(directUserRoles?.roles || []),
+              ...(rootRoles?.roles || []),
+            ]),
+          ];
+          return {
+            userAddress: address,
+            roles,
+            directRoles: allUserRoles,
+          };
+        });
+
+      const { data: membersWithReputationData } = await apolloClient.query<
+        ColonyMembersWithReputationQuery,
+        ColonyMembersWithReputationQueryVariables
+      >({
+        query: ColonyMembersWithReputationDocument,
+        variables: {
+          colonyAddress: colonyAddress.toLowerCase(),
+          domainId,
+        },
+        fetchPolicy: 'network-only',
+      });
+
+      const membersWithReputation = [
+        ...(membersWithReputationData?.colonyMembersWithReputation || []),
+      ];
+
+      const { data: members } = await apolloClient.query<
+        ColonyMembersQuery,
+        ColonyMembersQueryVariables
+      >({
+        query: ColonyMembersDocument,
+        variables: {
+          colonyAddress,
+        },
+        fetchPolicy: 'network-only',
+      });
+
+      const { data: bannedUsers } = await apolloClient.query<
+        BannedUsersQuery,
+        BannedUsersQueryVariables
+      >({
+        query: BannedUsersDocument,
+        variables: {
+          colonyAddress: colonyAddress.toLowerCase(),
+        },
+        fetchPolicy: 'network-only',
+      });
+
+      const contributors: any[] = [];
+      const watchers: any[] = [];
+
+      members?.subscribedUsers.forEach((user) => {
+        const {
+          profile: { walletAddress },
+        } = user;
+
+        const isUserBanned = bannedUsers?.bannedUsers?.find(
+          ({
+            id: bannedUserWalletAddress,
+            banned,
+          }: {
+            id: Address;
+            banned: boolean;
+          }) =>
+            banned &&
+            createAddress(bannedUserWalletAddress) ===
+              createAddress(walletAddress),
+        );
+
+        const domainRole = domainRolesArray.find(
+          (rolesObject) =>
+            createAddress(rolesObject.userAddress) ===
+            createAddress(walletAddress),
+        );
+
+        const indexInReputationArr = membersWithReputation.indexOf(
+          walletAddress.toLowerCase(),
+        );
+        if (indexInReputationArr > -1) {
+          membersWithReputation.splice(indexInReputationArr, 1);
+        }
+
+        if (domainRole || indexInReputationArr > -1) {
+          contributors.push({
+            ...user,
+            roles: domainRole ? domainRole.roles : [],
+            directRoles: domainRole ? domainRole.directRoles : [],
+            banned: !!isUserBanned,
+          });
+        } else {
+          watchers.push({ ...user, banned: !!isUserBanned });
+        }
+      });
+
+      membersWithReputation.forEach((walletAddress) => {
+        const address = createAddress(walletAddress);
+
+        const isUserBanned = bannedUsers?.bannedUsers?.find(
+          ({
+            id: bannedUserWalletAddress,
+            banned,
+          }: {
+            id: Address;
+            banned: boolean;
+          }) => banned && createAddress(bannedUserWalletAddress) === address,
+        );
+
+        contributors.push({
+          __typename: 'User',
+          id: address,
+          profile: {
+            __typename: 'UserProfile',
+            walletAddress: address,
+          },
+          roles: [],
+          directRoles: [],
+          banned: !!isUserBanned,
+        });
+      });
+
+      return { contributors, watchers };
     },
     async colonyDomain(_, { colonyAddress, domainId }) {
       const { data } = await apolloClient.query<

--- a/src/modules/core/components/MembersList/MembersList.tsx
+++ b/src/modules/core/components/MembersList/MembersList.tsx
@@ -14,6 +14,7 @@ interface Props<U> {
   domainId: number | undefined;
   users: U[];
   listGroupAppearance?: ListGroupAppearance;
+  canAdministerComments?: boolean;
 }
 
 const displayName = 'MembersList';
@@ -27,6 +28,7 @@ const MembersList = <U extends AnyUser = AnyUser>({
   domainId,
   users,
   listGroupAppearance,
+  canAdministerComments,
 }: Props<U>) => (
   <ListGroup appearance={listGroupAppearance}>
     {users.map((user) => (
@@ -39,6 +41,7 @@ const MembersList = <U extends AnyUser = AnyUser>({
         showUserReputation={showUserReputation}
         domainId={domainId}
         user={user}
+        canAdministerComments={canAdministerComments}
       />
     ))}
   </ListGroup>

--- a/src/modules/core/components/MembersList/MembersListItem.tsx
+++ b/src/modules/core/components/MembersList/MembersListItem.tsx
@@ -27,26 +27,35 @@ interface Props<U> {
   showUserReputation: boolean;
   domainId: number | undefined;
   user: U;
+  canAdministerComments?: boolean;
 }
 
 const UserAvatar = HookedUserAvatar({ fetchUser: false });
 
 const componentDisplayName = 'MembersList.MembersListItem';
 
-const MembersListItem = <U extends AnyUser = AnyUser>(props: Props<U>) => {
-  const {
-    colony,
-    domainId,
-    extraItemContent,
-    onRowClick,
-    showUserInfo,
-    showUserReputation,
-    user,
-  } = props;
+const MembersListItem = <U extends AnyUser = AnyUser>({
+  colony,
+  domainId,
+  extraItemContent,
+  onRowClick,
+  showUserInfo,
+  showUserReputation,
+  user,
+  canAdministerComments,
+}: Props<U>) => {
   const {
     profile: { walletAddress },
     banned = false,
   } = user as AnyUser & { banned: boolean };
+
+  const isUserBanned = useMemo(
+    () =>
+      canAdministerComments !== undefined
+        ? canAdministerComments && banned
+        : banned,
+    [banned, canAdministerComments],
+  );
 
   const userProfile = useUser(createAddress(walletAddress || AddressZero));
 
@@ -112,7 +121,7 @@ const MembersListItem = <U extends AnyUser = AnyUser>(props: Props<U>) => {
             showInfo={!onRowClick || showUserInfo}
             domainId={domainId}
             notSet={false}
-            banned={banned}
+            banned={isUserBanned}
           />
         </div>
         <div className={styles.usernameSection}>

--- a/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.tsx
@@ -1,14 +1,9 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { defineMessages } from 'react-intl';
 import { ROOT_DOMAIN_ID } from '@colony/colony-js';
 
 import { MiniSpinnerLoader } from '~core/Preloaders';
-import {
-  Colony,
-  useColonyMembersWithReputationQuery,
-  useMembersSubscription,
-  useBannedUsersQuery,
-} from '~data/index';
+import { Colony, useContributorsAndWatchersQuery } from '~data/index';
 import { COLONY_TOTAL_BALANCE_DOMAIN_ID } from '~constants';
 
 import styles from './ColonyMembers.css';
@@ -34,17 +29,18 @@ interface Props {
 const displayName = 'dashboard.ColonyHome.ColonyMembers';
 
 const ColonyMembers = ({
-  colony: { colonyAddress },
+  colony: { colonyAddress, colonyName },
   colony,
   currentDomainId = COLONY_TOTAL_BALANCE_DOMAIN_ID,
   maxAvatars,
 }: Props) => {
   const {
-    data: membersWithReputation,
-    loading: loadingColonyMembersWithReputation,
-  } = useColonyMembersWithReputationQuery({
+    data: members,
+    loading: loadingMembers,
+  } = useContributorsAndWatchersQuery({
     variables: {
       colonyAddress,
+      colonyName,
       domainId:
         currentDomainId === COLONY_TOTAL_BALANCE_DOMAIN_ID
           ? ROOT_DOMAIN_ID
@@ -52,38 +48,7 @@ const ColonyMembers = ({
     },
   });
 
-  const { data: members, loading: loadingMembers } = useMembersSubscription({
-    variables: {
-      colonyAddress,
-    },
-  });
-
-  const {
-    data: bannedMembers,
-    loading: loadingBannedUsers,
-  } = useBannedUsersQuery({
-    variables: {
-      colonyAddress,
-    },
-  });
-
-  const subscribers = useMemo(() => {
-    const allMembers = members?.subscribedUsers?.map(
-      ({ profile: { walletAddress } }) => walletAddress.toLowerCase(),
-    );
-
-    return (allMembers || []).filter(
-      (member) =>
-        membersWithReputation?.colonyMembersWithReputation?.indexOf(member) ===
-        -1,
-    );
-  }, [members, membersWithReputation]);
-
-  if (
-    loadingColonyMembersWithReputation ||
-    loadingMembers ||
-    loadingBannedUsers
-  ) {
+  if (loadingMembers) {
     return (
       <MiniSpinnerLoader
         className={styles.main}
@@ -97,16 +62,14 @@ const ColonyMembers = ({
   return (
     <>
       <MembersSubsection
-        members={membersWithReputation?.colonyMembersWithReputation}
-        bannedMembers={bannedMembers?.bannedUsers || []}
+        members={members?.contributorsAndWatchers?.contributors}
         colony={colony}
         isContributorsSubsection
       />
       {(currentDomainId === ROOT_DOMAIN_ID ||
         currentDomainId === COLONY_TOTAL_BALANCE_DOMAIN_ID) && (
         <MembersSubsection
-          members={subscribers}
-          bannedMembers={bannedMembers?.bannedUsers || []}
+          members={members?.contributorsAndWatchers?.watchers}
           colony={colony}
           maxAvatars={maxAvatars}
           isContributorsSubsection={false}

--- a/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.tsx
@@ -41,10 +41,7 @@ const ColonyMembers = ({
     variables: {
       colonyAddress,
       colonyName,
-      domainId:
-        currentDomainId === COLONY_TOTAL_BALANCE_DOMAIN_ID
-          ? ROOT_DOMAIN_ID
-          : currentDomainId,
+      domainId: currentDomainId,
     },
   });
 

--- a/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.tsx
@@ -45,7 +45,10 @@ const ColonyMembers = ({
   } = useColonyMembersWithReputationQuery({
     variables: {
       colonyAddress,
-      domainId: currentDomainId,
+      domainId:
+        currentDomainId === COLONY_TOTAL_BALANCE_DOMAIN_ID
+          ? ROOT_DOMAIN_ID
+          : currentDomainId,
     },
   });
 
@@ -64,13 +67,17 @@ const ColonyMembers = ({
     },
   });
 
-  const subscribers = useMemo(
-    () =>
-      members?.subscribedUsers?.map(
-        ({ profile: { walletAddress } }) => walletAddress,
-      ),
-    [members],
-  );
+  const subscribers = useMemo(() => {
+    const allMembers = members?.subscribedUsers?.map(
+      ({ profile: { walletAddress } }) => walletAddress.toLowerCase(),
+    );
+
+    return (allMembers || []).filter(
+      (member) =>
+        membersWithReputation?.colonyMembersWithReputation?.indexOf(member) ===
+        -1,
+    );
+  }, [members, membersWithReputation]);
 
   if (
     loadingColonyMembersWithReputation ||
@@ -90,7 +97,7 @@ const ColonyMembers = ({
   return (
     <>
       <MembersSubsection
-        members={subscribers}
+        members={membersWithReputation?.colonyMembersWithReputation}
         bannedMembers={bannedMembers?.bannedUsers || []}
         colony={colony}
         isContributorsSubsection
@@ -98,8 +105,8 @@ const ColonyMembers = ({
       {(currentDomainId === ROOT_DOMAIN_ID ||
         currentDomainId === COLONY_TOTAL_BALANCE_DOMAIN_ID) && (
         <MembersSubsection
+          members={subscribers}
           bannedMembers={bannedMembers?.bannedUsers || []}
-          members={membersWithReputation?.colonyMembersWithReputation}
           colony={colony}
           maxAvatars={maxAvatars}
           isContributorsSubsection={false}

--- a/src/modules/dashboard/components/ColonyHome/ColonyMembers/MembersSubsection.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMembers/MembersSubsection.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import Maybe from 'graphql/tsutils/Maybe';
 
@@ -10,9 +10,15 @@ import InviteLinkButton from '~dashboard/InviteLinkButton';
 
 import HookedUserAvatar from '~users/HookedUserAvatar';
 import useAvatarDisplayCounter from '~utils/hooks/useAvatarDisplayCounter';
-import { Colony, useLoggedInUser, BannedUser, UserProfile } from '~data/index';
+import {
+  Colony,
+  useLoggedInUser,
+  BannedUser,
+  UserProfile,
+  ColonyContributor,
+  ColonyWatcher,
+} from '~data/index';
 import { COLONY_TOTAL_BALANCE_DOMAIN_ID } from '~constants';
-import { Address } from '~types/index';
 import { useTransformer } from '~utils/hooks';
 import { getAllUserRoles } from '~modules/transformers';
 import { hasRoot, canAdminister } from '~modules/users/checks';
@@ -36,7 +42,7 @@ const MSG = defineMessages({
   },
   reputationFetchFailed: {
     id: `dashboard.ColonyHome.ColonyMembers.MembersSubsection.reputationFetchFailed`,
-    defaultMessage: `Failed to fetch the colony's 
+    defaultMessage: `Failed to fetch the colony's
       {isContributorsSubsection, select,
         true { contributors }
         other { watchers }
@@ -69,8 +75,7 @@ interface Props {
   colony: Colony;
   currentDomainId?: number;
   maxAvatars?: number;
-  members: Maybe<string[]>;
-  bannedMembers?: BannedMember[];
+  members?: ColonyContributor[] | ColonyWatcher[];
   isContributorsSubsection: boolean;
 }
 
@@ -83,7 +88,6 @@ const MAX_AVATARS = 12;
 const MembersSubsection = ({
   colony: { colonyName },
   members,
-  bannedMembers,
   isContributorsSubsection,
   colony,
   currentDomainId = COLONY_TOTAL_BALANCE_DOMAIN_ID,
@@ -106,33 +110,13 @@ const MembersSubsection = ({
   const {
     avatarsDisplaySplitRules,
     remainingAvatarsCount,
-  } = useAvatarDisplayCounter(maxAvatars, members, false);
+  } = useAvatarDisplayCounter(maxAvatars, members || [], false);
 
   const BASE_MEMBERS_ROUTE = `/colony/${colonyName}/members`;
   const membersPageRoute =
     currentDomainId === COLONY_TOTAL_BALANCE_DOMAIN_ID
       ? BASE_MEMBERS_ROUTE
       : `${BASE_MEMBERS_ROUTE}/${currentDomainId}`;
-
-  const colonyMembersWithBanStatus = useMemo(
-    () =>
-      (members || []).map((walletAddress) => {
-        const isUserBanned = bannedMembers?.find(
-          ({
-            id: bannedUserWalletAddress,
-            banned,
-          }: {
-            id: Address;
-            banned: boolean;
-          }) => banned && bannedUserWalletAddress === walletAddress,
-        );
-        return {
-          walletAddress,
-          banned: canAdministerComments ? !!isUserBanned : false,
-        };
-      }),
-    [members, bannedMembers, canAdministerComments],
-  );
 
   const setHeading = useCallback(
     (hasCounter) => (
@@ -188,14 +172,14 @@ const MembersSubsection = ({
     <div className={styles.main}>
       {setHeading(true)}
       <ul className={styles.userAvatars}>
-        {colonyMembersWithBanStatus
+        {members
           .slice(0, avatarsDisplaySplitRules)
-          .map(({ walletAddress, banned }) => (
+          .map(({ profile: { walletAddress }, banned }) => (
             <li className={styles.userAvatar} key={walletAddress}>
               <UserAvatar
                 size="xs"
                 address={walletAddress}
-                banned={banned}
+                banned={canAdministerComments && banned}
                 showInfo
                 notSet={false}
                 colony={colony}
@@ -219,7 +203,7 @@ const MembersSubsection = ({
                   ],
                 }}
               />
-              {banned && (
+              {canAdministerComments && banned && (
                 <div className={styles.userBanned}>
                   <Icon
                     appearance={{ size: 'extraTiny' }}

--- a/src/modules/dashboard/components/Members/Members.tsx
+++ b/src/modules/dashboard/components/Members/Members.tsx
@@ -85,7 +85,7 @@ const Members = ({ colony: { colonyAddress, colonyName }, colony }: Props) => {
      */
     parseInt(domainId, 10) || COLONY_TOTAL_BALANCE_DOMAIN_ID,
   );
-  const [dataPage, setDataPage] = useState<number>(1);
+  const [dataPage, setDataPage] = useState<number>(10);
 
   const selectedDomain = colony.domains.find(
     ({ ethDomainId }) => ethDomainId === selectedDomainId,
@@ -205,6 +205,8 @@ const Members = ({ colony: { colonyAddress, colonyName }, colony }: Props) => {
           />
         </Form>
       </div>
+      {/* PLACEHOLDER */}
+      <div>CONTRIBUTORS</div>
       {contributors.length ? (
         <MembersList<ColonyContributor>
           colony={colony}
@@ -228,6 +230,8 @@ const Members = ({ colony: { colonyAddress, colonyName }, colony }: Props) => {
           isLoadingData={loadingMembers}
         />
       )}
+      {/* PLACEHOLDER */}
+      <div>WATCHERS</div>
       {watchers?.length && (
         <MembersList<ColonyWatcher>
           colony={colony}

--- a/src/modules/dashboard/components/Members/Members.tsx
+++ b/src/modules/dashboard/components/Members/Members.tsx
@@ -1,6 +1,6 @@
-import React, { FC, useState, useMemo, useCallback } from 'react';
+import React, { FC, useState, useCallback } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
-import { ColonyRole, ROOT_DOMAIN_ID } from '@colony/colony-js';
+import { ROOT_DOMAIN_ID } from '@colony/colony-js';
 import sortBy from 'lodash/sortBy';
 import { useParams } from 'react-router-dom';
 
@@ -11,24 +11,19 @@ import UserPermissions from '~dashboard/UserPermissions';
 import Heading from '~core/Heading';
 import { Select, Form } from '~core/Fields';
 import { useTransformer } from '~utils/hooks';
-import { createAddress } from '~utils/web3';
 import {
-  AnyUser,
+  ColonyContributor,
+  ColonyWatcher,
   Colony,
-  useColonyMembersWithReputationQuery,
-  useMembersSubscription,
   useLoggedInUser,
   BannedUsersQuery,
+  useContributorsAndWatchersQuery,
 } from '~data/index';
 import {
   COLONY_TOTAL_BALANCE_DOMAIN_ID,
   ALLDOMAINS_DOMAIN_SELECTION,
 } from '~constants';
-import { Address } from '~types/index';
-import {
-  getAllUserRolesForDomain,
-  getAllUserRoles,
-} from '~modules/transformers';
+import { getAllUserRoles } from '~modules/transformers';
 import { hasRoot, canAdminister } from '~modules/users/checks';
 
 import styles from './Members.css';
@@ -60,17 +55,11 @@ interface Props {
   bannedUsers: BannedUsersQuery['bannedUsers'];
 }
 
-type Member = AnyUser & {
-  roles: ColonyRole[];
-  directRoles: ColonyRole[];
-  banned: boolean;
-};
-
 const displayName = 'dashboard.Members';
 
-const ITEMS_PER_PAGE = 30;
+const ITEMS_PER_PAGE = 1;
 
-const Members = ({ colony: { colonyAddress }, colony, bannedUsers }: Props) => {
+const Members = ({ colony: { colonyAddress, colonyName }, colony }: Props) => {
   const { domainId } = useParams<{
     domainId: string;
   }>();
@@ -115,26 +104,21 @@ const Members = ({ colony: { colonyAddress }, colony, bannedUsers }: Props) => {
     selectedDomain || {};
 
   const {
-    data: allMembers,
-    loading: loadingAllMembers,
-  } = useMembersSubscription({
+    data: members,
+    loading: loadingMembers,
+  } = useContributorsAndWatchersQuery({
     variables: {
       colonyAddress,
+      colonyName,
+      domainId:
+        currentDomainId === COLONY_TOTAL_BALANCE_DOMAIN_ID
+          ? ROOT_DOMAIN_ID
+          : currentDomainId,
     },
   });
 
-  const {
-    data: membersWithReputation,
-    loading: loadingColonyMembersWithReputation,
-  } = useColonyMembersWithReputationQuery({
-    variables: {
-      colonyAddress,
-      domainId:
-        currentDomainId !== COLONY_TOTAL_BALANCE_DOMAIN_ID
-          ? currentDomainId
-          : ROOT_DOMAIN_ID,
-    },
-  });
+  const contributors = members?.contributorsAndWatchers?.contributors || [];
+  const watchers = members?.contributorsAndWatchers?.watchers || [];
 
   const currentUserRoles = useTransformer(getAllUserRoles, [
     colony,
@@ -143,69 +127,6 @@ const Members = ({ colony: { colonyAddress }, colony, bannedUsers }: Props) => {
   const canAdministerComments =
     hasRegisteredProfile &&
     (hasRoot(currentUserRoles) || canAdminister(currentUserRoles));
-
-  /*
-   * @NOTE Skelethon Users Array
-   *
-   * This is just  an array of user "profiles" that only contain the user's address.
-   * This will be passed down to `MembersListItem` where the final component will do
-   * the actual "full" profile fetching.
-   *
-   * We had to resort to this because otherwise we run into hook callback "hell" while
-   * trying to fetch user profiles in a queue for an array of addresses.
-   *
-   * The opposite is also not possible, to fetch all profiles at once using a query, since
-   * this time we need only the members in the colony that have reputation, and that comes
-   * from the reputation oracle, which will just return us a list of addresses (which can
-   * or cannot be subscribers to the colony).
-   */
-  const skelethonUsers = useMemo(() => {
-    let displayMembers =
-      membersWithReputation?.colonyMembersWithReputation?.map((walletAddress) =>
-        createAddress(walletAddress),
-      ) || [];
-    if (currentDomainId === COLONY_TOTAL_BALANCE_DOMAIN_ID) {
-      const membersWithoutReputation =
-        allMembers?.subscribedUsers.map(({ profile: { walletAddress } }) =>
-          createAddress(walletAddress),
-        ) || [];
-      displayMembers = [
-        ...new Set([...displayMembers, ...membersWithoutReputation]),
-      ];
-    }
-
-    return displayMembers.map((walletAddress) => ({
-      id: walletAddress,
-      profile: { walletAddress },
-    }));
-  }, [allMembers, membersWithReputation, currentDomainId]);
-
-  const domainRoles = useTransformer(getAllUserRolesForDomain, [
-    colony,
-    /*
-     * If we have "All Domains" selected show the same permissions as on "Root"
-     */
-    currentDomainId === COLONY_TOTAL_BALANCE_DOMAIN_ID
-      ? ROOT_DOMAIN_ID
-      : currentDomainId,
-  ]);
-
-  const directDomainRoles = useTransformer(getAllUserRolesForDomain, [
-    colony,
-    /*
-     * If we have "All Domains" selected show the same permissions as on "Root"
-     */
-    currentDomainId === COLONY_TOTAL_BALANCE_DOMAIN_ID
-      ? ROOT_DOMAIN_ID
-      : currentDomainId,
-    true,
-  ]);
-
-  const inheritedDomainRoles = useTransformer(getAllUserRolesForDomain, [
-    colony,
-    ROOT_DOMAIN_ID,
-    true,
-  ]);
 
   const domainSelectOptions = sortBy(
     [...colony.domains, ALLDOMAINS_DOMAIN_SELECTION].map(
@@ -226,32 +147,7 @@ const Members = ({ colony: { colonyAddress }, colony, bannedUsers }: Props) => {
     setDataPage(dataPage + 1);
   }, [dataPage]);
 
-  const domainRolesArray = useMemo(() => {
-    return domainRoles
-      .sort(({ roles }) => (roles.includes(ColonyRole.Root) ? -1 : 1))
-      .filter(({ roles }) => !!roles.length)
-      .map(({ address, roles }) => {
-        const directUserRoles = directDomainRoles.find(
-          ({ address: userAddress }) => userAddress === address,
-        );
-        const rootRoles = inheritedDomainRoles.find(
-          ({ address: userAddress }) => userAddress === address,
-        );
-        const allUserRoles = [
-          ...new Set([
-            ...(directUserRoles?.roles || []),
-            ...(rootRoles?.roles || []),
-          ]),
-        ];
-        return {
-          userAddress: address,
-          roles,
-          directRoles: allUserRoles,
-        };
-      });
-  }, [directDomainRoles, domainRoles, inheritedDomainRoles]);
-
-  if (loadingAllMembers || loadingColonyMembersWithReputation) {
+  if (loadingMembers) {
     return (
       <div className={styles.main}>
         <SpinnerLoader
@@ -273,37 +169,12 @@ const Members = ({ colony: { colonyAddress }, colony, bannedUsers }: Props) => {
    * of the results, with the next waiting in line for a callback, but the current
    * timeframe doesn't allow for this, so I guess this is the "best" we can do for now
    */
-  const paginatedSkelethonUsers = skelethonUsers.slice(
+  const paginatedContributors = contributors.slice(
     0,
     ITEMS_PER_PAGE * dataPage,
   );
 
-  const members: Member[] = paginatedSkelethonUsers.map((user) => {
-    const {
-      profile: { walletAddress },
-    } = user;
-    const isUserBanned = bannedUsers.find(
-      ({
-        id: bannedUserWalletAddress,
-        banned,
-      }: {
-        id: Address;
-        banned: boolean;
-      }) =>
-        banned &&
-        createAddress(bannedUserWalletAddress) === createAddress(walletAddress),
-    );
-    const domainRole = domainRolesArray.find(
-      (rolesObject) =>
-        createAddress(rolesObject.userAddress) === createAddress(walletAddress),
-    );
-    return {
-      ...user,
-      roles: domainRole ? domainRole.roles : [],
-      directRoles: domainRole ? domainRole.directRoles : [],
-      banned: canAdministerComments ? !!isUserBanned : false,
-    };
-  });
+  const paginatedWatchers = watchers.slice(0, ITEMS_PER_PAGE * dataPage);
 
   return (
     <div className={styles.main}>
@@ -334,8 +205,8 @@ const Members = ({ colony: { colonyAddress }, colony, bannedUsers }: Props) => {
           />
         </Form>
       </div>
-      {skelethonUsers.length ? (
-        <MembersList<Member>
+      {contributors.length ? (
+        <MembersList<ColonyContributor>
           colony={colony}
           extraItemContent={({ roles, directRoles, banned }) => (
             <UserPermissions
@@ -345,17 +216,33 @@ const Members = ({ colony: { colonyAddress }, colony, bannedUsers }: Props) => {
             />
           )}
           domainId={currentDomainId}
-          users={members}
+          users={paginatedContributors}
+          canAdministerComments={canAdministerComments}
         />
       ) : (
         <FormattedMessage {...MSG.failedToFetch} />
       )}
-      {ITEMS_PER_PAGE * dataPage < skelethonUsers.length && (
+      {ITEMS_PER_PAGE * dataPage < contributors.length && (
         <LoadMoreButton
           onClick={handleDataPagination}
-          isLoadingData={
-            loadingAllMembers || loadingColonyMembersWithReputation
-          }
+          isLoadingData={loadingMembers}
+        />
+      )}
+      {watchers?.length && (
+        <MembersList<ColonyWatcher>
+          colony={colony}
+          domainId={currentDomainId}
+          users={paginatedWatchers}
+          canAdministerComments={canAdministerComments}
+          extraItemContent={({ banned }) => (
+            <UserPermissions roles={[]} directRoles={[]} banned={banned} />
+          )}
+        />
+      )}
+      {ITEMS_PER_PAGE * dataPage < watchers.length && (
+        <LoadMoreButton
+          onClick={handleDataPagination}
+          isLoadingData={loadingMembers}
         />
       )}
     </div>

--- a/src/modules/dashboard/components/Members/Members.tsx
+++ b/src/modules/dashboard/components/Members/Members.tsx
@@ -110,10 +110,7 @@ const Members = ({ colony: { colonyAddress, colonyName }, colony }: Props) => {
     variables: {
       colonyAddress,
       colonyName,
-      domainId:
-        currentDomainId === COLONY_TOTAL_BALANCE_DOMAIN_ID
-          ? ROOT_DOMAIN_ID
-          : currentDomainId,
+      domainId: currentDomainId,
     },
   });
 
@@ -230,24 +227,29 @@ const Members = ({ colony: { colonyAddress, colonyName }, colony }: Props) => {
           isLoadingData={loadingMembers}
         />
       )}
-      {/* PLACEHOLDER */}
-      <div>WATCHERS</div>
-      {watchers?.length && (
-        <MembersList<ColonyWatcher>
-          colony={colony}
-          domainId={currentDomainId}
-          users={paginatedWatchers}
-          canAdministerComments={canAdministerComments}
-          extraItemContent={({ banned }) => (
-            <UserPermissions roles={[]} directRoles={[]} banned={banned} />
+      {(currentDomainId === ROOT_DOMAIN_ID ||
+        currentDomainId === COLONY_TOTAL_BALANCE_DOMAIN_ID) && (
+        <>
+          {/* PLACEHOLDER */}
+          <div>WATCHERS</div>
+          {watchers?.length && (
+            <MembersList<ColonyWatcher>
+              colony={colony}
+              domainId={currentDomainId}
+              users={paginatedWatchers}
+              canAdministerComments={canAdministerComments}
+              extraItemContent={({ banned }) => (
+                <UserPermissions roles={[]} directRoles={[]} banned={banned} />
+              )}
+            />
           )}
-        />
-      )}
-      {ITEMS_PER_PAGE * dataPage < watchers.length && (
-        <LoadMoreButton
-          onClick={handleDataPagination}
-          isLoadingData={loadingMembers}
-        />
+          {ITEMS_PER_PAGE * dataPage < watchers.length && (
+            <LoadMoreButton
+              onClick={handleDataPagination}
+              isLoadingData={loadingMembers}
+            />
+          )}
+        </>
       )}
     </div>
   );

--- a/src/utils/hooks/useAvatarDisplayCounter.ts
+++ b/src/utils/hooks/useAvatarDisplayCounter.ts
@@ -1,9 +1,8 @@
-import Maybe from 'graphql/tsutils/Maybe';
 import { useMemo } from 'react';
 
 const useAvatarDisplayCounter = (
   maxAvatars: number,
-  members: Maybe<string[]>,
+  members: any[],
   isLastAvatarIncluded = true,
 ) => {
   const avatarsDisplaySplitRules = useMemo(() => {

--- a/src/utils/hooks/useAvatarDisplayCounter.ts
+++ b/src/utils/hooks/useAvatarDisplayCounter.ts
@@ -1,8 +1,11 @@
 import { useMemo } from 'react';
+import Maybe from 'graphql/tsutils/Maybe';
+
+import { ColonyContributor, ColonyWatcher } from '~data/index';
 
 const useAvatarDisplayCounter = (
   maxAvatars: number,
-  members: any[],
+  members: ColonyContributor[] | ColonyWatcher[] | Maybe<string[]>,
   isLastAvatarIncluded = true,
 ) => {
   const avatarsDisplaySplitRules = useMemo(() => {


### PR DESCRIPTION
## Description

This PR harmonises the data querying for the members (contributors & watchers). Unfortunately, we can't use members subscription any more. I've moved all of the data logic from `ColonyMembers` & `Members` to the query so that it's not duplicated and the components are lighter.

Please, note that they are title placeholders on the `Members` page - Sayan is working on the proper stuff.

**New stuff** ✨

- add `ContributorsAndWatchers` query, types & resolver

**Changes** 🏗

- update `ColonyMembers` & `MembersSubsection` with the new query
- update `Members`, `MembersList` & `MembersListItem` with the new query

<img width="691" alt="Screenshot 2022-05-18 at 18 21 52" src="https://user-images.githubusercontent.com/34057551/169093916-88a59e76-a8e8-485d-8bf5-8fac70875b26.png">
<img width="222" alt="Screenshot 2022-05-18 at 17 18 11" src="https://user-images.githubusercontent.com/34057551/169093921-51d7127b-99c6-4709-8765-918a2ea8740e.png">
<img width="715" alt="Screenshot 2022-05-18 at 17 18 04" src="https://user-images.githubusercontent.com/34057551/169093928-a5fcc5ab-023e-4cb5-b0c7-45aeece40efc.png">
<img width="648" alt="Screenshot 2022-05-18 at 18 28 08" src="https://user-images.githubusercontent.com/34057551/169094194-703e26a6-1cfd-4a9f-a37f-e7bd15b88b89.png">

resolves #3377