### PR TITLE
Add: Joined Colony List

### DIFF
--- a/src/modules/dashboard/components/SubscribedColoniesList/SubscribedColoniesDropdown.tsx
+++ b/src/modules/dashboard/components/SubscribedColoniesList/SubscribedColoniesDropdown.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+import ColonyAvatar from '~core/ColonyAvatar';
+import DropdownMenu, {
+  DropdownMenuSection,
+  DropdownMenuItem,
+} from '~core/DropdownMenu';
+import Popover from '~core/Popover';
+import { ProcessedColony } from '~data/generated';
+import styles from './SubscribedColoniesList.css';
+
+const displayName =
+  'dashboard.SubscribedColoniesList.SubscribedColoniesDropdown';
+
+export type Colony = Pick<
+  ProcessedColony,
+  | 'colonyName'
+  | 'colonyAddress'
+  | 'id'
+  | 'displayName'
+  | 'avatarHash'
+  | 'avatarURL'
+>;
+interface Props {
+  activeColony?: Colony;
+  coloniesList: Colony[];
+}
+
+const SubscribedColoniesDropdown = ({ activeColony, coloniesList }: Props) => {
+  const colonyToDisplay = activeColony || coloniesList[0];
+  return (
+    <Popover
+      content={() => {
+        return (
+          <DropdownMenu>
+            <DropdownMenuSection>
+              {coloniesList.map((colony) => (
+                <DropdownMenuItem key={colony.colonyAddress}>
+                  <NavLink
+                    activeClassName={styles.activeColony}
+                    title={colony.colonyName}
+                    to={`/colony/${colony.colonyName}`}
+                  >
+                    <div className={styles.dropdownItem}>
+                      <div className={styles.itemImage}>
+                        <ColonyAvatar
+                          colony={colony}
+                          colonyAddress={colony.colonyAddress}
+                          size="xs"
+                        />
+                      </div>
+                      <div>{colony.displayName}</div>
+                    </div>
+                  </NavLink>
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuSection>
+          </DropdownMenu>
+        );
+      }}
+      trigger="click"
+      showArrow={false}
+      placement="bottom"
+      popperOptions={{
+        modifiers: [
+          {
+            name: 'offset',
+            options: {
+              offset: [0, 5],
+            },
+          },
+        ],
+      }}
+    >
+      <NavLink
+        activeClassName={styles.activeColony}
+        className={styles.itemLink}
+        title={colonyToDisplay.colonyName}
+        to={`/colony/${colonyToDisplay.colonyName}`}
+      >
+        <div className={styles.itemImage}>
+          <ColonyAvatar
+            colony={colonyToDisplay}
+            colonyAddress={colonyToDisplay.colonyAddress}
+            size="xs"
+          />
+        </div>
+      </NavLink>
+    </Popover>
+  );
+};
+
+SubscribedColoniesDropdown.displayName = displayName;
+
+export default SubscribedColoniesDropdown;

--- a/src/modules/dashboard/components/SubscribedColoniesList/SubscribedColoniesList.css
+++ b/src/modules/dashboard/components/SubscribedColoniesList/SubscribedColoniesList.css
@@ -65,7 +65,12 @@
   }
 
   .newColonyItem {
-    display: none;
+    transform: scale(0.76) translateX(-8px);
+  }
+
+  .newColonyItem a {
+    height: auto;
+    width: auto;
   }
 
   .scrollableContainer {
@@ -75,12 +80,52 @@
   }
 
   .itemImage {
+    composes: itemLink;
     height: 28px;
     width: 28px;
+    border-width: 2px;
   }
 
   .itemLink {
     height: itemLinkSizeMobile;
     width: itemLinkSizeMobile;
+  }
+
+  .dropdownItem {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .activeColony > .dropdownItem {
+    color: var(--primary);
+  }
+
+  .scrollableContainer div[class*="DropdownMenu_main"] {
+    padding: 6px 0;
+  }
+
+  .scrollableContainer li[class*="DropdownMenuItem"] > *,
+  .scrollableContainer li[class*="DropdownMenuItem"]:only-child > * {
+    padding: 6px 0px 6px 12px;
+    color: var(--temp-grey-blue-7);
+  }
+
+  .scrollableContainer li[class*="DropdownMenuItem"] .activeColony .itemImage {
+    border-color: var(--primary);
+  }
+
+  .scrollableContainer li[class*="DropdownMenuItem"] figure {
+    border-radius: 50%;
+    box-shadow: 0px 1px 6px var(--drop-shadow);
+  }
+
+  .scrollableContainer div[class*="DropdownMenu"] {
+    max-height: 80vh;
+    overflow-y: scroll;
+  }
+
+  .scrollableContainer div[class*="popoverWrapper"] {
+    border-radius: 4px 0px 4px 4px;
   }
 }

--- a/src/modules/dashboard/components/SubscribedColoniesList/SubscribedColoniesList.css.d.ts
+++ b/src/modules/dashboard/components/SubscribedColoniesList/SubscribedColoniesList.css.d.ts
@@ -11,3 +11,4 @@ export const itemImage: string;
 export const newColonyIcon: string;
 export const newColonyItem: string;
 export const loadingColonies: string;
+export const dropdownItem: string;

--- a/src/modules/pages/components/RouteLayouts/Default/Default.tsx
+++ b/src/modules/pages/components/RouteLayouts/Default/Default.tsx
@@ -40,7 +40,7 @@ const Default = ({
   const SubscribedColonies = () =>
     hasSubscribedColonies ? (
       <div className={styles.coloniesList}>
-        <SubscribedColoniesList />
+        <SubscribedColoniesList path={location.pathname} />
       </div>
     ) : null;
 


### PR DESCRIPTION
Add a popover on the Active Colony avatar showing a list of subscribed colonies.

## Description

This PR focuses on Screen 2 of the [Figma Design](https://www.figma.com/file/DjVCPq7LpkjEMEfQZtKgBdC1/Style-Guide?node-id=0%3A1), namely the list of subscribed colonies on mobile. 

**New stuff** ✨

* `SubscribedColoniesDropdown`

**Changes** 🏗

* Passing the `path` to `SusbcribedColoniesList` so that it knows which of the colonies is the active one, and thus which to render as the menu icon. 


## Screenshots

![subscribed-cols](https://user-images.githubusercontent.com/64402732/175099115-adaea37a-e6b5-4602-8e80-55ac62d191c5.png)



Resolves #3520 
