### PR TITLE
Add title and description of expenditure

### DIFF
--- a/src/modules/dashboard/components/ExpenditurePage/ExpenditureSettings/ExpenditureSettings.css
+++ b/src/modules/dashboard/components/ExpenditurePage/ExpenditureSettings/ExpenditureSettings.css
@@ -1,4 +1,4 @@
-@value paddingTopBottom: 75px;
+@value paddingTopBottom: 60px;
 @value paddingRightLeft: 54px;
 
 .container {

--- a/src/modules/dashboard/components/ExpenditurePage/ExpenditureSettings/ExpenditureSettings.tsx
+++ b/src/modules/dashboard/components/ExpenditurePage/ExpenditureSettings/ExpenditureSettings.tsx
@@ -5,7 +5,6 @@ import { ROOT_DOMAIN_ID } from '@colony/colony-js';
 
 import { defineMessages } from 'react-intl';
 import {
-  Form,
   InputLabel,
   SelectHorizontal,
   SelectOption,
@@ -166,7 +165,7 @@ const ExpenditureSettings = () => {
       {loading ? (
         <SpinnerLoader appearance={{ size: 'medium' }} />
       ) : (
-        <Form initialValues={{}} onSubmit={() => {}}>
+        <>
           <FormSection appearance={{ border: 'bottom' }}>
             <div className={styles.blue}>
               <SelectHorizontal
@@ -238,7 +237,7 @@ const ExpenditureSettings = () => {
               </div>
             </div>
           </FormSection>
-        </Form>
+        </>
       )}
     </div>
   );

--- a/src/modules/dashboard/components/ExpenditurePage/TitleDescriptionSection/TitleDescriptionSection.css
+++ b/src/modules/dashboard/components/ExpenditurePage/TitleDescriptionSection/TitleDescriptionSection.css
@@ -1,0 +1,65 @@
+.container {
+  padding: 74px 25px;
+}
+
+.number {
+  margin-bottom: 16px;
+  font-size: var(--size-tiny);
+  font-weight: var(--weight-bold);
+  line-height: 18px;
+  color: var(--temp-grey-blue-7);
+}
+
+.title {
+  margin-bottom: 21px;
+  font-size: var(--size-medium-l);
+  font-weight: var(--weight-bold);
+  line-height: 24px;
+  color: var(--dark);
+  letter-spacing: 0.5px;
+}
+
+.titleContainer input {
+  padding: 0;
+  border-bottom: none;
+  font-size: var(--size-medium-l);
+  line-height: 24px;
+  color: var(--dark);
+  letter-spacing: 0.5px;
+}
+
+.titleContainer input::placeholder {
+  font-style: normal;
+  color: var(--temp-grey-blue-7);
+  opacity: 0.65;
+  letter-spacing: 0.5px;
+}
+
+.titleContainer p {
+  margin-bottom: 2px;
+}
+
+.description {
+  font-size: var(--size-normal);
+  font-weight: var(--weight-normal);
+  line-height: 18px;
+  color: var(--dark);
+  letter-spacing: 0.1px;
+}
+
+.descriptionContainer input {
+  padding: 0;
+  border-bottom: none;
+  font-size: var(--size-normal);
+  font-weight: var(--weight-normal);
+  line-height: 18px;
+  color: var(--dark);
+  letter-spacing: 0.1px;
+}
+
+.descriptionContainer input::placeholder {
+  font-style: normal;
+  color: var(--temp-grey-blue-7);
+  opacity: 0.5;
+  letter-spacing: 0.1px;
+}

--- a/src/modules/dashboard/components/ExpenditurePage/TitleDescriptionSection/TitleDescriptionSection.css
+++ b/src/modules/dashboard/components/ExpenditurePage/TitleDescriptionSection/TitleDescriptionSection.css
@@ -11,12 +11,15 @@
 }
 
 .title {
-  margin-bottom: 21px;
   font-size: var(--size-medium-l);
   font-weight: var(--weight-bold);
   line-height: 24px;
   color: var(--dark);
   letter-spacing: 0.5px;
+}
+
+.titleContainer {
+  margin-bottom: 21px;
 }
 
 .titleContainer input {
@@ -47,9 +50,9 @@
   letter-spacing: 0.1px;
 }
 
-.descriptionContainer input {
+.descriptionContainer textarea {
   padding: 0;
-  border-bottom: none;
+  border: none;
   font-size: var(--size-normal);
   font-weight: var(--weight-normal);
   line-height: 18px;
@@ -57,9 +60,25 @@
   letter-spacing: 0.1px;
 }
 
-.descriptionContainer input::placeholder {
+.descriptionContainer textarea::placeholder {
   font-style: normal;
   color: var(--temp-grey-blue-7);
   opacity: 0.5;
   letter-spacing: 0.1px;
+}
+
+.error textarea {
+  color: var(--danger);
+}
+
+.error textarea::placeholder {
+  color: var(--danger);
+}
+
+.error input {
+  color: var(--danger);
+}
+
+.error input::placeholder {
+  color: var(--danger);
 }

--- a/src/modules/dashboard/components/ExpenditurePage/TitleDescriptionSection/TitleDescriptionSection.css
+++ b/src/modules/dashboard/components/ExpenditurePage/TitleDescriptionSection/TitleDescriptionSection.css
@@ -52,6 +52,7 @@
 
 .descriptionContainer textarea {
   padding: 0;
+  overflow: hidden;
   border: none;
   font-size: var(--size-normal);
   font-weight: var(--weight-normal);

--- a/src/modules/dashboard/components/ExpenditurePage/TitleDescriptionSection/TitleDescriptionSection.css.d.ts
+++ b/src/modules/dashboard/components/ExpenditurePage/TitleDescriptionSection/TitleDescriptionSection.css.d.ts
@@ -1,0 +1,6 @@
+export const container: string;
+export const number: string;
+export const title: string;
+export const titleContainer: string;
+export const description: string;
+export const descriptionContainer: string;

--- a/src/modules/dashboard/components/ExpenditurePage/TitleDescriptionSection/TitleDescriptionSection.css.d.ts
+++ b/src/modules/dashboard/components/ExpenditurePage/TitleDescriptionSection/TitleDescriptionSection.css.d.ts
@@ -4,3 +4,4 @@ export const title: string;
 export const titleContainer: string;
 export const description: string;
 export const descriptionContainer: string;
+export const error: string;

--- a/src/modules/dashboard/components/ExpenditurePage/TitleDescriptionSection/TitleDescriptionSection.tsx
+++ b/src/modules/dashboard/components/ExpenditurePage/TitleDescriptionSection/TitleDescriptionSection.tsx
@@ -1,0 +1,59 @@
+import { useField } from 'formik';
+import React from 'react';
+import { defineMessages } from 'react-intl';
+import { Input } from '~core/Fields';
+
+import styles from './TitleDescriptionSection.css';
+
+const MSG = defineMessages({
+  titlePlaceholder: {
+    id: 'dashboard.Expenditures.TitleDescriptionSection.titlePlaceholder',
+    defaultMessage: 'Enter expenditure title',
+  },
+  descriptionPlaceholder: {
+    id: 'dashboard.Expenditures.TitleDescriptionSection.descriptionPlaceholder',
+    defaultMessage: 'Enter description',
+  },
+});
+
+interface Props {
+  isEditable?: boolean;
+}
+
+const TitleDescriptionSection = ({ isEditable }: Props) => {
+  const [, { value: title }] = useField('title');
+  const [, { value: description }] = useField('description');
+
+  return (
+    <div className={styles.container}>
+      {/* "Exp - 25" is temporary value, needs to be changed to fetched value, id? */}
+      <div className={styles.number}>Exp - 25</div>
+      <div className={styles.titleContainer}>
+        {isEditable ? (
+          <Input
+            name="title"
+            placeholder={MSG.titlePlaceholder}
+            appearance={{ theme: 'minimal' }}
+            defaultValue={title}
+          />
+        ) : (
+          <div className={styles.title}>{title}</div>
+        )}
+      </div>
+      <div className={styles.descriptionContainer}>
+        {isEditable ? (
+          <Input
+            name="description"
+            placeholder={MSG.descriptionPlaceholder}
+            appearance={{ theme: 'minimal' }}
+            defaultValue={title}
+          />
+        ) : (
+          <div className={styles.description}>{description}</div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TitleDescriptionSection;

--- a/src/modules/dashboard/components/ExpenditurePage/TitleDescriptionSection/TitleDescriptionSection.tsx
+++ b/src/modules/dashboard/components/ExpenditurePage/TitleDescriptionSection/TitleDescriptionSection.tsx
@@ -62,7 +62,7 @@ const TitleDescriptionSection = ({ isEditable }: Props) => {
             placeholder={MSG.descriptionPlaceholder}
             label=""
             minRows={1}
-            maxRows={12}
+            maxRows={100}
             elementOnly
           />
         ) : (

--- a/src/modules/dashboard/components/ExpenditurePage/TitleDescriptionSection/TitleDescriptionSection.tsx
+++ b/src/modules/dashboard/components/ExpenditurePage/TitleDescriptionSection/TitleDescriptionSection.tsx
@@ -1,7 +1,9 @@
 import { useField } from 'formik';
 import React from 'react';
 import { defineMessages } from 'react-intl';
-import { Input } from '~core/Fields';
+import classNames from 'classnames';
+
+import { Input, Textarea } from '~core/Fields';
 
 import styles from './TitleDescriptionSection.css';
 
@@ -21,32 +23,45 @@ interface Props {
 }
 
 const TitleDescriptionSection = ({ isEditable }: Props) => {
-  const [, { value: title }] = useField('title');
-  const [, { value: description }] = useField('description');
+  const [, { value: title, error: inputError }] = useField('title');
+  const [, { value: description, error: descriptionError }] = useField(
+    'description',
+  );
 
   return (
     <div className={styles.container}>
       {/* "Exp - 25" is temporary value, needs to be changed to fetched value, id? */}
       <div className={styles.number}>Exp - 25</div>
-      <div className={styles.titleContainer}>
+      <div
+        className={classNames(
+          styles.titleContainer,
+          inputError && styles.error,
+        )}
+      >
         {isEditable ? (
           <Input
             name="title"
             placeholder={MSG.titlePlaceholder}
             appearance={{ theme: 'minimal' }}
             defaultValue={title}
+            elementOnly
           />
         ) : (
           <div className={styles.title}>{title}</div>
         )}
       </div>
-      <div className={styles.descriptionContainer}>
+      <div
+        className={classNames(
+          styles.descriptionContainer,
+          descriptionError && styles.error,
+        )}
+      >
         {isEditable ? (
-          <Input
+          <Textarea
             name="description"
             placeholder={MSG.descriptionPlaceholder}
-            appearance={{ theme: 'minimal' }}
-            defaultValue={title}
+            label=""
+            elementOnly
           />
         ) : (
           <div className={styles.description}>{description}</div>

--- a/src/modules/dashboard/components/ExpenditurePage/TitleDescriptionSection/TitleDescriptionSection.tsx
+++ b/src/modules/dashboard/components/ExpenditurePage/TitleDescriptionSection/TitleDescriptionSection.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { defineMessages } from 'react-intl';
 import classNames from 'classnames';
 
-import { Input, Textarea } from '~core/Fields';
+import { Input, TextareaAutoresize } from '~core/Fields';
 
 import styles from './TitleDescriptionSection.css';
 
@@ -57,10 +57,12 @@ const TitleDescriptionSection = ({ isEditable }: Props) => {
         )}
       >
         {isEditable ? (
-          <Textarea
+          <TextareaAutoresize
             name="description"
             placeholder={MSG.descriptionPlaceholder}
             label=""
+            minRows={1}
+            maxRows={12}
             elementOnly
           />
         ) : (

--- a/src/modules/dashboard/components/ExpenditurePage/TitleDescriptionSection/index.ts
+++ b/src/modules/dashboard/components/ExpenditurePage/TitleDescriptionSection/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TitleDescriptionSection';

--- a/src/modules/pages/components/ExpenditurePage/ExpenditurePage.css
+++ b/src/modules/pages/components/ExpenditurePage/ExpenditurePage.css
@@ -14,11 +14,11 @@
 }
 
 .mainContent {
-  height: 100%;
+  min-height: calc(100vh - navBarHeight);
 }
 
 .sidebar {
-  height: calc(100vh - navBarHeight);
+  min-height: calc(100vh - navBarHeight);
   width: sidebarWidth;
   background-color: var(--grey-blue-3);
 }

--- a/src/modules/pages/components/ExpenditurePage/ExpenditurePage.tsx
+++ b/src/modules/pages/components/ExpenditurePage/ExpenditurePage.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { Form } from '~core/Fields';
 import ExpenditureSettings from '~dashboard/ExpenditurePage/ExpenditureSettings';
+import TitleDescriptionSection from '~dashboard/ExpenditurePage/TitleDescriptionSection';
 import { getMainClasses } from '~utils/css';
 
 import styles from './ExpenditurePage.css';
@@ -8,14 +10,18 @@ const displayName = 'pages.ExpenditurePage';
 
 const ExpenditurePage = () => {
   return (
-    <div className={getMainClasses({}, styles)}>
-      <aside className={styles.sidebar}>
-        <ExpenditureSettings />
-      </aside>
-      <div className={styles.mainContainer}>
-        <main className={styles.mainContent} />
+    <Form onSubmit={() => {}} initialValues={{}}>
+      <div className={getMainClasses({}, styles)}>
+        <aside className={styles.sidebar}>
+          <ExpenditureSettings />
+        </aside>
+        <div className={styles.mainContainer}>
+          <main className={styles.mainContent}>
+            <TitleDescriptionSection isEditable />
+          </main>
+        </div>
       </div>
-    </div>
+    </Form>
   );
 };
 


### PR DESCRIPTION
## Description
This PR adds section with title and description of expenditure. If title and description aren't provided or form is in edit state, there are inputs where these values ​​can be set. If the title and description are set, this section just displays them.

[Figma design - empty form](https://www.figma.com/file/dCtvv76S8mk5HNApjwmBto/Expenditures)
[Figma design - set values](https://www.figma.com/file/dCtvv76S8mk5HNApjwmBto/Expenditures?node-id=2420%3A1080905)

**New stuff** ✨

<img width="385" alt="Screenshot 2022-05-30 at 00 08 36" src="https://user-images.githubusercontent.com/91876137/170893194-684f11db-b172-404d-a669-5722781d1831.png">

<img width="495" alt="Screenshot 2022-05-30 at 00 09 24" src="https://user-images.githubusercontent.com/91876137/170893219-2c03dc60-526c-44cf-9da8-5cd2e58b0947.png">

## TODO

- add actual expenditure number

Resolves #3411
