### PR TITLE
Refactor and add filters to members page

### DIFF
--- a/src/modules/core/components/MembersList/MembersListItem.css
+++ b/src/modules/core/components/MembersList/MembersListItem.css
@@ -2,6 +2,7 @@
   display: flex;
   align-items: center;
   padding-right: 15px;
+  width: 698px;
 }
 
 .section {

--- a/src/modules/core/components/MembersList/MembersListItem.css
+++ b/src/modules/core/components/MembersList/MembersListItem.css
@@ -2,7 +2,7 @@
   display: flex;
   align-items: center;
   padding-right: 15px;
-  width: 698px;
+  min-width: 698px;
 }
 
 .section {

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -17,7 +17,6 @@ import LoadingTemplate from '~pages/LoadingTemplate';
 import Members from '~dashboard/Members';
 import WrongNetworkDialog from '~dashboard/ColonyHome/WrongNetworkDialog';
 import InviteLinkButton from '~dashboard/InviteLinkButton';
-import { MEMEBERS_FILTERS } from '~dashboard/ColonyMembers/MembersFilter';
 
 import {
   useColonyFromNameQuery,
@@ -28,7 +27,12 @@ import { getFormattedTokenValue } from '~utils/tokens';
 import { NOT_FOUND_ROUTE } from '~routes/index';
 import { checkIfNetworkIsAllowed } from '~utils/networks';
 
-import MembersFilter from './MembersFilter';
+import MembersFilter, {
+  BannedStatus,
+  FormValues,
+  MemberType,
+  VerificationType,
+} from './MembersFilter';
 import MemberControls from './MemberControls';
 import styles from './ColonyMembers.css';
 
@@ -46,7 +50,11 @@ const MSG = defineMessages({
 });
 
 const ColonyMembers = () => {
-  const [filters, setFilters] = useState<MEMEBERS_FILTERS[]>([]);
+  const [filters, setFilters] = useState<FormValues>({
+    memberType: MemberType.ALL,
+    verificationType: VerificationType.ALL,
+    bannedStatus: BannedStatus.ALL,
+  });
 
   const { networkId, ethereal } = useLoggedInUser();
   const { domainId } = useParams<{

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -20,6 +20,7 @@ import Members from '~dashboard/Members';
 import PermissionManagementDialog from '~dialogs/PermissionManagementDialog';
 import WrongNetworkDialog from '~dashboard/ColonyHome/WrongNetworkDialog';
 import InviteLinkButton from '~dashboard/InviteLinkButton';
+import ManageWhitelistDialog from '~dashboard/Dialogs/ManageWhitelistDialog';
 
 import {
   useColonyFromNameQuery,
@@ -39,7 +40,7 @@ import { hasRoot, canAdminister } from '~modules/users/checks';
 import { oneTxMustBeUpgraded } from '~modules/dashboard/checks';
 
 import styles from './ColonyMembers.css';
-import ManageWhitelistDialog from '~dashboard/Dialogs/ManageWhitelistDialog';
+import MembersFilter from './MembersFilter';
 
 const displayName = 'dashboard.ColonyMembers';
 
@@ -313,6 +314,7 @@ const ColonyMembers = () => {
               </>
             )}
           </ul>
+          <MembersFilter />
         </aside>
       </div>
     </div>

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -26,7 +26,6 @@ import {
   useColonyFromNameQuery,
   Colony,
   useColonyExtensionsQuery,
-  useBannedUsersQuery,
   useLoggedInUser,
   useUserReputationQuery,
 } from '~data/index';
@@ -115,15 +114,6 @@ const ColonyMembers = () => {
     variables: { address: colonyAddress },
   });
 
-  const {
-    data: bannedMembers,
-    loading: loadingBannedUsers,
-  } = useBannedUsersQuery({
-    variables: {
-      colonyAddress,
-    },
-  });
-
   const [selectedDomainId, setSelectedDomainId] = useState<number>(
     /*
      * @NOTE DomainId param sanitization
@@ -207,7 +197,6 @@ const ColonyMembers = () => {
   if (
     loading ||
     colonyExtensionLoading ||
-    loadingBannedUsers ||
     (colonyData?.colonyAddress &&
       !colonyData.processedColony &&
       !((colonyData.colonyAddress as any) instanceof Error))
@@ -230,8 +219,6 @@ const ColonyMembers = () => {
         <div className={styles.mainContent}>
           {colonyData && colonyData.processedColony && (
             <Members
-              colony={colonyData.processedColony}
-              bannedUsers={bannedMembers?.bannedUsers || []}
               selectedDomain={selectedDomainId}
               handleDomainChange={setSelectedDomainId}
             />

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useParams, Redirect } from 'react-router-dom';
 import { defineMessages } from 'react-intl';
-import { ColonyVersion, Extension } from '@colony/colony-js';
+import { ColonyVersion, Extension, ROOT_DOMAIN_ID } from '@colony/colony-js';
 import Decimal from 'decimal.js';
 import { AddressZero } from 'ethers/constants';
 
@@ -305,7 +305,13 @@ const ColonyMembers = () => {
               </>
             )}
           </ul>
-          <MembersFilter handleFiltersCallback={setFilters} />
+          <MembersFilter
+            handleFiltersCallback={setFilters}
+            isRoot={
+              selectedDomainId === ROOT_DOMAIN_ID ||
+              selectedDomainId === COLONY_TOTAL_BALANCE_DOMAIN_ID
+            }
+          />
         </aside>
       </div>
     </div>

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -21,6 +21,7 @@ import PermissionManagementDialog from '~dialogs/PermissionManagementDialog';
 import WrongNetworkDialog from '~dashboard/ColonyHome/WrongNetworkDialog';
 import InviteLinkButton from '~dashboard/InviteLinkButton';
 import ManageWhitelistDialog from '~dashboard/Dialogs/ManageWhitelistDialog';
+import { MEMEBERS_FILTERS } from '~dashboard/ColonyMembers/MembersFilter';
 
 import {
   useColonyFromNameQuery,
@@ -71,6 +72,8 @@ const MSG = defineMessages({
 });
 
 const ColonyMembers = () => {
+  const [filters, setFilters] = useState<MEMEBERS_FILTERS[]>([]);
+
   const {
     networkId,
     username,
@@ -221,6 +224,7 @@ const ColonyMembers = () => {
             <Members
               selectedDomain={selectedDomainId}
               handleDomainChange={setSelectedDomainId}
+              filters={filters}
             />
           )}
         </div>
@@ -301,7 +305,7 @@ const ColonyMembers = () => {
               </>
             )}
           </ul>
-          <MembersFilter />
+          <MembersFilter handleFiltersCallback={setFilters} />
         </aside>
       </div>
     </div>

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -1,13 +1,11 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams, Redirect } from 'react-router-dom';
 import { defineMessages } from 'react-intl';
-import { ColonyVersion, Extension, ROOT_DOMAIN_ID } from '@colony/colony-js';
+import { ROOT_DOMAIN_ID } from '@colony/colony-js';
 import Decimal from 'decimal.js';
 import { AddressZero } from 'ethers/constants';
 
-import Button from '~core/Button';
 import { useDialog } from '~core/Dialog';
-import { BanUserDialog } from '~core/Comment';
 import Heading from '~core/Heading';
 import Numeral from '~core/Numeral';
 import {
@@ -17,50 +15,26 @@ import {
 
 import LoadingTemplate from '~pages/LoadingTemplate';
 import Members from '~dashboard/Members';
-import PermissionManagementDialog from '~dialogs/PermissionManagementDialog';
 import WrongNetworkDialog from '~dashboard/ColonyHome/WrongNetworkDialog';
 import InviteLinkButton from '~dashboard/InviteLinkButton';
-import ManageWhitelistDialog from '~dashboard/Dialogs/ManageWhitelistDialog';
 import { MEMEBERS_FILTERS } from '~dashboard/ColonyMembers/MembersFilter';
 
 import {
   useColonyFromNameQuery,
-  Colony,
-  useColonyExtensionsQuery,
   useLoggedInUser,
   useUserReputationQuery,
 } from '~data/index';
-import { useTransformer } from '~utils/hooks';
 import { getFormattedTokenValue } from '~utils/tokens';
-import { useEnabledExtensions } from '~utils/hooks/useEnabledExtensions';
 import { NOT_FOUND_ROUTE } from '~routes/index';
 import { checkIfNetworkIsAllowed } from '~utils/networks';
-import { getAllUserRoles } from '~modules/transformers';
-import { hasRoot, canAdminister } from '~modules/users/checks';
-import { oneTxMustBeUpgraded } from '~modules/dashboard/checks';
 
-import styles from './ColonyMembers.css';
 import MembersFilter from './MembersFilter';
+import MemberControls from './MemberControls';
+import styles from './ColonyMembers.css';
 
 const displayName = 'dashboard.ColonyMembers';
 
 const MSG = defineMessages({
-  editPermissions: {
-    id: 'dashboard.ColonyMembers.editPermissions',
-    defaultMessage: 'Edit permissions',
-  },
-  banAddress: {
-    id: 'dashboard.ColonyMembers.banAddress',
-    defaultMessage: 'Ban address',
-  },
-  unbanAddress: {
-    id: 'dashboard.ColonyMembers.unbanAddress',
-    defaultMessage: 'Unban address',
-  },
-  manageWhitelist: {
-    id: 'dashboard.ColonyMembers.manageWhitelist',
-    defaultMessage: 'Manage address book',
-  },
   loadingText: {
     id: 'dashboard.ColonyMembers.loadingText',
     defaultMessage: 'Loading Colony',
@@ -74,20 +48,13 @@ const MSG = defineMessages({
 const ColonyMembers = () => {
   const [filters, setFilters] = useState<MEMEBERS_FILTERS[]>([]);
 
-  const {
-    networkId,
-    username,
-    ethereal,
-    walletAddress: currentUserWalletAddress,
-  } = useLoggedInUser();
+  const { networkId, ethereal } = useLoggedInUser();
   const { domainId } = useParams<{
     domainId: string;
   }>();
   const isNetworkAllowed = checkIfNetworkIsAllowed(networkId);
-  const hasRegisteredProfile = !!username && !ethereal;
 
   const openWrongNetworkDialog = useDialog(WrongNetworkDialog);
-  const openToggleBanningDialog = useDialog(BanUserDialog);
 
   const { colonyName } = useParams<{
     colonyName: string;
@@ -100,22 +67,11 @@ const ColonyMembers = () => {
 
   const colonyAddress = colonyData?.processedColony?.colonyAddress || '';
 
-  const { isVotingExtensionEnabled } = useEnabledExtensions({
-    colonyAddress,
-  });
-
   useEffect(() => {
     if (!ethereal && !isNetworkAllowed) {
       openWrongNetworkDialog();
     }
   }, [ethereal, isNetworkAllowed, openWrongNetworkDialog]);
-
-  const {
-    data: colonyExtensions,
-    loading: colonyExtensionLoading,
-  } = useColonyExtensionsQuery({
-    variables: { address: colonyAddress },
-  });
 
   const [selectedDomainId, setSelectedDomainId] = useState<number>(
     /*
@@ -141,23 +97,6 @@ const ColonyMembers = () => {
     fetchPolicy: 'cache-and-network',
   });
 
-  const openPermissionManagementDialog = useDialog(PermissionManagementDialog);
-
-  const handlePermissionManagementDialog = useCallback(() => {
-    openPermissionManagementDialog({
-      colony: colonyData?.processedColony as Colony,
-      isVotingExtensionEnabled,
-    });
-  }, [openPermissionManagementDialog, colonyData, isVotingExtensionEnabled]);
-
-  const openToggleManageWhitelistDialog = useDialog(ManageWhitelistDialog);
-
-  const handleToggleWhitelistDialog = useCallback(() => {
-    return openToggleManageWhitelistDialog({
-      colony: colonyData?.processedColony as Colony,
-    });
-  }, [openToggleManageWhitelistDialog, colonyData]);
-
   const nativeToken = colonyData?.processedColony?.tokens.find(
     ({ address }) =>
       address === colonyData?.processedColony?.nativeTokenAddress,
@@ -168,38 +107,8 @@ const ColonyMembers = () => {
     nativeToken?.decimals || DEFAULT_TOKEN_DECIMALS,
   );
 
-  // eslint-disable-next-line max-len
-  const oneTxPaymentExtension = colonyExtensions?.processedColony?.installedExtensions.find(
-    ({ details, extensionId: extensionName }) =>
-      details?.initialized &&
-      !details?.missingPermissions.length &&
-      extensionName === Extension.OneTxPayment,
-  );
-  const mustUpgradeOneTx = oneTxMustBeUpgraded(oneTxPaymentExtension);
-
-  const isSupportedColonyVersion =
-    parseInt(colonyData?.processedColony?.version || '1', 10) >=
-    ColonyVersion.LightweightSpaceship;
-
-  const currentUserRoles = useTransformer(getAllUserRoles, [
-    colonyData?.processedColony,
-    currentUserWalletAddress,
-  ]);
-  const canAdministerComments =
-    hasRegisteredProfile &&
-    (hasRoot(currentUserRoles) || canAdminister(currentUserRoles));
-  const canManageWhitelist = hasRegisteredProfile && hasRoot(currentUserRoles);
-
-  const controlsDisabled =
-    !isSupportedColonyVersion ||
-    !isNetworkAllowed ||
-    !hasRegisteredProfile ||
-    !colonyData?.processedColony?.isDeploymentFinished ||
-    mustUpgradeOneTx;
-
   if (
     loading ||
-    colonyExtensionLoading ||
     (colonyData?.colonyAddress &&
       !colonyData.processedColony &&
       !((colonyData.colonyAddress as any) instanceof Error))
@@ -249,62 +158,7 @@ const ColonyMembers = () => {
                 buttonAppearance={{ theme: 'blue' }}
               />
             </li>
-            {!controlsDisabled && (
-              <>
-                <li>
-                  <Button
-                    appearance={{ theme: 'blue' }}
-                    text={MSG.editPermissions}
-                    onClick={handlePermissionManagementDialog}
-                    disabled={
-                      !isSupportedColonyVersion ||
-                      !isNetworkAllowed ||
-                      !hasRegisteredProfile ||
-                      !colonyData?.processedColony?.isDeploymentFinished ||
-                      mustUpgradeOneTx
-                    }
-                  />
-                </li>
-                {canAdministerComments && (
-                  <>
-                    <li>
-                      <Button
-                        appearance={{ theme: 'blue' }}
-                        text={MSG.banAddress}
-                        onClick={() =>
-                          openToggleBanningDialog({
-                            colonyAddress:
-                              colonyData?.processedColony?.colonyAddress,
-                          })
-                        }
-                      />
-                    </li>
-                    <li>
-                      <Button
-                        appearance={{ theme: 'blue' }}
-                        text={MSG.unbanAddress}
-                        onClick={() =>
-                          openToggleBanningDialog({
-                            isBanning: false,
-                            colonyAddress:
-                              colonyData?.processedColony?.colonyAddress,
-                          })
-                        }
-                      />
-                    </li>
-                  </>
-                )}
-                {canManageWhitelist && (
-                  <li>
-                    <Button
-                      appearance={{ theme: 'blue' }}
-                      text={MSG.manageWhitelist}
-                      onClick={handleToggleWhitelistDialog}
-                    />
-                  </li>
-                )}
-              </>
-            )}
+            <MemberControls colony={colonyData?.processedColony} />
           </ul>
           <MembersFilter
             handleFiltersCallback={setFilters}

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -225,6 +225,7 @@ const ColonyMembers = () => {
               selectedDomain={selectedDomainId}
               handleDomainChange={setSelectedDomainId}
               filters={filters}
+              colony={colonyData?.processedColony}
             />
           )}
         </div>

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useParams, Redirect } from 'react-router-dom';
 import { defineMessages } from 'react-intl';
 import { ROOT_DOMAIN_ID } from '@colony/colony-js';
@@ -88,6 +88,13 @@ const ColonyMembers = () => {
     parseInt(domainId, 10) || COLONY_TOTAL_BALANCE_DOMAIN_ID,
   );
 
+  const isRootDomain = useMemo(
+    () =>
+      selectedDomainId === ROOT_DOMAIN_ID ||
+      selectedDomainId === COLONY_TOTAL_BALANCE_DOMAIN_ID,
+    [selectedDomainId],
+  );
+
   const { data: totalReputation } = useUserReputationQuery({
     variables: {
       address: AddressZero,
@@ -152,20 +159,19 @@ const ColonyMembers = () => {
             </p>
           </div>
           <ul className={styles.controls}>
-            <li>
-              <InviteLinkButton
-                colonyName={colonyName}
-                buttonAppearance={{ theme: 'blue' }}
-              />
-            </li>
+            {isRootDomain && (
+              <li>
+                <InviteLinkButton
+                  colonyName={colonyName}
+                  buttonAppearance={{ theme: 'blue' }}
+                />
+              </li>
+            )}
             <MemberControls colony={colonyData?.processedColony} />
           </ul>
           <MembersFilter
             handleFiltersCallback={setFilters}
-            isRoot={
-              selectedDomainId === ROOT_DOMAIN_ID ||
-              selectedDomainId === COLONY_TOTAL_BALANCE_DOMAIN_ID
-            }
+            isRoot={isRootDomain}
           />
         </aside>
       </div>

--- a/src/modules/dashboard/components/ColonyMembers/MemberControls/MemberControls.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/MemberControls/MemberControls.tsx
@@ -1,0 +1,181 @@
+import React, { useCallback, useEffect } from 'react';
+import { defineMessages } from 'react-intl';
+import { ColonyVersion, Extension } from '@colony/colony-js';
+
+import Button from '~core/Button';
+import { useDialog } from '~core/Dialog';
+import { BanUserDialog } from '~core/Comment';
+
+import PermissionManagementDialog from '~dialogs/PermissionManagementDialog';
+import WrongNetworkDialog from '~dashboard/ColonyHome/WrongNetworkDialog';
+import ManageWhitelistDialog from '~dashboard/Dialogs/ManageWhitelistDialog';
+
+import { Colony, useColonyExtensionsQuery, useLoggedInUser } from '~data/index';
+import { useTransformer } from '~utils/hooks';
+import { useEnabledExtensions } from '~utils/hooks/useEnabledExtensions';
+import { checkIfNetworkIsAllowed } from '~utils/networks';
+import { getAllUserRoles } from '~modules/transformers';
+import { hasRoot, canAdminister, canArchitect } from '~modules/users/checks';
+import { oneTxMustBeUpgraded } from '~modules/dashboard/checks';
+
+const displayName = 'dashboard.MemberControls';
+
+const MSG = defineMessages({
+  editPermissions: {
+    id: 'dashboard.MemberControls.editPermissions',
+    defaultMessage: 'Edit permissions',
+  },
+  banAddress: {
+    id: 'dashboard.MemberControls.banAddress',
+    defaultMessage: 'Ban address',
+  },
+  unbanAddress: {
+    id: 'dashboard.MemberControls.unbanAddress',
+    defaultMessage: 'Unban address',
+  },
+  manageWhitelist: {
+    id: 'dashboard.MemberControls.manageWhitelist',
+    defaultMessage: 'Manage address book',
+  },
+});
+
+interface Props {
+  colony: Colony;
+}
+
+const MemberControls = ({
+  colony,
+  colony: { colonyAddress, version, isDeploymentFinished },
+}: Props) => {
+  const {
+    networkId,
+    username,
+    ethereal,
+    walletAddress: currentUserWalletAddress,
+  } = useLoggedInUser();
+  const isNetworkAllowed = checkIfNetworkIsAllowed(networkId);
+  const hasRegisteredProfile = !!username && !ethereal;
+
+  const openWrongNetworkDialog = useDialog(WrongNetworkDialog);
+  const openToggleBanningDialog = useDialog(BanUserDialog);
+
+  const { isVotingExtensionEnabled } = useEnabledExtensions({
+    colonyAddress,
+  });
+
+  useEffect(() => {
+    if (!ethereal && !isNetworkAllowed) {
+      openWrongNetworkDialog();
+    }
+  }, [ethereal, isNetworkAllowed, openWrongNetworkDialog]);
+
+  const { data: colonyExtensions } = useColonyExtensionsQuery({
+    variables: { address: colonyAddress },
+  });
+
+  const openPermissionManagementDialog = useDialog(PermissionManagementDialog);
+
+  const handlePermissionManagementDialog = useCallback(() => {
+    openPermissionManagementDialog({
+      colony,
+      isVotingExtensionEnabled,
+    });
+  }, [openPermissionManagementDialog, colony, isVotingExtensionEnabled]);
+
+  const openToggleManageWhitelistDialog = useDialog(ManageWhitelistDialog);
+
+  const handleToggleWhitelistDialog = useCallback(() => {
+    return openToggleManageWhitelistDialog({
+      colony,
+    });
+  }, [openToggleManageWhitelistDialog, colony]);
+
+  // eslint-disable-next-line max-len
+  const oneTxPaymentExtension = colonyExtensions?.processedColony?.installedExtensions.find(
+    ({ details, extensionId: extensionName }) =>
+      details?.initialized &&
+      !details?.missingPermissions.length &&
+      extensionName === Extension.OneTxPayment,
+  );
+  const mustUpgradeOneTx = oneTxMustBeUpgraded(oneTxPaymentExtension);
+
+  const isSupportedColonyVersion =
+    parseInt(version || '1', 10) >= ColonyVersion.LightweightSpaceship;
+
+  const currentUserRoles = useTransformer(getAllUserRoles, [
+    colony,
+    currentUserWalletAddress,
+  ]);
+  const canMamangePermissions =
+    (hasRegisteredProfile && canArchitect(currentUserRoles)) ||
+    hasRoot(currentUserRoles);
+  const canAdministerComments =
+    hasRegisteredProfile &&
+    (hasRoot(currentUserRoles) || canAdminister(currentUserRoles));
+  const canManageWhitelist = hasRegisteredProfile && hasRoot(currentUserRoles);
+
+  const controlsDisabled =
+    !isSupportedColonyVersion ||
+    !isNetworkAllowed ||
+    !hasRegisteredProfile ||
+    !isDeploymentFinished ||
+    mustUpgradeOneTx;
+
+  return (
+    <>
+      {!controlsDisabled && (
+        <>
+          {canMamangePermissions && (
+            <li>
+              <Button
+                appearance={{ theme: 'blue' }}
+                text={MSG.editPermissions}
+                onClick={handlePermissionManagementDialog}
+              />
+            </li>
+          )}
+          {canAdministerComments && (
+            <>
+              <li>
+                <Button
+                  appearance={{ theme: 'blue' }}
+                  text={MSG.banAddress}
+                  onClick={() =>
+                    openToggleBanningDialog({
+                      colonyAddress,
+                    })
+                  }
+                />
+              </li>
+              <li>
+                <Button
+                  appearance={{ theme: 'blue' }}
+                  text={MSG.unbanAddress}
+                  onClick={() =>
+                    openToggleBanningDialog({
+                      isBanning: false,
+                      colonyAddress,
+                    })
+                  }
+                />
+              </li>
+            </>
+          )}
+          {canManageWhitelist && (
+            <li>
+              <Button
+                appearance={{ theme: 'blue' }}
+                text={MSG.manageWhitelist}
+                onClick={handleToggleWhitelistDialog}
+              />
+            </li>
+          )}
+        </>
+      )}
+    </>
+  );
+};
+
+MemberControls.displayName = displayName;
+
+export default MemberControls;

--- a/src/modules/dashboard/components/ColonyMembers/MemberControls/index.ts
+++ b/src/modules/dashboard/components/ColonyMembers/MemberControls/index.ts
@@ -1,0 +1,1 @@
+export { default } from './MemberControls';

--- a/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.css
+++ b/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.css
@@ -15,6 +15,10 @@
   color: var(--dark);
 }
 
+.filters > div {
+  width: 206px;
+}
+
 .checkboxes > label {
   margin-bottom: 15px;
 }

--- a/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.css
+++ b/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.css
@@ -22,3 +22,14 @@
 .filters > div {
   width: 206px;
 }
+
+.button {
+  padding: 0;
+  width: 206px;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  outline: inherit;
+}

--- a/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.css
+++ b/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.css
@@ -15,20 +15,10 @@
   color: var(--dark);
 }
 
+.filters {
+  margin-bottom: 110px;
+}
+
 .filters > div {
   width: 206px;
-}
-
-.checkboxes > label {
-  margin-bottom: 15px;
-}
-
-.checkboxes > label > span {
-  margin-right: 15px;
-}
-
-.checkboxes > label > label {
-  font-size: var(--size-small);
-  font-weight: var(--weight-normal);
-  color: var(--dark);
 }

--- a/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.css
+++ b/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.css
@@ -1,0 +1,30 @@
+.divider {
+  margin: 30px 0;
+  width: 220px;
+  background-color: var(--temp-grey-13);
+}
+
+.titleContainer {
+  margin-bottom: 17px;
+}
+
+.title {
+  margin-right: 15px;
+  font-size: var(--size-smallish);
+  font-weight: var(--weight-bold);
+  color: var(--dark);
+}
+
+.checkboxes > label {
+  margin-bottom: 15px;
+}
+
+.checkboxes > label > span {
+  margin-right: 15px;
+}
+
+.checkboxes > label > label {
+  font-size: var(--size-small);
+  font-weight: var(--weight-normal);
+  color: var(--dark);
+}

--- a/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.css
+++ b/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.css
@@ -22,14 +22,3 @@
 .filters > div {
   width: 206px;
 }
-
-.button {
-  padding: 0;
-  width: 206px;
-  border: none;
-  background: none;
-  color: inherit;
-  font: inherit;
-  cursor: pointer;
-  outline: inherit;
-}

--- a/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.css.d.ts
+++ b/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.css.d.ts
@@ -2,3 +2,4 @@ export const divider: string;
 export const titleContainer: string;
 export const title: string;
 export const filters: string;
+export const button: string;

--- a/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.css.d.ts
+++ b/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.css.d.ts
@@ -1,0 +1,4 @@
+export const divider: string;
+export const titleContainer: string;
+export const title: string;
+export const checkboxes: string;

--- a/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.css.d.ts
+++ b/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.css.d.ts
@@ -2,4 +2,3 @@ export const divider: string;
 export const titleContainer: string;
 export const title: string;
 export const filters: string;
-export const button: string;

--- a/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.css.d.ts
+++ b/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.css.d.ts
@@ -1,4 +1,5 @@
 export const divider: string;
 export const titleContainer: string;
 export const title: string;
+export const filters: string;
 export const checkboxes: string;

--- a/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.css.d.ts
+++ b/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.css.d.ts
@@ -2,4 +2,3 @@ export const divider: string;
 export const titleContainer: string;
 export const title: string;
 export const filters: string;
-export const checkboxes: string;

--- a/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.tsx
@@ -1,9 +1,9 @@
 import { FormikProps } from 'formik';
-import React, { useMemo } from 'react';
-import { defineMessage, FormattedMessage, MessageDescriptor } from 'react-intl';
+import React from 'react';
+import { defineMessage, FormattedMessage } from 'react-intl';
 
 import Button from '~core/Button';
-import { Form, Checkbox } from '~core/Fields';
+import { Form, Select } from '~core/Fields';
 
 import styles from './MembersFilter.css';
 
@@ -12,11 +12,19 @@ const displayName = 'dashboard.ColonyMembers.MembersFilter';
 const MSG = defineMessage({
   filter: {
     id: 'dashboard.ColonyMembers.MembersFilter.filter',
-    defaultMessage: 'Filter',
+    defaultMessage: 'Filters',
   },
   reset: {
     id: 'dashboard.ColonyMembers.MembersFilter.reset',
     defaultMessage: 'Reset',
+  },
+  allMembers: {
+    id: 'dashboard.ColonyMembers.MembersFilter.allMembers',
+    defaultMessage: 'All members',
+  },
+  any: {
+    id: 'dashboard.ColonyMembers.MembersFilter.allMembers',
+    defaultMessage: 'Any',
   },
   contributors: {
     id: 'dashboard.ColonyMembers.MembersFilter.contributors',
@@ -30,73 +38,96 @@ const MSG = defineMessage({
     id: 'dashboard.ColonyMembers.MembersFilter.verified',
     defaultMessage: 'Verified',
   },
+  unverified: {
+    id: 'dashboard.ColonyMembers.MembersFilter.unverified',
+    defaultMessage: 'Unverified',
+  },
   banned: {
     id: 'dashboard.ColonyMembers.MembersFilter.banned',
     defaultMessage: 'Banned',
   },
+  notBanned: {
+    id: 'dashboard.ColonyMembers.MembersFilter.notBanned',
+    defaultMessage: 'Not banned',
+  },
+  memberType: {
+    id: 'dashboard.ColonyMembers.MembersFilter.memberType',
+    defaultMessage: 'Member type',
+  },
+  bannedStatus: {
+    id: 'dashboard.ColonyMembers.MembersFilter.bannedStatus',
+    defaultMessage: 'Banned status',
+  },
+  verificationType: {
+    id: 'dashboard.ColonyMembers.MembersFilter.verificationType',
+    defaultMessage: 'Verification type',
+  },
 });
 
-export enum MEMEBERS_FILTERS {
+export enum MemberType {
+  ALL = 'all',
   CONTRIBUTORS = 'contributors',
   WATCHERS = 'watchers',
+}
+
+export enum VerificationType {
+  ALL = 'all',
   VERIFIED = 'verified',
+  UNVERIFIED = 'unverified',
+}
+
+export enum BannedStatus {
+  ALL = 'all',
   BANNED = 'banned',
+  NOT_BANNED = 'not_banned',
 }
 
-interface FormValues {
-  filters: MEMEBERS_FILTERS[];
+export interface FormValues {
+  memberType: MemberType;
+  verificationType: VerificationType;
+  bannedStatus: BannedStatus;
 }
 
-interface Filter {
-  name: MEMEBERS_FILTERS;
-  text: MessageDescriptor;
-}
+const memberTypes = [
+  { label: MSG.allMembers, value: MemberType.ALL },
+  { label: MSG.contributors, value: MemberType.CONTRIBUTORS },
+  { label: MSG.watchers, value: MemberType.WATCHERS },
+];
 
-const filters: Filter[] = [
-  {
-    name: MEMEBERS_FILTERS.CONTRIBUTORS,
-    text: MSG.contributors,
-  },
-  {
-    name: MEMEBERS_FILTERS.WATCHERS,
-    text: MSG.watchers,
-  },
-  {
-    name: MEMEBERS_FILTERS.VERIFIED,
-    text: MSG.verified,
-  },
-  {
-    name: MEMEBERS_FILTERS.BANNED,
-    text: MSG.banned,
-  },
+const verificationTypes = [
+  { label: MSG.any, value: VerificationType.ALL },
+  { label: MSG.verified, value: VerificationType.VERIFIED },
+  { label: MSG.unverified, value: VerificationType.UNVERIFIED },
+];
+
+const bannedStatuses = [
+  { label: MSG.any, value: BannedStatus.ALL },
+  { label: MSG.banned, value: BannedStatus.BANNED },
+  { label: MSG.notBanned, value: BannedStatus.NOT_BANNED },
 ];
 
 interface Props {
-  handleFiltersCallback: (filters: MEMEBERS_FILTERS[]) => void;
+  handleFiltersCallback: (filters: FormValues) => void;
   isRoot: boolean;
 }
 
 const MembersFilter = ({ handleFiltersCallback, isRoot }: Props) => {
-  const filtersList = useMemo(() => (isRoot ? filters : filters.slice(2)), [
-    isRoot,
-  ]);
-
-  const filterNames = useMemo(() => filtersList.map((item) => item.name), [
-    filtersList,
-  ]);
-
   return (
     <>
       <hr className={styles.divider} />
       <Form
-        initialValues={{ filters: filterNames }}
+        initialValues={{
+          memberType: MemberType.ALL,
+          verificationType: VerificationType.ALL,
+          bannedStatus: BannedStatus.ALL,
+        }}
         onSubmit={() => {}}
         enableReinitialize
       >
         {({ resetForm, values }: FormikProps<FormValues>) => {
-          handleFiltersCallback(values.filters);
+          handleFiltersCallback(values);
           return (
-            <>
+            <div className={styles.filters}>
               <div className={styles.titleContainer}>
                 <span className={styles.title}>
                   <FormattedMessage {...MSG.filter} />
@@ -107,17 +138,27 @@ const MembersFilter = ({ handleFiltersCallback, isRoot }: Props) => {
                   onClick={() => resetForm()}
                 />
               </div>
-              <div className={styles.checkboxes}>
-                {filtersList.map((item) => (
-                  <Checkbox
-                    value={item.name}
-                    name="filters"
-                    key={item.name}
-                    label={item.text}
-                  />
-                ))}
-              </div>
-            </>
+              {isRoot && (
+                <Select
+                  appearance={{ theme: 'grey' }}
+                  name="memberType"
+                  options={memberTypes}
+                  label={MSG.memberType}
+                />
+              )}
+              <Select
+                appearance={{ theme: 'grey' }}
+                name="verificationType"
+                options={verificationTypes}
+                label={MSG.verificationType}
+              />
+              <Select
+                appearance={{ theme: 'grey' }}
+                name="bannedStatus"
+                options={bannedStatuses}
+                label={MSG.bannedStatus}
+              />
+            </div>
           );
         }}
       </Form>

--- a/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.tsx
@@ -1,0 +1,101 @@
+import { FormikProps } from 'formik';
+import React from 'react';
+import { defineMessage, FormattedMessage } from 'react-intl';
+import Button from '~core/Button';
+
+import { Form, Checkbox } from '~core/Fields';
+
+import styles from './MembersFilter.css';
+
+const displayName = 'dashboard.ColonyMembers.MembersFilter';
+
+interface FormValues {
+  filters: string[];
+}
+
+const MSG = defineMessage({
+  filter: {
+    id: 'dashboard.ColonyMembers.MembersFilter.filter',
+    defaultMessage: 'Filter',
+  },
+  reset: {
+    id: 'dashboard.ColonyMembers.MembersFilter.reset',
+    defaultMessage: 'Reset',
+  },
+  contributors: {
+    id: 'dashboard.ColonyMembers.MembersFilter.contributors',
+    defaultMessage: 'Contributors',
+  },
+  watchers: {
+    id: 'dashboard.ColonyMembers.MembersFilter.watchers',
+    defaultMessage: 'Watchers',
+  },
+  verified: {
+    id: 'dashboard.ColonyMembers.MembersFilter.verified',
+    defaultMessage: 'Verified',
+  },
+  banned: {
+    id: 'dashboard.ColonyMembers.MembersFilter.banned',
+    defaultMessage: 'Banned',
+  },
+});
+
+const filters = [
+  {
+    name: 'contributors',
+    text: MSG.contributors,
+  },
+  {
+    name: 'watchers',
+    text: MSG.watchers,
+  },
+  {
+    name: 'verified',
+    text: MSG.verified,
+  },
+  {
+    name: 'banned',
+    text: MSG.banned,
+  },
+];
+
+const MembersFilter = () => {
+  return (
+    <>
+      <hr className={styles.divider} />
+      <Form
+        initialValues={{ filters: filters.map((item) => item.name) }}
+        onSubmit={() => {}}
+      >
+        {({ resetForm }: FormikProps<FormValues>) => (
+          <>
+            <div className={styles.titleContainer}>
+              <span className={styles.title}>
+                <FormattedMessage {...MSG.filter} />
+              </span>
+              <Button
+                text={MSG.reset}
+                appearance={{ theme: 'blue' }}
+                onClick={() => resetForm()}
+              />
+            </div>
+            <div className={styles.checkboxes}>
+              {filters.map((item) => (
+                <Checkbox
+                  value={item.name}
+                  name="filters"
+                  key={item.name}
+                  label={item.text}
+                />
+              ))}
+            </div>
+          </>
+        )}
+      </Form>
+    </>
+  );
+};
+
+MembersFilter.displayName = displayName;
+
+export default MembersFilter;

--- a/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.tsx
@@ -1,17 +1,13 @@
 import { FormikProps } from 'formik';
-import React from 'react';
-import { defineMessage, FormattedMessage } from 'react-intl';
-import Button from '~core/Button';
+import React, { useMemo } from 'react';
+import { defineMessage, FormattedMessage, MessageDescriptor } from 'react-intl';
 
+import Button from '~core/Button';
 import { Form, Checkbox } from '~core/Fields';
 
 import styles from './MembersFilter.css';
 
 const displayName = 'dashboard.ColonyMembers.MembersFilter';
-
-interface FormValues {
-  filters: string[];
-}
 
 const MSG = defineMessage({
   filter: {
@@ -40,57 +36,79 @@ const MSG = defineMessage({
   },
 });
 
-const filters = [
+export enum MEMEBERS_FILTERS {
+  CONTRIBUTORS = 'contributors',
+  WATCHERS = 'watchers',
+  VERIFIED = 'verified',
+  BANNED = 'banned',
+}
+
+interface FormValues {
+  filters: MEMEBERS_FILTERS[];
+}
+
+interface Filter {
+  name: MEMEBERS_FILTERS;
+  text: MessageDescriptor;
+}
+
+const filters: Filter[] = [
   {
-    name: 'contributors',
+    name: MEMEBERS_FILTERS.CONTRIBUTORS,
     text: MSG.contributors,
   },
   {
-    name: 'watchers',
+    name: MEMEBERS_FILTERS.WATCHERS,
     text: MSG.watchers,
   },
   {
-    name: 'verified',
+    name: MEMEBERS_FILTERS.VERIFIED,
     text: MSG.verified,
   },
   {
-    name: 'banned',
+    name: MEMEBERS_FILTERS.BANNED,
     text: MSG.banned,
   },
 ];
 
-const MembersFilter = () => {
+interface Props {
+  handleFiltersCallback: (filters: MEMEBERS_FILTERS[]) => void;
+}
+
+const MembersFilter = ({ handleFiltersCallback }: Props) => {
+  const filterNames = useMemo(() => filters.map((item) => item.name), []);
+
   return (
     <>
       <hr className={styles.divider} />
-      <Form
-        initialValues={{ filters: filters.map((item) => item.name) }}
-        onSubmit={() => {}}
-      >
-        {({ resetForm }: FormikProps<FormValues>) => (
-          <>
-            <div className={styles.titleContainer}>
-              <span className={styles.title}>
-                <FormattedMessage {...MSG.filter} />
-              </span>
-              <Button
-                text={MSG.reset}
-                appearance={{ theme: 'blue' }}
-                onClick={() => resetForm()}
-              />
-            </div>
-            <div className={styles.checkboxes}>
-              {filters.map((item) => (
-                <Checkbox
-                  value={item.name}
-                  name="filters"
-                  key={item.name}
-                  label={item.text}
+      <Form initialValues={{ filters: filterNames }} onSubmit={() => {}}>
+        {({ resetForm, values }: FormikProps<FormValues>) => {
+          handleFiltersCallback(values.filters);
+          return (
+            <>
+              <div className={styles.titleContainer}>
+                <span className={styles.title}>
+                  <FormattedMessage {...MSG.filter} />
+                </span>
+                <Button
+                  text={MSG.reset}
+                  appearance={{ theme: 'blue' }}
+                  onClick={() => resetForm()}
                 />
-              ))}
-            </div>
-          </>
-        )}
+              </div>
+              <div className={styles.checkboxes}>
+                {filters.map((item) => (
+                  <Checkbox
+                    value={item.name}
+                    name="filters"
+                    key={item.name}
+                    label={item.text}
+                  />
+                ))}
+              </div>
+            </>
+          );
+        }}
       </Form>
     </>
   );

--- a/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.tsx
@@ -73,15 +73,24 @@ const filters: Filter[] = [
 
 interface Props {
   handleFiltersCallback: (filters: MEMEBERS_FILTERS[]) => void;
+  isRoot: boolean;
 }
 
-const MembersFilter = ({ handleFiltersCallback }: Props) => {
-  const filterNames = useMemo(() => filters.map((item) => item.name), []);
+const MembersFilter = ({ handleFiltersCallback, isRoot }: Props) => {
+  const filterNames = useMemo(() => {
+    const filtersList = filters.map((item) => item.name);
+
+    return isRoot ? filtersList : filtersList.slice(2);
+  }, [isRoot]);
 
   return (
     <>
       <hr className={styles.divider} />
-      <Form initialValues={{ filters: filterNames }} onSubmit={() => {}}>
+      <Form
+        initialValues={{ filters: filterNames }}
+        onSubmit={() => {}}
+        enableReinitialize
+      >
         {({ resetForm, values }: FormikProps<FormValues>) => {
           handleFiltersCallback(values.filters);
           return (

--- a/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.tsx
@@ -112,7 +112,7 @@ interface Props {
 }
 
 const MembersFilter = ({ handleFiltersCallback, isRoot }: Props) => {
-  const selectRef = useRef<HTMLButtonElement>(null);
+  const selectRef = useRef<HTMLDivElement>(null);
 
   const scrollIntoView = () => {
     selectRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -162,11 +162,15 @@ const MembersFilter = ({ handleFiltersCallback, isRoot }: Props) => {
                 options={verificationTypes}
                 label={MSG.verificationType}
               />
-              <button
+              {/* Have to use `div` and not a button as we use button
+              further down in `Select` componment and it produces
+              a bad html hierarcy warning */}
+              <div
                 onClick={scrollIntoView}
                 ref={selectRef}
-                type="button"
-                className={styles.button}
+                role="button"
+                tabIndex={0}
+                onKeyUp={scrollIntoView}
               >
                 <Select
                   appearance={{ theme: 'grey' }}
@@ -174,7 +178,7 @@ const MembersFilter = ({ handleFiltersCallback, isRoot }: Props) => {
                   options={bannedStatuses}
                   label={MSG.bannedStatus}
                 />
-              </button>
+              </div>
             </div>
           );
         }}

--- a/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.tsx
@@ -77,11 +77,13 @@ interface Props {
 }
 
 const MembersFilter = ({ handleFiltersCallback, isRoot }: Props) => {
-  const filterNames = useMemo(() => {
-    const filtersList = filters.map((item) => item.name);
+  const filtersList = useMemo(() => (isRoot ? filters : filters.slice(2)), [
+    isRoot,
+  ]);
 
-    return isRoot ? filtersList : filtersList.slice(2);
-  }, [isRoot]);
+  const filterNames = useMemo(() => filtersList.map((item) => item.name), [
+    filtersList,
+  ]);
 
   return (
     <>
@@ -106,7 +108,7 @@ const MembersFilter = ({ handleFiltersCallback, isRoot }: Props) => {
                 />
               </div>
               <div className={styles.checkboxes}>
-                {filters.map((item) => (
+                {filtersList.map((item) => (
                   <Checkbox
                     value={item.name}
                     name="filters"

--- a/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.tsx
@@ -132,11 +132,15 @@ const MembersFilter = ({ handleFiltersCallback, isRoot }: Props) => {
                 <span className={styles.title}>
                   <FormattedMessage {...MSG.filter} />
                 </span>
-                <Button
-                  text={MSG.reset}
-                  appearance={{ theme: 'blue' }}
-                  onClick={() => resetForm()}
-                />
+                {(values.bannedStatus !== BannedStatus.ALL ||
+                  values.verificationType !== VerificationType.ALL ||
+                  values.memberType !== MemberType.ALL) && (
+                  <Button
+                    text={MSG.reset}
+                    appearance={{ theme: 'blue' }}
+                    onClick={() => resetForm()}
+                  />
+                )}
               </div>
               {isRoot && (
                 <Select

--- a/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/MembersFilter/MembersFilter.tsx
@@ -1,5 +1,5 @@
+import React, { useRef } from 'react';
 import { FormikProps } from 'formik';
-import React from 'react';
 import { defineMessage, FormattedMessage } from 'react-intl';
 
 import Button from '~core/Button';
@@ -112,6 +112,12 @@ interface Props {
 }
 
 const MembersFilter = ({ handleFiltersCallback, isRoot }: Props) => {
+  const selectRef = useRef<HTMLButtonElement>(null);
+
+  const scrollIntoView = () => {
+    selectRef.current?.scrollIntoView({ behavior: 'smooth' });
+  };
+
   return (
     <>
       <hr className={styles.divider} />
@@ -156,12 +162,19 @@ const MembersFilter = ({ handleFiltersCallback, isRoot }: Props) => {
                 options={verificationTypes}
                 label={MSG.verificationType}
               />
-              <Select
-                appearance={{ theme: 'grey' }}
-                name="bannedStatus"
-                options={bannedStatuses}
-                label={MSG.bannedStatus}
-              />
+              <button
+                onClick={scrollIntoView}
+                ref={selectRef}
+                type="button"
+                className={styles.button}
+              >
+                <Select
+                  appearance={{ theme: 'grey' }}
+                  name="bannedStatus"
+                  options={bannedStatuses}
+                  label={MSG.bannedStatus}
+                />
+              </button>
             </div>
           );
         }}

--- a/src/modules/dashboard/components/ColonyMembers/MembersFilter/index.ts
+++ b/src/modules/dashboard/components/ColonyMembers/MembersFilter/index.ts
@@ -1,1 +1,1 @@
-export { default } from './MembersFilter';
+export { default, MEMEBERS_FILTERS } from './MembersFilter';

--- a/src/modules/dashboard/components/ColonyMembers/MembersFilter/index.ts
+++ b/src/modules/dashboard/components/ColonyMembers/MembersFilter/index.ts
@@ -1,1 +1,7 @@
-export { default, MEMEBERS_FILTERS } from './MembersFilter';
+export {
+  default,
+  FormValues,
+  MemberType,
+  VerificationType,
+  BannedStatus,
+} from './MembersFilter';

--- a/src/modules/dashboard/components/ColonyMembers/MembersFilter/index.ts
+++ b/src/modules/dashboard/components/ColonyMembers/MembersFilter/index.ts
@@ -1,0 +1,1 @@
+export { default } from './MembersFilter';

--- a/src/modules/dashboard/components/Members/Members.tsx
+++ b/src/modules/dashboard/components/Members/Members.tsx
@@ -5,6 +5,8 @@ import sortBy from 'lodash/sortBy';
 
 import { SpinnerLoader } from '~core/Preloaders';
 import UserPermissions from '~dashboard/UserPermissions';
+import { MEMEBERS_FILTERS } from '~dashboard/ColonyMembers/MembersFilter';
+
 import { useTransformer } from '~utils/hooks';
 import {
   Colony,
@@ -46,6 +48,7 @@ interface Props {
   colony: Colony;
   selectedDomain: number | undefined;
   handleDomainChange: React.Dispatch<React.SetStateAction<number>>;
+  filters: MEMEBERS_FILTERS[];
 }
 
 export type Member = AnyUser & {

--- a/src/modules/dashboard/components/Members/Members.tsx
+++ b/src/modules/dashboard/components/Members/Members.tsx
@@ -5,7 +5,10 @@ import sortBy from 'lodash/sortBy';
 
 import { SpinnerLoader } from '~core/Preloaders';
 import UserPermissions from '~dashboard/UserPermissions';
-import { MEMEBERS_FILTERS } from '~dashboard/ColonyMembers/MembersFilter';
+import {
+  FormValues as FiltersFormValues,
+  MemberType,
+} from '~dashboard/ColonyMembers/MembersFilter';
 
 import { useTransformer } from '~utils/hooks';
 import {
@@ -48,7 +51,7 @@ interface Props {
   colony: Colony;
   selectedDomain: number | undefined;
   handleDomainChange: React.Dispatch<React.SetStateAction<number>>;
-  filters: MEMEBERS_FILTERS[];
+  filters: FiltersFormValues;
 }
 
 export type Member = AnyUser & {
@@ -145,7 +148,8 @@ const Members = ({
 
   const membersContent = useMemo(() => {
     const contributorsContent = (!isRootDomain ||
-      filters.includes(MEMEBERS_FILTERS.CONTRIBUTORS)) && (
+      filters.memberType === MemberType.ALL ||
+      filters.memberType === MemberType.CONTRIBUTORS) && (
       <MembersSection<ColonyContributor>
         isContributorsSection
         colony={colony}
@@ -165,7 +169,9 @@ const Members = ({
     );
 
     const watchersContent =
-      isRootDomain && filters.includes(MEMEBERS_FILTERS.WATCHERS) ? (
+      isRootDomain &&
+      (filters.memberType === MemberType.ALL ||
+        filters.memberType === MemberType.WATCHERS) ? (
         <MembersSection<ColonyWatcher>
           isContributorsSection={false}
           colony={colony}
@@ -195,20 +201,7 @@ const Members = ({
   ]);
 
   useEffect(() => {
-    if (
-      filters.includes(MEMEBERS_FILTERS.WATCHERS) ||
-      filters.includes(MEMEBERS_FILTERS.CONTRIBUTORS)
-    ) {
-      filterContributorsAndWatchers();
-    }
-
-    if (!filters.includes(MEMEBERS_FILTERS.WATCHERS)) {
-      setWatchers([]);
-    }
-
-    if (isRootDomain && !filters.includes(MEMEBERS_FILTERS.CONTRIBUTORS)) {
-      setContributors([]);
-    }
+    filterContributorsAndWatchers();
   }, [filterContributorsAndWatchers, filters, isRootDomain]);
 
   if (loadingMembers) {

--- a/src/modules/dashboard/components/Members/Members.tsx
+++ b/src/modules/dashboard/components/Members/Members.tsx
@@ -9,7 +9,6 @@ import { useTransformer } from '~utils/hooks';
 import {
   Colony,
   useLoggedInUser,
-  BannedUsersQuery,
   useContributorsAndWatchersQuery,
   ColonyContributor,
   ColonyWatcher,
@@ -45,7 +44,6 @@ const MSG = defineMessages({
 
 interface Props {
   colony: Colony;
-  bannedUsers: BannedUsersQuery['bannedUsers'];
   selectedDomain: number | undefined;
   handleDomainChange: React.Dispatch<React.SetStateAction<number>>;
 }

--- a/src/modules/dashboard/components/Members/Members.tsx
+++ b/src/modules/dashboard/components/Members/Members.tsx
@@ -64,6 +64,7 @@ const Members = ({
   colony,
   selectedDomain,
   handleDomainChange,
+  filters,
 }: Props) => {
   const [searchValue, setSearchValue] = useState<string>('');
   const {
@@ -110,20 +111,22 @@ const Members = ({
   );
 
   const filterContributorsAndWatchers = useCallback(
-    (filterValue) => {
+    (filterValue?) => {
       const filteredContributors = filterMembers<ColonyContributor>(
         members?.contributorsAndWatchers?.contributors || [],
         filterValue,
+        filters,
       );
       setContributors(filteredContributors);
 
       const filteredWatchers = filterMembers<ColonyWatcher>(
         members?.contributorsAndWatchers?.watchers || [],
         filterValue,
+        filters,
       );
       setWatchers(filteredWatchers);
     },
-    [members],
+    [members, filters],
   );
 
   // handles search values & close button
@@ -137,7 +140,10 @@ const Members = ({
   );
 
   const membersContent = useMemo(() => {
-    const contributorsContent = (
+    const contributorsContent = ((selectedDomain !==
+      COLONY_TOTAL_BALANCE_DOMAIN_ID &&
+      selectedDomain !== ROOT_DOMAIN_ID) ||
+      filters.includes(MEMEBERS_FILTERS.CONTRIBUTORS)) && (
       <MembersSection<ColonyContributor>
         isContributorsSection
         colony={colony}
@@ -157,8 +163,9 @@ const Members = ({
     );
 
     const watchersContent =
-      selectedDomain === ROOT_DOMAIN_ID ||
-      selectedDomain === COLONY_TOTAL_BALANCE_DOMAIN_ID ? (
+      (selectedDomain === ROOT_DOMAIN_ID ||
+        selectedDomain === COLONY_TOTAL_BALANCE_DOMAIN_ID) &&
+      filters.includes(MEMEBERS_FILTERS.WATCHERS) ? (
         <MembersSection<ColonyWatcher>
           isContributorsSection={false}
           colony={colony}
@@ -177,7 +184,19 @@ const Members = ({
         {watchersContent}
       </>
     );
-  }, [canAdministerComments, colony, contributors, selectedDomain, watchers]);
+  }, [
+    canAdministerComments,
+    colony,
+    contributors,
+    selectedDomain,
+    watchers,
+    filters,
+  ]);
+
+  useEffect(() => filterContributorsAndWatchers(), [
+    filterContributorsAndWatchers,
+    filters,
+  ]);
 
   if (loadingMembers) {
     return (

--- a/src/modules/dashboard/components/Members/MembersTitle.css
+++ b/src/modules/dashboard/components/Members/MembersTitle.css
@@ -3,6 +3,7 @@
   justify-content: space-between;
   align-items: center;
   margin-bottom: 35px;
+  min-width: 698px;
   border-bottom: 1px solid var(--temp-grey-13);
 }
 

--- a/src/modules/dashboard/components/Members/filterMembers.ts
+++ b/src/modules/dashboard/components/Members/filterMembers.ts
@@ -54,7 +54,7 @@ export const filterMembers = <M extends ColonyContributor | ColonyWatcher>(
         return banned && textFilter;
       }
 
-      if (filters?.bannedStatus !== BannedStatus.NOT_BANNED) {
+      if (filters?.bannedStatus === BannedStatus.NOT_BANNED) {
         return !banned && textFilter;
       }
     }

--- a/src/modules/dashboard/components/Members/filterMembers.ts
+++ b/src/modules/dashboard/components/Members/filterMembers.ts
@@ -1,21 +1,64 @@
+import { MEMEBERS_FILTERS } from '~dashboard/ColonyMembers/MembersFilter';
+
 import { ColonyContributor, ColonyWatcher } from '~data/index';
 
 export const filterMembers = <M extends ColonyContributor | ColonyWatcher>(
   data: M[],
-  filterValue: string,
+  filterValue?: string,
+  filtersList?: MEMEBERS_FILTERS[],
 ): M[] => {
-  if (!filterValue) {
+  const excludeBanned = !filtersList?.includes(MEMEBERS_FILTERS.BANNED);
+  const excludeVerified = !filtersList?.includes(MEMEBERS_FILTERS.VERIFIED);
+
+  /* No filters */
+  if (!filterValue && !excludeBanned && !excludeVerified) {
     return data;
   }
 
-  return data.filter(
-    (member) =>
-      member?.profile?.username
+  /* Only text filter */
+  if (filterValue && !excludeBanned && !excludeVerified) {
+    return data.filter(
+      ({ profile, id }) =>
+        profile?.username?.toLowerCase().includes(filterValue.toLowerCase()) ||
+        profile?.walletAddress
+          ?.toLowerCase()
+          .includes(filterValue.toLowerCase()) ||
+        id?.toLowerCase().includes(filterValue.toLowerCase()),
+    );
+  }
+
+  /* Only checkbox filters */
+  if (!filterValue) {
+    return data.filter(({ banned, isWhitelisted }) => {
+      if (excludeBanned && excludeVerified) {
+        return !banned && !isWhitelisted;
+      }
+
+      if (excludeBanned) {
+        return !banned;
+      }
+
+      return !isWhitelisted;
+    });
+  }
+
+  /* All the filters together */
+  return data.filter(({ banned, isWhitelisted, profile, id }) => {
+    const textFilter =
+      profile?.username?.toLowerCase().includes(filterValue?.toLowerCase()) ||
+      profile?.walletAddress
         ?.toLowerCase()
-        .includes(filterValue.toLowerCase()) ||
-      member?.profile?.walletAddress
-        ?.toLowerCase()
-        .includes(filterValue.toLowerCase()) ||
-      member?.id?.toLowerCase().includes(filterValue.toLowerCase()),
-  );
+        .includes(filterValue?.toLowerCase()) ||
+      id?.toLowerCase().includes(filterValue?.toLowerCase());
+
+    if (excludeBanned && excludeVerified) {
+      return !banned && !isWhitelisted && textFilter;
+    }
+
+    if (excludeBanned) {
+      return !banned && textFilter;
+    }
+
+    return !isWhitelisted && textFilter;
+  });
 };


### PR DESCRIPTION
## Description

This PR adds filters to the members page. It also refactors the code a bit to split and simplify it. I've also added fixed width to the MembersListItem so that watchers item list doesn't shrink when there are no contributors.

Please, note that the hover state of the `reset` button for the filters is not as in the specs. It was agreed with Arren that it will stay the same as all other buttons above.

Update figma specs
https://www.figma.com/file/qQoBbyyDXkuHwoqHIOGjEu/Colony-Simplified?node-id=7705%3A91695

<img width="1028" alt="Screenshot 2022-07-01 at 16 08 23" src="https://user-images.githubusercontent.com/34057551/176913877-da6a345c-5506-4adc-ab04-de4b3565c81f.png">


**New stuff** ✨

- add filters checkboxes and logic

**Changes** 🏗

- extract MemberControls to a separate component
- fix the MembersListItem width

resolves #3381