### PR TITLE
Update the way manage whitelist dialog refreshes

### DIFF
--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -74,6 +74,7 @@ const ColonyMembers = () => {
 
   const { data: colonyData, error, loading } = useColonyFromNameQuery({
     variables: { name: colonyName, address: '' },
+    pollInterval: 5000,
   });
 
   const colonyAddress = colonyData?.processedColony?.colonyAddress || '';


### PR DESCRIPTION
## Description

This PR fixes the refresh of the manage whitelist dialog when opened from Members page

**Changes** 🏗

- add polling to `colonyFromNameQuery`

resolves #3454 
