### PR TITLE
Fix Border on Clickable User Avatar

### DIFF
--- a/src/modules/core/components/ActionsList/ActionsListItem.css
+++ b/src/modules/core/components/ActionsList/ActionsListItem.css
@@ -41,7 +41,6 @@
 
 .avatar:hover figure {
   border-color: var(--primary);
-  background: var(--primary);
 }
 
 .status::before {

--- a/src/modules/core/components/UserAvatar/UserAvatar.css
+++ b/src/modules/core/components/UserAvatar/UserAvatar.css
@@ -3,6 +3,15 @@
   line-height: 0;
 }
 
+.main > figure {
+  border: 2px solid transparent;
+  border-radius: 100%;
+}
+
+.main:hover figure {
+  border-color: var(--primary);
+}
+
 .stateShowOnClick {
   cursor: pointer;
 }

--- a/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.css
@@ -22,7 +22,6 @@
 .userAvatar {
   display: inline-block;
   margin: 0 15px 15px 0;
-  border: 2px solid transparent;
   border-radius: 50px;
 }
 

--- a/src/modules/users/components/AvatarDropdown/AvatarDropdown.css
+++ b/src/modules/users/components/AvatarDropdown/AvatarDropdown.css
@@ -5,7 +5,6 @@
 .avatarButton {
   padding: 0;
   border: 0;
-  border: 2px solid transparent;
   border-radius: 50%;
   background: transparent;
   cursor: pointer;


### PR DESCRIPTION
## Description

This PR (my first!) is to fix a couple of issues with borders on User Avatars. 

First, it corrects the missing border when hovering over the avatar in the members' list.  

Second, it fixes an issue with the border bleeding into the background when a user has a transparent image as their avatar. 

**New stuff** ✨

- [x] Add transparent border to UserAvatar
- [x] Add border color on hover state

**Changes** 🏗

* none

**Deletions** ⚰️

- [x] Remove transparent border from AvatarDropdown.avatarButton (to avoid border duplication on this element)
- [x] Remove transparent border from ColonyMembers.userAvatar (to avoid border duplication)
- [x] Remove background colour from ActionsListItem.avatar:hover 


## Screen Captures

### Members' list border on hover

**_Please ignore the shadow when hoving on the avatar in the top right, it looks fine in my browser. Just look at the border, which is the correct size (not duplicated)._**

![hover-avatar](https://user-images.githubusercontent.com/64402732/172676212-9cffbf54-656f-4e23-9af7-c60ca00b6303.gif)

### Background bleed fix when using a transparent background

**_When hovering, the background of the transparent avatar does not change. And, the border behaves correctly._**

![hover-avatar-2](https://user-images.githubusercontent.com/64402732/172677279-5e9815ea-837e-4333-81d3-56b0d2448162.gif)

### Members list avatar on colony main page

**_Border is correct size on hover (not duplicated). Please ignore shadow, it's my screen recorder not the browser._**

![hover-members-avatar](https://user-images.githubusercontent.com/64402732/172816302-de7bc8ad-d37c-4930-a254-6e97a29d2684.gif)

## TODO
*none

Resolves #3428 
