### PR TITLE
Align connect wallet button on mobile

### DIFF
--- a/src/modules/pages/components/RouteLayouts/UserNavigation.css
+++ b/src/modules/pages/components/RouteLayouts/UserNavigation.css
@@ -200,6 +200,7 @@
 
   .main {
     height: 100%;
+    gap: 7px;
   }
 
   /* Fade effect when number of colonies is > 7 */
@@ -219,6 +220,7 @@
   .connectWalletButton {
     margin-top: 7px;
     margin-bottom: 7px;
+    margin-right: 0px;
     width: 120px;
   }
 }

--- a/src/modules/users/components/ConnectWalletWizard/ConnectWalletPopover/ConnectWalletPopover.tsx
+++ b/src/modules/users/components/ConnectWalletWizard/ConnectWalletPopover/ConnectWalletPopover.tsx
@@ -36,7 +36,7 @@ const ConnectWalletPopover = ({ children }: Props) => {
   const popoverOffset = useMemo(() => {
     const skid =
       removeValueUnits(refWidth) + removeValueUnits(horizontalOffset);
-    return isMobile ? [-15, 15] : [-1 * skid, removeValueUnits(verticalOffset)];
+    return isMobile ? [-33, 15] : [-1 * skid, removeValueUnits(verticalOffset)];
   }, [isMobile]);
 
   return (


### PR DESCRIPTION
## Description

This PR is a small fix to align the connect wallet button when signed out on mobile.

**Changes** 🏗

* Connect wallet styles and popover alignment.

## TODO

- [ ] Create relevant issue

(Resolves | Contributes to) #31415
