### PR TITLE
Add link to Funds page in Incoming Funds text

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyUnclaimedTransfers/ColonyUnclaimedTransfers.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyUnclaimedTransfers/ColonyUnclaimedTransfers.css
@@ -53,3 +53,7 @@
   width: 166px;
   text-align: left;
 }
+
+.manageFundsLink {
+  color: var(--colony-blue);
+}

--- a/src/modules/dashboard/components/ColonyHome/ColonyUnclaimedTransfers/ColonyUnclaimedTransfers.css.d.ts
+++ b/src/modules/dashboard/components/ColonyHome/ColonyUnclaimedTransfers/ColonyUnclaimedTransfers.css.d.ts
@@ -5,3 +5,4 @@ export const tokenSymbol: string;
 export const firstLineContainer: string;
 export const button: string;
 export const tooltip: string;
+export const manageFundsLink: string;

--- a/src/modules/dashboard/components/ColonyHome/ColonyUnclaimedTransfers/ColonyUnclaimedTransfers.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyUnclaimedTransfers/ColonyUnclaimedTransfers.tsx
@@ -13,6 +13,7 @@ import Heading from '~core/Heading';
 import NavLink from '~core/NavLink';
 import Numeral from '~core/Numeral';
 import { Tooltip } from '~core/Popover';
+import Link from '~core/Link';
 
 import { ActionTypes } from '~redux/index';
 import { mergePayload } from '~utils/actions';
@@ -136,9 +137,15 @@ const ColonyUnclaimedTransfers = ({
         </li>
         {claimsLength > 1 && (
           <li>
-            <div className={styles.tokenItem}>
-              <FormattedMessage {...MSG.more} values={{ extraClaims }} />
-            </div>
+            <Link
+              className={styles.manageFundsLink}
+              to={`/colony/${colonyName}/funds`}
+              data-test="manageFunds"
+            >
+              <div className={styles.tokenItem}>
+                <FormattedMessage {...MSG.more} values={{ extraClaims }} />
+              </div>
+            </Link>
           </li>
         )}
       </ul>


### PR DESCRIPTION
## Description

-This PR 'linkifys' the `+ {NUMBER_HERE} more` text with the Incoming Funds page.

*For testing, make sure you have more than 1 token available for claiming in the incoming funds aside section.
<img width="449" alt="Screenshot 2022-06-09 at 11 37 09" src="https://user-images.githubusercontent.com/582700/172828048-74b6c806-efd4-4e19-93cd-3f560fcc8c46.png">


Resolves #3444
