### PR TITLE
Add: Mobile responsive Members page

### DIFF
--- a/src/modules/core/components/InfoPopover/MemberInfoPopover/MemberInfoPopover.css
+++ b/src/modules/core/components/InfoPopover/MemberInfoPopover/MemberInfoPopover.css
@@ -1,4 +1,5 @@
 @value reputationColor: rgb(255, 176, 0);
+@value query700 from '~styles/queries.css';
 
 .main {
   padding: 20px 25px 25px 25px;
@@ -117,4 +118,20 @@
   position: absolute;
   top: 3px;
   right: 5px;
+}
+
+@media screen and query700 {
+  .main {
+    padding-left: 15px;
+    max-width: 100vw;
+  }
+
+  .main div[class*="CopyableAddress_main"] {
+    gap: 10px;
+  }
+
+  .main span[class*="MaskedAddress"] {
+    padding-right: 10px;
+    overflow-wrap: anywhere;
+  }
 }

--- a/src/modules/core/components/InfoPopover/MemberInfoPopover/MemberInfoPopover.css.d.ts
+++ b/src/modules/core/components/InfoPopover/MemberInfoPopover/MemberInfoPopover.css.d.ts
@@ -1,4 +1,5 @@
 export const reputationColor: string;
+export const query700: string;
 export const main: string;
 export const section: string;
 export const loadingSpinnerContainer: string;

