### PR TITLE
Remove default grouped transactions count from TransactionStatus

### DIFF
--- a/src/modules/users/components/GasStation/TransactionCard/TransactionStatus.tsx
+++ b/src/modules/users/components/GasStation/TransactionCard/TransactionStatus.tsx
@@ -47,7 +47,7 @@ const displayName = 'users.GasStation.TransactionStatus';
 const TransactionStatus = ({
   hash,
   status,
-  groupCount = 4,
+  groupCount,
   loadingRelated,
 }: Props) => (
   <div


### PR DESCRIPTION
Seems like this was introduced in https://github.com/JoinColony/colonyDapp/commit/d45701d460f466f2ad5a0b48dbaafb0ee2d4ddc8 but I couldn't find the rationale behind it. So paging @ArmandoGraterol for especially reviewing this. Please let me know if I missed something. 

Fixes #3435.
