### PR TITLE
Add: Mobile responsive Funds page

### DIFF
--- a/src/modules/core/components/MaskedAddress/MaskedAddress.css
+++ b/src/modules/core/components/MaskedAddress/MaskedAddress.css
@@ -13,6 +13,6 @@
 
 @media screen and query700 {
   .middleSection {
-    overflow-wrap: break-word;
+    overflow-wrap: anywhere;
   }
 }

--- a/src/modules/dashboard/components/ColonyFunding/ColonyFunding.css
+++ b/src/modules/dashboard/components/ColonyFunding/ColonyFunding.css
@@ -1,3 +1,4 @@
+@value query700 from '~styles/queries.css';
 
 .main {
   display: grid;
@@ -48,4 +49,136 @@
   height: 100%;
   width: calc(100% - 60px);
   position: relative;
+}
+
+@media screen and query700 {
+  .main {
+    display: block;
+    margin-top: 0;
+  }
+
+  .content {
+    justify-content: flex-start;
+    height: auto;
+    gap: 20px;
+  }
+
+  .titleContainer {
+    align-items: center;
+    margin-bottom: 20px;
+    padding: 0 14px;
+    height: 50px;
+  }
+
+  .titleContainer h3 {
+    margin: 0;
+    width: auto;
+  }
+
+  .aside {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 0;
+  }
+
+  .banner {
+    margin: 0 0 40px;
+  }
+
+  .titleContainer + div > ul {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 5px;
+  }
+
+  .titleContainer + div > ul * {
+    margin: 0;
+  }
+
+  .titleContainer + div > ul > div {
+    width: calc(100% - 28px);
+  }
+
+  .content div > li:only-child {
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: center;
+    min-height: 0px;
+    gap: 10px;
+    box-shadow: none;
+  }
+
+  .content div > li:only-child div {
+    align-items: center;
+    gap: 10px;
+  }
+
+  .content div > li:only-child > div:nth-child(3) {
+    line-height: 12px;
+  }
+
+  .titleContainer ul {
+    width: 200px;
+    top: calc(100% + 2px);
+    right: 0px;
+  }
+
+  .titleContainer + div {
+    padding-bottom: 0;
+  }
+
+  .content div[role='tooltip'] {
+    width: calc(100%);
+
+    /* @NOTE This is a hack to get the popover to appear in the correct place.
+    * It is normally styled by passing an `offset` prop to the popover, but
+    * this `TokenCard` popover is used in the Wallet page also, so any offset prop would
+    * affect stylings on both pages.
+    */
+    transform: translate(0px, 55px) !important;
+  }
+
+  .content div[role='tooltip'] > div > div {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    background: white;
+    gap: 10px;
+  }
+
+  .content div[role='tooltip'] > div > div > div:first-child {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+  }
+
+  .content figure {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .content figure > div {
+    position: static;
+  }
+
+  .content.content p + div > div { /* Repeating the .content class increases specificity and prevents override from selector above. */
+    align-items: flex-start;
+    gap: 30px;
+  }
+
+  .content p + div > div > div:first-child {
+    overflow-wrap: anywhere;
+  }
+
+  .content p + div span:nth-child(2) {
+    padding-right: 10px;
+    line-height: 0px;
+  }
+
+  .content p + div button {
+    line-height: 10px;
+  }
 }

--- a/src/modules/dashboard/components/ColonyFunding/ColonyFunding.css
+++ b/src/modules/dashboard/components/ColonyFunding/ColonyFunding.css
@@ -140,6 +140,10 @@
     transform: translate(0px, 55px) !important;
   }
 
