### PR TITLE
Fix error message overflow

### DIFF
--- a/src/modules/users/components/GasStation/TransactionCard/GroupedTransactionCard.css
+++ b/src/modules/users/components/GasStation/TransactionCard/GroupedTransactionCard.css
@@ -83,5 +83,6 @@
   margin-left: 14px;
   font-size: var(--size-unreadable);
   font-weight: var(--weight-bold);
+  line-height: 1.6;
   color: var(--danger);
 }

--- a/src/modules/users/components/GasStation/TransactionCard/GroupedTransactionCard.css
+++ b/src/modules/users/components/GasStation/TransactionCard/GroupedTransactionCard.css
@@ -2,7 +2,8 @@
   display: flex;
   align-items: center;
   padding: 12px 15px 12px 20px;
-  height: 40px;
+  height: auto;
+  min-height: 40px;
   border-left: 3px solid var(--temp-grey-5);
   border-top: 1px solid var(--grey-blue-1);
   font-size: var(--size-small);
@@ -79,16 +80,7 @@
 
 .failedDescription {
   display: block;
-
-  /*
-   * @NOTE This breaks design consistency
-   *
-   * This does not a use a state symbol like all the others, it just displays
-   * skewed copy under the action's name.
-   *
-   * Because of this, we must *heavily* use negative margins to align text properly.
-   */
-  margin: -4px 0 -12px 14px;
+  margin-left: 14px;
   font-size: var(--size-unreadable);
   font-weight: var(--weight-bold);
   color: var(--danger);


### PR DESCRIPTION
## Description

Currently, long error messages in the actions popover are overflowing their container. This PR fixes this.

**New stuff** ✨

- [x] Add min height of error message at 40px

**Changes** 🏗

- [x] Set height of error message to auto

**Deletions** ⚰️

- [x] Remove negative margins on the error message container (because it was interfering with padding of ancestor li)
- [x] Remove comment explaining the use of negative margins (now redundant)

## Screenshot

**_The error message no longer overflows its container, and maintains correct padding between ancestor li element._**
**_Updated with line height of 1.6._**

![line-height](https://user-images.githubusercontent.com/64402732/173057932-d1d38366-b9f5-41a9-b469-77d10f55dbb6.png)


## TODO

none

Resolves #3430 
