### PR TITLE
Allow overflow of `ManageWhitelistDialog`

### DIFF
--- a/src/modules/core/components/Dialog/Dialog.css
+++ b/src/modules/core/components/Dialog/Dialog.css
@@ -31,7 +31,3 @@
   stroke: var(--colony-white);
   cursor: pointer;
 }
-
-.overflowEnabled {
-  overflow: initial;
-}

--- a/src/modules/core/components/Dialog/Dialog.css.d.ts
+++ b/src/modules/core/components/Dialog/Dialog.css.d.ts
@@ -2,4 +2,3 @@ export const modal: string;
 export const main: string;
 export const dialogOuterActions: string;
 export const closeIconButton: string;
-export const overflowEnabled: string;

--- a/src/modules/core/components/Dialog/Dialog.tsx
+++ b/src/modules/core/components/Dialog/Dialog.tsx
@@ -1,6 +1,5 @@
 import React, { ReactNode } from 'react';
 import { defineMessages } from 'react-intl';
-import classnames from 'classnames';
 
 import Icon from '~core/Icon';
 
@@ -22,8 +21,6 @@ interface Props {
   children: ReactNode;
   /** Determines if the Dialog can be dismissed */
   isDismissable?: boolean;
-  /** Determines if the Dialog should allow elements to overflow */
-  noOverflow?: boolean;
 }
 
 const displayName = 'Dialog';
@@ -32,15 +29,12 @@ const Dialog = ({
   children,
   cancel,
   isDismissable = true,
-  noOverflow = true,
   ...props
 }: Props) => (
   <Modal
     {...props}
     role="dialog"
-    className={classnames(styles.modal, {
-      [styles.overflowEnabled]: !noOverflow,
-    })}
+    className={styles.modal}
     onRequestClose={cancel}
     isOpen
   >
@@ -59,13 +53,7 @@ const Dialog = ({
         </button>
       </div>
     )}
-    <div
-      className={classnames(styles.main, {
-        [styles.overflowEnabled]: !noOverflow,
-      })}
-    >
-      {children}
-    </div>
+    <div className={styles.main}>{children}</div>
   </Modal>
 );
 

--- a/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/ManageWhitelistDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/ManageWhitelistDialog.tsx
@@ -180,7 +180,7 @@ const ManageWhitelistDialog = ({
       }}
     >
       {(formValues: FormikProps<FormValues>) => (
-        <Dialog cancel={cancel} noOverflow={false}>
+        <Dialog cancel={cancel}>
           <DialogForm
             {...formValues}
             colony={colony}


### PR DESCRIPTION
## Description

-This PR updates the dapp to allow overflow of ManageWhitelistDialog when appropriate.

<img width="574" alt="Screenshot 2022-06-08 at 17 29 37" src="https://user-images.githubusercontent.com/582700/172669220-deefa8cf-8937-4423-b6d2-2a005cad8367.png">

Prop noOverflow in Dialog is no longer necessary, so was removed.


Resolves #3432
