### PR TITLE
Add Remove Safe Dialog

### DIFF
--- a/src/modules/core/components/Fields/Checkbox/Checkbox.css
+++ b/src/modules/core/components/Fields/Checkbox/Checkbox.css
@@ -52,16 +52,8 @@
   box-shadow: 0 0 0 3px  color-mod(var(--temp-grey-blue-9) alpha(25%));
 }
 
-.themePink:not(:active) + .checkbox {
-  box-shadow: 0 0 2px 1px var(--temp-grey-blue-9);
-}
-
 .themePink.delegate.not(:focus) + .checkbox {
-  box-shadow: 0 0 3px 1px  color-mod(var(--primary) alpha(25%));
-}
-
-.themePink:active + .checkbox {
-  box-shadow: 0 0 2px 1px var(--pink);
+  box-shadow: 0 0 0 3px color-mod(var(--temp-grey-blue-9) alpha(25%));
 }
 
 .themePink.stateIsChecked .checkbox {

--- a/src/modules/core/components/Fields/Checkbox/Checkbox.css
+++ b/src/modules/core/components/Fields/Checkbox/Checkbox.css
@@ -47,6 +47,32 @@
   background-color: var(--temp-grey-2);
 }
 
+.themePink:not(.stateIsChecked) .checkbox {
+  border: 1px solid var(--temp-grey-blue-9);
+  box-shadow: 0 0 0 3px  color-mod(var(--temp-grey-blue-9) alpha(25%));
+}
+
+.themePink:not(:active) + .checkbox {
+  box-shadow: 0 0 2px 1px var(--temp-grey-blue-9);
+}
+
+.themePink.delegate.not(:focus) + .checkbox {
+  box-shadow: 0 0 3px 1px  color-mod(var(--primary) alpha(25%));
+}
+
+.themePink:active + .checkbox {
+  box-shadow: 0 0 2px 1px var(--pink);
+}
+
+.themePink.stateIsChecked .checkbox {
+  border: 1px solid var(--pink);
+  box-shadow: 0 0 0 3px color-mod(var(--pink) alpha(25%));
+}
+
+.themePink.delegate:focus + .checkbox {
+  box-shadow: 0 0 0 3px color-mod(var(--pink) alpha(25%));
+}
+
 /* Direction */
 
 .directionHorizontal {
@@ -77,6 +103,14 @@
   bottom: 0;
   background-color: var(--primary);
   content: '';
+}
+
+.themePink.stateIsChecked .checkbox .checkmark::before {
+  background-color: var(--pink);
+}
+
+.themePink.stateIsChecked .checkbox .checkmark::after {
+  background-color: var(--pink);
 }
 
 .stateDisabled {

--- a/src/modules/core/components/Fields/Checkbox/Checkbox.css
+++ b/src/modules/core/components/Fields/Checkbox/Checkbox.css
@@ -48,12 +48,12 @@
 }
 
 .themePink:not(.stateIsChecked) .checkbox {
-  border: 1px solid var(--temp-grey-blue-9);
-  box-shadow: 0 0 0 3px  color-mod(var(--temp-grey-blue-9) alpha(25%));
+  border: 1px solid var(--temp-grey-blue-4);
+  box-shadow: 0 0 0 3px  color-mod(var(--temp-grey-blue-4) alpha(25%));
 }
 
