### PR TITLE
Fix Numeral default size

### DIFF
--- a/src/modules/core/components/Numeral/Numeral.css
+++ b/src/modules/core/components/Numeral/Numeral.css
@@ -1,5 +1,5 @@
 .main {
-  font-size: var(--size-normal);
+  font-size: inherit;
 }
 
 /*


### PR DESCRIPTION
## Description

This PR makes the Numeral main class inherit its font size instead of setting it to 14px by default and thereby overwriting the size of its container.

**New stuff** ✨

* none

**Changes** 🏗

- [x] Set font-size to "inherit" on Numeral.main 

**Deletions** ⚰️

* none

## Screenshot 

**_The numeral font is the same as its container, 13px_**

![default-font](https://user-images.githubusercontent.com/64402732/172908042-f3a3311b-3fc8-4722-ba52-d0da2714510d.png)


## TODO

* none

Resolves #3419 
