### PR TITLE
Fixing margin on button icon

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyDomainSelector/CreateDomainButton.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyDomainSelector/CreateDomainButton.css
@@ -33,5 +33,5 @@
 
 .buttonIcon {
   position: absolute;
-  left: 0;
+  left: 5px;
 }


### PR DESCRIPTION
## Description

This PR fixes the lack of margin between the Add New Team member "+" icon and its container.

**Changes** 🏗

- [x] Change position:left from 0px to 5px

## Screenshot

**_The add icon is the correct distance from its container, per the [figma design](https://www.figma.com/file/DjVCPq7LpkjEMEfQZtKgBdC1/Style-Guide?node-id=94%3A0)_**

![add-new-mbr-btn](https://user-images.githubusercontent.com/64402732/172881396-ed013f18-90ae-446d-8d86-0eadcd5a7c9e.png)

Resolves #3424 
