### PR TITLE
Address Book filter on UserPicker is disabled if there are no addresses

### DIFF
--- a/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialog.tsx
@@ -117,7 +117,7 @@ const CreatePaymentDialog = ({
   const filteredVerifiedRecipients = useMemo(() => {
     return isWhitelistActivated &&
       colonyData?.processedColony?.whitelistedAddresses &&
-      colonyData?.processedColony?.whitelistedAddresses?.length > 0
+      colonyData.processedColony.whitelistedAddresses.length > 0
       ? (colonyMembers?.subscribedUsers || []).filter((member) =>
           colonyData?.processedColony?.whitelistedAddresses.some(
             (el) => el.toLowerCase() === member.id.toLowerCase(),

--- a/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialog.tsx
@@ -115,7 +115,9 @@ const CreatePaymentDialog = ({
     colonyData?.processedColony?.isWhitelistActivated;
 
   const filteredVerifiedRecipients = useMemo(() => {
-    return isWhitelistActivated
+    return isWhitelistActivated &&
+      colonyData?.processedColony?.whitelistedAddresses &&
+      colonyData?.processedColony?.whitelistedAddresses?.length > 0
       ? (colonyMembers?.subscribedUsers || []).filter((member) =>
           colonyData?.processedColony?.whitelistedAddresses.some(
             (el) => el.toLowerCase() === member.id.toLowerCase(),


### PR DESCRIPTION
## Description

This adds a check to the `whitelistedAddresses` user filter, so, that the filter does not work if there are no addresses in the Address Book.

**New stuff** ✨

* Adds check for 0 length of `whitelistedAddresses`

## Testing

1. Add a user to the Address book, it will auto activate it.
2. Remove the user from the Address book.
3. Go to a UserPicker and try to select a user, it should allow you to select any user again.

Resolves #3466
