### PR TITLE
Add disabled styles for Claim button in Incoming Funds aside

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyUnclaimedTransfers/ColonyUnclaimedTransfers.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyUnclaimedTransfers/ColonyUnclaimedTransfers.css
@@ -44,9 +44,19 @@
   color: var(--action-secondary);
 }
 
+.button:disabled {
+  background-color: color-mod(var(--text-disabled) alpha(16%));
+  color: var(--text-disabled);
+}
+
 .button:hover {
   text-decoration: underline;
   cursor: pointer;
+}
+
+.button:disabled:hover {
+  text-decoration: none;
+  cursor: default;
 }
 
 .tooltip {


### PR DESCRIPTION
### How to test:

1. Create 2 colonies.
2. Send a payment from one colony to the other one.
3. Go to the colony you just sent the tokens to and refresh.
4. You should now see the `Incoming Funds` section and the ability to claim it
5. Now log out and see if the `Claim` button shows and acts as `disabled` as it should.
6. You can also test the `disabled` state by connecting a wallet with no registered username.

![FireShot Capture 626 - Actions - Colony - wonker - localhost](https://user-images.githubusercontent.com/18473896/173932535-b4233572-5a7b-44ff-b189-29af76dc2ce8.png)

**NOTE:** After this PR the feature _should be_ good to be merged into `master`, just in case any of you want to test the whole feature 1 last time.

Resolves #3497 