-.themePink.delegate.not(:focus) + .checkbox {
-  box-shadow: 0 0 0 3px color-mod(var(--temp-grey-blue-9) alpha(25%));
+.themePink.delegate:not(:focus) + .checkbox {
+  box-shadow: 0 0 0 3px color-mod(var(--temp-grey-blue-4) alpha(25%));
 }
 
 .themePink.stateIsChecked .checkbox {

--- a/src/modules/core/components/Fields/Checkbox/Checkbox.css.d.ts
+++ b/src/modules/core/components/Fields/Checkbox/Checkbox.css.d.ts
@@ -4,6 +4,8 @@ export const checkbox: string;
 export const stateIsChecked: string;
 export const checkmark: string;
 export const themeDark: string;
+export const themePink: string;
+export const not: string;
 export const directionHorizontal: string;
 export const directionVertical: string;
 export const stateDisabled: string;

--- a/src/modules/core/components/Fields/Checkbox/Checkbox.css.d.ts
+++ b/src/modules/core/components/Fields/Checkbox/Checkbox.css.d.ts
@@ -5,7 +5,6 @@ export const stateIsChecked: string;
 export const checkmark: string;
 export const themeDark: string;
 export const themePink: string;
-export const not: string;
 export const directionHorizontal: string;
 export const directionVertical: string;
 export const stateDisabled: string;

--- a/src/modules/core/components/Fields/Checkbox/Checkbox.tsx
+++ b/src/modules/core/components/Fields/Checkbox/Checkbox.tsx
@@ -19,7 +19,7 @@ import { getMainClasses } from '~utils/css';
 import styles from './Checkbox.css';
 
 interface Appearance {
-  theme: 'dark';
+  theme: 'dark' | 'pink';
   direction: 'vertical' | 'horizontal';
 }
 

--- a/src/modules/dashboard/components/ColonyHomeActions/ColonyHomeActions.tsx
+++ b/src/modules/dashboard/components/ColonyHomeActions/ColonyHomeActions.tsx
@@ -25,6 +25,7 @@ import ColonyTokenManagementDialog from '~dialogs/ColonyTokenManagementDialog';
 import { SmiteDialog, AwardDialog } from '~dialogs/AwardAndSmiteDialogs';
 import ManageGnosisSafeDialog from '~dialogs/ManageGnosisSafeDialog';
 import GnosisControlSafeDialog from '~dialogs/GnosisControlSafeDialog';
+import RemoveSafeDialog from '~dialogs/RemoveSafeDialog';
 
 import { useEnabledExtensions } from '~utils/hooks/useEnabledExtensions';
 
@@ -230,16 +231,7 @@ const ColonyHomeActions = ({ colony, ethDomainId }: Props) => {
     // {
     //   component: AddExistingSafeDialog,
     //   props: {
-    //     prevStep: 'dashboard.AddExistingSafeDialog',
-    //     colony,
-    //     isVotingExtensionEnabled,
-    //     ethDomainId,
-    //   },
-    // },
-    // {
-    //   component: RemoveSafeDialog,
-    //   props: {
-    //     prevStep: 'dashboard.RemoveSafeDialog',
+    //     prevStep: 'dashboard.ManageGnosisSafeDialog',
     //     colony,
     //     isVotingExtensionEnabled,
     //     ethDomainId,
@@ -252,6 +244,24 @@ const ColonyHomeActions = ({ colony, ethDomainId }: Props) => {
         colony,
       },
     },
+    {
+      component: RemoveSafeDialog,
+      props: {
+        prevStep: 'dashboard.ManageGnosisSafeDialog',
+        colony,
+        isVotingExtensionEnabled,
+        ethDomainId,
+      },
+    },
+    // {
+    //   component: ControlSafeDialog,
+    //   props: {
+    //     prevStep: 'dashboard.ManageGnosisSafeDialog',
+    //     colony,
+    //     isVotingExtensionEnabled,
+    //     ethDomainId,
+    //   },
+    // },
 
     {
       component: PermissionManagementDialog,

--- a/src/modules/dashboard/components/ColonyHomeActions/ColonyHomeActions.tsx
+++ b/src/modules/dashboard/components/ColonyHomeActions/ColonyHomeActions.tsx
@@ -249,8 +249,6 @@ const ColonyHomeActions = ({ colony, ethDomainId }: Props) => {
       props: {
         prevStep: 'dashboard.ManageGnosisSafeDialog',
         colony,
-        isVotingExtensionEnabled,
-        ethDomainId,
       },
     },
     // {

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialog.tsx
@@ -29,27 +29,27 @@ const safes: Safe[] = [
     name: 'All Saints (Gnosis Chain)',
     address: '0x3a157280ca91bB49dAe3D1619C55Da7F9D4438c2',
   },
-  {
-    name: '(Mainnet)',
-    address: '0x4a157280ca91bB49dAe3D1619C55Da7F9D4438c3',
-  },
-  {
-    name: 'Big safe',
-    address: '0x5a157280ca91bB49dAe3D1619C55Da7F9D4438c2',
-  },
-  {
-    name: `Just a test with a very very long name,
-    hang on its even longer!!!!!!!!`,
-    address: '0x6a157280ca91bB49dAe3D1619C55Da7F9D4438c3',
-  },
-  {
-    name: 'blalabalabal',
-    address: '0x7a157280ca91bB49dAe3D1619C55Da7F9D4438c2',
-  },
-  {
-    name: 'final test',
-    address: '0x8a157280ca91bB49dAe3D1619C55Da7F9D4438c3',
-  },
+  // {
+  //   name: '(Mainnet)',
+  //   address: '0x4a157280ca91bB49dAe3D1619C55Da7F9D4438c3',
+  // },
+  // {
+  //   name: 'Big safe',
+  //   address: '0x5a157280ca91bB49dAe3D1619C55Da7F9D4438c2',
+  // },
+  // {
+  //   name: `Just a test with a very very long name,
+  //   hang on its even longer!!!!!!!!`,
+  //   address: '0x6a157280ca91bB49dAe3D1619C55Da7F9D4438c3',
+  // },
+  // {
+  //   name: 'blalabalabal',
+  //   address: '0x7a157280ca91bB49dAe3D1619C55Da7F9D4438c2',
+  // },
+  // {
+  //   name: 'final test',
+  //   address: '0x8a157280ca91bB49dAe3D1619C55Da7F9D4438c3',
+  // },
 ];
 
 const RemoveSafeDialog = ({
@@ -62,7 +62,8 @@ const RemoveSafeDialog = ({
   return (
     <ActionForm
       initialValues={{
-        safeList: [],
+        // if there's only 1 safe then that safe is already checked.
+        safeList: safes.length === 1 ? safes[0].address : [],
       }}
       // @TODO need to update action, in another PR
       submit={ActionTypes.COLONY_ACTION_RECOVERY}

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialog.tsx
@@ -1,58 +1,61 @@
 import React from 'react';
 import { FormikProps } from 'formik';
 
-import Dialog, { DialogProps } from '~core/Dialog';
+import Dialog, { DialogProps, ActionDialogProps } from '~core/Dialog';
 import { ActionForm } from '~core/Fields';
 import { Address } from '~types/index';
 
-import { Colony } from '~data/index';
+// import { Colony } from '~data/index';
 import { ActionTypes } from '~redux/index';
 import { WizardDialogType } from '~utils/hooks';
 
 import { Safe } from './types';
 import DialogForm from './RemoveSafeDialogForm';
 
-export interface FormValues {
-  safeList: Address[];
-}
-
-interface CustomWizardDialogProps {
-  prevStep: string;
-  colony: Colony;
-}
-
-type Props = DialogProps & WizardDialogType<object> & CustomWizardDialogProps;
-
 const displayName = 'dashboard.RemoveSafeDialog';
 
 // Mock data for testing
 const safes: Safe[] = [
   {
-    name: 'All Saints (Gnosis Chain)',
+    name: 'All Saints',
+    chain: `Gnosis Chain`,
     address: '0x3a157280ca91bB49dAe3D1619C55Da7F9D4438c2',
   },
   // {
-  //   name: '(Mainnet)',
+  //   name: '',
+  //   chain: `Mainnet`
   //   address: '0x4a157280ca91bB49dAe3D1619C55Da7F9D4438c3',
   // },
   // {
   //   name: 'Big safe',
+  //  chain: `Mainnet`
   //   address: '0x5a157280ca91bB49dAe3D1619C55Da7F9D4438c2',
   // },
   // {
   //   name: `Just a test with a very very long name,
   //   hang on its even longer!!!!!!!!`,
+  //  chain: `Mainnet`
   //   address: '0x6a157280ca91bB49dAe3D1619C55Da7F9D4438c3',
   // },
   // {
   //   name: 'blalabalabal',
+  //  chain: `Mainnet`
   //   address: '0x7a157280ca91bB49dAe3D1619C55Da7F9D4438c2',
   // },
   // {
   //   name: 'final test',
+  //   chain: `Mainnet`
   //   address: '0x8a157280ca91bB49dAe3D1619C55Da7F9D4438c3',
   // },
 ];
+
+export interface FormValues {
+  safeList: Address[];
+}
+
+type Props = DialogProps &
+  Partial<WizardDialogType<object>> &
+  Omit<ActionDialogProps, 'isVotingExtensionEnabled'>;
 
 const RemoveSafeDialog = ({
   cancel,
@@ -68,9 +71,9 @@ const RemoveSafeDialog = ({
         safeList: safes.length === 1 ? [safes[0].address] : [],
       }}
       // @TODO need to update action, in another PR
-      submit={ActionTypes.COLONY_ACTION_RECOVERY}
-      error={ActionTypes.COLONY_ACTION_RECOVERY_ERROR}
-      success={ActionTypes.COLONY_ACTION_RECOVERY_SUCCESS}
+      submit={ActionTypes.COLONY_ACTION_GENERIC}
+      error={ActionTypes.COLONY_ACTION_GENERIC_ERROR}
+      success={ActionTypes.COLONY_ACTION_GENERIC_SUCCESS}
       onSuccess={close}
     >
       {(formValues: FormikProps<FormValues>) => {
@@ -79,7 +82,7 @@ const RemoveSafeDialog = ({
             <DialogForm
               {...formValues}
               colony={colony}
-              back={() => callStep(prevStep)}
+              back={prevStep && callStep ? () => callStep(prevStep) : undefined}
               safeList={safes}
             />
           </Dialog>

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialog.tsx
@@ -1,20 +1,18 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import { FormikProps } from 'formik';
-import * as yup from 'yup';
-import { useHistory } from 'react-router-dom';
 
 import Dialog, { DialogProps } from '~core/Dialog';
 import { ActionForm } from '~core/Fields';
 
-import { Colony, useLoggedInUser } from '~data/index';
+import { Colony } from '~data/index';
 import { ActionTypes } from '~redux/index';
 import { WizardDialogType } from '~utils/hooks';
-import { pipe, withMeta, mapPayload } from '~utils/actions';
 
+import { Safe } from './types';
 import DialogForm from './RemoveSafeDialogForm';
 
 export interface FormValues {
-  annotation: string;
+  safeList: string[];
 }
 
 interface CustomWizardDialogProps {
@@ -26,57 +24,64 @@ type Props = DialogProps & WizardDialogType<object> & CustomWizardDialogProps;
 
 const displayName = 'dashboard.RemoveSafeDialog';
 
+const safes: Safe[] = [
+  {
+    name: 'All Saints (Gnosis Chain)',
+    address: '0x3a157280ca91bB49dAe3D1619C55Da7F9D4438c2',
+  },
+  {
+    name: '(Mainnet)',
+    address: '0x4a157280ca91bB49dAe3D1619C55Da7F9D4438c3',
+  },
+  {
+    name: 'Big safe',
+    address: '0x5a157280ca91bB49dAe3D1619C55Da7F9D4438c2',
+  },
+  {
+    name: `Just a test with a very very long name,
+    hang on its even longer!!!!!!!!`,
+    address: '0x6a157280ca91bB49dAe3D1619C55Da7F9D4438c3',
+  },
+  {
+    name: 'blalabalabal',
+    address: '0x7a157280ca91bB49dAe3D1619C55Da7F9D4438c2',
+  },
+  {
+    name: 'final test',
+    address: '0x8a157280ca91bB49dAe3D1619C55Da7F9D4438c3',
+  },
+];
+
 const RemoveSafeDialog = ({
   cancel,
   close,
   callStep,
   prevStep,
-  colony: { colonyName, colonyAddress },
   colony,
 }: Props) => {
-  const { walletAddress } = useLoggedInUser();
-  const history = useHistory();
-
-  const validationSchema = yup.object().shape({
-    annotation: yup.string().max(4000),
-  });
-
-  const transform = useCallback(
-    pipe(
-      mapPayload(({ annotation: annotationMessage }) => {
-        return {
-          colonyName,
-          colonyAddress,
-          walletAddress,
-          annotationMessage,
-        };
-      }),
-      withMeta({ history }),
-    ),
-    [],
-  );
-
   return (
     <ActionForm
       initialValues={{
-        annotation: undefined,
+        safeList: [],
       }}
+      // @TODO need to update action, in another PR
       submit={ActionTypes.COLONY_ACTION_RECOVERY}
       error={ActionTypes.COLONY_ACTION_RECOVERY_ERROR}
       success={ActionTypes.COLONY_ACTION_RECOVERY_SUCCESS}
-      validationSchema={validationSchema}
       onSuccess={close}
-      transform={transform}
     >
-      {(formValues: FormikProps<FormValues>) => (
-        <Dialog cancel={cancel}>
-          <DialogForm
-            {...formValues}
-            colony={colony}
-            back={() => callStep(prevStep)}
-          />
-        </Dialog>
-      )}
+      {(formValues: FormikProps<FormValues>) => {
+        return (
+          <Dialog cancel={cancel}>
+            <DialogForm
+              {...formValues}
+              colony={colony}
+              back={() => callStep(prevStep)}
+              safeList={safes}
+            />
+          </Dialog>
+        );
+      }}
     </ActionForm>
   );
 };

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialog.tsx
@@ -1,0 +1,86 @@
+import React, { useCallback } from 'react';
+import { FormikProps } from 'formik';
+import * as yup from 'yup';
+import { useHistory } from 'react-router-dom';
+
+import Dialog, { DialogProps } from '~core/Dialog';
+import { ActionForm } from '~core/Fields';
+
+import { Colony, useLoggedInUser } from '~data/index';
+import { ActionTypes } from '~redux/index';
+import { WizardDialogType } from '~utils/hooks';
+import { pipe, withMeta, mapPayload } from '~utils/actions';
+
+import DialogForm from './RemoveSafeDialogForm';
+
+export interface FormValues {
+  annotation: string;
+}
+
+interface CustomWizardDialogProps {
+  prevStep: string;
+  colony: Colony;
+}
+
+type Props = DialogProps & WizardDialogType<object> & CustomWizardDialogProps;
+
+const displayName = 'dashboard.RemoveSafeDialog';
+
+const RemoveSafeDialog = ({
+  cancel,
+  close,
+  callStep,
+  prevStep,
+  colony: { colonyName, colonyAddress },
+  colony,
+}: Props) => {
+  const { walletAddress } = useLoggedInUser();
+  const history = useHistory();
+
+  const validationSchema = yup.object().shape({
+    annotation: yup.string().max(4000),
+  });
+
+  const transform = useCallback(
+    pipe(
+      mapPayload(({ annotation: annotationMessage }) => {
+        return {
+          colonyName,
+          colonyAddress,
+          walletAddress,
+          annotationMessage,
+        };
+      }),
+      withMeta({ history }),
+    ),
+    [],
+  );
+
+  return (
+    <ActionForm
+      initialValues={{
+        annotation: undefined,
+      }}
+      submit={ActionTypes.COLONY_ACTION_RECOVERY}
+      error={ActionTypes.COLONY_ACTION_RECOVERY_ERROR}
+      success={ActionTypes.COLONY_ACTION_RECOVERY_SUCCESS}
+      validationSchema={validationSchema}
+      onSuccess={close}
+      transform={transform}
+    >
+      {(formValues: FormikProps<FormValues>) => (
+        <Dialog cancel={cancel}>
+          <DialogForm
+            {...formValues}
+            colony={colony}
+            back={() => callStep(prevStep)}
+          />
+        </Dialog>
+      )}
+    </ActionForm>
+  );
+};
+
+RemoveSafeDialog.displayName = displayName;
+
+export default RemoveSafeDialog;

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialog.tsx
@@ -3,6 +3,7 @@ import { FormikProps } from 'formik';
 
 import Dialog, { DialogProps } from '~core/Dialog';
 import { ActionForm } from '~core/Fields';
+import { Address } from '~types/index';
 
 import { Colony } from '~data/index';
 import { ActionTypes } from '~redux/index';
@@ -12,7 +13,7 @@ import { Safe } from './types';
 import DialogForm from './RemoveSafeDialogForm';
 
 export interface FormValues {
-  safeList: string[];
+  safeList: Address[];
 }
 
 interface CustomWizardDialogProps {
@@ -24,6 +25,7 @@ type Props = DialogProps & WizardDialogType<object> & CustomWizardDialogProps;
 
 const displayName = 'dashboard.RemoveSafeDialog';
 
+// Mock data for testing
 const safes: Safe[] = [
   {
     name: 'All Saints (Gnosis Chain)',
@@ -63,7 +65,7 @@ const RemoveSafeDialog = ({
     <ActionForm
       initialValues={{
         // if there's only 1 safe then that safe is already checked.
-        safeList: safes.length === 1 ? safes[0].address : [],
+        safeList: safes.length === 1 ? [safes[0].address] : [],
       }}
       // @TODO need to update action, in another PR
       submit={ActionTypes.COLONY_ACTION_RECOVERY}

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialogForm.css
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialogForm.css
@@ -6,7 +6,16 @@
 }
 
 .description {
+  margin-top: 28px;
+  margin-bottom: 15px;
   font-size: var(--size-normal);
   font-weight: var(--weight-bold);
   color: var(--dark);
+}
+
+.content {
+  margin-top: 15px;
+  margin-bottom: 48px;
+  max-height: 290px;
+  overflow: auto;
 }

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialogForm.css
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialogForm.css
@@ -1,0 +1,12 @@
+.title {
+  font-size: var(--size-medium-l);
+  font-weight: var(--weight-bold);
+  line-height: 24px;
+  color: var(--dark);
+}
+
+.description {
+  font-size: var(--size-normal);
+  font-weight: var(--weight-bold);
+  color: var(--dark);
+}

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialogForm.css
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialogForm.css
@@ -5,6 +5,18 @@
   color: var(--dark);
 }
 
+.emptySafeList {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 40px;
+  margin-bottom: 60px;
+  font-size: var(--size-medium-l);
+  font-weight: var(--weight-normal);
+  line-height: 24px;
+  color: var(--dark);
+}
+
 .description {
   margin-top: 28px;
   margin-bottom: 15px;

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialogForm.css
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialogForm.css
@@ -28,6 +28,6 @@
 .content {
   margin-top: 15px;
   margin-bottom: 48px;
-  max-height: 290px;
+  max-height: 295px;
   overflow: auto;
 }

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialogForm.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialogForm.css.d.ts
@@ -1,3 +1,4 @@
 export const title: string;
+export const emptySafeList: string;
 export const description: string;
 export const content: string;

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialogForm.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialogForm.css.d.ts
@@ -1,0 +1,2 @@
+export const title: string;
+export const description: string;

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialogForm.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialogForm.css.d.ts
@@ -1,2 +1,3 @@
 export const title: string;
 export const description: string;
+export const content: string;

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialogForm.tsx
@@ -20,11 +20,11 @@ import styles from './RemoveSafeDialogForm.css';
 const MSG = defineMessages({
   title: {
     id: 'dashboard.RemoveSafeDialog.RemoveSafeDialogForm.title',
-    defaultMessage: 'Remove safe',
+    defaultMessage: 'Remove Safe',
   },
   desc: {
     id: 'dashboard.RemoveSafeDialog.RemoveSafeDialogForm.desc',
-    defaultMessage: 'Select safe you wish to remove',
+    defaultMessage: 'Select Safe you wish to remove',
   },
   emptySafeMsg: {
     id: 'dashboard.RemoveSafeDialog.RemoveSafeDialogForm.emptySafeMsg',
@@ -80,7 +80,7 @@ const RemoveSafeDialogForm = ({
                 <SafeListItem
                   key={item.address}
                   safe={item}
-                  isChecked={values.safeList.includes(item.address)}
+                  isChecked={values?.safeList?.includes(item.address)}
                 />
               ))}
             </div>

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialogForm.tsx
@@ -6,7 +6,8 @@ import Button from '~core/Button';
 import DialogSection from '~core/Dialog/DialogSection';
 import Heading from '~core/Heading';
 
-import { useLoggedInUser, Colony } from '~data/index';
+import { ActionDialogProps } from '~core/Dialog';
+import { useLoggedInUser } from '~data/index';
 import { useTransformer } from '~utils/hooks';
 import { getAllUserRoles } from '~modules/transformers';
 import { canEnterRecoveryMode } from '~modules/users/checks';
@@ -32,9 +33,7 @@ const MSG = defineMessages({
   },
 });
 
-interface Props {
-  back: () => void;
-  colony: Colony;
+interface Props extends Omit<ActionDialogProps, 'isVotingExtensionEnabled'> {
   safeList: Safe[];
 }
 

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialogForm.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { FormattedMessage, defineMessages } from 'react-intl';
+import { FormikProps } from 'formik';
+
+import Button from '~core/Button';
+import DialogSection from '~core/Dialog/DialogSection';
+import Heading from '~core/Heading';
+
+import { useLoggedInUser, Colony } from '~data/index';
+import { useTransformer } from '~utils/hooks';
+import { getAllUserRoles } from '~modules/transformers';
+import { canEnterRecoveryMode } from '~modules/users/checks';
+
+import { FormValues } from './RemoveSafeDialog';
+import styles from './RemoveSafeDialogForm.css';
+
+const MSG = defineMessages({
+  title: {
+    id: 'dashboard.RemoveSafeDialog.RemoveSafeDialogForm.title',
+    defaultMessage: 'Remove safe',
+  },
+  desc: {
+    id: 'dashboard.RemoveSafeDialog.RemoveSafeDialogForm.desc',
+    defaultMessage: 'Select safe you wish to remove',
+  },
+});
+
+interface Props {
+  back: () => void;
+  colony: Colony;
+}
+
+const RemoveSafeDialogForm = ({
+  back,
+  colony,
+  handleSubmit,
+  isSubmitting,
+}: Props & FormikProps<FormValues>) => {
+  const { walletAddress, username, ethereal } = useLoggedInUser();
+
+  const allUserRoles = useTransformer(getAllUserRoles, [colony, walletAddress]);
+
+  const hasRegisteredProfile = !!username && !ethereal;
+
+  const userHasPermission =
+    hasRegisteredProfile && canEnterRecoveryMode(allUserRoles);
+
+  return (
+    <>
+      <DialogSection appearance={{ theme: 'heading' }}>
+        <Heading
+          appearance={{ size: 'medium', margin: 'none' }}
+          text={MSG.title}
+          className={styles.title}
+        />
+      </DialogSection>
+      <DialogSection>
+        <div className={styles.description}>
+          <FormattedMessage {...MSG.desc} />
+        </div>
+      </DialogSection>
+      <DialogSection>
+        <p>blabla</p>
+      </DialogSection>
+      <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
+        <Button
+          appearance={{ theme: 'secondary', size: 'large' }}
+          onClick={back}
+          text={{ id: 'button.back' }}
+        />
+        <Button
+          appearance={{ theme: 'primary', size: 'large' }}
+          text={{ id: 'button.confirm' }}
+          onClick={() => handleSubmit()}
+          loading={isSubmitting}
+          disabled={!userHasPermission || isSubmitting}
+          data-test="removeSafeConfirmButton"
+        />
+      </DialogSection>
+    </>
+  );
+};
+
+export default RemoveSafeDialogForm;

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialogForm.tsx
@@ -26,6 +26,10 @@ const MSG = defineMessages({
     id: 'dashboard.RemoveSafeDialog.RemoveSafeDialogForm.desc',
     defaultMessage: 'Select safe you wish to remove',
   },
+  emptySafeMsg: {
+    id: 'dashboard.RemoveSafeDialog.RemoveSafeDialogForm.emptySafeMsg',
+    defaultMessage: 'No Safes found to remove.',
+  },
 });
 
 interface Props {
@@ -57,22 +61,32 @@ const RemoveSafeDialogForm = ({
           className={styles.title}
         />
       </DialogSection>
-      <DialogSection appearance={{ theme: 'sidePadding' }}>
-        <div className={styles.description}>
-          <FormattedMessage {...MSG.desc} />
+      {!safeList.length ? (
+        <DialogSection appearance={{ theme: 'sidePadding' }}>
+          <div className={styles.emptySafeList}>
+            <FormattedMessage {...MSG.emptySafeMsg} />
+          </div>
+        </DialogSection>
+      ) : (
+        <div>
+          <DialogSection appearance={{ theme: 'sidePadding' }}>
+            <div className={styles.description}>
+              <FormattedMessage {...MSG.desc} />
+            </div>
+          </DialogSection>
+          <DialogSection appearance={{ theme: 'sidePadding' }}>
+            <div className={styles.content}>
+              {safeList.map((item) => (
+                <SafeListItem
+                  key={item.address}
+                  safe={item}
+                  isChecked={values.safeList.includes(item.address)}
+                />
+              ))}
+            </div>
+          </DialogSection>
         </div>
-      </DialogSection>
-      <DialogSection appearance={{ theme: 'sidePadding' }}>
-        <div className={styles.content}>
-          {safeList.map((item) => (
-            <SafeListItem
-              key={item.address}
-              safe={item}
-              isChecked={values.safeList.includes(item.address)}
-            />
-          ))}
-        </div>
-      </DialogSection>
+      )}
       <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
         <Button
           appearance={{ theme: 'secondary', size: 'large' }}

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialogForm.tsx
@@ -11,7 +11,10 @@ import { useTransformer } from '~utils/hooks';
 import { getAllUserRoles } from '~modules/transformers';
 import { canEnterRecoveryMode } from '~modules/users/checks';
 
+import SafeListItem from './SafeListItem';
+import { Safe } from './types';
 import { FormValues } from './RemoveSafeDialog';
+
 import styles from './RemoveSafeDialogForm.css';
 
 const MSG = defineMessages({
@@ -28,6 +31,7 @@ const MSG = defineMessages({
 interface Props {
   back: () => void;
   colony: Colony;
+  safeList: Safe[];
 }
 
 const RemoveSafeDialogForm = ({
@@ -35,13 +39,12 @@ const RemoveSafeDialogForm = ({
   colony,
   handleSubmit,
   isSubmitting,
+  values,
+  safeList,
 }: Props & FormikProps<FormValues>) => {
   const { walletAddress, username, ethereal } = useLoggedInUser();
-
   const allUserRoles = useTransformer(getAllUserRoles, [colony, walletAddress]);
-
   const hasRegisteredProfile = !!username && !ethereal;
-
   const userHasPermission =
     hasRegisteredProfile && canEnterRecoveryMode(allUserRoles);
 
@@ -54,13 +57,21 @@ const RemoveSafeDialogForm = ({
           className={styles.title}
         />
       </DialogSection>
-      <DialogSection>
+      <DialogSection appearance={{ theme: 'sidePadding' }}>
         <div className={styles.description}>
           <FormattedMessage {...MSG.desc} />
         </div>
       </DialogSection>
-      <DialogSection>
-        <p>blabla</p>
+      <DialogSection appearance={{ theme: 'sidePadding' }}>
+        <div className={styles.content}>
+          {safeList.map((item) => (
+            <SafeListItem
+              key={item.address}
+              safe={item}
+              isChecked={values.safeList.includes(item.address)}
+            />
+          ))}
+        </div>
       </DialogSection>
       <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
         <Button
@@ -69,11 +80,13 @@ const RemoveSafeDialogForm = ({
           text={{ id: 'button.back' }}
         />
         <Button
-          appearance={{ theme: 'primary', size: 'large' }}
+          appearance={{ theme: 'pink', size: 'large' }}
           text={{ id: 'button.confirm' }}
           onClick={() => handleSubmit()}
           loading={isSubmitting}
-          disabled={!userHasPermission || isSubmitting}
+          disabled={
+            !userHasPermission || isSubmitting || !values?.safeList.length
+          }
           data-test="removeSafeConfirmButton"
         />
       </DialogSection>

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/SafeListItem.css
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/SafeListItem.css
@@ -4,8 +4,9 @@
   align-items: center;
   margin-bottom: 8px;
   padding: 11px 11px;
-  border-radius: var(--radius-tiny);
+  height: 42px;
   border: 1px solid color-mod(var(--action-secondary) alpha(25%));
+  border-radius: var(--radius-tiny);
   background-color: color-mod(var(--action-secondary) alpha(5%));
 }
 

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/SafeListItem.css
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/SafeListItem.css
@@ -1,0 +1,53 @@
+.main {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  margin-bottom: 8px;
+  padding: 11px 11px;
+  border-radius: var(--radius-tiny);
+  border: 1px solid color-mod(var(--action-secondary) alpha(25%));
+  background-color: color-mod(var(--action-secondary) alpha(5%));
+}
+
+.main:last-child {
+  margin-bottom: 0px;
+}
+
+.avatar {
+  min-width: 26px;
+}
+
+.checked {
+  border: 1px solid var(--pink);
+  background-color: color-mod(var(--pink) alpha(12%));
+}
+
+.address {
+  composes: inlineEllipsis from '~styles/text.css';
+  margin-top: 4px;
+  font-size: var(--size-smallish);
+  font-weight: var(--weight-normal);
+  color: var(--temp-grey-blue-7);
+  cursor: pointer;
+}
+
+.checkbox {
+  margin-top: 4px;
+  margin-right: 8px;
+}
+
+.label {
+  margin-right: 10px;
+  margin-left: 8px;
+  overflow: hidden;
+  font-size: var(--size-smallish);
+  font-weight: var(--weight-medium);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.selectedLabel {
+  composes: label;
+  font-weight: var(--weight-bold);
+  color: var(--grey-2);
+}

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/SafeListItem.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/SafeListItem.css.d.ts
@@ -1,0 +1,7 @@
+export const main: string;
+export const avatar: string;
+export const checked: string;
+export const address: string;
+export const checkbox: string;
+export const label: string;
+export const selectedLabel: string;

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/SafeListItem.tsx
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/SafeListItem.tsx
@@ -43,7 +43,7 @@ const SafeListItem = ({ safe, isChecked }: Props) => {
       />
 
       <span className={`${isChecked ? styles.selectedLabel : styles.label}`}>
-        {safe.name}
+        {`${safe.name} (${safe.chain})`}
       </span>
 
       <InvisibleCopyableAddress

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/SafeListItem.tsx
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/SafeListItem.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { defineMessages } from 'react-intl';
+
+import Avatar from '~core/Avatar';
+import { Checkbox } from '~core/Fields';
+import MaskedAddress from '~core/MaskedAddress';
+import InvisibleCopyableAddress from '~core/InvisibleCopyableAddress';
+import { Safe } from './types';
+
+import styles from './SafeListItem.css';
+
+const MSG = defineMessages({
+  copyMessage: {
+    id: 'dashboard.Dialogs.RemoveSafeDialog.SafeListItem.copyMessage',
+    defaultMessage: 'Click to copy Gnosis Safe address',
+  },
+});
+
+interface Props {
+  safe: Safe;
+  isChecked: boolean;
+}
+
+const SafeListItem = ({ safe, isChecked }: Props) => {
+  return (
+    <div
+      className={`${styles.main} ${isChecked && styles.checked}`}
+      data-test="safeListItem"
+    >
+      <Checkbox
+        name="safeList"
+        appearance={{ theme: 'pink' }}
+        value={safe.address}
+        className={styles.checkbox}
+      />
+      <Avatar
+        avatarURL={undefined}
+        placeholderIcon="circle-close"
+        seed={safe.address}
+        title={safe.name || safe.address}
+        size="xs"
+        className={styles.avatar}
+      />
+
+      <span className={`${isChecked ? styles.selectedLabel : styles.label}`}>
+        {safe.name}
+      </span>
+
+      <InvisibleCopyableAddress
+        address={safe.address}
+        copyMessage={MSG.copyMessage}
+      >
+        <div className={styles.address}>
+          <MaskedAddress address={safe.address} />
+        </div>
+      </InvisibleCopyableAddress>
+    </div>
+  );
+};
+
+SafeListItem.displayName = 'dashboard.RemoveSafeDialog.SafeListItem';
+
+export default SafeListItem;

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/index.ts
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/index.ts
@@ -1,0 +1,1 @@
+export { default } from './RemoveSafeDialog';

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/index.ts
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/index.ts
@@ -1,1 +1,3 @@
 export { default } from './RemoveSafeDialog';
+
+export { default as SafeListItem } from './SafeListItem';

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/types.ts
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/types.ts
@@ -2,5 +2,6 @@ import { Address } from '~types/index';
 
 export interface Safe {
   name: string;
+  chain: string;
   address: Address;
 }

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/types.ts
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/types.ts
@@ -1,0 +1,6 @@
+import { Address } from '~types/index';
+
+export interface Safe {
+  name: string;
+  address: Address;
+}

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -46,7 +46,6 @@
   --temp-grey-blue-6: rgb(231, 242, 246); /* Used for user profile gradient end color */
   --temp-grey-blue-7: rgb(118, 116, 139); /* Used for the wallet connect button in the user navigation */
   --temp-grey-blue-8: rgb(238, 242, 245); /* Used for the actions list hover background */
-  --temp-grey-blue-9: rgb(200, 214, 245); /* Used for Safe Control Checkbox */
   --drop-shadow: rgba(62, 118, 244, 0.14);
   --text-disabled: rgb(194, 204, 204);
 

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -46,6 +46,7 @@
   --temp-grey-blue-6: rgb(231, 242, 246); /* Used for user profile gradient end color */
   --temp-grey-blue-7: rgb(118, 116, 139); /* Used for the wallet connect button in the user navigation */
   --temp-grey-blue-8: rgb(238, 242, 245); /* Used for the actions list hover background */
+  --temp-grey-blue-9: rgb(200, 214, 245); /* Used for Safe Control Checkbox */
   --drop-shadow: rgba(62, 118, 244, 0.14);
   --text-disabled: rgb(194, 204, 204);
 


### PR DESCRIPTION
## Description

This PR adds the Remove Safe Dialog (UI only).

- [x]  You click the Remove Safe menu entry and it opens the Remove Safe dialog.
- [x]  Basic dialog functionality like going back button, a submit button (only the button's UI and validation), close dialog on overlay or button click.
- [x]  The dialog shows a list of checkboxes, 1 checkbox for each safe.
- [x]  You enter the Dialog and if there's only 1 safe then that safe is already checked.
- [x]  You enter the Dialog and if there are no safes then the message No safes found to remove. is shown.
- [x]  The dialog form has validation for relevant fields that disable the submit button if it fails. Example: If no checkbox is checked then you shouldn't be able to click the submit button.
- [x] Protect against ridiculously long Safe names. 

[Figma link](https://www.figma.com/file/LlVmeMQxHVA04evfrgZyuN/Safe-Control?node-id=115%3A9509)
Resolves #3449

<img width="591" alt="Screenshot 2022-06-21 at 14 48 38" src="https://user-images.githubusercontent.com/582700/174801585-6bad1bb4-b63f-4377-af76-18141f7ead55.png">

Handle many safes:
<img width="446" alt="Screenshot 2022-06-21 at 14 49 07" src="https://user-images.githubusercontent.com/582700/174801619-256113be-e475-411a-ab5b-44b846ca673f.png">

Handle if there's only 1 safe then that safe is already checked:
<img width="562" alt="Screenshot 2022-06-21 at 15 29 20" src="https://user-images.githubusercontent.com/582700/174801703-393b6866-e73d-4fb6-a141-a25aa0dc99f3.png">

No safes:
<img width="583" alt="Screenshot 2022-06-21 at 15 19 25" src="https://user-images.githubusercontent.com/582700/174801679-3553336a-4699-4e39-a4a1-f772295f257c.png">

I have included copying functionality for safe address. Users may want to double check address before deleting. (I can easily remove if necessary)
<img width="660" alt="Screenshot 2022-06-21 at 14 49 54" src="https://user-images.githubusercontent.com/582700/174801650-daaec475-d93f-4d4a-8566-dc2739961bd6.png">

