### PR TITLE
Address book tx redirects

### DIFF
--- a/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/ManageWhitelistDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/ManageWhitelistDialog.tsx
@@ -44,6 +44,7 @@ const displayName = 'dashboard.ManageWhitelistDialog';
 
 const ManageWhitelistDialog = ({
   cancel,
+  close,
   callStep,
   prevStep,
   colony,
@@ -175,6 +176,7 @@ const ManageWhitelistDialog = ({
         if (tabIndex === TABS.ADD_ADDRESS) {
           setFormSuccess(true);
         }
+        close();
       }}
     >
       {(formValues: FormikProps<FormValues>) => (

--- a/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/ManageWhitelistDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/ManageWhitelistDialogForm.tsx
@@ -142,6 +142,11 @@ const ManageWhitelistDialogForm = ({
               inputSuccessMsg={MSG.inputSuccess}
               fileSuccessMsg={MSG.fileSuccess}
             />
+            <Annotations
+              label={MSG.annotation}
+              name="annotation"
+              disabled={!userHasPermission}
+            />
           </TabPanel>
           <TabPanel>
             {(whitelistedUsers?.length && (
@@ -155,15 +160,13 @@ const ManageWhitelistDialogForm = ({
                 />
               </>
             )) || <NoWhitelistedAddressesState />}
+            <Annotations
+              label={MSG.annotation}
+              name="annotation"
+              disabled={!userHasPermission}
+            />
           </TabPanel>
         </Tabs>
-      </DialogSection>
-      <DialogSection>
-        <Annotations
-          label={MSG.annotation}
-          name="annotation"
-          disabled={!userHasPermission}
-        />
       </DialogSection>
       {!userHasPermission && (
         <DialogSection appearance={{ theme: 'sidePadding' }}>

--- a/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/ManageWhitelistDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/ManageWhitelistDialogForm.tsx
@@ -145,7 +145,7 @@ const ManageWhitelistDialogForm = ({
             <Annotations
               label={MSG.annotation}
               name="annotation"
-              disabled={!userHasPermission}
+              disabled={!userHasPermission || isSubmitting}
             />
           </TabPanel>
           <TabPanel>
@@ -163,7 +163,7 @@ const ManageWhitelistDialogForm = ({
             <Annotations
               label={MSG.annotation}
               name="annotation"
-              disabled={!userHasPermission}
+              disabled={!userHasPermission || isSubmitting}
             />
           </TabPanel>
         </Tabs>

--- a/src/modules/dashboard/sagas/whitelist/manageVerifiedRecipients.ts
+++ b/src/modules/dashboard/sagas/whitelist/manageVerifiedRecipients.ts
@@ -8,7 +8,7 @@ import {
   ColonyFromNameDocument,
 } from '~data/index';
 import { Action, ActionTypes, AllActions } from '~redux/index';
-import { putError, takeFrom } from '~utils/saga/effects';
+import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
 
 import {
   createTransaction,
@@ -34,7 +34,7 @@ function* manageVerifiedRecipients({
     annotationMessage,
     isWhitelistActivated,
   },
-  meta: { id: metaId },
+  meta: { id: metaId, history },
   meta,
 }: Action<ActionTypes.COLONY_VERIFIED_RECIPIENTS_MANAGE>) {
   let txChannel;
@@ -177,6 +177,10 @@ function* manageVerifiedRecipients({
       payload: {},
       meta,
     });
+
+    if (colonyName) {
+      yield routeRedirect(`/colony/${colonyName}/tx/${txHash}`, history);
+    }
   } catch (error) {
     return yield putError(
       ActionTypes.COLONY_VERIFIED_RECIPIENTS_MANAGE_ERROR,

--- a/src/redux/types/actions/colony.ts
+++ b/src/redux/types/actions/colony.ts
@@ -5,6 +5,7 @@ import {
   ErrorActionType,
   UniqueActionType,
   UniqueActionTypeWithoutPayload,
+  MetaWithHistory,
 } from './index';
 
 export type ColonyActionTypes =
@@ -124,7 +125,7 @@ export type ColonyActionTypes =
         colonyName: string;
         isWhitelistActivated: boolean;
       },
-      WithKey
+      MetaWithHistory<object>
     >
   | ErrorActionType<ActionTypes.COLONY_VERIFIED_RECIPIENTS_MANAGE_ERROR, object>
   | UniqueActionType<


### PR DESCRIPTION
This PR makes address book transactions redirect to the transactions details page. It also makes the annotations box reset on tab change in that action's modal.

Fixes #3436.