### PR TITLE
Add provider caching for domain balances

### DIFF
--- a/src/modules/core/sagas/utils/extendedJsonRpcProvider.ts
+++ b/src/modules/core/sagas/utils/extendedJsonRpcProvider.ts
@@ -37,10 +37,17 @@ export class ExtendedJsonRpcProvider extends JsonRpcProvider {
     let useCache = false;
     const tx = await resolveProperties(transaction);
 
-    // Only use cache calls if we're on the actions page / colony home
+    // Use cache calls if we're on the actions page / colony home
     const regex = new RegExp('^/colony/[^/]*$');
     if (regex.test(window.location.pathname)) {
       useCache = true;
+    }
+
+    // Unless we're querying the user's token balances
+    const sig = tx.data.slice(0, 10);
+    // getUserLock(address,address) / getTotalObligation(address,address) / balanceOf(address)
+    if (sig === '0x1cc17c52' || sig === '0x006ad100' || sig === '0x70a08231') {
+      useCache = false;
     }
 
     const block = await blockTag;

--- a/src/modules/core/sagas/utils/extendedJsonRpcProvider.ts
+++ b/src/modules/core/sagas/utils/extendedJsonRpcProvider.ts
@@ -1,12 +1,27 @@
-import { JsonRpcProvider, BlockTag } from 'ethers/providers';
+import {
+  JsonRpcProvider,
+  BlockTag,
+  TransactionRequest,
+} from 'ethers/providers';
 import { poll, serializeTransaction, resolveProperties } from 'ethers/utils';
-import { TransactionRequest } from 'ethers';
+
+type CachedRPCResponse = {
+  response: Promise<string>;
+  timestamp: number;
+};
 
 export class ExtendedJsonRpcProvider extends JsonRpcProvider {
   _parentGetCode: (
     addressOrName: string | Promise<string>,
     blockTag?: BlockTag | Promise<BlockTag>,
   ) => Promise<string>;
+
+  _parentCall: (
+    transaction: TransactionRequest,
+    blockTag?: BlockTag | Promise<BlockTag>,
+  ) => Promise<string>;
+
+  cachedData: { [key: string]: CachedRPCResponse } = {};
 
   constructor(...args) {
     super(...args);
@@ -29,15 +44,15 @@ export class ExtendedJsonRpcProvider extends JsonRpcProvider {
       this.cachedData[key] &&
       this.cachedData[key].timestamp > Date.now() - 60000
     ) {
-      return this.cachedData[key].value;
+      return this.cachedData[key].response;
     }
 
     this.cachedData[key] = {
       timestamp: Date.now(),
-      value: this._parentCall(transaction, blockTag),
+      response: this._parentCall(transaction, blockTag),
     };
 
-    return this.cachedData[key].value;
+    return this.cachedData[key].response;
   }
 
   getCode(

--- a/src/modules/core/sagas/utils/extendedJsonRpcProvider.ts
+++ b/src/modules/core/sagas/utils/extendedJsonRpcProvider.ts
@@ -34,11 +34,13 @@ export class ExtendedJsonRpcProvider extends JsonRpcProvider {
     transaction: TransactionRequest,
     blockTag?: BlockTag | Promise<BlockTag>,
   ): Promise<string> {
+    let useCache = false;
     const tx = await resolveProperties(transaction);
 
-    // Never cache calls to addr(bytes32)
-    if (tx.data.slice(0, 10) === '0x3b3b57de') {
-      return this._parentCall(transaction, blockTag);
+    // Only use cache calls if we're on the actions page / colony home
+    const regex = new RegExp('^/colony/[^/]*$');
+    if (regex.test(window.location.pathname)) {
+      useCache = true;
     }
 
     const block = await blockTag;
@@ -58,6 +60,7 @@ export class ExtendedJsonRpcProvider extends JsonRpcProvider {
     }
 
     if (
+      useCache &&
       this.cachedData[key] &&
       this.cachedData[key].timestamp > now - cacheTime
     ) {

--- a/src/modules/core/sagas/utils/extendedJsonRpcProvider.ts
+++ b/src/modules/core/sagas/utils/extendedJsonRpcProvider.ts
@@ -1,5 +1,6 @@
 import { JsonRpcProvider, BlockTag } from 'ethers/providers';
-import { poll } from 'ethers/utils';
+import { poll, serializeTransaction, resolveProperties } from 'ethers/utils';
+import { TransactionRequest } from 'ethers';
 
 export class ExtendedJsonRpcProvider extends JsonRpcProvider {
   _parentGetCode: (
@@ -10,6 +11,33 @@ export class ExtendedJsonRpcProvider extends JsonRpcProvider {
   constructor(...args) {
     super(...args);
     this._parentGetCode = super.getCode;
+    this._parentCall = super.call;
+    this.cachedData = {};
+  }
+
+  async call(
+    transaction: TransactionRequest,
+    blockTag?: BlockTag | Promise<BlockTag>,
+  ): Promise<string> {
+    const tx = await resolveProperties(transaction);
+
+    const { from } = tx;
+    delete tx.from;
+    const key = `${serializeTransaction(tx)}:${from || ''}`;
+
+    if (
+      this.cachedData[key] &&
+      this.cachedData[key].timestamp > Date.now() - 60000
+    ) {
+      return this.cachedData[key].value;
+    }
+
+    this.cachedData[key] = {
+      timestamp: Date.now(),
+      value: this._parentCall(transaction, blockTag),
+    };
+
+    return this.cachedData[key].value;
   }
 
   getCode(


### PR DESCRIPTION
This PR adds in more overwrites to `ethers`'s provider, using our own extended version of it... `ExtendedJsonRpcProvider`

This time we're using it to cache `eth_call` requests and storing them in the local browser's cache.

This reduces the load and number of requests we make to our production RPC endpoint

_NOTE: This is Alex's own work, I'm just handling the PR/merge/deploy overhead_

### Testing

While this can be tested locally as well, it's more suited for a production environment where more requests are going out.

- Create a colony
- When on the colony home page, open your dev tools to the network tab
- Refresh the page
- Note the number or requests made initially and on subsequent requests
- Browse between pages (home, extensions, funds, etc) to simulate more requests going out