### PR TITLE
Add: Mobile Responsive Extensions Home Page

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyHomeLayout.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHomeLayout.css
@@ -74,8 +74,12 @@
   .mainContent {
     display: grid;
     padding: 0;
-    grid-area: fundsAndActions;
+    grid-area: main;
     grid-template:
+      /*
+      * @TODO Generalise grid row names
+      * as this class is used on multiple pages.
+      */
       "fundColony" auto
       "actionsMenu" auto
       "actionsSummary" auto
@@ -88,8 +92,12 @@
     width: 100%;
     grid-template:
       "joinColony" auto
-      "fundsAndActions" auto
+      "main" auto
       / 1fr;
+  }
+
+  .minimalGrid .mainContent {
+    grid-column: 1 / 2;
   }
 
   .domainsDropdownContainer {

--- a/src/modules/dashboard/components/ColonyHome/ColonyHomeLayout.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHomeLayout.css
@@ -75,15 +75,8 @@
     display: grid;
     padding: 0;
     grid-area: main;
-    grid-template:
-      /*
-      * @TODO Generalise grid row names
-      * as this class is used on multiple pages.
-      */
-      "fundColony" auto
-      "actionsMenu" auto
-      "actionsSummary" auto
-      / 1fr;
+    grid-template-columns: 1fr;
+    grid-auto-rows: auto;
   }
 
   .mainContentGrid {

--- a/src/modules/dashboard/components/ColonyTotalFunds/ColonyTotalFunds.css
+++ b/src/modules/dashboard/components/ColonyTotalFunds/ColonyTotalFunds.css
@@ -102,7 +102,6 @@
     padding: 0 14px;
     height: 77px;
     border-bottom: 1px solid var(--temp-grey-13);
-    grid-area: fundColony;
   }
 
   .totalBalanceCopy {

--- a/src/modules/dashboard/components/Extensions/ExtensionCard.css
+++ b/src/modules/dashboard/components/Extensions/ExtensionCard.css
@@ -1,4 +1,5 @@
 @value lineHeight from './Extensions.css';
+@value query700 from '~styles/queries.css';
 
 .main {
   display: block;
@@ -62,4 +63,10 @@
   position: absolute;
   right: 20px;
   bottom: 20px;
+}
+
+@media screen and query700 {
+  .main {
+    margin: 0;
+  }
 }

--- a/src/modules/dashboard/components/Extensions/ExtensionCard.css.d.ts
+++ b/src/modules/dashboard/components/Extensions/ExtensionCard.css.d.ts
@@ -1,4 +1,5 @@
 export const lineHeight: string;
+export const query700: string;
 export const main: string;
 export const card: string;
 export const header: string;

--- a/src/modules/dashboard/components/Extensions/Extensions.css
+++ b/src/modules/dashboard/components/Extensions/Extensions.css
@@ -1,4 +1,5 @@
 @value lineHeight: 18px;
+@value query700 from '~styles/queries.css';
 
 .main {
   display: grid;
@@ -41,4 +42,53 @@
 
 .loadingSpinner {
   margin-top: 100px;
+}
+
+@media screen and query700 {
+  .main {
+    display: flex;
+    flex-direction: column;
+    padding-bottom: 120px;
+  }
+
+  .description {
+    margin: 0;
+    padding: 0 14px;
+  }
+
+  .main hr {
+    height: 0.8px; /* 1px looks thicker than the borders on the other elements. */
+    background-color: var(--temp-grey-13);
+  }
+
+  .content > div:first-child span {
+    margin-bottom: 20px;
+    font-family: var(--family-primary);
+    font-size: var(--size-medium-l);
+    font-weight: var(--weight-bold);
+    line-height: 1.5;
+    word-break: normal;
+    white-space: pre-line;
+    color: var(--dark);
+  }
+
+  .content > div:first-child {
+    margin-top: 15px;
+    padding: 0 14px;
+  }
+
+  .main h3 {
+    margin-bottom: 30px;
+    padding: 0 14px;
+  }
+
+  .cards {
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .availableExtensionsWrapper {
+    margin-top: 30px;
+  }
 }

--- a/src/modules/dashboard/components/Extensions/Extensions.css.d.ts
+++ b/src/modules/dashboard/components/Extensions/Extensions.css.d.ts
@@ -1,4 +1,5 @@
 export const lineHeight: string;
+export const query700: string;
 export const main: string;
 export const description: string;
 export const content: string;


### PR DESCRIPTION
## Description

This PR is for making the Extensions home page mobile responsive. It does not have a design in Figma but follows the pattern of the other pages. 

It is not focused on the extensions details page (i.e when you click on a specific extension, e.g. `governance`). This is picked up in #3557.

**Changes** 🏗

* Adapted the `Extensions` and related components for mobile
*  Tiny refactor to the `ColonyHomeLayout` grid to generalise it for use across multiple screens such as this one (whereas before I'd styled it specifically for the Colony Home page)

## Screenshots 

![extensions-mob-1](https://user-images.githubusercontent.com/64402732/176411305-e3c2fd2e-1012-4681-a699-a23c74af7504.png)

![extensions-mob](https://user-images.githubusercontent.com/64402732/176411296-6afa7270-907a-4f50-bc69-8102c4bedd50.png)


Resolves #3508