+  .content div[role='tooltip'] > div {
+    max-width: 100%;
+  }
+
   .content div[role='tooltip'] > div > div {
     display: flex;
     flex-direction: column;

--- a/src/modules/dashboard/components/ColonyFunding/ColonyFunding.css.d.ts
+++ b/src/modules/dashboard/components/ColonyFunding/ColonyFunding.css.d.ts
@@ -1,3 +1,4 @@
+export const query700: string;
 export const main: string;
 export const titleContainer: string;
 export const content: string;

--- a/src/modules/dashboard/components/ColonyFunding/ColonyFunding.tsx
+++ b/src/modules/dashboard/components/ColonyFunding/ColonyFunding.tsx
@@ -2,6 +2,7 @@ import React, { ComponentProps, useMemo, useState } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { Redirect, RouteChildrenProps } from 'react-router-dom';
 import sortBy from 'lodash/sortBy';
+import { useMediaQuery } from 'react-responsive';
 
 import { COLONY_TOTAL_BALANCE_DOMAIN_ID } from '~constants';
 import { Form, Select } from '~core/Fields';
@@ -11,10 +12,13 @@ import ColonyFundingBanner from '~dashboard/ColonyFundingBanner';
 import ColonyFundingMenu from '~dashboard/ColonyFundingMenu';
 import TokenCardList from '~dashboard/TokenCardList';
 import UnclaimedTransfers from '~dashboard/UnclaimedTransfers';
+import ColonyHomeInfo from '~dashboard/ColonyHome/ColonyHomeInfo';
+import ColonyDomainSelector from '~dashboard/ColonyHome/ColonyDomainSelector';
 import { useColonyFromNameQuery } from '~data/index';
 
 import { NOT_FOUND_ROUTE } from '~routes/index';
 
+import { query700 as query } from '~styles/queries.css';
 import styles from './ColonyFunding.css';
 
 const MSG = defineMessages({
@@ -86,6 +90,8 @@ const ColonyFunding = ({ match }: Props) => {
     return typeof label === 'string' ? label : formatMessage(label);
   }, [domainChoices, formatMessage, selectedDomainId]);
 
+  const isMobile = useMediaQuery({ query });
+
   if (
     loading ||
     (data?.colonyAddress &&
@@ -106,35 +112,52 @@ const ColonyFunding = ({ match }: Props) => {
 
   const { processedColony: colony } = data;
 
+  const Aside = () => (
+    <aside className={styles.aside}>
+      <ColonyFundingMenu selectedDomainId={selectedDomainId} colony={colony} />
+    </aside>
+  );
+
   return (
     <div className={styles.main}>
       <div className={styles.content}>
         <div>
+          {isMobile && (
+            <ColonyHomeInfo colony={colony} showNavigation isMobile />
+          )}
           <div className={styles.titleContainer}>
             <Heading
               text={MSG.title}
               textValues={{ selectedDomainLabel }}
               appearance={{ size: 'medium', theme: 'dark' }}
             />
-            <Form
-              initialValues={{
-                selectDomain: COLONY_TOTAL_BALANCE_DOMAIN_ID.toString(),
-              }}
-              onSubmit={() => {}}
-            >
-              <Select
-                appearance={{
-                  alignOptions: 'right',
-                  width: 'content',
-                  theme: 'alt',
-                }}
-                elementOnly
-                label={MSG.labelSelectDomain}
-                name="selectDomain"
-                onChange={(value) => setSelectedDomainId(Number(value))}
-                options={domainChoices}
+            {isMobile ? (
+              <ColonyDomainSelector
+                colony={colony}
+                filteredDomainId={selectedDomainId}
+                onDomainChange={setSelectedDomainId}
               />
-            </Form>
+            ) : (
+              <Form
+                initialValues={{
+                  selectDomain: COLONY_TOTAL_BALANCE_DOMAIN_ID.toString(),
+                }}
+                onSubmit={() => {}}
+              >
+                <Select
+                  appearance={{
+                    alignOptions: 'right',
+                    width: 'content',
+                    theme: 'alt',
+                  }}
+                  elementOnly
+                  label={MSG.labelSelectDomain}
+                  name="selectDomain"
+                  onChange={(value) => setSelectedDomainId(Number(value))}
+                  options={domainChoices}
+                />
+              </Form>
+            )}
           </div>
           <UnclaimedTransfers colony={colony} />
           <TokenCardList
@@ -145,16 +168,12 @@ const ColonyFunding = ({ match }: Props) => {
             domainId={selectedDomainId}
           />
         </div>
+        {isMobile && <Aside />}
         <div className={styles.banner}>
           <ColonyFundingBanner colonyAddress={colony.colonyAddress} />
         </div>
       </div>
-      <aside className={styles.aside}>
-        <ColonyFundingMenu
-          selectedDomainId={selectedDomainId}
-          colony={colony}
-        />
-      </aside>
+      {!isMobile && <Aside />}
     </div>
   );
 };

--- a/src/modules/dashboard/components/ColonyFundingBanner/ColonyFundingBanner.css
+++ b/src/modules/dashboard/components/ColonyFundingBanner/ColonyFundingBanner.css
@@ -1,3 +1,5 @@
+@value query700 from '~styles/queries.css';
+
 .main {
   padding: 30px 0 0;
   border-top: 1px solid var(--temp-grey-5);
@@ -13,4 +15,10 @@
 
 .address > span + span {
   margin-left: 10px;
+}
+
+@media screen and query700 {
+  .main {
+    font-size: var(--size-smallish);
+  }
 }

--- a/src/modules/dashboard/components/ColonyFundingBanner/ColonyFundingBanner.css
+++ b/src/modules/dashboard/components/ColonyFundingBanner/ColonyFundingBanner.css
@@ -19,6 +19,12 @@
 
 @media screen and query700 {
   .main {
+    padding-left: 14px;
+    padding-right: 14px;
     font-size: var(--size-smallish);
+  }
+
+  .address {
+    word-break: break-word;
   }
 }

--- a/src/modules/dashboard/components/ColonyFundingBanner/ColonyFundingBanner.css.d.ts
+++ b/src/modules/dashboard/components/ColonyFundingBanner/ColonyFundingBanner.css.d.ts
@@ -1,2 +1,3 @@
+export const query700: string;
 export const main: string;
 export const address: string;

--- a/src/modules/dashboard/components/ColonyFundingMenu/ColonyFundingMenu.css
+++ b/src/modules/dashboard/components/ColonyFundingMenu/ColonyFundingMenu.css
@@ -1,3 +1,22 @@
+@value query700 from '~styles/queries.css';
+
 .main li + li {
   margin: 18px 0 0;
+}
+
+@media screen and query700 {
+  .main {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 15px;
+  }
+
+  .main button {
+    font-size: var(--size-normal);
+  }
+
+  .main li + li {
+    margin: 0;
+  }
 }

--- a/src/modules/dashboard/components/ColonyFundingMenu/ColonyFundingMenu.css.d.ts
+++ b/src/modules/dashboard/components/ColonyFundingMenu/ColonyFundingMenu.css.d.ts
@@ -1,1 +1,2 @@
+export const query700: string;
 export const main: string;

--- a/src/modules/dashboard/components/ColonyFundingMenu/ColonyFundingMenu.tsx
+++ b/src/modules/dashboard/components/ColonyFundingMenu/ColonyFundingMenu.tsx
@@ -21,6 +21,7 @@ import { checkIfNetworkIsAllowed } from '~utils/networks';
 import { getUserRolesForDomain } from '~modules/transformers';
 import { userHasRole } from '~modules/users/checks';
 import { oneTxMustBeUpgraded } from '~modules/dashboard/checks';
+import { SimpleMessageValues } from '~types/index';
 
 import styles from './ColonyFundingMenu.css';
 
@@ -120,54 +121,46 @@ const ColonyFundingMenu = ({
   const isSupportedColonyVersion =
     parseInt(version, 10) >= ColonyVersion.LightweightSpaceship;
 
+  const isDisabled =
+    !isSupportedColonyVersion ||
+    !isNetworkAllowed ||
+    !hasRegisteredProfile ||
+    !isDeploymentFinished ||
+    mustUpgradeOneTx;
+
+  interface FIProps {
+    text: SimpleMessageValues;
+    handleClick: () => void;
+    disabled: boolean;
+  }
+
+  const FundingItem = ({ text, handleClick, disabled }: FIProps) => (
+    <li>
+      <Button
+        text={text}
+        appearance={{ theme: 'blue' }}
+        onClick={handleClick}
+        disabled={isDisabled || disabled}
+      />
+    </li>
+  );
   return (
     <ul className={styles.main}>
-      <li className={styles.listItem}>
-        <Button
-          text={MSG.navItemMoveTokens}
-          appearance={{ theme: 'blue' }}
-          onClick={handleMoveTokens}
-          disabled={
-            !canMoveTokens ||
-            !isSupportedColonyVersion ||
-            !isNetworkAllowed ||
-            !hasRegisteredProfile ||
-            !isDeploymentFinished ||
-            mustUpgradeOneTx
-          }
-        />
-      </li>
-      <li className={styles.listItem}>
-        <Button
-          text={MSG.navItemMintNewTokens}
-          appearance={{ theme: 'blue' }}
-          onClick={handleMintTokens}
-          disabled={
-            !canUserMintNativeToken ||
-            !isSupportedColonyVersion ||
-            !isNetworkAllowed ||
-            !hasRegisteredProfile ||
-            !isDeploymentFinished ||
-            mustUpgradeOneTx
-          }
-        />
-      </li>
-      <li className={styles.listItem}>
-        <Button
-          text={MSG.navItemManageTokens}
-          appearance={{ theme: 'blue' }}
-          onClick={handleEditTokens}
-          disabled={
-            !canEdit ||
-            !isSupportedColonyVersion ||
-            !isNetworkAllowed ||
-            !hasRegisteredProfile ||
-            !isDeploymentFinished ||
-            mustUpgradeOneTx
-          }
-          data-test="manageTokens"
-        />
-      </li>
+      <FundingItem
+        text={MSG.navItemMoveTokens}
+        handleClick={handleMoveTokens}
+        disabled={!canMoveTokens}
+      />
+      <FundingItem
+        text={MSG.navItemMintNewTokens}
+        handleClick={handleMintTokens}
+        disabled={!canUserMintNativeToken}
+      />
+      <FundingItem
+        text={MSG.navItemManageTokens}
+        handleClick={handleEditTokens}
+        disabled={!canEdit}
+      />
     </ul>
   );
 };

--- a/src/modules/dashboard/components/ColonyFundingMenu/ColonyFundingMenu.tsx
+++ b/src/modules/dashboard/components/ColonyFundingMenu/ColonyFundingMenu.tsx
@@ -122,7 +122,7 @@ const ColonyFundingMenu = ({
 
   return (
     <ul className={styles.main}>
-      <li>
+      <li className={styles.listItem}>
         <Button
           text={MSG.navItemMoveTokens}
           appearance={{ theme: 'blue' }}
@@ -137,7 +137,7 @@ const ColonyFundingMenu = ({
           }
         />
       </li>
-      <li>
+      <li className={styles.listItem}>
         <Button
           text={MSG.navItemMintNewTokens}
           appearance={{ theme: 'blue' }}
@@ -152,7 +152,7 @@ const ColonyFundingMenu = ({
           }
         />
       </li>
-      <li>
+      <li className={styles.listItem}>
         <Button
           text={MSG.navItemManageTokens}
           appearance={{ theme: 'blue' }}

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -183,7 +183,7 @@ const Routes = () => {
           routeProps={({ colonyName }) => ({
             backText: ColonyBackText,
             backRoute: `/colony/${colonyName}`,
-            hasSubscribedColonies: false,
+            hasSubscribedColonies: isMobile,
           })}
         />
         <AlwaysAccesibleRoute


### PR DESCRIPTION
## Description

This PR adresses the mobile responsive design for the Funds page. There is no design for this one, so I've freestyled a bit (e.g. with the `ColonyFundingMenu` list items). 

**Changes** 🏗

* Adapting `ColonyFunding` and related components for mobile
* Refactor `ColonyFundingMenu` item list

## Screenshots

**_Funds page on mobile_**
![funds-mob](https://user-images.githubusercontent.com/64402732/176225718-8c641c28-e6db-4e2e-856a-9133b2e3d77d.png)

**_Info popover_**
![fund-info-popover](https://user-images.githubusercontent.com/64402732/176225696-38d7e94b-0cd9-4238-be37-fbd5c2168ca8.png)

Resolves #3494 
