### PR TITLE
Update Pinata Lib

### DIFF
--- a/src/context/getIPFSWithFallback.ts
+++ b/src/context/getIPFSWithFallback.ts
@@ -6,42 +6,48 @@ import { raceAgainstTimeout } from '~utils/async';
 const DEFAULT_TIMEOUT_GET = 10000;
 const DEFAULT_TIMEOUT_POST = 30000;
 
-const getIPFSWithFallback = (ipfsNode: IPFSNode, pinataClient: Pinata) => {
-  const ipfsWithTimeout = {
-    getString: async (hash) =>
-      raceAgainstTimeout(
-        ipfsNode.getString(hash),
-        DEFAULT_TIMEOUT_GET,
-        new Error('Timeout reached trying to get data from IPFS'),
-      ),
-    addString: async (data) =>
-      raceAgainstTimeout(
-        ipfsNode.addString(data),
-        DEFAULT_TIMEOUT_POST,
-        new Error('Timeout reached trying to upload data to IPFS'),
-      ),
-  };
-  const pinataWithTimeout = {
-    getString: async (hash) =>
-      raceAgainstTimeout(
-        pinataClient.getJSON(hash),
-        DEFAULT_TIMEOUT_GET,
-        new Error('Timeout reached trying to get data from IPFS via Pinata'),
-      ),
-    addString: async (data) =>
-      raceAgainstTimeout(
-        pinataClient.addJSON(data),
-        DEFAULT_TIMEOUT_POST,
-        new Error('Timeout reached trying to upload data to IPFS via Pinata'),
-      ),
-  };
-  if (process.env.NODE_ENV === 'development') {
+const getIPFSWithFallback = (ipfsNode?: IPFSNode, pinataClient?: Pinata) => {
+  let ipfsWithTimeout;
+  if (ipfsNode) {
+    ipfsWithTimeout = {
+      getString: async (hash) =>
+        raceAgainstTimeout(
+          ipfsNode.getString(hash),
+          DEFAULT_TIMEOUT_GET,
+          new Error('Timeout reached trying to get data from IPFS'),
+        ),
+      addString: async (data) =>
+        raceAgainstTimeout(
+          ipfsNode.addString(data),
+          DEFAULT_TIMEOUT_POST,
+          new Error('Timeout reached trying to upload data to IPFS'),
+        ),
+    };
+  }
+  let pinataWithTimeout;
+  if (pinataClient) {
+    pinataWithTimeout = {
+      getString: async (hash) =>
+        raceAgainstTimeout(
+          pinataClient.getJSON(hash),
+          DEFAULT_TIMEOUT_GET,
+          new Error('Timeout reached trying to get data from IPFS via Pinata'),
+        ),
+      addString: async (data) =>
+        raceAgainstTimeout(
+          pinataClient.addJSON(data),
+          DEFAULT_TIMEOUT_POST,
+          new Error('Timeout reached trying to upload data to IPFS via Pinata'),
+        ),
+    };
+  }
+  if (ipfsWithTimeout) {
     return ipfsWithTimeout;
   }
-  if (!(process.env.PINATA_API_KEY && process.env.PINATA_API_SECRET)) {
-    return ipfsWithTimeout;
+  if (pinataWithTimeout) {
+    return pinataWithTimeout;
   }
-  return pinataWithTimeout;
+  return null;
 };
 
 export default getIPFSWithFallback;

--- a/src/context/ipfsNodeContext.ts
+++ b/src/context/ipfsNodeContext.ts
@@ -1,5 +1,0 @@
-import IPFSNode from '../lib/ipfs';
-
-const ipfsNode = new IPFSNode();
-
-export default ipfsNode;

--- a/src/context/ipfsWithFallbackContext.ts
+++ b/src/context/ipfsWithFallbackContext.ts
@@ -1,8 +1,19 @@
-import pinataClient from './pinataClient';
-import ipfsNode from './ipfsNodeContext';
+import IPFSNode from '../lib/ipfs';
 
+import pinataClient from './pinataClient';
 import getIPFSWithFallback from './getIPFSWithFallback';
 
-const ipfsWithFallback = getIPFSWithFallback(ipfsNode, pinataClient);
+const getIPFSContext = () => {
+  if (
+    process.env.NODE_ENV === 'development' ||
+    !(process.env.PINATA_API_KEY && process.env.PINATA_API_SECRET)
+  ) {
+    const ipfsNode = new IPFSNode();
+    return getIPFSWithFallback(ipfsNode);
+  }
+  return getIPFSWithFallback(undefined, pinataClient);
+};
+
+const ipfsWithFallback = getIPFSContext();
 
 export default ipfsWithFallback;

--- a/src/data/resolvers/colony.ts
+++ b/src/data/resolvers/colony.ts
@@ -141,13 +141,18 @@ export const getProcessedColony = async (
         avatar = await ipfs.getString(colonyAvatarHash);
         avatarObject = JSON.parse(avatar as string);
       } catch (error) {
-        log.verbose('Could not fetch colony avatar', avatar);
-        log.verbose(
-          `Could not parse IPFS avatar for colony:`,
-          ensName,
-          'with hash:',
-          colonyAvatarHash,
-        );
+        /*
+         * @NOTE Silent error if avatar hash is null
+         */
+        if (colonyAvatarHash) {
+          log.verbose('Could not fetch colony avatar', avatar);
+          log.verbose(
+            `Could not parse IPFS avatar for colony:`,
+            ensName,
+            'with hash:',
+            colonyAvatarHash,
+          );
+        }
       }
     }
   } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,15 @@ import { createElement } from 'react';
 import { render } from 'react-dom';
 import ReactModal from 'react-modal';
 import userflow from 'userflow.js';
+import { errors } from 'ethers';
 
 import './styles/main.css';
 import './modules/validations';
 
 import App from './App';
 import store from '~redux/createReduxStore';
+
+errors.setLogLevel('error');
 
 const rootNode = document.getElementById('root');
 

--- a/src/lib/pinata/Pinata.ts
+++ b/src/lib/pinata/Pinata.ts
@@ -25,7 +25,8 @@ class Pinata {
     let responseData: string | undefined;
     try {
       if (!hash) {
-        throw new Error(`IPFS hash was not provided: ${hash}`);
+        // Silent error
+        return null;
       }
       const response = await this.cache.getCacheObject(hash);
       responseData = await response?.text();

--- a/src/lib/pinata/PinataCache.ts
+++ b/src/lib/pinata/PinataCache.ts
@@ -20,7 +20,7 @@ class PinataCache {
     /*
      * Make sure the cache is initialized
      */
-    this.init();
+    await this.init();
 
     const HASH_URL = `${PINATA_GATEWAY}/${hash}`;
     try {
@@ -53,7 +53,7 @@ class PinataCache {
     /*
      * Make sure the cache is initialized
      */
-    this.init();
+    await this.init();
 
     const HASH_URL = `${PINATA_GATEWAY}/${hash}`;
     try {

--- a/src/lib/pinata/PinataCache.ts
+++ b/src/lib/pinata/PinataCache.ts
@@ -1,0 +1,78 @@
+import { log } from '~utils/debug';
+
+import { PINATA_GATEWAY, PINATA_CACHE_STORE } from './constants';
+
+class PinataCache {
+  private cache?: Cache = undefined;
+
+  constructor() {
+    this.init();
+  }
+
+  async init(): Promise<Cache> {
+    if (!this.cache) {
+      this.cache = await caches.open(PINATA_CACHE_STORE);
+    }
+    return this.cache;
+  }
+
+  async getCacheObject(hash: string): Promise<Response | null> {
+    /*
+     * Make sure the cache is initialized
+     */
+    this.init();
+
+    const HASH_URL = `${PINATA_GATEWAY}/${hash}`;
+    try {
+      /*
+       * @NOTE That this.cache exists at this point in time, just that TS doesn't
+       * realize this as it can't properly deal with async constructor assignments
+       */
+      let response = await this.cache?.match(new Request(HASH_URL));
+      if (!response) {
+        response = (await this.setCacheObject(hash)) as Response;
+        log.verbose(`Could not fetch Pinata Cache entry for hash '${hash}'`);
+        if (!response) {
+          throw new Error(
+            `Could not fetch Pinata IPFS entry (both Cache or Gateway for hash ${hash}`,
+          );
+        }
+      }
+      return response;
+    } catch (error) {
+      log.verbose('Could not get IPFS hash from Pinata Cache:', HASH_URL);
+      log.verbose(error);
+      return null;
+    }
+  }
+
+  async setCacheObject(
+    hash: string,
+    networkResponse?: Response,
+  ): Promise<Response | null> {
+    /*
+     * Make sure the cache is initialized
+     */
+    this.init();
+
+    const HASH_URL = `${PINATA_GATEWAY}/${hash}`;
+    try {
+      if (!networkResponse) {
+        /*
+         * @NOTE That this.cache exists at this point in time, just that TS doesn't
+         * realize this as it can't properly deal with async constructor assignments
+         */
+        await this.cache?.add(new Request(HASH_URL));
+      } else {
+        await this.cache?.put(HASH_URL, networkResponse);
+      }
+      return this.getCacheObject(hash);
+    } catch (error) {
+      log.verbose('Could not set the Pinata Cache entry for hash', HASH_URL);
+      log.verbose(error);
+      return null;
+    }
+  }
+}
+
+export default PinataCache;

--- a/src/lib/pinata/PinataCache.ts
+++ b/src/lib/pinata/PinataCache.ts
@@ -29,9 +29,16 @@ class PinataCache {
        * realize this as it can't properly deal with async constructor assignments
        */
       let response = await this.cache?.match(new Request(HASH_URL));
+      /*
+       * @NOTE If we don't find the object in the local cache, attempt to get it
+       * from the Gateway
+       */
       if (!response) {
         response = (await this.setCacheObject(hash)) as Response;
         log.verbose(`Could not fetch Pinata Cache entry for hash '${hash}'`);
+        /*
+         * @NOTE Only if we can't find it via the Gateway that we'll throw
+         */
         if (!response) {
           throw new Error(
             `Could not fetch Pinata IPFS entry (both Cache or Gateway for hash ${hash}`,
@@ -62,8 +69,18 @@ class PinataCache {
          * @NOTE That this.cache exists at this point in time, just that TS doesn't
          * realize this as it can't properly deal with async constructor assignments
          */
+        /*
+         * @NOTE If we don't have a network response already, it means that we didn't
+         * upload the IPFS blob ourself, in which case, we'll have to request it from
+         * the Gateway
+         */
         await this.cache?.add(new Request(HASH_URL));
       } else {
+        /*
+         * @NOTE If we have a network response, that means that we've uploaded to IPFS
+         * ourselfs, so there's no point in fetching it again from the Gateway as we
+         * already have this data locally
+         */
         await this.cache?.put(HASH_URL, networkResponse);
       }
       return this.getCacheObject(hash);

--- a/src/lib/pinata/constants.ts
+++ b/src/lib/pinata/constants.ts
@@ -5,3 +5,4 @@ export const PINATA_API_KEY: string | undefined =
 export const PINATA_API_SECRET: string | undefined =
   process.env.PINATA_API_SECRET || undefined;
 export const JSON_MIME_TYPE = 'application/json';
+export const PINATA_CACHE_STORE = 'pinata-cache';

--- a/src/lib/pinata/constants.ts
+++ b/src/lib/pinata/constants.ts
@@ -1,4 +1,4 @@
-export const PINATA_GATEWAY = 'https://cloudflare-ipfs.com/ipfs';
+export const PINATA_GATEWAY = 'https://pinata-gateway.colony.io/ipfs';
 export const PINATA_ENDPOINT = 'https://api.pinata.cloud/pinning';
 export const PINATA_API_KEY: string | undefined =
   process.env.PINATA_API_KEY || undefined;

--- a/src/lib/pinata/index.ts
+++ b/src/lib/pinata/index.ts
@@ -1,1 +1,2 @@
 export { default } from './Pinata';
+export { default as PinataCache } from './PinataCache';


### PR DESCRIPTION
This PR attempts to fix our current Dapp IPFS slowness by improving content fetching from the IPFS network. 

This will most likely be a combination of better remote gateways, local caching, as well as remote caching.

![Screenshot from 2022-06-21 21-48-25](https://user-images.githubusercontent.com/1193222/174875720-1fc0a0ba-1aa3-4702-b990-f282a0639f5f.png)

Because of the below changes, you'll see less output in the console

### Changes:
- [x] Update Pinata Lib Gateway to use our custom one: pinata-gateway.colony.io
- [x] Add a custom Pinata Cache that caches IPFS requests locally
- [x] Refactored the way we initialize the IPFS context _(so that we don't instantiate `IPFSNode` in production)_
- [x] Silenced some loud warnings _(when attempting to fetch a `null` IPFS hash)_
- [x] Silenced `etherscan`'s multiple definitions warning

### Testing

Note that _(unless you know what you're doing, and generate proper API keys and secrets)_ this cannot be properly tested locally. 

However, currently it's been deployed to QA, where it can be tested.

Resolves #3521
