### PR TITLE
[verified recipients] Notification dot alignment

### DIFF
--- a/src/modules/pages/components/RouteLayouts/UserNavigation.css
+++ b/src/modules/pages/components/RouteLayouts/UserNavigation.css
@@ -48,7 +48,7 @@
 
 .notificationsHighlight {
   display: block;
-  margin: -20px -4px 0 0;
+  margin: -24px -3px 0 0;/* Using negative margins to group the notification dot and icon. */
   height: 9px;
   width: 9px;
   position: relative;


### PR DESCRIPTION
## Description

I took the liberty to position the notification icon vertically centered, without the notification dot. (So that when there is no notification it still looks good.

Compare with current QA for reference:

This PR

![Screenshot 2022-06-08 at 16-56-16 Actions Colony - gi](https://user-images.githubusercontent.com/14034137/172649534-81439a9f-1764-485c-bba2-dfe556581f8f.png)

Current QA

![Screenshot 2022-06-08 at 16-56-26 Actions Colony - ek](https://user-images.githubusercontent.com/14034137/172649574-dc19d82d-7766-403f-a186-0aaa4aaa64cb.png)

Resolves #3433.