### PR TITLE
Add control safe dialog

### DIFF
--- a/src/modules/core/components/Button/AddItemButton.css
+++ b/src/modules/core/components/Button/AddItemButton.css
@@ -1,26 +1,32 @@
-.button > button {
-  padding: 0px 24px 1px 6px;
+.main {
+  display: flex;
+  align-items: center;
+  padding: 0px 24px 0px 6px;
   height: 44px;
   border: none;
   border-radius: 32px;
   background-color: color-mod(var(--action-secondary) alpha(12%));
   font-weight: var(--weight-normal);
   color: var(--action-secondary);
+
+  &:hover {
+    cursor: pointer;
+  }
 }
 
-.button div {
-  display: flex;
-  align-items: center;
-  height: 44px;
+.main[disabled] {
+  background-color: color-mod(var(--text-disabled) alpha(12%));
+  color: var(--text-disabled);
 }
 
-.button i {
+.main i {
   margin-right: 10px;
-  height: 28px;
-  width: 28px;
 }
 
-.button svg {
+.main svg {
   fill: var(--action-secondary);
-  stroke: var(--action-secondary);
+}
+
+.main[disabled] svg {
+  fill: var(--text-disabled);
 }

--- a/src/modules/core/components/Button/AddItemButton.css
+++ b/src/modules/core/components/Button/AddItemButton.css
@@ -1,0 +1,26 @@
+.button > button {
+  padding: 0px 24px 1px 6px;
+  height: 44px;
+  border: none;
+  border-radius: 32px;
+  background-color: color-mod(var(--action-secondary) alpha(12%));
+  font-weight: var(--weight-normal);
+  color: var(--action-secondary);
+}
+
+.button div {
+  display: flex;
+  align-items: center;
+  height: 44px;
+}
+
+.button i {
+  margin-right: 10px;
+  height: 28px;
+  width: 28px;
+}
+
+.button svg {
+  fill: var(--action-secondary);
+  stroke: var(--action-secondary);
+}

--- a/src/modules/core/components/Button/AddItemButton.css.d.ts
+++ b/src/modules/core/components/Button/AddItemButton.css.d.ts
@@ -1,0 +1,1 @@
+export const button: string;

--- a/src/modules/core/components/Button/AddItemButton.css.d.ts
+++ b/src/modules/core/components/Button/AddItemButton.css.d.ts
@@ -1,1 +1,1 @@
-export const button: string;
+export const main: string;

--- a/src/modules/core/components/Button/AddItemButton.tsx
+++ b/src/modules/core/components/Button/AddItemButton.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { MessageDescriptor } from 'react-intl';
+
+import { SimpleMessageValues } from '~types/index';
+
+import IconButton from './IconButton';
+import styles from './AddItemButton.css';
+
+interface Props {
+  /** Name of the icon to display */
+  icon?: string;
+  /** A string or a `messageDescriptor` that make up the button's text label */
+  text: MessageDescriptor;
+  /** Values for message descriptors */
+  textValues?: SimpleMessageValues;
+}
+
+const displayName = 'dashboard.DomainDropdown.AddItemButton';
+
+const AddItemButton = ({ text, icon, textValues }: Props) => {
+  return (
+    <div className={styles.button}>
+      <IconButton icon={icon} text={text} textValues={textValues} />
+    </div>
+  );
+};
+
+AddItemButton.displayName = displayName;
+
+export default AddItemButton;

--- a/src/modules/core/components/Button/AddItemButton.tsx
+++ b/src/modules/core/components/Button/AddItemButton.tsx
@@ -5,7 +5,7 @@ import Icon from '../Icon';
 import styles from './AddItemButton.css';
 
 interface Props {
-  /** A string or a `messageDescriptor` that make up the button's text label */
+  /** A `messageDescriptor` that make up the button's text label */
   text: MessageDescriptor;
 
   disabled?: boolean;

--- a/src/modules/core/components/Button/AddItemButton.tsx
+++ b/src/modules/core/components/Button/AddItemButton.tsx
@@ -1,27 +1,33 @@
 import React from 'react';
-import { MessageDescriptor } from 'react-intl';
+import { FormattedMessage, MessageDescriptor } from 'react-intl';
 
-import { SimpleMessageValues } from '~types/index';
-
-import IconButton from './IconButton';
+import Icon from '../Icon';
 import styles from './AddItemButton.css';
 
 interface Props {
-  /** Name of the icon to display */
-  icon?: string;
   /** A string or a `messageDescriptor` that make up the button's text label */
   text: MessageDescriptor;
-  /** Values for message descriptors */
-  textValues?: SimpleMessageValues;
+
+  disabled?: boolean;
+
+  handleClick?: () => void;
 }
 
 const displayName = 'dashboard.DomainDropdown.AddItemButton';
 
-const AddItemButton = ({ text, icon, textValues }: Props) => {
+const AddItemButton = ({ text, handleClick, disabled }: Props) => {
   return (
-    <div className={styles.button}>
-      <IconButton icon={icon} text={text} textValues={textValues} />
-    </div>
+    <button
+      className={styles.main}
+      onClick={handleClick}
+      type="button"
+      disabled={disabled}
+    >
+      <Icon name="circle-plus" title={text} appearance={{ size: 'medium' }} />
+      <span>
+        <FormattedMessage {...text} />
+      </span>
+    </button>
   );
 };
 

--- a/src/modules/core/components/Button/AddItemButton.tsx
+++ b/src/modules/core/components/Button/AddItemButton.tsx
@@ -13,7 +13,7 @@ interface Props {
   handleClick?: () => void;
 }
 
-const displayName = 'dashboard.DomainDropdown.AddItemButton';
+const displayName = 'Button.AddItemButton';
 
 const AddItemButton = ({ text, handleClick, disabled }: Props) => {
   return (

--- a/src/modules/core/components/Button/index.ts
+++ b/src/modules/core/components/Button/index.ts
@@ -4,3 +4,4 @@ export { default as ConfirmButton } from './ConfirmButton';
 export { default as DottedAddButton } from './DottedAddButton';
 export { default as DialogActionButton } from './DialogActionButton';
 export { default as IconButton } from './IconButton';
+export { default as AddItemButton } from './AddItemButton';

--- a/src/modules/core/components/SingleUserPicker/SingleSafePicker.tsx
+++ b/src/modules/core/components/SingleUserPicker/SingleSafePicker.tsx
@@ -4,6 +4,7 @@ import { GnosisSafe } from '~dashboard/Dialogs/GnosisControlSafeDialog';
 
 import SingleUserPicker from './SingleUserPicker';
 
+/* SingleSafePicker is a wrapper around SingleUserPicker component */
 interface Props extends ComponentProps<typeof SingleUserPicker> {
   data: GnosisSafe[];
 }
@@ -14,6 +15,7 @@ const SingleSafePicker = ({ data, ...props }: Props) => {
   const formattedData = useMemo(
     () =>
       data.map((item) => ({
+        id: item.address,
         profile: {
           displayName: `${item.name} (${item.chain})`,
           walletAddress: item.address,
@@ -22,7 +24,13 @@ const SingleSafePicker = ({ data, ...props }: Props) => {
     [data],
   );
 
-  return <SingleUserPicker {...props} data={formattedData} />;
+  return (
+    <SingleUserPicker
+      {...props}
+      data={formattedData}
+      placholderIconName="gnosis-logo"
+    />
+  );
 };
 
 SingleSafePicker.displayName = displayName;

--- a/src/modules/core/components/SingleUserPicker/SingleSafePicker.tsx
+++ b/src/modules/core/components/SingleUserPicker/SingleSafePicker.tsx
@@ -1,0 +1,30 @@
+import React, { ComponentProps, useMemo } from 'react';
+
+import { GnosisSafe } from '~dashboard/Dialogs/GnosisControlSafeDialog';
+
+import SingleUserPicker from './SingleUserPicker';
+
+interface Props extends ComponentProps<typeof SingleUserPicker> {
+  data: GnosisSafe[];
+}
+
+const displayName = 'SingleUserPicker.SingleSafePicker';
+
+const SingleSafePicker = ({ data, ...props }: Props) => {
+  const formattedData = useMemo(
+    () =>
+      data.map((item) => ({
+        profile: {
+          displayName: `${item.name} (${item.chain})`,
+          walletAddress: item.address,
+        },
+      })),
+    [data],
+  );
+
+  return <SingleUserPicker {...props} data={formattedData} />;
+};
+
+SingleSafePicker.displayName = displayName;
+
+export default SingleSafePicker;

--- a/src/modules/core/components/SingleUserPicker/SingleUserPicker.css
+++ b/src/modules/core/components/SingleUserPicker/SingleUserPicker.css
@@ -160,3 +160,9 @@
   fill: var(--primary);
   transform: rotate(180deg);
 }
+
+.maskedAddress > span {
+  margin-left: 5px;
+  font-weight: 500;
+  color: var(--temp-grey-blue-7);
+}

--- a/src/modules/core/components/SingleUserPicker/SingleUserPicker.css.d.ts
+++ b/src/modules/core/components/SingleUserPicker/SingleUserPicker.css.d.ts
@@ -16,3 +16,4 @@ export const errorHorizontal: string;
 export const omniContainer: string;
 export const arrowIcon: string;
 export const arrowIconActive: string;
+export const maskedAddress: string;

--- a/src/modules/core/components/SingleUserPicker/SingleUserPicker.tsx
+++ b/src/modules/core/components/SingleUserPicker/SingleUserPicker.tsx
@@ -109,6 +109,9 @@ interface Props extends WithOmnipickerInProps {
 
   /* An option to show masked address next to display name for the selected item */
   showMaskedAddress?: boolean;
+
+  /* icon name for the avatar placeholder */
+  placholderIconName?: string;
 }
 
 interface EnhancedProps extends Props, WrappedComponentProps {}
@@ -141,6 +144,7 @@ const SingleUserPicker = ({
   itemDataTest,
   valueDataTest,
   showMaskedAddress = false,
+  placholderIconName = 'filled-circle-person',
 }: EnhancedProps) => {
   const [, { error, touched, value }, { setValue }] = useField<AnyUser | null>(
     name,
@@ -209,7 +213,7 @@ const SingleUserPicker = ({
           ) : (
             <Icon
               className={omniPickerIsOpen ? styles.focusIcon : styles.icon}
-              name="filled-circle-person"
+              name={placholderIconName}
               title={MSG.selectMember}
             />
           )}

--- a/src/modules/core/components/SingleUserPicker/SingleUserPicker.tsx
+++ b/src/modules/core/components/SingleUserPicker/SingleUserPicker.tsx
@@ -8,6 +8,7 @@ import { AnyUser } from '~data/index';
 import { Address, SimpleMessageValues } from '~types/index';
 import { getMainClasses } from '~utils/css';
 
+import MaskedAddress from '../MaskedAddress';
 import {
   ItemDataType,
   withOmniPicker,
@@ -105,6 +106,9 @@ interface Props extends WithOmnipickerInProps {
 
   /** Provides value for data-test prop in the value of the input used on cypress testing */
   valueDataTest?: string;
+
+  /* An option to show masked address next to display name for the selected item */
+  showMaskedAddress?: boolean;
 }
 
 interface EnhancedProps extends Props, WrappedComponentProps {}
@@ -136,6 +140,7 @@ const SingleUserPicker = ({
   dataTest,
   itemDataTest,
   valueDataTest,
+  showMaskedAddress = false,
 }: EnhancedProps) => {
   const [, { error, touched, value }, { setValue }] = useField<AnyUser | null>(
     name,
@@ -224,6 +229,11 @@ const SingleUserPicker = ({
                   {value.profile.displayName ||
                     value.profile.username ||
                     value.profile.walletAddress}
+                  {showMaskedAddress && (
+                    <span className={styles.maskedAddress}>
+                      <MaskedAddress address={value.profile.walletAddress} />
+                    </span>
+                  )}
                 </button>
               )
             }

--- a/src/modules/core/components/SingleUserPicker/index.ts
+++ b/src/modules/core/components/SingleUserPicker/index.ts
@@ -1,5 +1,6 @@
 export { default } from './SingleUserPicker';
 
+export { default as SingleSafePicker } from './SingleSafePicker';
 export { default as ItemDefault } from './ItemDefault';
 
 export * from './utils';

--- a/src/modules/dashboard/components/ColonyHomeActions/ColonyHomeActions.tsx
+++ b/src/modules/dashboard/components/ColonyHomeActions/ColonyHomeActions.tsx
@@ -24,6 +24,7 @@ import ManageReputationDialog from '~dialogs/ManageReputationDialog';
 import ColonyTokenManagementDialog from '~dialogs/ColonyTokenManagementDialog';
 import { SmiteDialog, AwardDialog } from '~dialogs/AwardAndSmiteDialogs';
 import ManageGnosisSafeDialog from '~dialogs/ManageGnosisSafeDialog';
+import GnosisControlSafeDialog from '~dialogs/GnosisControlSafeDialog';
 
 import { useEnabledExtensions } from '~utils/hooks/useEnabledExtensions';
 
@@ -220,7 +221,7 @@ const ColonyHomeActions = ({ colony, ethDomainId }: Props) => {
       props: {
         nextStepAddExistingSafe: 'dashboard.AddExistingSafeDialog',
         nextStepRemoveSafe: 'dashboard.RemoveSafeDialog',
-        nextStepControlSafe: 'dashboard.StepControlSafeDialog',
+        nextStepControlSafe: 'dashboard.GnosisControlSafeDialog',
         prevStep: 'dashboard.AdvancedDialog',
         colony,
         isVotingExtensionEnabled,
@@ -245,15 +246,15 @@ const ColonyHomeActions = ({ colony, ethDomainId }: Props) => {
     //     ethDomainId,
     //   },
     // },
-    // {
-    //   component: ControlSafeDialog,
-    //   props: {
-    //     prevStep: 'dashboard.ControlSafeDialog',
-    //     colony,
-    //     isVotingExtensionEnabled,
-    //     ethDomainId,
-    //   },
-    // },
+    {
+      component: GnosisControlSafeDialog,
+      props: {
+        prevStep: 'dashboard.ManageGnosisSafeDialog',
+        colony,
+        isVotingExtensionEnabled,
+        ethDomainId,
+      },
+    },
 
     {
       component: PermissionManagementDialog,

--- a/src/modules/dashboard/components/ColonyHomeActions/ColonyHomeActions.tsx
+++ b/src/modules/dashboard/components/ColonyHomeActions/ColonyHomeActions.tsx
@@ -250,8 +250,6 @@ const ColonyHomeActions = ({ colony, ethDomainId }: Props) => {
       props: {
         prevStep: 'dashboard.ManageGnosisSafeDialog',
         colony,
-        isVotingExtensionEnabled,
-        ethDomainId,
       },
     },
 

--- a/src/modules/dashboard/components/ColonyHomeActions/ColonyHomeActions.tsx
+++ b/src/modules/dashboard/components/ColonyHomeActions/ColonyHomeActions.tsx
@@ -224,7 +224,6 @@ const ColonyHomeActions = ({ colony, ethDomainId }: Props) => {
         nextStepControlSafe: 'dashboard.GnosisControlSafeDialog',
         prevStep: 'dashboard.AdvancedDialog',
         colony,
-        isVotingExtensionEnabled,
       },
     },
     // @todo - ready to be implemented in another PR.

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { FormikProps } from 'formik';
+import * as yup from 'yup';
 
 import Dialog, { DialogProps, ActionDialogProps } from '~core/Dialog';
 import { ActionForm } from '~core/Fields';
@@ -9,8 +10,7 @@ import { WizardDialogType } from '~utils/hooks';
 
 import GnosisControlSafeForm from './GnosisControlSafeForm';
 
-const displayName = 'dashboard.GnosisControlSafeDialog';
-
+/* to remove when data is wired in */
 const safes = [
   {
     name: 'All Saints',
@@ -18,20 +18,46 @@ const safes = [
     chain: 'Gnosis Chain',
   },
   {
-    name: '(Mainnet)',
+    name: '',
     address: '0x3a157280ca91bB49dAe3D1619C55Da7F9D4438c3',
     chain: 'Mainnet',
   },
 ];
 
 export interface FormValues {
-  safeType: any;
-  transactionType: any;
+  safe: string;
+  transactionType: string;
 }
+
+export const transactionOptions = [
+  {
+    value: 'transferFunds',
+    label: 'Transfer funds',
+  },
+  {
+    value: 'transferNft',
+    label: 'Transfer NFT',
+  },
+  {
+    value: 'contractInteraction',
+    label: 'Contract interaction',
+  },
+  {
+    value: 'rawTransaction',
+    label: 'Raw transaction',
+  },
+];
+
+const displayName = 'dashboard.GnosisControlSafeDialog';
 
 type Props = DialogProps &
   Partial<WizardDialogType<object>> &
   ActionDialogProps;
+
+const validationSchema = yup.object().shape({
+  safe: yup.string().required(),
+  transactionType: yup.string().required(),
+});
 
 const GnosisControlSafeDialog = ({
   colony,
@@ -41,7 +67,11 @@ const GnosisControlSafeDialog = ({
 }: Props) => {
   return (
     <ActionForm
-      initialValues={{}}
+      initialValues={{
+        safe: undefined,
+        transactionType: transactionOptions[0],
+      }}
+      validationSchema={validationSchema}
       submit={ActionTypes.COLONY_ACTION_GENERIC}
       success={ActionTypes.COLONY_ACTION_GENERIC_SUCCESS}
       error={ActionTypes.COLONY_ACTION_GENERIC_ERROR}

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import Dialog, { DialogProps, ActionDialogProps } from '~core/Dialog';
+import { ActionForm } from '~core/Fields';
+
+import { ActionTypes } from '~redux/index';
+import { WizardDialogType } from '~utils/hooks';
+
+const displayName = 'dashboard.GnosisControlSafeDialog';
+
+type Props = DialogProps &
+  Partial<WizardDialogType<object>> &
+  ActionDialogProps;
+
+const GnosisControlSafeDialog = ({ cancel }: Props) => {
+  return (
+    <ActionForm
+      initialValues={{}}
+      submit={ActionTypes.COLONY_ACTION_GENERIC}
+      success={ActionTypes.COLONY_ACTION_GENERIC_SUCCESS}
+      error={ActionTypes.COLONY_ACTION_GENERIC_ERROR}
+    >
+      {() => (
+        <Dialog cancel={cancel}>
+          <div>DIALOG</div>
+        </Dialog>
+      )}
+    </ActionForm>
+  );
+};
+
+GnosisControlSafeDialog.displayName = displayName;
+
+export default GnosisControlSafeDialog;

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
@@ -11,6 +11,19 @@ import GnosisControlSafeForm from './GnosisControlSafeForm';
 
 const displayName = 'dashboard.GnosisControlSafeDialog';
 
+const safes = [
+  {
+    name: 'All Saints',
+    address: '0x3a157280ca91bB49dAe3D1619C55Da7F9D4438c2',
+    chain: 'Gnosis Chain',
+  },
+  {
+    name: '(Mainnet)',
+    address: '0x3a157280ca91bB49dAe3D1619C55Da7F9D4438c3',
+    chain: 'Mainnet',
+  },
+];
+
 export interface FormValues {
   safeType: any;
   transactionType: any;
@@ -39,6 +52,7 @@ const GnosisControlSafeDialog = ({
             {...formValues}
             back={callStep && prevStep ? () => callStep(prevStep) : undefined}
             colony={colony}
+            safes={safes}
           />
         </Dialog>
       )}

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FormikProps } from 'formik';
 
 import Dialog, { DialogProps, ActionDialogProps } from '~core/Dialog';
 import { ActionForm } from '~core/Fields';
@@ -6,13 +7,25 @@ import { ActionForm } from '~core/Fields';
 import { ActionTypes } from '~redux/index';
 import { WizardDialogType } from '~utils/hooks';
 
+import GnosisControlSafeForm from './GnosisControlSafeForm';
+
 const displayName = 'dashboard.GnosisControlSafeDialog';
+
+export interface FormValues {
+  safeType: any;
+  transactionType: any;
+}
 
 type Props = DialogProps &
   Partial<WizardDialogType<object>> &
   ActionDialogProps;
 
-const GnosisControlSafeDialog = ({ cancel }: Props) => {
+const GnosisControlSafeDialog = ({
+  colony,
+  cancel,
+  callStep,
+  prevStep,
+}: Props) => {
   return (
     <ActionForm
       initialValues={{}}
@@ -20,9 +33,13 @@ const GnosisControlSafeDialog = ({ cancel }: Props) => {
       success={ActionTypes.COLONY_ACTION_GENERIC_SUCCESS}
       error={ActionTypes.COLONY_ACTION_GENERIC_ERROR}
     >
-      {() => (
+      {(formValues: FormikProps<FormValues>) => (
         <Dialog cancel={cancel}>
-          <div>DIALOG</div>
+          <GnosisControlSafeForm
+            {...formValues}
+            back={callStep && prevStep ? () => callStep(prevStep) : undefined}
+            colony={colony}
+          />
         </Dialog>
       )}
     </ActionForm>

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css
@@ -1,0 +1,1 @@
+@value wideButton: 160px;

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css
@@ -1,4 +1,4 @@
-@value wideButton: 160px;
+@value wideButton: 197px;
 @value width: 419px;
 
 .heading {

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css
@@ -1,1 +1,25 @@
 @value wideButton: 160px;
+@value width: 419px;
+
+.safePicker {
+  margin: 20px 0;
+}
+
+.safePicker input {
+  width: width;
+  max-width: 419px;
+}
+
+.safePicker button {
+  max-width: width;
+  color: var(--dark);
+}
+
+.safePicker i {
+  left: 412px;
+}
+
+.addTransaction {
+  margin-bottom: 20px;
+  text-align: center;
+}

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css
@@ -20,6 +20,7 @@
 }
 
 .addTransaction {
+  display: flex;
+  justify-content: center;
   margin-bottom: 20px;
-  text-align: center;
 }

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css
@@ -1,13 +1,17 @@
 @value wideButton: 160px;
 @value width: 419px;
 
+.heading {
+  margin-bottom: 20px;
+}
+
 .safePicker {
   margin: 20px 0;
 }
 
 .safePicker input {
   width: width;
-  max-width: 419px;
+  max-width: width;
 }
 
 .safePicker button {

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css.d.ts
@@ -1,0 +1,1 @@
+export const wideButton: string;

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css.d.ts
@@ -1,4 +1,5 @@
 export const wideButton: string;
 export const width: string;
+export const heading: string;
 export const safePicker: string;
 export const addTransaction: string;

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css.d.ts
@@ -1,1 +1,4 @@
 export const wideButton: string;
+export const width: string;
+export const safePicker: string;
+export const addTransaction: string;

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
@@ -160,7 +160,7 @@ const GnosisControlSafeForm = ({
       </DialogSection>
       <DialogSection>
         <div className={styles.addTransaction}>
-          <AddItemButton text={MSG.buttonTransaction} />
+          <AddItemButton text={MSG.buttonTransaction} disabled />
         </div>
       </DialogSection>
       <DialogSection appearance={{ align: 'right', theme: 'footer' }}>

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
@@ -4,6 +4,7 @@ import { FormikProps } from 'formik';
 
 import Avatar from '~core/Avatar';
 import { DialogSection } from '~core/Dialog';
+import { Select } from '~core/Fields';
 import Heading from '~core/Heading';
 import ExternalLink from '~core/ExternalLink';
 import Button, { AddItemButton } from '~core/Button';
@@ -15,7 +16,6 @@ import { Address } from '~types/index';
 
 import { FormValues, transactionOptions } from './GnosisControlSafeDialog';
 import styles from './GnosisControlSafeForm.css';
-import { Select } from '~core/Fields';
 
 const MSG = defineMessages({
   title: {
@@ -32,7 +32,7 @@ const MSG = defineMessages({
   },
   safePickerPlaceholder: {
     id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.safePickerPlaceholder`,
-    defaultMessage: 'Select safe to control',
+    defaultMessage: 'Select Safe to control',
   },
   transactionLabel: {
     id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.transactionLabel`,
@@ -47,8 +47,7 @@ const MSG = defineMessages({
     defaultMessage: 'Add another transaction',
   },
   buttonInteract: {
-    id:
-      'dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.buttonInteract',
+    id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.buttonInteract`,
     defaultMessage: 'Interact',
   },
 });
@@ -87,10 +86,12 @@ const GnosisControlSafeForm = ({
   return (
     <>
       <DialogSection>
-        <Heading
-          appearance={{ size: 'medium', margin: 'none', theme: 'dark' }}
-          text={MSG.title}
-        />
+        <div className={styles.heading}>
+          <Heading
+            appearance={{ size: 'medium', margin: 'none', theme: 'dark' }}
+            text={MSG.title}
+          />
+        </div>
       </DialogSection>
       <DialogSection appearance={{ theme: 'sidePadding' }}>
         <FormattedMessage

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
@@ -1,19 +1,21 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { FormikProps } from 'formik';
 
+import Avatar from '~core/Avatar';
 import { DialogSection } from '~core/Dialog';
 import Heading from '~core/Heading';
 import ExternalLink from '~core/ExternalLink';
-import Button from '~core/Button';
+import Button, { AddItemButton } from '~core/Button';
 import SingleUserPicker, { filterUserSelection } from '~core/SingleUserPicker';
 
 import { GNOSIS_SAFE_INTEGRATION_LEARN_MORE } from '~externalUrls';
 import { Colony } from '~data/index';
+import { Address } from '~types/index';
 
 import { FormValues } from './GnosisControlSafeDialog';
 import styles from './GnosisControlSafeForm.css';
-import Avatar from '~core/Avatar';
+import { Select } from '~core/Fields';
 
 const MSG = defineMessages({
   title: {
@@ -28,6 +30,22 @@ const MSG = defineMessages({
     id: 'dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.selectSafe',
     defaultMessage: 'Select Safe',
   },
+  safePickerPlaceholder: {
+    id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.safePickerPlaceholder`,
+    defaultMessage: 'Select safe to control',
+  },
+  transactionLabel: {
+    id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.transactionLabel`,
+    defaultMessage: 'Select transaction type',
+  },
+  transactionPlaceholder: {
+    id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.transactionPlaceholder`,
+    defaultMessage: 'Select transaction',
+  },
+  buttonTransaction: {
+    id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.buttonTransaction`,
+    defaultMessage: 'Add another transaction',
+  },
   buttonInteract: {
     id:
       'dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.buttonInteract',
@@ -37,8 +55,15 @@ const MSG = defineMessages({
 
 const displayName = 'dashboard.GnosisControlSafeDialog.GnosisControlSafeForm';
 
+export interface GnosisSafe {
+  name: string;
+  address: Address;
+  chain: string;
+}
+
 interface Props {
   colony: Colony;
+  safes: GnosisSafe[];
   back?: () => void;
 }
 
@@ -52,10 +77,41 @@ const renderAvatar = (address: string, item) => (
   />
 );
 
+const transactionOptions = [
+  {
+    value: 'transferFunds',
+    label: 'Transfer funds',
+  },
+  {
+    value: 'transferNft',
+    label: 'Transfer NFT',
+  },
+  {
+    value: 'contractInteraction',
+    label: 'Contract interaction',
+  },
+  {
+    value: 'rawTransaction',
+    label: 'Raw transaction',
+  },
+];
+
 const GnosisControlSafeForm = ({
   back,
   handleSubmit,
+  safes,
 }: Props & FormikProps<FormValues>) => {
+  const updatedSafes = useMemo(
+    () =>
+      safes.map((item) => ({
+        profile: {
+          displayName: `${item.name} (${item.chain})`,
+          walletAddress: item.address,
+        },
+      })),
+    [safes],
+  );
+
   return (
     <>
       <DialogSection>
@@ -77,16 +133,35 @@ const GnosisControlSafeForm = ({
         />
       </DialogSection>
       <DialogSection>
-        <SingleUserPicker
-          appearance={{ width: 'wide' }}
-          // data={subscribedUsers}
-          label={MSG.selectSafe}
-          name="safeType"
-          filter={filterUserSelection}
-          renderAvatar={renderAvatar}
-          // disabled={inputDisabled}
-          // placeholder={MSG.userPickerPlaceholder}
+        <div className={styles.safePicker}>
+          <SingleUserPicker
+            appearance={{ width: 'wide' }}
+            label={MSG.selectSafe}
+            name="safeType"
+            filter={filterUserSelection}
+            renderAvatar={renderAvatar}
+            data={updatedSafes}
+            showMaskedAddress
+            // disabled={inputDisabled}
+            placeholder={MSG.safePickerPlaceholder}
+          />
+        </div>
+      </DialogSection>
+      <DialogSection appearance={{ theme: 'sidePadding' }}>
+        <Select
+          options={transactionOptions}
+          label={MSG.transactionLabel}
+          // onChange={handleDomainChange}
+          name="transactionType"
+          appearance={{ theme: 'grey', width: 'fluid' }}
+          placeholder={MSG.transactionPlaceholder}
+          // disabled={isSubmitting}
         />
+      </DialogSection>
+      <DialogSection>
+        <div className={styles.addTransaction}>
+          <AddItemButton icon="circle-plus" text={MSG.buttonTransaction} />
+        </div>
       </DialogSection>
       <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
         <Button

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
@@ -160,7 +160,7 @@ const GnosisControlSafeForm = ({
       </DialogSection>
       <DialogSection>
         <div className={styles.addTransaction}>
-          <AddItemButton icon="circle-plus" text={MSG.buttonTransaction} />
+          <AddItemButton text={MSG.buttonTransaction} />
         </div>
       </DialogSection>
       <DialogSection appearance={{ align: 'right', theme: 'footer' }}>

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+import { FormikProps } from 'formik';
+
+import { DialogSection } from '~core/Dialog';
+import Heading from '~core/Heading';
+import ExternalLink from '~core/ExternalLink';
+import Button from '~core/Button';
+import SingleUserPicker, { filterUserSelection } from '~core/SingleUserPicker';
+
+import { GNOSIS_SAFE_INTEGRATION_LEARN_MORE } from '~externalUrls';
+import { Colony } from '~data/index';
+
+import { FormValues } from './GnosisControlSafeDialog';
+import styles from './GnosisControlSafeForm.css';
+import Avatar from '~core/Avatar';
+
+const MSG = defineMessages({
+  title: {
+    id: 'dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.title',
+    defaultMessage: 'Control Safe',
+  },
+  description: {
+    id: 'dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.description',
+    defaultMessage: `You can use Control Safe to interact with other third party smart contracts. Be careful. <a>Learn more</a>`,
+  },
+  selectSafe: {
+    id: 'dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.selectSafe',
+    defaultMessage: 'Select Safe',
+  },
+  buttonInteract: {
+    id:
+      'dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.buttonInteract',
+    defaultMessage: 'Interact',
+  },
+});
+
+const displayName = 'dashboard.GnosisControlSafeDialog.GnosisControlSafeForm';
+
+interface Props {
+  colony: Colony;
+  back?: () => void;
+}
+
+const renderAvatar = (address: string, item) => (
+  <Avatar
+    seed={address.toLocaleLowerCase()}
+    size="xs"
+    notSet={false}
+    title={item.name}
+    placeholderIcon="at-sign-circle"
+  />
+);
+
+const GnosisControlSafeForm = ({
+  back,
+  handleSubmit,
+}: Props & FormikProps<FormValues>) => {
+  return (
+    <>
+      <DialogSection>
+        <Heading
+          appearance={{ size: 'medium', margin: 'none', theme: 'dark' }}
+          text={MSG.title}
+        />
+      </DialogSection>
+      <DialogSection appearance={{ theme: 'sidePadding' }}>
+        <FormattedMessage
+          {...MSG.description}
+          values={{
+            a: (chunks) => (
+              <ExternalLink href={GNOSIS_SAFE_INTEGRATION_LEARN_MORE}>
+                {chunks}
+              </ExternalLink>
+            ),
+          }}
+        />
+      </DialogSection>
+      <DialogSection>
+        <SingleUserPicker
+          appearance={{ width: 'wide' }}
+          // data={subscribedUsers}
+          label={MSG.selectSafe}
+          name="safeType"
+          filter={filterUserSelection}
+          renderAvatar={renderAvatar}
+          // disabled={inputDisabled}
+          // placeholder={MSG.userPickerPlaceholder}
+        />
+      </DialogSection>
+      <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
+        <Button
+          appearance={{ theme: 'secondary', size: 'large' }}
+          onClick={back}
+          text={{ id: 'button.back' }}
+        />
+        <Button
+          appearance={{ theme: 'primary', size: 'large' }}
+          onClick={() => handleSubmit()}
+          text={MSG.buttonInteract}
+          // loading={isSubmitting}
+          // disabled={!isValid || inputDisabled}
+          style={{ width: styles.wideButton }}
+        />
+      </DialogSection>
+    </>
+  );
+};
+
+GnosisControlSafeForm.displayName = displayName;
+
+export default GnosisControlSafeForm;

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { FormikProps } from 'formik';
 
@@ -7,13 +7,13 @@ import { DialogSection } from '~core/Dialog';
 import Heading from '~core/Heading';
 import ExternalLink from '~core/ExternalLink';
 import Button, { AddItemButton } from '~core/Button';
-import SingleUserPicker, { filterUserSelection } from '~core/SingleUserPicker';
+import { SingleSafePicker, filterUserSelection } from '~core/SingleUserPicker';
 
 import { GNOSIS_SAFE_INTEGRATION_LEARN_MORE } from '~externalUrls';
 import { Colony } from '~data/index';
 import { Address } from '~types/index';
 
-import { FormValues } from './GnosisControlSafeDialog';
+import { FormValues, transactionOptions } from './GnosisControlSafeDialog';
 import styles from './GnosisControlSafeForm.css';
 import { Select } from '~core/Fields';
 
@@ -77,41 +77,13 @@ const renderAvatar = (address: string, item) => (
   />
 );
 
-const transactionOptions = [
-  {
-    value: 'transferFunds',
-    label: 'Transfer funds',
-  },
-  {
-    value: 'transferNft',
-    label: 'Transfer NFT',
-  },
-  {
-    value: 'contractInteraction',
-    label: 'Contract interaction',
-  },
-  {
-    value: 'rawTransaction',
-    label: 'Raw transaction',
-  },
-];
-
 const GnosisControlSafeForm = ({
   back,
   handleSubmit,
   safes,
+  isSubmitting,
+  isValid,
 }: Props & FormikProps<FormValues>) => {
-  const updatedSafes = useMemo(
-    () =>
-      safes.map((item) => ({
-        profile: {
-          displayName: `${item.name} (${item.chain})`,
-          walletAddress: item.address,
-        },
-      })),
-    [safes],
-  );
-
   return (
     <>
       <DialogSection>
@@ -134,15 +106,15 @@ const GnosisControlSafeForm = ({
       </DialogSection>
       <DialogSection>
         <div className={styles.safePicker}>
-          <SingleUserPicker
+          <SingleSafePicker
             appearance={{ width: 'wide' }}
             label={MSG.selectSafe}
-            name="safeType"
+            name="safe"
             filter={filterUserSelection}
             renderAvatar={renderAvatar}
-            data={updatedSafes}
+            data={safes}
             showMaskedAddress
-            // disabled={inputDisabled}
+            disabled={isSubmitting}
             placeholder={MSG.safePickerPlaceholder}
           />
         </div>
@@ -151,11 +123,10 @@ const GnosisControlSafeForm = ({
         <Select
           options={transactionOptions}
           label={MSG.transactionLabel}
-          // onChange={handleDomainChange}
           name="transactionType"
           appearance={{ theme: 'grey', width: 'fluid' }}
           placeholder={MSG.transactionPlaceholder}
-          // disabled={isSubmitting}
+          disabled={isSubmitting}
         />
       </DialogSection>
       <DialogSection>
@@ -173,8 +144,8 @@ const GnosisControlSafeForm = ({
           appearance={{ theme: 'primary', size: 'large' }}
           onClick={() => handleSubmit()}
           text={MSG.buttonInteract}
-          // loading={isSubmitting}
-          // disabled={!isValid || inputDisabled}
+          loading={isSubmitting}
+          disabled={!isValid || isSubmitting}
           style={{ width: styles.wideButton }}
         />
       </DialogSection>

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
@@ -46,9 +46,9 @@ const MSG = defineMessages({
     id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.buttonTransaction`,
     defaultMessage: 'Add another transaction',
   },
-  buttonInteract: {
-    id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.buttonInteract`,
-    defaultMessage: 'Interact',
+  buttonCreateTransaction: {
+    id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.buttonCreateTransaction`,
+    defaultMessage: 'Create transaction',
   },
 });
 
@@ -144,7 +144,7 @@ const GnosisControlSafeForm = ({
         <Button
           appearance={{ theme: 'primary', size: 'large' }}
           onClick={() => handleSubmit()}
-          text={MSG.buttonInteract}
+          text={MSG.buttonCreateTransaction}
           loading={isSubmitting}
           disabled={!isValid || isSubmitting}
           style={{ width: styles.wideButton }}

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/index.ts
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/index.ts
@@ -1,0 +1,1 @@
+export { default } from './GnosisControlSafeDialog';

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/index.ts
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/index.ts
@@ -1,1 +1,2 @@
 export { default } from './GnosisControlSafeDialog';
+export { GnosisSafe } from './GnosisControlSafeForm';

--- a/src/modules/externalUrls.ts
+++ b/src/modules/externalUrls.ts
@@ -53,4 +53,4 @@ export const REPUTATION_LEARN_MORE = `https://colony.gitbook.io/colony/key-conce
 /*
  * Gnosis safe control
  */
-export const GNOSIS_SAFE_INTEGRATION_LEARN_MORE = `https://colony.gitbook.io/colony/key-concepts/reputation/award-reputatiohttps://colony.gitbook.io/colony/manage-funds/gnosis-safe-integration`;
+export const GNOSIS_SAFE_INTEGRATION_LEARN_MORE = `https://colony.gitbook.io/colony/manage-funds/gnosis-safe-integration`;

--- a/src/modules/externalUrls.ts
+++ b/src/modules/externalUrls.ts
@@ -49,3 +49,8 @@ export const RECOVERY_HELP = `https://colony.gitbook.io/colony/advanced-features
  * Reputation & Smite
  */
 export const REPUTATION_LEARN_MORE = `https://colony.gitbook.io/colony/key-concepts/reputation/award-reputation`;
+
+/*
+ * Gnosis safe control
+ */
+export const GNOSIS_SAFE_INTEGRATION_LEARN_MORE = `https://colony.gitbook.io/colony/key-concepts/reputation/award-reputatiohttps://colony.gitbook.io/colony/manage-funds/gnosis-safe-integration`;


### PR DESCRIPTION
## Description

This PR implements Control Safe dialog UI. 

**New stuff** ✨

- add `AddItemButton` core component
- add `SingleSafePicker` core component. We can't really use the `SingleUserPicker` component as it is and I think that just rewriting/repeating code is not worth it. So my solution is to just modify the data structure in this core component. I tried a couple of different options and IMHO it's the easiest/most straight-forward. I am ready to consider other options if you have better ideas.
- add option of `showMaskedAddress` to `SingleUserPicker`
- add `GnosisControlSafeDialog` & its form

**To do** 
I was thinking of creating a couple of variations of the `AddItemButton` and replace the `Create new team` button with it. I would create a separate issue for that. It doesn't look right in my view right now anyway... @arrenv, I think that this is mostly a question to you.
<img width="408" alt="Screenshot 2022-06-22 at 22 56 31" src="https://user-images.githubusercontent.com/34057551/175124878-1c6d6396-5071-4efe-8e3c-138b02d2c001.png">

resolves #3450 