### PR TITLE
Fix/3461-magnify-icon

### DIFF
--- a/src/modules/dashboard/components/Members/MembersTitle.css
+++ b/src/modules/dashboard/components/Members/MembersTitle.css
@@ -49,10 +49,10 @@
 }
 
 .icon {
-  height: 30px;
-  width: 30px;
+  height: 20px;
+  width: 20px;
   position: absolute;
-  top: 50%;
+  top: 40%;
   right: 2px;
   z-index: 1;
   transform: translateY(-50%);


### PR DESCRIPTION
## Description

This PR fixes the oversized Search Icon in the Watchers and Contributors feature.

**Changes** 🏗

- [x] Set icon height and width to *20px* as per [figma](https://www.figma.com/file/qQoBbyyDXkuHwoqHIOGjEu/Colony-Simplified?node-id=6736%3A90099)

## Screenshot

**_Search icon is the correct height_**

![search-icon](https://user-images.githubusercontent.com/64402732/173342175-4cd94d9a-df41-496c-8459-2790a525b8d3.png)

![search-icon-20](https://user-images.githubusercontent.com/64402732/173342185-83ae0841-8eef-4005-ba6e-7ea49ce92546.png)

Resolves #3461 
