### PR TITLE
Members page contributors/watchers (UI only)

### DIFF
--- a/src/modules/dashboard/components/Members/Members.tsx
+++ b/src/modules/dashboard/components/Members/Members.tsx
@@ -6,6 +6,8 @@ import { useParams } from 'react-router-dom';
 
 import MembersSection from './MembersSection';
 
+import UserPermissions from '~dashboard/UserPermissions';
+
 import { SpinnerLoader } from '~core/Preloaders';
 import Heading from '~core/Heading';
 import { Select, Form } from '~core/Fields';
@@ -15,6 +17,8 @@ import {
   useLoggedInUser,
   BannedUsersQuery,
   useContributorsAndWatchersQuery,
+  ColonyContributor,
+  ColonyWatcher,
 } from '~data/index';
 import {
   COLONY_TOTAL_BALANCE_DOMAIN_ID,
@@ -188,12 +192,21 @@ const Members = ({ colony: { colonyAddress, colonyName }, colony }: Props) => {
       </div>
 
       {contributors.length ? (
-        <MembersSection
+        <MembersSection<ColonyContributor>
           colony={colony}
           currentDomainId={currentDomainId}
           title={MSG.contributorsTitle}
-          members={contributors}
+          members={contributors as ColonyContributor[]}
           canAdministerComments={canAdministerComments}
+          membersListExtraItemContent={({ roles, directRoles, banned }) => {
+            return (
+              <UserPermissions
+                roles={roles}
+                directRoles={directRoles}
+                banned={banned}
+              />
+            );
+          }}
         />
       ) : (
         <FormattedMessage {...MSG.failedToFetch} />
@@ -202,13 +215,16 @@ const Members = ({ colony: { colonyAddress, colonyName }, colony }: Props) => {
         currentDomainId === COLONY_TOTAL_BALANCE_DOMAIN_ID) && (
         <>
           {watchers?.length && (
-            <MembersSection
+            <MembersSection<ColonyWatcher>
               colony={colony}
               currentDomainId={currentDomainId}
               title={MSG.watchersTitle}
               description={MSG.watchersDescription}
-              members={watchers}
+              members={watchers as ColonyWatcher[]}
               canAdministerComments={canAdministerComments}
+              membersListExtraItemContent={({ banned }) => (
+                <UserPermissions roles={[]} directRoles={[]} banned={banned} />
+              )}
             />
           )}
         </>

--- a/src/modules/dashboard/components/Members/Members.tsx
+++ b/src/modules/dashboard/components/Members/Members.tsx
@@ -49,19 +49,6 @@ const MSG = defineMessages({
     id: 'dashboard.Members.failedToFetch',
     defaultMessage: "Could not fetch the colony's members",
   },
-  contributorsTitle: {
-    id: 'dashboard.Members.contributorsTitle',
-    defaultMessage: 'Contributors',
-  },
-  watchersTitle: {
-    id: 'dashboard.Members.watchersTitle',
-    defaultMessage: 'Watchers',
-  },
-
-  watchersDescription: {
-    id: 'dashboard.Members.watchersDescription',
-    defaultMessage: "Members who don't currently have any reputation",
-  },
 });
 
 interface Props {
@@ -193,12 +180,12 @@ const Members = ({ colony: { colonyAddress, colonyName }, colony }: Props) => {
 
       {contributors.length ? (
         <MembersSection<ColonyContributor>
+          isContributorsSection
           colony={colony}
           currentDomainId={currentDomainId}
-          title={MSG.contributorsTitle}
           members={contributors as ColonyContributor[]}
           canAdministerComments={canAdministerComments}
-          membersListExtraItemContent={({ roles, directRoles, banned }) => {
+          extraItemContent={({ roles, directRoles, banned }) => {
             return (
               <UserPermissions
                 roles={roles}
@@ -216,13 +203,12 @@ const Members = ({ colony: { colonyAddress, colonyName }, colony }: Props) => {
         <>
           {watchers?.length && (
             <MembersSection<ColonyWatcher>
+              isContributorsSection={false}
               colony={colony}
               currentDomainId={currentDomainId}
-              title={MSG.watchersTitle}
-              description={MSG.watchersDescription}
               members={watchers as ColonyWatcher[]}
               canAdministerComments={canAdministerComments}
-              membersListExtraItemContent={({ banned }) => (
+              extraItemContent={({ banned }) => (
                 <UserPermissions roles={[]} directRoles={[]} banned={banned} />
               )}
             />

--- a/src/modules/dashboard/components/Members/MembersSection.css
+++ b/src/modules/dashboard/components/Members/MembersSection.css
@@ -1,0 +1,19 @@
+.bar {
+  display: flex;
+  align-items: baseline;
+  margin-top: 25px;
+  margin-bottom: 13px;
+}
+
+.title {
+  font-size: var(--size-smallish);
+  font-weight: var(--weight-bold);
+  color: var(--dark);
+}
+
+.description {
+  margin-left: 9px;
+  font-size: var(--size-tiny);
+  font-weight: var(--weight-bold);
+  color: var(--temp-grey-blue-7);
+}

--- a/src/modules/dashboard/components/Members/MembersSection.css.d.ts
+++ b/src/modules/dashboard/components/Members/MembersSection.css.d.ts
@@ -1,0 +1,3 @@
+export const bar: string;
+export const title: string;
+export const description: string;

--- a/src/modules/dashboard/components/Members/MembersSection.tsx
+++ b/src/modules/dashboard/components/Members/MembersSection.tsx
@@ -1,0 +1,103 @@
+import React, { useState, useCallback } from 'react';
+
+import { FormattedMessage, MessageDescriptor } from 'react-intl';
+import styles from './MembersSection.css';
+
+import MembersList from '~core/MembersList';
+import {
+  Colony,
+  useMembersSubscription,
+  ColonyWatcher,
+  ColonyContributor,
+} from '~data/index';
+
+import UserPermissions from '~dashboard/UserPermissions';
+import LoadMoreButton from '~core/LoadMoreButton';
+
+const displayName = 'dashboard.MembersSection';
+
+interface Props {
+  title: MessageDescriptor;
+  description?: MessageDescriptor;
+  colony: Colony;
+  currentDomainId: number;
+  members: ColonyWatcher[] | ColonyContributor[];
+  canAdministerComments: boolean;
+}
+
+const ITEMS_PER_SECTION = 10;
+const MembersSection = ({
+  title,
+  description,
+  colony: { colonyAddress },
+  colony,
+  currentDomainId,
+  members,
+  canAdministerComments,
+}: // @NOTE Add another optional paramater called sortingParams/sortingFun to handle sorting
+Props) => {
+  const [dataSection, setDataPage] = useState<number>(1);
+
+  const paginatedMembers = members.slice(0, ITEMS_PER_SECTION * dataSection);
+  const handleDataPagination = useCallback(() => {
+    setDataPage(dataSection + 1);
+  }, [dataSection]);
+
+  const { loading: loadingAllMembers } = useMembersSubscription({
+    variables: {
+      colonyAddress,
+    },
+  });
+  // Runtime type check, the `roles` property only exists in Contributors
+  const memberKind = 'roles' in members?.[0] ? 'contributor' : 'watcher';
+
+  return (
+    <>
+      <div className={styles.bar}>
+        <div className={styles.title}>
+          <FormattedMessage {...title} />
+        </div>
+        {description && (
+          <div className={styles.description}>
+            <FormattedMessage {...description} />
+          </div>
+        )}
+      </div>
+      {memberKind === 'contributor' ? (
+        <MembersList<ColonyContributor>
+          colony={colony}
+          extraItemContent={({ roles, directRoles, banned }) => (
+            <UserPermissions
+              roles={roles}
+              directRoles={directRoles}
+              banned={banned}
+            />
+          )}
+          domainId={currentDomainId}
+          users={paginatedMembers as ColonyContributor[]}
+          canAdministerComments={canAdministerComments}
+        />
+      ) : (
+        <MembersList<ColonyWatcher>
+          colony={colony}
+          extraItemContent={({ banned }) => (
+            <UserPermissions roles={[]} directRoles={[]} banned={banned} />
+          )}
+          domainId={currentDomainId}
+          users={paginatedMembers as ColonyWatcher[]}
+          canAdministerComments={canAdministerComments}
+        />
+      )}
+      {ITEMS_PER_SECTION * dataSection < members.length && (
+        <LoadMoreButton
+          onClick={handleDataPagination}
+          isLoadingData={loadingAllMembers}
+        />
+      )}
+    </>
+  );
+};
+
+MembersSection.displayName = displayName;
+
+export default MembersSection;

--- a/src/modules/dashboard/components/Members/MembersSection.tsx
+++ b/src/modules/dashboard/components/Members/MembersSection.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, ReactNode } from 'react';
 
-import { FormattedMessage, MessageDescriptor } from 'react-intl';
+import { FormattedMessage, defineMessages } from 'react-intl';
 import styles from './MembersSection.css';
 
 import MembersList from '~core/MembersList';
@@ -15,26 +15,39 @@ import LoadMoreButton from '~core/LoadMoreButton';
 
 const displayName = 'dashboard.MembersSection';
 
+const MSG = defineMessages({
+  contributorsTitle: {
+    id: 'dashboard.Members.contributorsTitle',
+    defaultMessage: 'Contributors',
+  },
+  watchersTitle: {
+    id: 'dashboard.Members.watchersTitle',
+    defaultMessage: 'Watchers',
+  },
+  watchersDescription: {
+    id: 'dashboard.Members.watchersDescription',
+    defaultMessage: "Members who don't currently have any reputation",
+  },
+});
+
 interface Props<U> {
-  title: MessageDescriptor;
-  description?: MessageDescriptor;
+  isContributorsSection: boolean;
   colony: Colony;
   currentDomainId: number;
   members: ColonyWatcher[] | ColonyContributor[];
   canAdministerComments: boolean;
-  membersListExtraItemContent: (user: U) => ReactNode;
+  extraItemContent: (user: U) => ReactNode;
 }
 
 const ITEMS_PER_SECTION = 10;
 const MembersSection = <U extends ColonyWatcher | ColonyContributor>({
-  title,
-  description,
   colony: { colonyAddress },
   colony,
   currentDomainId,
   members,
   canAdministerComments,
-  membersListExtraItemContent,
+  extraItemContent,
+  isContributorsSection,
 }: // @NOTE Add another optional paramater called sortingParams/sortingFun to handle sorting
 Props<U>) => {
   const [dataSection, setDataPage] = useState<number>(1);
@@ -54,17 +67,21 @@ Props<U>) => {
     <>
       <div className={styles.bar}>
         <div className={styles.title}>
-          <FormattedMessage {...title} />
+          <FormattedMessage
+            {...(isContributorsSection
+              ? MSG.contributorsTitle
+              : MSG.watchersTitle)}
+          />
         </div>
-        {description && (
+        {!isContributorsSection && (
           <div className={styles.description}>
-            <FormattedMessage {...description} />
+            <FormattedMessage {...MSG.watchersDescription} />
           </div>
         )}
       </div>
       <MembersList
         colony={colony}
-        extraItemContent={membersListExtraItemContent}
+        extraItemContent={extraItemContent}
         domainId={currentDomainId}
         users={paginatedMembers}
         canAdministerComments={canAdministerComments}

--- a/src/modules/dashboard/components/Members/MembersSection.tsx
+++ b/src/modules/dashboard/components/Members/MembersSection.tsx
@@ -4,12 +4,7 @@ import { FormattedMessage, defineMessages } from 'react-intl';
 import styles from './MembersSection.css';
 
 import MembersList from '~core/MembersList';
-import {
-  Colony,
-  useMembersSubscription,
-  ColonyWatcher,
-  ColonyContributor,
-} from '~data/index';
+import { Colony, ColonyWatcher, ColonyContributor } from '~data/index';
 
 import LoadMoreButton from '~core/LoadMoreButton';
 
@@ -41,7 +36,6 @@ interface Props<U> {
 
 const ITEMS_PER_SECTION = 10;
 const MembersSection = <U extends ColonyWatcher | ColonyContributor>({
-  colony: { colonyAddress },
   colony,
   currentDomainId,
   members,
@@ -50,18 +44,12 @@ const MembersSection = <U extends ColonyWatcher | ColonyContributor>({
   isContributorsSection,
 }: // @NOTE Add another optional paramater called sortingParams/sortingFun to handle sorting
 Props<U>) => {
-  const [dataSection, setDataPage] = useState<number>(1);
+  const [dataPage, setDataPage] = useState<number>(1);
 
-  const paginatedMembers = members.slice(0, ITEMS_PER_SECTION * dataSection);
+  const paginatedMembers = members.slice(0, ITEMS_PER_SECTION * dataPage);
   const handleDataPagination = useCallback(() => {
-    setDataPage(dataSection + 1);
-  }, [dataSection]);
-
-  const { loading: loadingAllMembers } = useMembersSubscription({
-    variables: {
-      colonyAddress,
-    },
-  });
+    setDataPage(dataPage + 1);
+  }, [dataPage]);
 
   return (
     <>
@@ -86,11 +74,8 @@ Props<U>) => {
         users={paginatedMembers}
         canAdministerComments={canAdministerComments}
       />
-      {ITEMS_PER_SECTION * dataSection < members.length && (
-        <LoadMoreButton
-          onClick={handleDataPagination}
-          isLoadingData={loadingAllMembers}
-        />
+      {ITEMS_PER_SECTION * dataPage < members.length && (
+        <LoadMoreButton onClick={handleDataPagination} isLoadingData={false} />
       )}
     </>
   );


### PR DESCRIPTION
## Description


This PR introduces a MembersSection component (in the Members page) that can be reused for contributors/watchers etc. It also adds the UI and styling for the said component.

The base branch for this PR is set as the logic branch for this feature. I was not sure if this approach or asking people to review changes from just my commit is more canonical.

*Request for comments*

- What do think about the level of decoupling of the MembersSection component? I am not super happy about it but since many related features are yet to be merged/implemented there was no easy way to decide the appropriate code organization.

*Things not implemented* (as those are part of other issues despite being in the same spec)

- The columns redesign of the Members
- The Title Bar 
- Search bar 
- Right aside things

![Screenshot 2022-05-20 at 16-29-02 Members Colony - Pequod](https://user-images.githubusercontent.com/14034137/169514334-36294914-afed-4432-a6e1-181069b39266.png)



Resolves #3379.
