### PR TITLE
Improve UX of `MemberInfoPopover`

### DIFF
--- a/src/modules/core/components/InfoPopover/MemberInfoPopover/MemberInfoPopover.tsx
+++ b/src/modules/core/components/InfoPopover/MemberInfoPopover/MemberInfoPopover.tsx
@@ -81,11 +81,7 @@ const MemberInfoPopover = ({
     fetchPolicy: 'no-cache',
   });
 
-  if (
-    loadingNativeTokenAddress ||
-    loadingUserReputation ||
-    loadingUserBalance
-  ) {
+  if (loadingNativeTokenAddress || loadingUserBalance) {
     return (
       <div className={`${styles.main} ${styles.loadingSpinnerContainer}`}>
         <SpinnerLoader
@@ -129,6 +125,7 @@ const MemberInfoPopover = ({
               isCurrentUserReputation={
                 currentUserWalletAddress === walletAddress
               }
+              isUserReputationLoading={loadingUserReputation}
             />
           </div>
         )}

--- a/src/modules/core/components/InfoPopover/MemberInfoPopover/UserReputation.tsx
+++ b/src/modules/core/components/InfoPopover/MemberInfoPopover/UserReputation.tsx
@@ -10,6 +10,7 @@ import { ZeroValue } from '~utils/reputation';
 import styles from './MemberInfoPopover.css';
 import Icon from '~core/Icon';
 import Numeral from '~core/Numeral';
+import { SpinnerLoader } from '~core/Preloaders';
 
 const displayName = `InfoPopover.MemberInfoPopover.UserReputation`;
 
@@ -18,6 +19,7 @@ interface Props {
   // eslint-disable-next-line max-len
   userReputationForTopDomains: UserReputationForTopDomainsQuery['userReputationForTopDomains'];
   isCurrentUserReputation: boolean;
+  isUserReputationLoading?: boolean;
 }
 
 const MSG = defineMessages({
@@ -43,6 +45,7 @@ const UserReputation = ({
   colony,
   userReputationForTopDomains,
   isCurrentUserReputation,
+  isUserReputationLoading = false,
 }: Props) => {
   const formattedUserReputations = userReputationForTopDomains?.map(
     ({ domainId, ...rest }) => {
@@ -66,51 +69,64 @@ const UserReputation = ({
         }}
         text={MSG.labelText}
       />
-      {isEmpty(formattedUserReputations) ? (
-        <p className={styles.noReputationDescription}>
-          <FormattedMessage
-            {...MSG.noReputationDescription}
-            values={{ isCurrentUserReputation }}
-          />
-        </p>
+      {isUserReputationLoading ? (
+        <SpinnerLoader
+          appearance={{
+            theme: 'grey',
+            size: 'small',
+          }}
+        />
       ) : (
-        <ul>
-          {formattedUserReputations.map(
-            ({ reputationDomain, reputationPercentage }) => (
-              <li
-                key={`${reputationDomain?.name}-${reputationPercentage}`}
-                className={styles.domainReputationItem}
-              >
-                <p className={styles.domainName}>{reputationDomain?.name}</p>
-                <div className={styles.reputationContainer}>
-                  {reputationPercentage === ZeroValue.NearZero && (
-                    <div className={styles.reputation}>
-                      {reputationPercentage}
+        <>
+          {isEmpty(formattedUserReputations) ? (
+            <p className={styles.noReputationDescription}>
+              <FormattedMessage
+                {...MSG.noReputationDescription}
+                values={{ isCurrentUserReputation }}
+              />
+            </p>
+          ) : (
+            <ul>
+              {formattedUserReputations.map(
+                ({ reputationDomain, reputationPercentage }) => (
+                  <li
+                    key={`${reputationDomain?.name}-${reputationPercentage}`}
+                    className={styles.domainReputationItem}
+                  >
+                    <p className={styles.domainName}>
+                      {reputationDomain?.name}
+                    </p>
+                    <div className={styles.reputationContainer}>
+                      {reputationPercentage === ZeroValue.NearZero && (
+                        <div className={styles.reputation}>
+                          {reputationPercentage}
+                        </div>
+                      )}
+                      {reputationPercentage !== ZeroValue.NearZero && (
+                        <Numeral
+                          className={styles.reputation}
+                          appearance={{ theme: 'primary' }}
+                          value={reputationPercentage}
+                          suffix="%"
+                        />
+                      )}
+                      <Icon
+                        name="star"
+                        appearance={{ size: 'extraTiny' }}
+                        className={styles.icon}
+                        title={MSG.starReputationTitle}
+                        titleValues={{
+                          reputation: reputationPercentage,
+                          domainName: reputationDomain?.name,
+                        }}
+                      />
                     </div>
-                  )}
-                  {reputationPercentage !== ZeroValue.NearZero && (
-                    <Numeral
-                      className={styles.reputation}
-                      appearance={{ theme: 'primary' }}
-                      value={reputationPercentage}
-                      suffix="%"
-                    />
-                  )}
-                  <Icon
-                    name="star"
-                    appearance={{ size: 'extraTiny' }}
-                    className={styles.icon}
-                    title={MSG.starReputationTitle}
-                    titleValues={{
-                      reputation: reputationPercentage,
-                      domainName: reputationDomain?.name,
-                    }}
-                  />
-                </div>
-              </li>
-            ),
+                  </li>
+                ),
+              )}
+            </ul>
           )}
-        </ul>
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Description

While a little difficult to test in local dev, this issues removes the `UserReputation` needing to be loaded before opening the `MemberInfoPopover`, and instead adds a loader to the reputation within the `MemberInfoPopover`.

I tested using a custom setTimeout variable.

This should improve the UX of the component in production, thanks to Raul for pointing it out.

![loading-reputation-fix](https://user-images.githubusercontent.com/33682027/176022325-7e21047c-afc4-4c04-974f-90385d712190.gif)


**New stuff** ✨

* Adds loader in `UserReputation`

**Changes** 🏗

* Removed `loadingUserReputation` from `MemberInfoPopover` check.

Resolves #3539 
