### PR TITLE
Create user info summary (mobile)

### DIFF
--- a/src/modules/core/components/DropdownMenu/DropdownMenu.css
+++ b/src/modules/core/components/DropdownMenu/DropdownMenu.css
@@ -6,7 +6,7 @@
   display: block;
 }
 
-.baseStyles button {
+.baseStyles > ul > li > button {
   /* Reset button styles to look like a link in here */
   display: block;
   width: 100%;

--- a/src/modules/core/components/ExternalLink/ExternalLink.css
+++ b/src/modules/core/components/ExternalLink/ExternalLink.css
@@ -1,3 +1,6 @@
+@value queries: "~styles/queries.css";
+@value query700 from queries;
+
 .main {
   font-size: var(--size-small);
   font-weight: var(--weight-bold);
@@ -7,4 +10,11 @@
 .main:hover {
   text-decoration: underline;
   color: var(--dark-blue);
+}
+@media screen and query700 {
+  .main {
+    font-size: inherit;
+    font-weight: inherit;
+    color: inherit;
+  }
 }

--- a/src/modules/core/components/ExternalLink/ExternalLink.css.d.ts
+++ b/src/modules/core/components/ExternalLink/ExternalLink.css.d.ts
@@ -1,1 +1,3 @@
+export const queries: string;
+export const query700: string;
 export const main: string;

--- a/src/modules/core/components/HamburgerMenu/HamburgerMenu.css
+++ b/src/modules/core/components/HamburgerMenu/HamburgerMenu.css
@@ -1,26 +1,20 @@
-@value queries: "~styles/queries.css";
-@value query700 from queries;
-
-.container {
-  display: none;
+.main {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 0px 14px 0px 14px;
+  height: 100%;
+  border-left: 1px solid var(--temp-grey-13);
+  gap: 5px;
 }
 
-@media screen and query700 {
-  .container {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    margin-left: 7px;
-    padding: 0px 14px 0px 14px;
-    height: 100%;
-    border-left: 1px solid var(--temp-grey-13);
-    gap: 5px;
-  }
+.menu-line {
+  height: 3px;
+  width: 21px;
+  background-color: var(--primary);
+}
 
-  .menu-line {
-    height: 3px;
-    width: 21px;
-    background-color: var(--primary);
-  }
+.menuOpen {
+  background-color: white;
 }

--- a/src/modules/core/components/HamburgerMenu/HamburgerMenu.css.d.ts
+++ b/src/modules/core/components/HamburgerMenu/HamburgerMenu.css.d.ts
@@ -1,4 +1,3 @@
-export const queries: string;
-export const query700: string;
-export const container: string;
+export const main: string;
 export const menuLine: string;
+export const menuOpen: string;

--- a/src/modules/core/components/HamburgerMenu/HamburgerMenu.tsx
+++ b/src/modules/core/components/HamburgerMenu/HamburgerMenu.tsx
@@ -1,14 +1,24 @@
 import React from 'react';
+import classnames from 'classnames';
 
 import styles from './HamburgerMenu.css';
 
 const displayName = 'HamburgerMenu';
 
-const HamburgerMenu = () => {
-  const MenuLine = () => <div className={styles.menuLine} />;
+interface Props {
+  isOpen: boolean;
+}
+const HamburgerMenu = ({ isOpen }: Props) => {
+  const MenuLine = () => (
+    <div
+      className={classnames(styles.menuLine, {
+        [styles.menuOpen]: isOpen,
+      })}
+    />
+  );
 
   return (
-    <div className={styles.container}>
+    <div className={styles.main}>
       <MenuLine />
       <MenuLine />
       <MenuLine />

--- a/src/modules/core/components/NavLink/NavLink.css
+++ b/src/modules/core/components/NavLink/NavLink.css
@@ -1,3 +1,11 @@
+@value query700 from '~styles/queries.css';
+
 .active {
   color: var(--sky-blue);
+}
+
+@media screen and query700 {
+  .active {
+    color: var(--primary);
+  }
 }

--- a/src/modules/core/components/NavLink/NavLink.css.d.ts
+++ b/src/modules/core/components/NavLink/NavLink.css.d.ts
@@ -1,1 +1,2 @@
+export const query700: string;
 export const active: string;

--- a/src/modules/pages/components/RouteLayouts/UserNavigation.tsx
+++ b/src/modules/pages/components/RouteLayouts/UserNavigation.tsx
@@ -15,6 +15,11 @@ import { readyTransactionsCount } from '~users/GasStation/transactionGroup';
 import AvatarDropdown from '~users/AvatarDropdown';
 import InboxPopover from '~users/Inbox/InboxPopover';
 import { ConnectWalletPopover } from '~users/ConnectWalletWizard';
+import HamburgerDropdown from '~users/HamburgerDropdown/HamburgerDropdown';
+import { useSelector } from '~utils/hooks';
+import { useAutoLogin, getLastWallet } from '~utils/autoLogin';
+import { checkIfNetworkIsAllowed } from '~utils/networks';
+import { getUserTokenBalanceData } from '~utils/tokens';
 
 import {
   useUserNotificationsQuery,
@@ -23,16 +28,12 @@ import {
   useColonyFromNameQuery,
   Colony,
 } from '~data/index';
-import { useSelector } from '~utils/hooks';
-import { useAutoLogin, getLastWallet } from '~utils/autoLogin';
-import { checkIfNetworkIsAllowed } from '~utils/networks';
+
 import { SUPPORTED_NETWORKS } from '~constants';
 
 import { groupedTransactionsAndMessages } from '../../../core/selectors';
 
 import styles from './UserNavigation.css';
-import HamburgerMenu from '~core/HamburgerMenu/HamburgerMenu';
-import { getUserTokenBalanceData } from '~utils/tokens';
 
 const MSG = defineMessages({
   inboxTitle: {
@@ -266,7 +267,11 @@ const UserNavigation = () => {
             userCanNavigate,
           }}
         />
-        <HamburgerMenu />
+        <HamburgerDropdown
+          onlyLogout={!isNetworkAllowed}
+          colony={colonyData?.processedColony as Colony}
+          colonyName={colonyName}
+        />
       </div>
     </>
   );

--- a/src/modules/pages/components/RouteLayouts/UserNavigation.tsx
+++ b/src/modules/pages/components/RouteLayouts/UserNavigation.tsx
@@ -32,6 +32,7 @@ import { groupedTransactionsAndMessages } from '../../../core/selectors';
 
 import styles from './UserNavigation.css';
 import HamburgerMenu from '~core/HamburgerMenu/HamburgerMenu';
+import { getUserTokenBalanceData } from '~utils/tokens';
 
 const MSG = defineMessages({
   inboxTitle: {
@@ -48,7 +49,10 @@ const MSG = defineMessages({
   },
   walletAutologin: {
     id: 'pages.NavigationWrapper.UserNavigation.walletAutologin',
-    defaultMessage: 'Connecting wallet...',
+    defaultMessage: `{isMobile, select,
+      true {Connecting...}
+      other {Connecting wallet...}
+    }`,
   },
   userReputationTooltip: {
     id: 'pages.NavigationWrapper.UserNavigation.userReputationTooltip',
@@ -180,14 +184,16 @@ const UserNavigation = () => {
         )}
         {previousWalletConnected && attemptingAutoLogin && userDataLoading ? (
           <div className={styles.walletAutoLogin}>
-            <MiniSpinnerLoader title={MSG.walletAutologin} />
+            <MiniSpinnerLoader
+              title={MSG.walletAutologin}
+              titleTextValues={{ isMobile: false }}
+            />
           </div>
         ) : (
           <div className={`${styles.elementWrapper} ${styles.walletWrapper}`}>
             {userCanNavigate && nativeToken && userLock && (
               <UserTokenActivationButton
-                nativeToken={nativeToken}
-                userLock={userLock}
+                tokenBalanceData={getUserTokenBalanceData(userLock)}
                 colony={colonyData?.processedColony}
                 walletAddress={walletAddress}
                 dataTest="tokenActivationButton"
@@ -249,8 +255,16 @@ const UserNavigation = () => {
           </InboxPopover>
         )}
         <AvatarDropdown
-          onlyLogout={!isNetworkAllowed}
+          spinnerMsg={MSG.walletAutologin}
           colony={colonyData?.processedColony as Colony}
+          onlyLogout={!isNetworkAllowed}
+          tokenBalanceData={getUserTokenBalanceData(userLock)}
+          appState={{
+            previousWalletConnected,
+            attemptingAutoLogin,
+            userDataLoading,
+            userCanNavigate,
+          }}
         />
         <HamburgerMenu />
       </div>

--- a/src/modules/users/components/AvatarDropdown/AvatarDropdown.tsx
+++ b/src/modules/users/components/AvatarDropdown/AvatarDropdown.tsx
@@ -4,12 +4,14 @@ import { useMediaQuery } from 'react-responsive';
 
 import Popover from '~core/Popover';
 import HookedUserAvatar from '~users/HookedUserAvatar';
-import { useLoggedInUser, Colony } from '~data/index';
+import { Colony, useLoggedInUser } from '~data/index';
 import { removeValueUnits } from '~utils/css';
-import { query700 as query } from '~styles/queries.css';
-
+import { SimpleMessageValues } from '~types/index';
+import { UserTokenBalanceData } from '~types/tokens';
 import AvatarDropdownPopover from './AvatarDropdownPopover';
+import AvatarDropdownPopoverMobile from './AvatarDropdownPopoverMobile';
 
+import { query700 as query } from '~styles/queries.css';
 import styles, {
   refWidth,
   horizontalOffset,
@@ -18,17 +20,32 @@ import styles, {
 
 const UserAvatar = HookedUserAvatar();
 
+export interface AppState {
+  previousWalletConnected: string | null;
+  attemptingAutoLogin: boolean;
+  userDataLoading: boolean;
+  userCanNavigate: boolean;
+}
+
 interface Props {
   onlyLogout?: boolean;
   colony: Colony;
+  spinnerMsg: SimpleMessageValues;
+  tokenBalanceData: UserTokenBalanceData;
+  appState: AppState;
 }
 
 const displayName = 'users.AvatarDropdown';
 
-const AvatarDropdown = ({ onlyLogout = false, colony }: Props) => {
-  const { username, walletAddress, ethereal } = useLoggedInUser();
+const AvatarDropdown = ({
+  onlyLogout = false,
+  colony,
+  spinnerMsg,
+  tokenBalanceData,
+  appState,
+}: Props) => {
   const isMobile = useMediaQuery({ query });
-
+  const { username, walletAddress, ethereal } = useLoggedInUser();
   /*
    * @NOTE Offset Calculations
    * See: https://popper.js.org/docs/v2/modifiers/offset/
@@ -45,20 +62,33 @@ const AvatarDropdown = ({ onlyLogout = false, colony }: Props) => {
   const popoverOffset = useMemo(() => {
     const skid =
       removeValueUnits(refWidth) + removeValueUnits(horizontalOffset);
-    return isMobile ? [0, 5] : [-1 * skid, removeValueUnits(verticalOffset)];
+    return isMobile ? [-70, 5] : [-1 * skid, removeValueUnits(verticalOffset)];
   }, [isMobile]);
 
-  return (
-    <Popover
-      content={({ close }) => (
+  const popoverContent = isMobile
+    ? () =>
+        username &&
+        walletAddress && (
+          <AvatarDropdownPopoverMobile
+            {...{
+              walletAddress,
+              colony,
+              appState,
+              spinnerMsg,
+              tokenBalanceData,
+            }}
+          />
+        )
+    : ({ close }) => (
         <AvatarDropdownPopover
           closePopover={close}
-          username={username}
           walletConnected={!!walletAddress && !ethereal}
-          onlyLogout={onlyLogout}
-          colony={colony}
+          {...{ username, onlyLogout, colony }}
         />
-      )}
+      );
+  return (
+    <Popover
+      content={popoverContent}
       trigger="click"
       showArrow={false}
       popperOptions={{
@@ -83,11 +113,13 @@ const AvatarDropdown = ({ onlyLogout = false, colony }: Props) => {
           type="button"
           data-test="avatarDropdown"
         >
-          <UserAvatar
-            address={walletAddress}
-            notSet={ethereal}
-            size={isMobile ? 'xs' : 's'}
-          />
+          {walletAddress && (
+            <UserAvatar
+              address={walletAddress}
+              notSet={ethereal}
+              size={isMobile ? 'xs' : 's'}
+            />
+          )}
         </button>
       )}
     </Popover>

--- a/src/modules/users/components/AvatarDropdown/AvatarDropdownPopover.css
+++ b/src/modules/users/components/AvatarDropdown/AvatarDropdownPopover.css
@@ -1,3 +1,0 @@
-.externalLink {
-  color: var(--grey-4);
-}

--- a/src/modules/users/components/AvatarDropdown/AvatarDropdownPopover.css.d.ts
+++ b/src/modules/users/components/AvatarDropdown/AvatarDropdownPopover.css.d.ts
@@ -1,1 +1,0 @@
-export const externalLink: string;

--- a/src/modules/users/components/AvatarDropdown/AvatarDropdownPopover.tsx
+++ b/src/modules/users/components/AvatarDropdown/AvatarDropdownPopover.tsx
@@ -1,59 +1,15 @@
-import React, { useCallback } from 'react';
-import { defineMessages } from 'react-intl';
+import React from 'react';
 
-import { ActionButton } from '~core/Button';
-import NavLink from '~core/NavLink';
-import ExternalLink from '~core/ExternalLink';
-import { FEEDBACK, HELP } from '~externalUrls';
-
-import { Colony } from '~data/index';
-import DropdownMenu, {
-  DropdownMenuSection,
-  DropdownMenuItem,
-} from '~core/DropdownMenu';
-import { ActionTypes } from '~redux/index';
-import {
-  USER_EDIT_ROUTE,
-  CREATE_COLONY_ROUTE,
-  CREATE_USER_ROUTE,
-} from '~routes/index';
-
-import styles from './AvatarDropdownPopover.css';
-
-const MSG = defineMessages({
-  buttonGetStarted: {
-    id: 'users.AvatarDropdown.AvatarDropdownPopover.buttonGetStarted',
-    defaultMessage: 'Get started',
-  },
-  myProfile: {
-    id: 'users.AvatarDropdown.AvatarDropdownPopover.link.myProfile',
-    defaultMessage: 'My Profile',
-  },
-  settings: {
-    id: 'users.AvatarDropdown.AvatarDropdownPopover.link.colonySettings',
-    defaultMessage: 'Settings',
-  },
-  createColony: {
-    id: 'users.AvatarDropdown.AvatarDropdownPopover.link.createColony',
-    defaultMessage: 'Create a Colony',
-  },
-  reportBugs: {
-    id: 'users.AvatarDropdown.AvatarDropdownPopover.link.reportBugs',
-    defaultMessage: 'Report Bugs',
-  },
-  helpCenter: {
-    id: 'users.AvatarDropdown.AvatarDropdownPopover.link.helpCenter',
-    defaultMessage: 'Help Center',
-  },
-  signOut: {
-    id: 'users.AvatarDropdown.AvatarDropdownPopover.link.signOut',
-    defaultMessage: 'Sign Out',
-  },
-});
+import { Colony, Maybe } from '~data/index';
+import DropdownMenu from '~core/DropdownMenu';
+import UserSection from '~users/PopoverSection/UserSection';
+import ColonySection from '~users/PopoverSection/ColonySection';
+import HelperSection from '~users/PopoverSection/HelperSection';
+import MetaSection from '~users/PopoverSection/MetaSection';
 
 interface Props {
   closePopover: () => void;
-  username?: string | null;
+  username?: Maybe<string>;
   walletConnected?: boolean;
   onlyLogout?: boolean;
   colony: Colony;
@@ -68,97 +24,18 @@ const AvatarDropdownPopover = ({
   onlyLogout = false,
   colony,
 }: Props) => {
-  const renderUserSection = useCallback(() => {
-    return (
-      <DropdownMenuSection separator>
-        {!username && (
-          <DropdownMenuItem>
-            <NavLink
-              to={{
-                pathname: CREATE_USER_ROUTE,
-                state: colony?.colonyName
-                  ? { colonyURL: `/colony/${colony?.colonyName}` }
-                  : {},
-              }}
-              text={MSG.buttonGetStarted}
-            />
-          </DropdownMenuItem>
-        )}
-        {username && (
-          <DropdownMenuItem>
-            <NavLink
-              to={`/user/${username}`}
-              text={MSG.myProfile}
-              data-test="userProfile"
-            />
-          </DropdownMenuItem>
-        )}
-        {username && (
-          <DropdownMenuItem>
-            <NavLink
-              to={USER_EDIT_ROUTE}
-              text={MSG.settings}
-              data-test="userProfileSettings"
-            />
-          </DropdownMenuItem>
-        )}
-      </DropdownMenuSection>
-    );
-  }, [colony, username]);
-
-  const renderColonySection = () => (
-    <DropdownMenuSection separator>
-      <DropdownMenuItem>
-        <NavLink to={CREATE_COLONY_ROUTE} text={MSG.createColony} />
-      </DropdownMenuItem>
-    </DropdownMenuSection>
-  );
-
-  const renderHelperSection = () => (
-    <DropdownMenuSection separator>
-      <DropdownMenuItem>
-        <ExternalLink
-          href={FEEDBACK}
-          text={MSG.reportBugs}
-          className={styles.externalLink}
-        />
-      </DropdownMenuItem>
-      <DropdownMenuItem>
-        <ExternalLink
-          href={HELP}
-          text={MSG.helpCenter}
-          className={styles.externalLink}
-        />
-      </DropdownMenuItem>
-    </DropdownMenuSection>
-  );
-
-  const renderMetaSection = () =>
-    walletConnected && (
-      <DropdownMenuSection separator>
-        <DropdownMenuItem>
-          <ActionButton
-            appearance={{ theme: 'no-style' }}
-            text={MSG.signOut}
-            submit={ActionTypes.USER_LOGOUT}
-            error={ActionTypes.USER_LOGOUT_ERROR}
-            success={ActionTypes.USER_LOGOUT_SUCCESS}
-          />
-        </DropdownMenuItem>
-      </DropdownMenuSection>
-    );
-
   return (
     <DropdownMenu onClick={closePopover}>
       {!onlyLogout ? (
         <>
-          {renderUserSection()}
-          {renderColonySection()}
-          {renderHelperSection()}
-          {renderMetaSection()}
+          {/* Move into separate components for reuse in HamburgerDropdownPopover */}
+          <UserSection colony={colony} username={username} />
+          <ColonySection />
+          <HelperSection />
+          {walletConnected && <MetaSection />}
         </>
       ) : (
-        <>{renderMetaSection()}</>
+        walletConnected && <MetaSection />
       )}
     </DropdownMenu>
   );

--- a/src/modules/users/components/AvatarDropdown/AvatarDropdownPopoverMobile.css
+++ b/src/modules/users/components/AvatarDropdown/AvatarDropdownPopoverMobile.css
@@ -1,0 +1,31 @@
+.buttonContainer {
+  display: flex;
+  justify-content: center;
+  padding: 10px 6px;
+}
+
+.itemContainer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 10px;
+  color: var(--temp-grey-blue-7);
+}
+
+.itemChild {
+  padding: 0px 6px;
+  height: 100%;
+  border-radius: 4px;
+  background-color: color-mod(var(--temp-grey-blue-7) alpha(10%));
+}
+
+.walletAutoLogin {
+  display: flex;
+  align-items: center;
+  height: 26px;
+  gap: 14px;
+}
+
+.walletAutoLogin h4 {
+  margin-bottom: 0;
+}

--- a/src/modules/users/components/AvatarDropdown/AvatarDropdownPopoverMobile.css.d.ts
+++ b/src/modules/users/components/AvatarDropdown/AvatarDropdownPopoverMobile.css.d.ts
@@ -1,0 +1,4 @@
+export const buttonContainer: string;
+export const itemContainer: string;
+export const itemChild: string;
+export const walletAutoLogin: string;

--- a/src/modules/users/components/AvatarDropdown/AvatarDropdownPopoverMobile.tsx
+++ b/src/modules/users/components/AvatarDropdown/AvatarDropdownPopoverMobile.tsx
@@ -1,0 +1,158 @@
+import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import Button from '~core/Button';
+import { Colony } from '~data/index';
+import DropdownMenu, {
+  DropdownMenuSection,
+  DropdownMenuItem,
+} from '~core/DropdownMenu';
+import MaskedAddress from '~core/MaskedAddress';
+import MemberReputation from '~core/MemberReputation';
+import UserTokenActivationDisplay from '../UserTokenActivationButton/UserTokenActivationDisplay';
+import { MiniSpinnerLoader } from '~core/Preloaders';
+import { SimpleMessageValues } from '~types/index';
+import { UserTokenBalanceData } from '~types/tokens';
+import { TokenActivationPopover } from '../TokenActivation';
+import { AppState } from './AvatarDropdown';
+
+import styles from './AvatarDropdownPopoverMobile.css';
+
+const MSG = defineMessages({
+  manageTokens: {
+    id: 'users.AvatarDropdown.AvatarDropdownPopoverMobile.manageTokens',
+    defaultMessage: 'Manage Tokens',
+  },
+  address: {
+    id: 'users.AvatarDropdown.AvatarDropdownPopoverMobile.address',
+    defaultMessage: 'Address',
+  },
+  balance: {
+    id: 'users.AvatarDropdown.AvatarDropdownPopoverMobile.balance',
+    defaultMessage: 'Balance',
+  },
+  reputation: {
+    id: 'users.AvatarDropdown.AvatarDropdownPopoverMobile.reputation',
+    defaultMessage: 'Reputation',
+  },
+});
+
+interface Props {
+  colony?: Colony;
+  walletAddress: string;
+  spinnerMsg: SimpleMessageValues;
+  tokenBalanceData: UserTokenBalanceData;
+  appState: AppState;
+}
+
+const displayName = 'users.AvatarDropdown.AvatarDropdownPopoverMobile';
+
+const AvatarDropdownPopoverMobile = ({
+  colony,
+  walletAddress,
+  spinnerMsg,
+  tokenBalanceData,
+  appState,
+}: Props) => {
+  const {
+    nativeToken,
+    activeBalance,
+    inactiveBalance,
+    totalBalance,
+    lockedBalance,
+    isPendingBalanceZero,
+  } = tokenBalanceData;
+
+  const {
+    previousWalletConnected,
+    attemptingAutoLogin,
+    userDataLoading,
+    userCanNavigate,
+  } = appState;
+
+  const colonyAddress = colony?.colonyAddress;
+  const ItemContainer = ({
+    message,
+    children,
+  }: {
+    message: SimpleMessageValues;
+    children?: React.ReactChild | false | null;
+  }) => {
+    return (
+      <div className={styles.itemContainer}>
+        <FormattedMessage {...message} />
+        <div className={styles.itemChild}>
+          {previousWalletConnected && attemptingAutoLogin && userDataLoading ? (
+            <MiniSpinnerLoader
+              className={styles.walletAutoLogin}
+              title={spinnerMsg}
+              titleTextValues={{ isMobile: true }}
+            />
+          ) : (
+            children
+          )}
+        </div>
+      </div>
+    );
+  };
+  return (
+    <DropdownMenu>
+      <DropdownMenuSection separator>
+        <DropdownMenuItem>
+          <ItemContainer message={MSG.address}>
+            {colonyAddress && <MaskedAddress address={colonyAddress} />}
+          </ItemContainer>
+        </DropdownMenuItem>
+        <DropdownMenuItem>
+          <ItemContainer message={MSG.balance}>
+            {userCanNavigate && nativeToken && (
+              <UserTokenActivationDisplay
+                {...{ nativeToken, inactiveBalance, totalBalance }}
+              />
+            )}
+          </ItemContainer>
+        </DropdownMenuItem>
+        <DropdownMenuItem>
+          <ItemContainer message={MSG.reputation}>
+            {colonyAddress && (
+              <MemberReputation
+                walletAddress={walletAddress}
+                colonyAddress={colonyAddress}
+                showIconTitle={false}
+              />
+            )}
+          </ItemContainer>
+        </DropdownMenuItem>
+        <DropdownMenuItem>
+          <div className={styles.buttonContainer}>
+            {nativeToken && (
+              <TokenActivationPopover
+                activeTokens={activeBalance}
+                inactiveTokens={inactiveBalance}
+                totalTokens={totalBalance}
+                lockedTokens={lockedBalance}
+                token={nativeToken}
+                {...{ colony, walletAddress, isPendingBalanceZero }}
+              >
+                {({ toggle, ref }) => (
+                  <Button
+                    appearance={{ theme: 'primary', size: 'medium' }}
+                    onClick={toggle}
+                    innerRef={ref}
+                    data-test="manageTokensButton"
+                  >
+                    <FormattedMessage {...MSG.manageTokens} />
+                  </Button>
+                )}
+              </TokenActivationPopover>
+            )}
+          </div>
+        </DropdownMenuItem>
+      </DropdownMenuSection>
+    </DropdownMenu>
+  );
+};
+
+AvatarDropdownPopoverMobile.displayName = displayName;
+
+export default AvatarDropdownPopoverMobile;

--- a/src/modules/users/components/AvatarDropdown/AvatarDropdownPopoverMobile.tsx
+++ b/src/modules/users/components/AvatarDropdown/AvatarDropdownPopoverMobile.tsx
@@ -9,10 +9,11 @@ import DropdownMenu, {
 } from '~core/DropdownMenu';
 import MaskedAddress from '~core/MaskedAddress';
 import MemberReputation from '~core/MemberReputation';
-import UserTokenActivationDisplay from '../UserTokenActivationButton/UserTokenActivationDisplay';
 import { MiniSpinnerLoader } from '~core/Preloaders';
 import { SimpleMessageValues } from '~types/index';
 import { UserTokenBalanceData } from '~types/tokens';
+
+import UserTokenActivationDisplay from '../UserTokenActivationButton/UserTokenActivationDisplay';
 import { TokenActivationPopover } from '../TokenActivation';
 import { AppState } from './AvatarDropdown';
 

--- a/src/modules/users/components/HamburgerDropdown/HamburgerDropdown.css
+++ b/src/modules/users/components/HamburgerDropdown/HamburgerDropdown.css
@@ -1,0 +1,18 @@
+@value query700 from "~styles/queries.css";
+
+.hamburgerButton {
+  display: none;
+}
+
+@media screen and query700 {
+  .hamburgerButton {
+    display: block;
+    padding: 0;
+    height: 100%;
+    border: 0;
+  }
+
+  .activeDropdown {
+    background-color: var(--temp-grey-blue-7);
+  }
+}

--- a/src/modules/users/components/HamburgerDropdown/HamburgerDropdown.css.d.ts
+++ b/src/modules/users/components/HamburgerDropdown/HamburgerDropdown.css.d.ts
@@ -1,0 +1,3 @@
+export const query700: string;
+export const hamburgerButton: string;
+export const activeDropdown: string;

--- a/src/modules/users/components/HamburgerDropdown/HamburgerDropdown.tsx
+++ b/src/modules/users/components/HamburgerDropdown/HamburgerDropdown.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import classnames from 'classnames';
+
+import HamburgerMenu from '~core/HamburgerMenu/HamburgerMenu';
+import Popover from '~core/Popover';
+import { Colony, useLoggedInUser } from '~data/index';
+import HamburgerDropdownPopover from './HamburgerDropdownPopover';
+
+import styles from './HamburgerDropdown.css';
+
+interface Props {
+  onlyLogout?: boolean;
+  colony: Colony;
+  colonyName: string;
+}
+
+const displayName = 'users.HamburgerDropdown';
+
+const HamburgerDropdown = ({ onlyLogout, colony, colonyName }: Props) => {
+  const { username, walletAddress, ethereal } = useLoggedInUser();
+  return (
+    <Popover
+      content={({ close }) => (
+        <HamburgerDropdownPopover
+          closePopover={close}
+          isWalletConnected={!!walletAddress && !ethereal}
+          {...{
+            colony,
+            colonyName,
+            onlyLogout,
+            username,
+          }}
+        />
+      )}
+      trigger="click"
+      showArrow={false}
+      popperOptions={{
+        modifiers: [
+          {
+            name: 'offset',
+            options: {
+              offset: [0, 0],
+            },
+          },
+        ],
+      }}
+    >
+      {({ isOpen, toggle, ref, id }) => (
+        <button
+          id={id}
+          ref={ref}
+          className={classnames(styles.hamburgerButton, {
+            [styles.activeDropdown]: isOpen,
+          })}
+          onClick={toggle}
+          type="button"
+          data-test="hamburgerDropdown"
+        >
+          <HamburgerMenu {...{ isOpen }} />
+        </button>
+      )}
+    </Popover>
+  );
+};
+
+HamburgerDropdown.displayName = displayName;
+
+export default HamburgerDropdown;

--- a/src/modules/users/components/HamburgerDropdown/HamburgerDropdownPopover.css
+++ b/src/modules/users/components/HamburgerDropdown/HamburgerDropdownPopover.css
@@ -1,0 +1,18 @@
+.menu {
+  border-radius: var(--radius-normal);
+  border-top-right-radius: 0px;
+  background-color: var(--temp-grey-blue-7);
+}
+
+.menu li[class*="DropdownMenuItem"] > a {
+  padding: 5px 15px;
+}
+
+.menu li {
+  color: white;
+}
+
+.menu ul[class*="DropdownMenuSection_separator"]:nth-child(4),
+.menu ul[class*="DropdownMenuSection_separator"]:nth-child(5) {
+  border-top: none;
+}

--- a/src/modules/users/components/HamburgerDropdown/HamburgerDropdownPopover.css.d.ts
+++ b/src/modules/users/components/HamburgerDropdown/HamburgerDropdownPopover.css.d.ts
@@ -1,0 +1,1 @@
+export const menu: string;

--- a/src/modules/users/components/HamburgerDropdown/HamburgerDropdownPopover.tsx
+++ b/src/modules/users/components/HamburgerDropdown/HamburgerDropdownPopover.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { defineMessages } from 'react-intl';
+
+import { Colony, Maybe } from '~data/index';
+import DropdownMenu, {
+  DropdownMenuItem,
+  DropdownMenuSection,
+} from '~core/DropdownMenu';
+import {
+  ColonySection,
+  HelperSection,
+  MetaSection,
+  UserSection,
+} from '~users/PopoverSection';
+import NavLink from '~core/NavLink';
+
+import styles from './HamburgerDropdownPopover.css';
+
+const MSG = defineMessages({
+  actions: {
+    id: 'users.HamburgerDropdown.HamburgerDropdownPopover.link.actions',
+    defaultMessage: 'Actions',
+  },
+  funds: {
+    id: 'users.HamburgerDropdown.HamburgerDropdownPopover.link.funds',
+    defaultMessage: 'Funds',
+  },
+  members: {
+    id: 'users.HamburgerDropdown.HamburgerDropdownPopover.link.members',
+    defaultMessage: 'Members',
+  },
+  extensions: {
+    id: 'users.HamburgerDropdown.HamburgerDropdownPopover.link.extensions',
+    defaultMessage: 'Extensions',
+  },
+});
+
+const displayName = 'users.HamburgerDropdown.HamburgerDropdownPopover';
+
+interface Props {
+  onlyLogout?: boolean;
+  closePopover: () => void;
+  colony: Colony;
+  colonyName: string;
+  username?: Maybe<string>;
+  isWalletConnected: boolean;
+}
+
+const HamburgerDropdownPopover = ({
+  closePopover,
+  onlyLogout,
+  colony,
+  colonyName,
+  username,
+  isWalletConnected = false,
+}: Props) => {
+  const colonyHomePath = `/colony/${colonyName}`;
+  return (
+    <div className={styles.menu}>
+      <DropdownMenu onClick={closePopover}>
+        {!onlyLogout && (
+          <>
+            {username && (
+              <DropdownMenuSection>
+                <DropdownMenuItem>
+                  <NavLink to={colonyHomePath} text={MSG.actions} />
+                </DropdownMenuItem>
+                <DropdownMenuItem>
+                  <NavLink to={`${colonyHomePath}/funds`} text={MSG.funds} />
+                </DropdownMenuItem>
+                <DropdownMenuItem>
+                  <NavLink
+                    to={`${colonyHomePath}/members`}
+                    text={MSG.members}
+                  />
+                </DropdownMenuItem>
+                <DropdownMenuItem>
+                  <NavLink
+                    to={`${colonyHomePath}/extensions`}
+                    text={MSG.extensions}
+                  />
+                </DropdownMenuItem>
+              </DropdownMenuSection>
+            )}
+            <UserSection colony={colony} username={username} />
+            <ColonySection />
+            <HelperSection />
+          </>
+        )}
+        {isWalletConnected && <MetaSection />}
+      </DropdownMenu>
+    </div>
+  );
+};
+
+HamburgerDropdownPopover.displayName = displayName;
+
+export default HamburgerDropdownPopover;

--- a/src/modules/users/components/PopoverSection/ColonySection.tsx
+++ b/src/modules/users/components/PopoverSection/ColonySection.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { defineMessages } from 'react-intl';
+import { DropdownMenuItem, DropdownMenuSection } from '~core/DropdownMenu';
+import NavLink from '~core/NavLink';
+import { CREATE_COLONY_ROUTE } from '~routes/routeConstants';
+
+const MSG = defineMessages({
+  createColony: {
+    id: 'users.PopoverSection.ColonySection.link.createColony',
+    defaultMessage: 'Create a Colony',
+  },
+});
+
+const displayName = 'users.PopoverSection.ColonySection';
+
+const ColonySection = () => (
+  <DropdownMenuSection separator>
+    <DropdownMenuItem>
+      <NavLink to={CREATE_COLONY_ROUTE} text={MSG.createColony} />
+    </DropdownMenuItem>
+  </DropdownMenuSection>
+);
+
+ColonySection.displayName = displayName;
+
+export default ColonySection;

--- a/src/modules/users/components/PopoverSection/ColonySection.tsx
+++ b/src/modules/users/components/PopoverSection/ColonySection.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { defineMessages } from 'react-intl';
+
 import { DropdownMenuItem, DropdownMenuSection } from '~core/DropdownMenu';
 import NavLink from '~core/NavLink';
 import { CREATE_COLONY_ROUTE } from '~routes/routeConstants';

--- a/src/modules/users/components/PopoverSection/HelperSection.css
+++ b/src/modules/users/components/PopoverSection/HelperSection.css
@@ -1,0 +1,12 @@
+@value queries: "~styles/queries.css";
+@value query700 from queries;
+
+.externalLink {
+  color: var(--grey-4);
+}
+
+@media screen and query700 {
+  .externalLink {
+    color: white;
+  }
+}

--- a/src/modules/users/components/PopoverSection/HelperSection.css.d.ts
+++ b/src/modules/users/components/PopoverSection/HelperSection.css.d.ts
@@ -1,0 +1,3 @@
+export const queries: string;
+export const query700: string;
+export const externalLink: string;

--- a/src/modules/users/components/PopoverSection/HelperSection.tsx
+++ b/src/modules/users/components/PopoverSection/HelperSection.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { defineMessages } from 'react-intl';
+import { DropdownMenuItem, DropdownMenuSection } from '~core/DropdownMenu';
+import ExternalLink from '~core/ExternalLink';
+import { FEEDBACK, HELP } from '~externalUrls';
+
+import styles from './HelperSection.css';
+
+const MSG = defineMessages({
+  reportBugs: {
+    id: 'users.PopoverSection.HelperSection.link.reportBugs',
+    defaultMessage: 'Report Bugs',
+  },
+  helpCenter: {
+    id: 'users.PopoverSection.HelperSection.link.helpCenter',
+    defaultMessage: 'Help Center',
+  },
+});
+
+const displayName = 'users.PopoverSection.HelperSection';
+
+const HelperSection = () => (
+  <DropdownMenuSection separator>
+    <DropdownMenuItem>
+      <ExternalLink
+        href={FEEDBACK}
+        text={MSG.reportBugs}
+        className={styles.externalLink}
+      />
+    </DropdownMenuItem>
+    <DropdownMenuItem>
+      <ExternalLink
+        href={HELP}
+        text={MSG.helpCenter}
+        className={styles.externalLink}
+      />
+    </DropdownMenuItem>
+  </DropdownMenuSection>
+);
+
+HelperSection.displayName = displayName;
+
+export default HelperSection;

--- a/src/modules/users/components/PopoverSection/HelperSection.tsx
+++ b/src/modules/users/components/PopoverSection/HelperSection.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { defineMessages } from 'react-intl';
+
 import { DropdownMenuItem, DropdownMenuSection } from '~core/DropdownMenu';
 import ExternalLink from '~core/ExternalLink';
 import { FEEDBACK, HELP } from '~externalUrls';
@@ -8,11 +9,11 @@ import styles from './HelperSection.css';
 
 const MSG = defineMessages({
   reportBugs: {
-    id: 'users.PopoverSection.HelperSection.link.reportBugs',
+    id: 'users.PopoverSection.HelperSection.reportBugs',
     defaultMessage: 'Report Bugs',
   },
   helpCenter: {
-    id: 'users.PopoverSection.HelperSection.link.helpCenter',
+    id: 'users.PopoverSection.HelperSection.helpCenter',
     defaultMessage: 'Help Center',
   },
 });

--- a/src/modules/users/components/PopoverSection/MetaSection.tsx
+++ b/src/modules/users/components/PopoverSection/MetaSection.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { defineMessages } from 'react-intl';
+
 import { ActionButton } from '~core/Button';
 import { DropdownMenuItem, DropdownMenuSection } from '~core/DropdownMenu';
 import { ActionTypes } from '~redux/actionTypes';

--- a/src/modules/users/components/PopoverSection/MetaSection.tsx
+++ b/src/modules/users/components/PopoverSection/MetaSection.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { defineMessages } from 'react-intl';
+import { ActionButton } from '~core/Button';
+import { DropdownMenuItem, DropdownMenuSection } from '~core/DropdownMenu';
+import { ActionTypes } from '~redux/actionTypes';
+
+const MSG = defineMessages({
+  signOut: {
+    id: 'users.PopoverSection.MetaSection.link.signOut',
+    defaultMessage: 'Sign Out',
+  },
+});
+
+const displayName = 'users.PopoverSection.MetaSection';
+
+const MetaSection = () => (
+  <DropdownMenuSection separator>
+    <DropdownMenuItem>
+      <ActionButton
+        appearance={{ theme: 'no-style' }}
+        text={MSG.signOut}
+        submit={ActionTypes.USER_LOGOUT}
+        error={ActionTypes.USER_LOGOUT_ERROR}
+        success={ActionTypes.USER_LOGOUT_SUCCESS}
+      />
+    </DropdownMenuItem>
+  </DropdownMenuSection>
+);
+
+MetaSection.displayName = displayName;
+
+export default MetaSection;

--- a/src/modules/users/components/PopoverSection/UserSection.tsx
+++ b/src/modules/users/components/PopoverSection/UserSection.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { defineMessages } from 'react-intl';
+
 import { DropdownMenuItem, DropdownMenuSection } from '~core/DropdownMenu';
 import NavLink from '~core/NavLink';
 import { Colony, Maybe } from '~data/index';
@@ -15,7 +16,7 @@ const MSG = defineMessages({
     defaultMessage: 'My Profile',
   },
   settings: {
-    id: 'users.PopoverSection.UserSection.link.colonySettings',
+    id: 'users.PopoverSection.UserSection.link.settings',
     defaultMessage: 'Settings',
   },
 });
@@ -44,22 +45,22 @@ const UserSection = ({ colony, username }: Props) => (
       </DropdownMenuItem>
     )}
     {username && (
-      <DropdownMenuItem>
-        <NavLink
-          to={`/user/${username}`}
-          text={MSG.myProfile}
-          data-test="userProfile"
-        />
-      </DropdownMenuItem>
-    )}
-    {username && (
-      <DropdownMenuItem>
-        <NavLink
-          to={USER_EDIT_ROUTE}
-          text={MSG.settings}
-          data-test="userProfileSettings"
-        />
-      </DropdownMenuItem>
+      <>
+        <DropdownMenuItem>
+          <NavLink
+            to={`/user/${username}`}
+            text={MSG.myProfile}
+            data-test="userProfile"
+          />
+        </DropdownMenuItem>
+        <DropdownMenuItem>
+          <NavLink
+            to={USER_EDIT_ROUTE}
+            text={MSG.settings}
+            data-test="userProfileSettings"
+          />
+        </DropdownMenuItem>
+      </>
     )}
   </DropdownMenuSection>
 );

--- a/src/modules/users/components/PopoverSection/UserSection.tsx
+++ b/src/modules/users/components/PopoverSection/UserSection.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { defineMessages } from 'react-intl';
+import { DropdownMenuItem, DropdownMenuSection } from '~core/DropdownMenu';
+import NavLink from '~core/NavLink';
+import { Colony, Maybe } from '~data/index';
+import { CREATE_USER_ROUTE, USER_EDIT_ROUTE } from '~routes/routeConstants';
+
+const MSG = defineMessages({
+  buttonGetStarted: {
+    id: 'users.PopoverSection.UserSection.buttonGetStarted',
+    defaultMessage: 'Get started',
+  },
+  myProfile: {
+    id: 'users.PopoverSection.UserSection.link.myProfile',
+    defaultMessage: 'My Profile',
+  },
+  settings: {
+    id: 'users.PopoverSection.UserSection.link.colonySettings',
+    defaultMessage: 'Settings',
+  },
+});
+
+interface Props {
+  colony?: Colony;
+  username?: Maybe<string>;
+  itemClassName?: string;
+}
+
+const displayName = 'users.PopoverSection.UserSection';
+
+const UserSection = ({ colony, username }: Props) => (
+  <DropdownMenuSection separator>
+    {!username && (
+      <DropdownMenuItem>
+        <NavLink
+          to={{
+            pathname: CREATE_USER_ROUTE,
+            state: colony?.colonyName
+              ? { colonyURL: `/colony/${colony?.colonyName}` }
+              : {},
+          }}
+          text={MSG.buttonGetStarted}
+        />
+      </DropdownMenuItem>
+    )}
+    {username && (
+      <DropdownMenuItem>
+        <NavLink
+          to={`/user/${username}`}
+          text={MSG.myProfile}
+          data-test="userProfile"
+        />
+      </DropdownMenuItem>
+    )}
+    {username && (
+      <DropdownMenuItem>
+        <NavLink
+          to={USER_EDIT_ROUTE}
+          text={MSG.settings}
+          data-test="userProfileSettings"
+        />
+      </DropdownMenuItem>
+    )}
+  </DropdownMenuSection>
+);
+
+UserSection.displayName = displayName;
+
+export default UserSection;

--- a/src/modules/users/components/PopoverSection/index.ts
+++ b/src/modules/users/components/PopoverSection/index.ts
@@ -1,0 +1,4 @@
+export { default as ColonySection } from './ColonySection';
+export { default as HelperSection } from './HelperSection';
+export { default as UserSection } from './UserSection';
+export { default as MetaSection } from './MetaSection';

--- a/src/modules/users/components/UserTokenActivationButton/UserTokenActivationButton.tsx
+++ b/src/modules/users/components/UserTokenActivationButton/UserTokenActivationButton.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
-import { bigNumberify } from 'ethers/utils';
 
 import { TokenActivationPopover } from '~users/TokenActivation';
 import { Tooltip } from '~core/Popover';
-import { getFormattedTokenValue } from '~utils/tokens';
-import Numeral from '~core/Numeral';
-import { FullColonyFragment, UserLock, UserToken } from '~data/index';
+import { FullColonyFragment } from '~data/index';
 import { Address } from '~types/index';
+import UserTokenActivationDisplay from './UserTokenActivationDisplay';
+import { UserTokenBalanceData } from '~types/tokens';
 
 import styles from './UserTokenActivationButton.css';
 
@@ -21,33 +20,26 @@ const MSG = defineMessages({
   },
 });
 interface Props {
-  userLock: UserLock;
-  nativeToken: UserToken;
   colony?: FullColonyFragment;
   walletAddress: Address;
   dataTest: string;
+  tokenBalanceData: UserTokenBalanceData;
 }
 
 const UserTokenActivationButton = ({
-  nativeToken,
-  userLock,
   colony,
   walletAddress,
   dataTest,
+  tokenBalanceData,
 }: Props) => {
-  const inactiveBalance = bigNumberify(nativeToken?.balance || 0);
-
-  const lockedBalance = bigNumberify(userLock?.totalObligation || 0);
-  const activeBalance = bigNumberify(userLock?.activeTokens || 0);
-  const totalBalance = inactiveBalance.add(activeBalance).add(lockedBalance);
-  const isPendingBalanceZero = bigNumberify(
-    userLock?.pendingBalance || 0,
-  ).isZero();
-
-  const formattedTotalBalance = getFormattedTokenValue(
+  const {
+    nativeToken,
+    activeBalance,
+    inactiveBalance,
     totalBalance,
-    nativeToken.decimals,
-  );
+    lockedBalance,
+    isPendingBalanceZero,
+  } = tokenBalanceData; // State shared with AvatarDropdownPopoverMobile
 
   return (
     <TokenActivationPopover
@@ -88,18 +80,9 @@ const UserTokenActivationButton = ({
                 ],
               }}
             >
-              <div>
-                <span
-                  className={`${styles.dot} ${
-                    (inactiveBalance.gt(0) || totalBalance.isZero()) &&
-                    styles.dotInactive
-                  }`}
-                />
-                <Numeral
-                  value={formattedTotalBalance}
-                  suffix={nativeToken?.symbol}
-                />
-              </div>
+              <UserTokenActivationDisplay
+                {...{ nativeToken, inactiveBalance, totalBalance }}
+              />
             </Tooltip>
           </button>
         </>

--- a/src/modules/users/components/UserTokenActivationButton/UserTokenActivationDisplay.tsx
+++ b/src/modules/users/components/UserTokenActivationButton/UserTokenActivationDisplay.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { BigNumber } from 'ethers/utils';
+import classnames from 'classnames';
+
+import { getFormattedTokenValue } from '~utils/tokens';
+import Numeral from '~core/Numeral';
+import { UserToken } from '~data/generated';
+
+import styles from './UserTokenActivationButton.css';
+
+const displayName =
+  'users.UserTokenActivationButton.UserTokenActivationDisplay';
+
+interface Props {
+  nativeToken?: UserToken;
+  inactiveBalance: BigNumber;
+  totalBalance: BigNumber;
+}
+
+const UserTokenActivationDisplay = ({
+  nativeToken,
+  inactiveBalance,
+  totalBalance,
+}: Props) => {
+  const formattedTotalBalance = getFormattedTokenValue(
+    totalBalance,
+    nativeToken?.decimals,
+  );
+
+  return (
+    <div>
+      <span
+        className={classnames(styles.dot, {
+          [styles.dotInactive]: inactiveBalance.gt(0) || totalBalance.isZero(),
+        })}
+      />
+      <Numeral value={formattedTotalBalance} suffix={nativeToken?.symbol} />
+    </div>
+  );
+};
+
+UserTokenActivationDisplay.displayName = displayName;
+export default UserTokenActivationDisplay;

--- a/src/types/tokens.ts
+++ b/src/types/tokens.ts
@@ -1,0 +1,11 @@
+import { BigNumber } from 'ethers/utils';
+import { UserToken } from '~data/generated';
+
+export interface UserTokenBalanceData {
+  nativeToken: UserToken;
+  inactiveBalance: BigNumber;
+  lockedBalance: BigNumber;
+  activeBalance: BigNumber;
+  totalBalance: BigNumber;
+  isPendingBalanceZero: boolean;
+}

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -2,8 +2,9 @@ import { bigNumberify, BigNumberish } from 'ethers/utils';
 import Decimal from 'decimal.js';
 
 import { minimalFormatter } from '~utils/numbers';
-import { TokenWithBalances } from '~data/index';
+import { TokenWithBalances, UserLock } from '~data/index';
 import { DEFAULT_TOKEN_DECIMALS, SMALL_TOKEN_AMOUNT_FORMAT } from '~constants';
+import { UserTokenBalanceData } from '~types/tokens';
 
 export const getBalanceFromToken = (
   token: TokenWithBalances | undefined,
@@ -69,4 +70,24 @@ export const getFormattedTokenValue = (
   return minimalFormatter({
     value: decimalValue.toString(),
   });
+};
+
+export const getUserTokenBalanceData = (userLock: UserLock | undefined) => {
+  const nativeToken = userLock?.nativeToken;
+  const inactiveBalance = bigNumberify(nativeToken?.balance || 0);
+  const lockedBalance = bigNumberify(userLock?.totalObligation || 0);
+  const activeBalance = bigNumberify(userLock?.activeTokens || 0);
+  const totalBalance = inactiveBalance.add(activeBalance).add(lockedBalance);
+  const isPendingBalanceZero = bigNumberify(
+    userLock?.pendingBalance || 0,
+  ).isZero();
+
+  return {
+    nativeToken,
+    inactiveBalance,
+    lockedBalance,
+    activeBalance,
+    totalBalance,
+    isPendingBalanceZero,
+  } as UserTokenBalanceData;
 };


### PR DESCRIPTION
## Description

This PR is for the creation and wiring up of a User info summary menu (accesible from User avatar). [Was formerly a larger PR that I've now split up, hence the incongruous branch name]

This relates to screen 3 of the [design](https://www.figma.com/file/DjVCPq7LpkjEMEfQZtKgBdC1/Style-Guide?node-id=6643%3A9926).

**New stuff** ✨

- [x]  `AvatarDropdownPopoverMobile` component

## Screenshots

**_Avatar popover_**

![user-info](https://user-images.githubusercontent.com/64402732/174665223-dd95baa8-a0ce-4277-bf46-a1dc9c8d6256.png)

**_Manage tokens_**

![manage-tokens](https://user-images.githubusercontent.com/64402732/174665502-d9a6c7be-f6d5-47c0-a288-f9e8c3cac56e.png)

## TODO

- [x] Build popover 
- [x] Wire up manage tokens
- [x] Implement requested changes

Resolves #3480 