--- a/src/modules/core/components/MembersList/Actions/MemberActions.css
+++ b/src/modules/core/components/MembersList/Actions/MemberActions.css
@@ -1,3 +1,5 @@
+@value query700 from '~styles/queries.css';
+
 .actionsButton {
   padding: 0;
   height: 18px;
@@ -37,4 +39,10 @@
 .activeDropdown .actionsIcon,
 .actionsButton:hover .actionsIcon {
   fill: var(--action-secondary);
+}
+
+@media screen and query700 {
+  .actionsButton {
+    transform: scale(1.8);
+  }
 }

--- a/src/modules/core/components/MembersList/Actions/MemberActions.css.d.ts
+++ b/src/modules/core/components/MembersList/Actions/MemberActions.css.d.ts
@@ -1,3 +1,4 @@
+export const query700: string;
 export const actionsButton: string;
 export const activeDropdown: string;
 export const actionsIcon: string;

--- a/src/modules/core/components/MembersList/Actions/MemberActions.tsx
+++ b/src/modules/core/components/MembersList/Actions/MemberActions.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { defineMessages } from 'react-intl';
 import classnames from 'classnames';
+import { useMediaQuery } from 'react-responsive';
 
 import Icon from '~core/Icon';
 import Popover from '~core/Popover';
@@ -8,6 +9,7 @@ import { Colony } from '~data/index';
 
 import MemberActionsPopover from './MemberActionsPopover';
 
+import { query700 as query } from '~styles/queries.css';
 import styles from './MemberActions.css';
 
 const MSG = defineMessages({
@@ -35,6 +37,9 @@ const MemberActions = ({
   isBanned,
 }: Props) => {
   const [isOpen, setOpen] = useState(false);
+  const isMobile = useMediaQuery({ query });
+  const offset = isMobile ? [0, 0] : [40, 15];
+
   return (
     <Popover
       content={({ close }) => (
@@ -57,7 +62,7 @@ const MemberActions = ({
           {
             name: 'offset',
             options: {
-              offset: [40, 15],
+              offset,
             },
           },
         ],

--- a/src/modules/core/components/MembersList/Actions/MemberActionsPopover.css
+++ b/src/modules/core/components/MembersList/Actions/MemberActionsPopover.css
@@ -1,3 +1,5 @@
+@value query700 from '~styles/queries.css';
+
 .actionButton {
   composes: flexContainerRow flexAlignCenter from '~styles/layout.css';
   font-size: var(--size-normal);
@@ -12,4 +14,14 @@
 .actionButton i svg {
   fill: var(--temp-grey-blue-7);
   stroke: none;
+}
+
+@media screen and query700 {
+  div[class*="MembersListItem_main"] div[class*="DropdownMenu_main"] {
+    padding: 6px 0;
+  }
+
+  div[class*="MembersListItem_main"] li[class*="DropdownMenuItem"] {
+    padding: 6px 0 6px 12px;
+  }
 }

--- a/src/modules/core/components/MembersList/Actions/MemberActionsPopover.css.d.ts
+++ b/src/modules/core/components/MembersList/Actions/MemberActionsPopover.css.d.ts
@@ -1,1 +1,2 @@
+export const query700: string;
 export const actionButton: string;

--- a/src/modules/core/components/MembersList/MembersListItem.css
+++ b/src/modules/core/components/MembersList/MembersListItem.css
@@ -1,3 +1,5 @@
+@value query700 from '~styles/queries.css';
+
 .main {
   display: flex;
   align-items: center;
@@ -68,4 +70,43 @@
 
 .whitelistedIconTooltip {
   width: initial;
+}
+
+@media screen and query700 {
+  .main {
+    position: relative;
+    overflow: visible;
+    background: white;
+  }
+
+  .section {
+    order: -1;
+  }
+
+  .main button {
+    display: flex;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    background-color: transparent;
+  }
+
+  .main button svg {
+    transform: scale(0.8);
+    fill: var(--temp-grey-blue-7);
+    stroke: none;
+  }
+
+  .main div[role="tooltip"] {
+    display: flex;
+    align-items: center;
+  }
+
+  .main div[role="tooltip"] button {
+    padding: 0;
+  }
+
+  .reputationSection {
+    width: auto;
+  }
 }

--- a/src/modules/core/components/MembersList/MembersListItem.css.d.ts
+++ b/src/modules/core/components/MembersList/MembersListItem.css.d.ts
@@ -1,3 +1,4 @@
+export const query700: string;
 export const main: string;
 export const section: string;
 export const usernameSection: string;

--- a/src/modules/core/components/MembersList/MembersListItem.tsx
+++ b/src/modules/core/components/MembersList/MembersListItem.tsx
@@ -6,23 +6,26 @@ import React, {
   useState,
 } from 'react';
 import { AddressZero } from 'ethers/constants';
-
 import { defineMessages } from 'react-intl';
-import { createAddress } from '~utils/web3';
+import { useMediaQuery } from 'react-responsive';
+
 import UserMention from '~core/UserMention';
 import { ListGroupItem } from '~core/ListGroup';
 import MemberReputation from '~core/MemberReputation';
-import { AnyUser, Colony, useUser } from '~data/index';
-import { ENTER } from '~types/index';
-import HookedUserAvatar from '~users/HookedUserAvatar';
-import { getMainClasses } from '~utils/css';
-
-import MemberActions from './Actions';
-
-import styles from './MembersListItem.css';
 import InvisibleCopyableAddress from '~core/InvisibleCopyableAddress';
 import MaskedAddress from '~core/MaskedAddress';
 import IconTooltip from '~core/IconTooltip';
+
+import HookedUserAvatar from '~users/HookedUserAvatar';
+import { AnyUser, Colony, useUser } from '~data/index';
+import { ENTER } from '~types/index';
+import { getMainClasses } from '~utils/css';
+
+import MemberActions from './Actions';
+import { createAddress } from '~utils/web3';
+
+import styles from './MembersListItem.css';
+import { query700 as query } from '~styles/queries.css';
 
 interface Props<U> {
   extraItemContent?: (user: U) => ReactNode;
@@ -101,6 +104,7 @@ const MembersListItem = <U extends AnyUser = AnyUser>({
   const nativeToken = colony.tokens.find(
     (token) => token.address === colony.nativeTokenAddress,
   );
+  const isMobile = useMediaQuery({ query });
 
   return (
     <ListGroupItem>
@@ -157,7 +161,9 @@ const MembersListItem = <U extends AnyUser = AnyUser>({
             )}
           </div>
         </div>
-        {renderedExtraItemContent && <div>{renderedExtraItemContent}</div>}
+        {renderedExtraItemContent && !isMobile && (
+          <div>{renderedExtraItemContent}</div>
+        )}
         {showUserReputation && (
           <div className={styles.reputationSection}>
             <MemberReputation

--- a/src/modules/core/components/MembersList/SortingRow/SortingRow.css
+++ b/src/modules/core/components/MembersList/SortingRow/SortingRow.css
@@ -1,3 +1,5 @@
+@value query700 from '~styles/queries.css';
+
 .container {
   display: flex;
   justify-content: flex-end;
@@ -22,4 +24,11 @@
   position: relative;
   top: -6px;
   fill: var(--temp-grey-blue-7);
+}
+
+@media screen and query700 {
+  .container {
+    padding-right: 0;
+    gap: 0;
+  }
 }

--- a/src/modules/core/components/MembersList/SortingRow/SortingRow.css.d.ts
+++ b/src/modules/core/components/MembersList/SortingRow/SortingRow.css.d.ts
@@ -1,3 +1,4 @@
+export const query700: string;
 export const container: string;
 export const sortingButton: string;
 export const sortingIcon: string;

--- a/src/modules/dashboard/components/ColonyHome/ColonyHomeInfo.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHomeInfo.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import ColonyTitle from './ColonyTitle';
+import ColonyNavigation from './ColonyNavigation';
+
+import styles from './ColonyHomeLayout.css';
+
+const displayName = 'dashboard.ColonyHome.ColonyHomeInfo';
+
+const ColonyHomeInfo = ({ colony, isMobile, showNavigation }) => (
+  <aside className={styles.leftAside}>
+    <ColonyTitle colony={colony} />
+    {!isMobile && showNavigation && <ColonyNavigation colony={colony} />}
+  </aside>
+);
+
+ColonyHomeInfo.displayName = displayName;
+
+export default ColonyHomeInfo;

--- a/src/modules/dashboard/components/ColonyHome/ColonyHomeInfo.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHomeInfo.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { Colony } from '~data/index';
+
 import ColonyTitle from './ColonyTitle';
 import ColonyNavigation from './ColonyNavigation';
 
@@ -7,7 +9,13 @@ import styles from './ColonyHomeLayout.css';
 
 const displayName = 'dashboard.ColonyHome.ColonyHomeInfo';
 
-const ColonyHomeInfo = ({ colony, isMobile, showNavigation }) => (
+interface Props {
+  colony: Colony;
+  isMobile: boolean;
+  showNavigation: boolean;
+}
+
+const ColonyHomeInfo = ({ colony, isMobile, showNavigation }: Props) => (
   <aside className={styles.leftAside}>
     <ColonyTitle colony={colony} />
     {!isMobile && showNavigation && <ColonyNavigation colony={colony} />}

--- a/src/modules/dashboard/components/ColonyHome/ColonyHomeLayout.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHomeLayout.tsx
@@ -12,8 +12,7 @@ import { checkIfNetworkIsAllowed } from '~utils/networks';
 
 import ColonyFunding from './ColonyFunding';
 import ColonyUnclaimedTransfers from './ColonyUnclaimedTransfers';
-import ColonyTitle from './ColonyTitle';
-import ColonyNavigation from './ColonyNavigation';
+import ColonyHomeInfo from './ColonyHomeInfo';
 import ColonyMembers from './ColonyMembers';
 import ColonyExtensions from './ColonyExtensions';
 import ColonyDomainDescription from './ColonyDomainDescription';
@@ -70,10 +69,7 @@ const ColonyHomeLayout = ({
       <div
         className={showSidebar ? styles.mainContentGrid : styles.minimalGrid}
       >
-        <aside className={styles.leftAside}>
-          <ColonyTitle colony={colony} />
-          {!isMobile && showNavigation && <ColonyNavigation colony={colony} />}
-        </aside>
+        <ColonyHomeInfo {...{ colony, isMobile, showNavigation }} />
         <div className={styles.mainContent}>
           {showControls && (
             <>

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css
@@ -1,3 +1,4 @@
+@value query700 from '~styles/queries.css';
 
 .main {
   composes: stretchHorizontal from '~styles/layout.css';
@@ -48,4 +49,32 @@
 .reputationPoints {
   line-height: 18px;
   color: var(--dark);
+}
+
+@media screen and query700 {
+  .mainContentGrid {
+    display: grid;
+    margin: 0;
+    width: 100%;
+    grid-template:
+      "joinColony" auto
+      "membersSection" auto
+      / 1fr;
+  }
+
+  .mainContent {
+    margin: 0;
+    padding: 0;
+    padding-bottom: 60px;
+    grid-area: membersSection;
+  }
+
+  .loadingWrapper {
+    margin: 0;
+    width: 100%;
+  }
+
+  .rightAside {
+    display: none;
+  }
 }

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css.d.ts
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.css.d.ts
@@ -1,3 +1,4 @@
+export const query700: string;
 export const main: string;
 export const mainContentGrid: string;
 export const mainContent: string;

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -4,6 +4,7 @@ import { defineMessages } from 'react-intl';
 import { ColonyVersion, Extension } from '@colony/colony-js';
 import Decimal from 'decimal.js';
 import { AddressZero } from 'ethers/constants';
+import { useMediaQuery } from 'react-responsive';
 
 import Button from '~core/Button';
 import { useDialog } from '~core/Dialog';
@@ -37,9 +38,11 @@ import { checkIfNetworkIsAllowed } from '~utils/networks';
 import { getAllUserRoles } from '~modules/transformers';
 import { hasRoot, canAdminister } from '~modules/users/checks';
 import { oneTxMustBeUpgraded } from '~modules/dashboard/checks';
+import ManageWhitelistDialog from '~dashboard/Dialogs/ManageWhitelistDialog';
+import ColonyHomeInfo from '~dashboard/ColonyHome/ColonyHomeInfo';
 
 import styles from './ColonyMembers.css';
-import ManageWhitelistDialog from '~dashboard/Dialogs/ManageWhitelistDialog';
+import { query700 as query } from '~styles/queries.css';
 
 const displayName = 'dashboard.ColonyMembers';
 
@@ -206,6 +209,8 @@ const ColonyMembers = () => {
     !colonyData?.processedColony?.isDeploymentFinished ||
     mustUpgradeOneTx;
 
+  const isMobile = useMediaQuery({ query });
+
   if (
     loading ||
     colonyExtensionLoading ||
@@ -229,6 +234,13 @@ const ColonyMembers = () => {
   return (
     <div className={styles.main}>
       <div className={styles.mainContentGrid}>
+        {isMobile && (
+          <ColonyHomeInfo
+            colony={colonyData.processedColony}
+            showNavigation
+            isMobile
+          />
+        )}
         <div className={styles.mainContent}>
           {colonyData && colonyData.processedColony && (
             <Members

--- a/src/modules/dashboard/components/Members/Members.css
+++ b/src/modules/dashboard/components/Members/Members.css
@@ -1,3 +1,5 @@
+@value query700 from '~styles/queries.css';
+
 .membersContainer {
   display: flex;
 }
@@ -88,4 +90,20 @@
   justify-content: center;
   align-items: center;
   margin-bottom: 50px;
+}
+
+@media screen and query700 {
+  .main {
+    margin: 0;
+    min-width: 0;
+  }
+
+  .titleContainer {
+    margin-bottom: 10px;
+    padding: 0 14px;
+  }
+
+  .titleContainer h3 {
+    margin: 0;
+  }
 }

--- a/src/modules/dashboard/components/Members/Members.css.d.ts
+++ b/src/modules/dashboard/components/Members/Members.css.d.ts
@@ -1,3 +1,4 @@
+export const query700: string;
 export const membersContainer: string;
 export const main: string;
 export const tableBody: string;
@@ -7,3 +8,4 @@ export const subscribeButton: string;
 export const subscribedIcon: string;
 export const unsubscribedIcon: string;
 export const noResults: string;
+export const titleContainer: string;

--- a/src/modules/dashboard/components/Members/Members.tsx
+++ b/src/modules/dashboard/components/Members/Members.tsx
@@ -204,6 +204,7 @@ const Members = ({
         searchValue={searchValue}
         setSearchValue={setSearchValue}
         handleSearch={handleSearch}
+        colony={colony}
       />
       {!contributors?.length && !watchers?.length ? (
         <div className={styles.noResults}>

--- a/src/modules/dashboard/components/Members/MembersSection.css
+++ b/src/modules/dashboard/components/Members/MembersSection.css
@@ -1,3 +1,5 @@
+@value query700 from '~styles/queries.css';
+
 .bar {
   display: flex;
   align-items: baseline;
@@ -35,4 +37,22 @@
 
 .membersList > ul {
   box-shadow: none;
+}
+
+@media screen and query700 {
+  .bar {
+    justify-content: center;
+    flex-direction: column;
+    margin-top: 20px;
+    margin-bottom: 20px;
+  }
+
+  .title {
+    padding: 0 14px;
+  }
+
+  .description {
+    margin-left: 0px;
+    padding: 0 14px;
+  }
 }

--- a/src/modules/dashboard/components/Members/MembersSection.css.d.ts
+++ b/src/modules/dashboard/components/Members/MembersSection.css.d.ts
@@ -1,3 +1,4 @@
+export const query700: string;
 export const bar: string;
 export const title: string;
 export const contributorsTitle: string;

--- a/src/modules/dashboard/components/Members/MembersTitle.css
+++ b/src/modules/dashboard/components/Members/MembersTitle.css
@@ -1,3 +1,5 @@
+@value query700 from '~styles/queries.css';
+
 .titleContainer {
   display: flex;
   justify-content: space-between;
@@ -87,4 +89,33 @@
   right: 25px;
   z-index: 2;
   transform: translateY(-50%);
+}
+
+@media screen and query700 {
+  .titleContainer {
+    margin-bottom: 11px;
+    padding: 0 14px;
+  }
+
+  .titleLeft {
+    justify-content: space-between;
+    height: 50px;
+    width: 100%;
+  }
+
+  .titleLeft ul {
+    width: 200px;
+    top: calc(100% + 2px);
+    right: 0px;
+  }
+
+  .titleLeft ul button {
+    justify-content: flex-start;
+    margin-left: 10px;
+    gap: 10px;
+  }
+
+  .titleLeft ul button div:first-child {
+    position: static;
+  }
 }

--- a/src/modules/dashboard/components/Members/MembersTitle.css.d.ts
+++ b/src/modules/dashboard/components/Members/MembersTitle.css.d.ts
@@ -1,3 +1,4 @@
+export const query700: string;
 export const titleContainer: string;
 export const titleLeft: string;
 export const titleSelect: string;

--- a/src/modules/dashboard/components/Members/MembersTitle.tsx
+++ b/src/modules/dashboard/components/Members/MembersTitle.tsx
@@ -1,16 +1,24 @@
 import React, { useCallback, Dispatch, useRef, SetStateAction } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
+import { useMediaQuery } from 'react-responsive';
 
 import Heading from '~core/Heading';
 import Icon from '~core/Icon';
 import { Select, Form } from '~core/Fields';
 
 import styles from './MembersTitle.css';
+import { query700 as query } from '~styles/queries.css';
+import ColonyDomainSelector from '~dashboard/ColonyHome/ColonyDomainSelector';
+import { FullColonyFragment } from '~data/generated';
 
 const MSG = defineMessages({
   title: {
     id: 'dashboard.Members.MembersTitle.title',
-    defaultMessage: 'Members: ',
+    defaultMessage: `{isMobile, select, 
+      true {Members}
+      other {Members: }
+    }
+  `,
   },
   search: {
     id: 'dashboard.Members.MembersTitle.search',
@@ -36,6 +44,7 @@ interface Props {
   searchValue: string;
   setSearchValue: Dispatch<SetStateAction<string>>;
   handleSearch: (e: any) => void;
+  colony: FullColonyFragment;
 }
 
 const displayName = 'dashboard.MembersTitle';
@@ -46,6 +55,7 @@ const MembersTitle = ({
   domainSelectOptions,
   searchValue,
   handleSearch,
+  colony,
 }: Props) => {
   const { formatMessage } = useIntl();
   const searchInput = useRef<HTMLInputElement>(null);
@@ -78,66 +88,78 @@ const MembersTitle = ({
     (e.target as HTMLInputElement).placeholder = '';
   }, []);
 
+  const isMobile = useMediaQuery({ query });
   return (
     <div className={styles.titleContainer}>
       <div className={styles.titleLeft}>
         <Heading
           text={MSG.title}
           appearance={{ size: 'medium', theme: 'dark' }}
+          textValues={{ isMobile }}
         />
-        <Form
-          initialValues={{ filter: currentDomainId.toString() }}
-          onSubmit={() => {}}
-        >
-          <div className={styles.titleSelect}>
-            <Select
-              appearance={{
-                alignOptions: 'right',
-                size: 'mediumLarge',
-                theme: 'alt',
-              }}
-              elementOnly
-              label={MSG.labelFilter}
-              name="filter"
-              onChange={handleDomainChange}
-              options={domainSelectOptions}
-            />
-          </div>
-        </Form>
-      </div>
-      <div className={styles.searchContainer}>
-        <input
-          name="search"
-          ref={searchInput}
-          value={searchValue}
-          className={styles.input}
-          onChange={handleSearch}
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
-        />
-        {searchValue && (
-          <button
-            className={styles.clearButton}
-            onClick={handleSearch}
-            type="button"
+        {isMobile ? (
+          <ColonyDomainSelector
+            colony={colony}
+            filteredDomainId={currentDomainId}
+            onDomainChange={handleDomainChange}
+          />
+        ) : (
+          <Form
+            initialValues={{ filter: currentDomainId.toString() }}
+            onSubmit={() => {}}
           >
-            <Icon
-              appearance={{ size: 'normal' }}
-              name="close"
-              title={{ id: 'button.close' }}
-            />
-          </button>
+            <div className={styles.titleSelect}>
+              <Select
+                appearance={{
+                  alignOptions: 'right',
+                  size: 'mediumLarge',
+                  theme: 'alt',
+                }}
+                elementOnly
+                label={MSG.labelFilter}
+                name="filter"
+                onChange={handleDomainChange}
+                options={domainSelectOptions}
+              />
+            </div>
+          </Form>
         )}
-        <Icon
-          appearance={{ size: 'normal' }}
-          className={styles.icon}
-          name="search"
-          title={MSG.search}
-          onClick={handleFocusRef}
-          onMouseEnter={handleMouseEnterRef}
-          onMouseLeave={handleMouseLeaveRef}
-        />
       </div>
+      {!isMobile && (
+        <div className={styles.searchContainer}>
+          <input
+            name="search"
+            ref={searchInput}
+            value={searchValue}
+            className={styles.input}
+            onChange={handleSearch}
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
+          />
+          {searchValue && (
+            <button
+              className={styles.clearButton}
+              onClick={handleSearch}
+              type="button"
+            >
+              <Icon
+                appearance={{ size: 'normal' }}
+                name="close"
+                title={{ id: 'button.close' }}
+              />
+            </button>
+          )}
+          <Icon
+            appearance={{ size: 'normal' }}
+            className={styles.icon}
+            name="search"
+            title={MSG.search}
+            onClick={handleFocusRef}
+            onMouseEnter={handleMouseEnterRef}
+            onMouseLeave={handleMouseLeaveRef}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/modules/pages/components/RouteLayouts/Default/Default.css
+++ b/src/modules/pages/components/RouteLayouts/Default/Default.css
@@ -56,6 +56,7 @@
 
   .head {
     display: flex;
+    justify-content: flex-end;
     min-height: 43px; /* Prevents breakage when no colonies present */
     border-bottom: 1px solid var(--temp-grey-13);
   }

--- a/src/modules/pages/components/RouteLayouts/Default/Default.tsx
+++ b/src/modules/pages/components/RouteLayouts/Default/Default.tsx
@@ -6,12 +6,11 @@ import { RouteComponentProps } from '~pages/RouteLayouts';
 import SubscribedColoniesList from '~dashboard/SubscribedColoniesList';
 import SimpleNav from '../SimpleNav';
 import HistoryNavigation from '../HistoryNavigation';
-
-import styles from './Default.css';
-import navStyles from '../SimpleNav/SimpleNav.css';
+import UserNavigation from '../UserNavigation';
 
 import { query700 as query } from '~styles/queries.css';
-import UserNavigation from '../UserNavigation';
+import styles from './Default.css';
+import navStyles from '../SimpleNav/SimpleNav.css';
 
 interface Props {
   children: ReactNode;
@@ -47,7 +46,7 @@ const Default = ({
   return (
     <div className={styles.main}>
       <SimpleNav>
-        {backLinkExists && (
+        {backLinkExists && !isMobile && (
           <HistoryNavigation
             backRoute={backRoute}
             backText={backText}

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo } from 'react';
 import { Route, Redirect, Switch } from 'react-router-dom';
 import { defineMessages } from 'react-intl';
 import { useDispatch } from 'redux-react-hook';
+import { useMediaQuery } from 'react-responsive';
 
 import { WalletMethod } from '~immutable/index';
 import CreateColonyWizard from '~dashboard/CreateColonyWizard';
@@ -52,6 +53,7 @@ import {
 import AlwaysAccesibleRoute from './AlwaysAccesibleRoute';
 import WalletRequiredRoute from './WalletRequiredRoute';
 import { useTitle } from '~utils/hooks/useTitle';
+import { query700 as query } from '~styles/queries.css';
 
 const MSG = defineMessages({
   userProfileEditBack: {
@@ -82,7 +84,7 @@ const Routes = () => {
   const didClaimProfile = !!username;
 
   useTitle();
-
+  const isMobile = useMediaQuery({ query });
   /**
    * @NOTE Memoized Switch
    *
@@ -210,7 +212,7 @@ const Routes = () => {
           routeProps={({ colonyName }) => ({
             backText: ColonyBackText,
             backRoute: `/colony/${colonyName}`,
-            hasSubscribedColonies: false,
+            hasSubscribedColonies: isMobile,
           })}
         />
         <AlwaysAccesibleRoute
@@ -255,7 +257,7 @@ const Routes = () => {
         <Redirect to={NOT_FOUND_ROUTE} />
       </Switch>
     ),
-    [didClaimProfile, isConnected, username],
+    [didClaimProfile, isConnected, username, isMobile],
   );
 
   if (isAppLoading) {


### PR DESCRIPTION
## Description

This PR is for a mobile responsive Members page, per screen 5 of the [Figma design](https://www.figma.com/file/DjVCPq7LpkjEMEfQZtKgBdC1/Style-Guide).

**New stuff** ✨

* Extracted `ColonyHomeInfo` from `ColonyHomeLayout` for reuse in `ColonyMembers`

**Changes** 🏗

*  `ColonyMembers`, `Members`, `MembersListItem` and related components styled for mobile.

## Screenshots

**_Members page_**
![mem-mob-page](https://user-images.githubusercontent.com/64402732/175572866-653aa192-1750-41cb-a311-283b4516217b.png)

**_Teams dropdown_**
![teams-menu](https://user-images.githubusercontent.com/64402732/175574000-c76c9d2b-985d-4cf2-822f-44517f4b4e8d.png)

**_Kebab_**
![kebab-mob](https://user-images.githubusercontent.com/64402732/175573731-0613eb68-91d1-45ac-96d2-8880f7494104.png)

**_Info popover_**
![info-popover-mob](https://user-images.githubusercontent.com/64402732/175573715-e98fbba7-c6fb-4eb3-b6c7-149a16c80735.png)

**_Pagination set to 10 members_**
![mem-mob-page](https://user-images.githubusercontent.com/64402732/175499549-23c2bc96-d1b4-480a-86a8-839449da6a1b.png)

Resolves  #3479
