### PR TITLE
Add error message when fewer than 3 characters

### DIFF
--- a/src/modules/core/components/Comment/Input/CommentInput.css
+++ b/src/modules/core/components/Comment/Input/CommentInput.css
@@ -33,6 +33,8 @@
 }
 
 .sendInstructions {
+  position: absolute;
+  right: 0;
   margin-top: 5px;
   font-size: var(--size-tiny);
   font-weight: var(--weight-bold);
@@ -54,6 +56,26 @@
 .sendInstructionsFadeIn {
   composes: sendInstructions;
   opacity: 1;
+}
+
+.minCharactersWarningFadeOut {
+  margin-top: 5px;
+  font-size: var(--size-tiny);
+  font-weight: var(--weight-bold);
+  text-align: left;
+  color: var(--temp-grey-0);
+  opacity: 0;
+  white-space: nowrap;
+  transition: opacity 0.2s linear;
+}
+
+.minCharactersWarning {
+  composes: minCharactersWarningFadeOut;
+  opacity: 1;
+}
+
+.inputMessage {
+  display: flex;
 }
 
 .submitting {

--- a/src/modules/core/components/Comment/Input/CommentInput.css
+++ b/src/modules/core/components/Comment/Input/CommentInput.css
@@ -33,9 +33,9 @@
 }
 
 .sendInstructions {
+  margin-top: 5px;
   position: absolute;
   right: 0;
-  margin-top: 5px;
   font-size: var(--size-tiny);
   font-weight: var(--weight-bold);
   text-align: right;
@@ -63,9 +63,9 @@
   font-size: var(--size-tiny);
   font-weight: var(--weight-bold);
   text-align: left;
+  white-space: nowrap;
   color: var(--temp-grey-0);
   opacity: 0;
-  white-space: nowrap;
   transition: opacity 0.2s linear;
 }
 

--- a/src/modules/core/components/Comment/Input/CommentInput.css.d.ts
+++ b/src/modules/core/components/Comment/Input/CommentInput.css.d.ts
@@ -4,4 +4,7 @@ export const main: string;
 export const commentBox: string;
 export const sendInstructions: string;
 export const sendInstructionsFadeIn: string;
+export const minCharactersWarningFadeOut: string;
+export const minCharactersWarning: string;
+export const inputMessage: string;
 export const submitting: string;

--- a/src/modules/core/components/Comment/Input/CommentInput.tsx
+++ b/src/modules/core/components/Comment/Input/CommentInput.tsx
@@ -153,7 +153,12 @@ const CommentInput = ({
         validateOnMount
         validateOnBlur
       >
-        {({ values, isSubmitting, isValid, handleSubmit }: FormikProps<FormValues>) => {
+        {({
+          values,
+          isSubmitting,
+          isValid,
+          handleSubmit,
+        }: FormikProps<FormValues>) => {
           const { message } = values;
           return (
             <div className={styles.commentBox} ref={commentBoxRef}>
@@ -176,8 +181,7 @@ const CommentInput = ({
                   <SpinnerLoader />
                 </div>
               )}
-              <div
-                className={styles.inputMessage}>
+              <div className={styles.inputMessage}>
                 <div
                   className={
                     !isValid && message.length > 0
@@ -185,9 +189,7 @@ const CommentInput = ({
                       : styles.minCharactersWarningFadeOut
                   }
                 >
-                  <FormattedMessage
-                    {...MSG.minCharactersWarning}
-                  />
+                  <FormattedMessage {...MSG.minCharactersWarning} />
                 </div>
                 <div
                   className={
@@ -214,7 +216,7 @@ const CommentInput = ({
                 </div>
               </div>
             </div>
-          )
+          );
         }}
       </Form>
     </div>

--- a/src/modules/core/components/Comment/Input/CommentInput.tsx
+++ b/src/modules/core/components/Comment/Input/CommentInput.tsx
@@ -36,6 +36,10 @@ const MSG = defineMessages({
     id: 'core.Comment.CommentInput.commentInstuctions',
     defaultMessage: `{sendCombo} to send {newLineCombo} for a new line`,
   },
+  minCharactersWarning: {
+    id: 'core.Comment.CommentInput.minCharactersWarning',
+    defaultMessage: `You must enter at least 3 characters to comment`,
+  },
   newLineCombo: {
     id: 'core.Comment.CommentInput.newLineCombo',
     defaultMessage: 'Shift+Return',
@@ -149,52 +153,69 @@ const CommentInput = ({
         validateOnMount
         validateOnBlur
       >
-        {({ isSubmitting, isValid, handleSubmit }: FormikProps<FormValues>) => (
-          <div className={styles.commentBox} ref={commentBoxRef}>
-            <TextareaAutoresize
-              elementOnly
-              label={MSG.commentInputPlaceholder}
-              name="message"
-              placeholder={
-                disabledInputPlaceholder || MSG.commentInputPlaceholder
-              }
-              minRows={1}
-              maxRows={6}
-              onKeyDown={(event) => handleKeyboardSubmit(event, handleSubmit)}
-              innerRef={(ref) => setCommentBoxInputRef(ref)}
-              disabled={isSubmitting || disabled}
-              dataTest="commentInput"
-            />
-            {isSubmitting && (
-              <div className={styles.submitting}>
-                <SpinnerLoader />
-              </div>
-            )}
-            <div
-              className={
-                isValid
-                  ? styles.sendInstructionsFadeIn
-                  : styles.sendInstructions
-              }
-            >
-              <FormattedMessage
-                {...MSG.commentInstuctions}
-                values={{
-                  sendCombo: (
-                    <b>
-                      <FormattedMessage {...MSG.sendCombo} />
-                    </b>
-                  ),
-                  newLineCombo: (
-                    <b>
-                      <FormattedMessage {...MSG.newLineCombo} />
-                    </b>
-                  ),
-                }}
+        {({ values, isSubmitting, isValid, handleSubmit }: FormikProps<FormValues>) => {
+          const { message } = values;
+          return (
+            <div className={styles.commentBox} ref={commentBoxRef}>
+              <TextareaAutoresize
+                elementOnly
+                label={MSG.commentInputPlaceholder}
+                name="message"
+                placeholder={
+                  disabledInputPlaceholder || MSG.commentInputPlaceholder
+                }
+                minRows={1}
+                maxRows={6}
+                onKeyDown={(event) => handleKeyboardSubmit(event, handleSubmit)}
+                innerRef={(ref) => setCommentBoxInputRef(ref)}
+                disabled={isSubmitting || disabled}
+                dataTest="commentInput"
               />
+              {isSubmitting && (
+                <div className={styles.submitting}>
+                  <SpinnerLoader />
+                </div>
+              )}
+              <div
+                className={styles.inputMessage}>
+                <div
+                  className={
+                    !isValid && message.length > 0
+                      ? styles.minCharactersWarning
+                      : styles.minCharactersWarningFadeOut
+                  }
+                >
+                  <FormattedMessage
+                    {...MSG.minCharactersWarning}
+                  />
+                </div>
+                <div
+                  className={
+                    isValid
+                      ? styles.sendInstructionsFadeIn
+                      : styles.sendInstructions
+                  }
+                >
+                  <FormattedMessage
+                    {...MSG.commentInstuctions}
+                    values={{
+                      sendCombo: (
+                        <b>
+                          <FormattedMessage {...MSG.sendCombo} />
+                        </b>
+                      ),
+                      newLineCombo: (
+                        <b>
+                          <FormattedMessage {...MSG.newLineCombo} />
+                        </b>
+                      ),
+                    }}
+                  />
+                </div>
+              </div>
             </div>
-          </div>
-        )}
+          )
+        }}
       </Form>
     </div>
   );


### PR DESCRIPTION
## Description

When you try to add a comment in the Actions comments that contains fewer than 3 characters, the form will not submit. However, currently there is no feedback in the UI informing the user why. This PR fixes that by displaying a message to the user that their comment should contain at least 3 characters. 

**New stuff** ✨

* -[x] Display message: "You must enter at least 3 characters to comment" when input value contains more than 0 and fewer than 3 characters.

__Note: This is the message element I've added:__

```
<div
  className={
    !isValid && message.length > 0
      ? styles.minCharactersWarning
      : styles.minCharactersWarningFadeOut
  }
  >
  <FormattedMessage
    {...MSG.minCharactersWarning}
  />
</div>
```

- [x] Wrap both messages in a flex container so they format nicely
- [x] Set the "Return to Send" message position to absolute so it doesn't overlap

**Changes** 🏗

* None

**Deletions** ⚰️

* None

## Screenshot

**_The warning message is displayed after the user has entered a character and fades once the user has entered 3._**

![message-demo](https://user-images.githubusercontent.com/64402732/172842052-45e5d288-cfdc-4c2e-96a8-f423201c560a.gif)


## TODO

None

Resolves #3426
