### PR TITLE
Update `contributorsAndWatchers` query resolver to fix members with reputation list

### DIFF
--- a/src/data/resolvers/colony.ts
+++ b/src/data/resolvers/colony.ts
@@ -330,7 +330,7 @@ export const colonyResolvers = ({
       _,
       {
         colonyAddress,
-        domainId = COLONY_TOTAL_BALANCE_DOMAIN_ID,
+        domainId = ROOT_DOMAIN_ID,
       }: { colonyAddress: Address; domainId: number },
     ) {
       const colonyClient = await colonyManager.getClient(

--- a/src/data/resolvers/colony.ts
+++ b/src/data/resolvers/colony.ts
@@ -362,13 +362,16 @@ export const colonyResolvers = ({
       });
       const verifiedAddresses = colony?.processedColony.whitelistedAddresses;
 
+      const domainIdchecked =
+        domainId === COLONY_TOTAL_BALANCE_DOMAIN_ID ? ROOT_DOMAIN_ID : domainId;
+
       const domainRoles = getAllUserRolesForDomain(
         colony?.processedColony,
-        domainId === COLONY_TOTAL_BALANCE_DOMAIN_ID ? ROOT_DOMAIN_ID : domainId,
+        domainIdchecked,
       );
       const directDomainRoles = getAllUserRolesForDomain(
         colony?.processedColony,
-        domainId === COLONY_TOTAL_BALANCE_DOMAIN_ID ? ROOT_DOMAIN_ID : domainId,
+        domainIdchecked,
         true,
       );
 
@@ -408,7 +411,7 @@ export const colonyResolvers = ({
         query: ColonyMembersWithReputationDocument,
         variables: {
           colonyAddress: colonyAddress.toLowerCase(),
-          domainId,
+          domainId: domainIdchecked,
         },
         fetchPolicy: 'network-only',
       });
@@ -438,17 +441,6 @@ export const colonyResolvers = ({
         },
         fetchPolicy: 'network-only',
       });
-
-      // const { data: verifiedUsers } = await apolloClient.query<
-      //   VerifiedUsersQuery,
-      //   VerifiedUsersQueryVariables
-      // >({
-      //   query: VerifiedUsersDo,
-      //   variables: {
-      //     colonyAddress,
-      //   },
-      //   fetchPolicy: 'network-only',
-      // });
 
       const contributors: any[] = [];
       const watchers: any[] = [];
@@ -520,6 +512,9 @@ export const colonyResolvers = ({
           profile: {
             __typename: 'UserProfile',
             walletAddress: address,
+            avatarHash: null,
+            displayName: null,
+            username: null,
           },
           roles: [],
           directRoles: [],


### PR DESCRIPTION
## Description

This PR fixes the resolver of the `contributorsAndWatchers` query.

I have noticed that `colonyMembersWithReputation` resolver takes `COLONY_TOTAL_BALANCE_DOMAIN_ID` as a default domain. In this case it will always return an empty list. I put root domain id as a default because I assume we want to have all of the members with reputation if no domain id is passed and having always no addresses returned in this case doesn't make sense.

**Changes** 🏗

- update `contributorsAndWatchers` resolver
- update `colonyMembersWithReputation` resolver

resolves #3507 