### PR TITLE
Rename Motions and Disputes Extension

### DIFF
--- a/src/data/staticData/extensionData.tsx
+++ b/src/data/staticData/extensionData.tsx
@@ -209,7 +209,7 @@ const coinMachineMessages = {
 const votingReputationMessages = {
   votingReputationName: {
     id: 'extensions.votingReputation.name',
-    defaultMessage: 'Motions & Disputes (Reputation)',
+    defaultMessage: 'Governance (Reputation Weighted)',
   },
   votingReputationDescriptionShort: {
     id: 'extensions.votingReputation.description',

--- a/src/utils/hooks/useTitle.ts
+++ b/src/utils/hooks/useTitle.ts
@@ -95,7 +95,7 @@ const MSG = defineMessages({
   colonyExtensionDetails: {
     id: 'utils.hooks.useTitle.colonyExtensionDetails',
     defaultMessage: `Extensions > {extensionId, select,
-      VotingReputation {Motions & Disputes}
+      VotingReputation {Governance}
       CoinMachine {Coin Machine}
       OneTxPayment {One Transaction Payment}
       other {{extensionId}}
@@ -105,7 +105,7 @@ const MSG = defineMessages({
   colonyExtensionSetup: {
     id: 'utils.hooks.useTitle.colonyExtensionSetup',
     defaultMessage: `Extensions > {extensionId, select,
-      VotingReputation {Motions & Disputes}
+      VotingReputation {Governance}
       CoinMachine {Coin Machine}
       OneTxPayment {One Transaction Payment}
       other {{extensionId}}


### PR DESCRIPTION
## Description

This PR is to rename the Motions and Disputes extension and all references to it in the Dapp.

**Changes** 🏗

- [x] Change "Motions & Disputes (Reputation)" to "Governance (Reputation Weighted)".
- [x] Change page title at relevant extension routes

## Screenshot

![governance](https://user-images.githubusercontent.com/64402732/172890843-268ac24d-6dc9-43f9-b1e6-9fdddecb55a7.png)

**_Page title updated as well_**
![governance-title](https://user-images.githubusercontent.com/64402732/173071517-66376976-7abf-49db-b63f-b2c8dad2ecd3.png)


## TODO

- [x] Research other locations in which old title may be
- [x] Inform relevant teams
- [x] Create issue documenting the location of other references (#3468)


Resolves  #3420 
