### PR TITLE
Add: Extensions details page mobile

### DIFF
--- a/src/modules/core/components/BreadCrumb/BreadCrumb.css
+++ b/src/modules/core/components/BreadCrumb/BreadCrumb.css
@@ -1,3 +1,5 @@
+@value query700 from '~styles/queries.css';
+
 .main {
   display: flex;
   overflow: hidden;
@@ -33,4 +35,11 @@
   display: inline-block;
   padding: 3px 5px;
   vertical-align: top;
+}
+
+@media screen and query700 {
+  .arrow {
+    padding: 0px 5px;
+    line-height: 24px;
+  }
 }

--- a/src/modules/core/components/BreadCrumb/BreadCrumb.css.d.ts
+++ b/src/modules/core/components/BreadCrumb/BreadCrumb.css.d.ts
@@ -1,3 +1,4 @@
+export const query700: string;
 export const main: string;
 export const invisibleLink: string;
 export const breadCrumble: string;

--- a/src/modules/core/components/BreadCrumb/SingleCrumb.tsx
+++ b/src/modules/core/components/BreadCrumb/SingleCrumb.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import { useMediaQuery } from 'react-responsive';
 
 import NavLink from '~core/NavLink';
 
 import { CrumbText } from './BreadCrumb';
 
+import { query700 as query } from '~styles/queries.css';
 import styles from './BreadCrumb.css';
 
 interface Props {
@@ -14,6 +16,9 @@ interface Props {
 
 const SingleCrumb = ({ crumbText, crumbLink, lastCrumb }: Props) => {
   const crumbTitle = typeof crumbText === 'string' ? crumbText : '';
+  const isMobile = useMediaQuery({ query });
+  const Chevron = () => <span className={styles.arrow}>&gt;</span>;
+
   if (lastCrumb) {
     return (
       <div className={styles.elementLast} title={crumbTitle}>
@@ -39,8 +44,9 @@ const SingleCrumb = ({ crumbText, crumbLink, lastCrumb }: Props) => {
         ) : (
           crumbText
         )}
+        {isMobile && <Chevron />}
       </span>
-      <span className={styles.arrow}>&gt;</span>
+      {!isMobile && <Chevron />}
     </div>
   );
 };

--- a/src/modules/core/components/MaskedAddress/MaskedAddress.css
+++ b/src/modules/core/components/MaskedAddress/MaskedAddress.css
@@ -15,4 +15,8 @@
   .middleSection {
     overflow-wrap: break-word;
   }
+
+  .address {
+    overflow-wrap: anywhere;
+  }
 }

--- a/src/modules/dashboard/components/Extensions/ExtensionActionButton.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionActionButton.tsx
@@ -2,12 +2,15 @@ import React, { useCallback } from 'react';
 import { defineMessages } from 'react-intl';
 import { useHistory, useParams } from 'react-router';
 import { ColonyVersion } from '@colony/colony-js';
+import { useMediaQuery } from 'react-responsive';
 
 import Button, { ActionButton, IconButton } from '~core/Button';
 import { ColonyExtensionQuery } from '~data/index';
 import { ExtensionData } from '~data/staticData/extensionData';
 import { ActionTypes } from '~redux/index';
 import { Address } from '~types/index';
+import { waitForElement } from '~utils/dom';
+import { query700 as query } from '~styles/queries.css';
 
 import { getButtonAction } from './utils';
 
@@ -42,10 +45,16 @@ const ExtensionActionButton = ({
     colonyName: string;
     extensionId: string;
   }>();
+  const isMobile = useMediaQuery({ query });
 
-  const handleEnableButtonClick = useCallback(() => {
+  const handleEnableButtonClick = useCallback(async () => {
     history.push(`/colony/${colonyName}/extensions/${extensionId}/setup`);
-  }, [colonyName, extensionId, history]);
+    // Generate a smooth scroll to `Form` on mobile when clicking `Enable`
+    if (isMobile) {
+      const offset = (await waitForElement('#enableExtnTitle')).offsetTop;
+      window.scrollTo({ top: offset - 20, behavior: 'smooth' });
+    }
+  }, [colonyName, extensionId, history, isMobile]);
 
   const isSupportedColonyVersion =
     parseInt(colonyVersion || '1', 10) >= ColonyVersion.LightweightSpaceship;

--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.css
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.css
@@ -1,3 +1,5 @@
+@value query700 from '~styles/queries.css';
+
 .main {
   composes: main from "./Extensions.css";
   margin-right: 100px;
@@ -102,4 +104,72 @@
 .contractAddress {
   font-size: var(--size-smallish);
   cursor: pointer;
+}
+
+@media screen and query700 {
+  .main {
+    margin: 0;
+  }
+
+  .main > div:first-child {
+    align-items: center;
+    flex-wrap: wrap;
+    padding: 15px 14px 0px;
+  }
+
+  .main > div:first-child > div {
+    display: flex;
+    flex-wrap: wrap;
+    flex-basis: fit-content;
+  }
+
+  .main span {
+    white-space: normal;
+  }
+
+  .main > div:first-child span:nth-child(2) {
+    margin: 1px 2px 0px;
+  }
+
+  .main > div:first-child > div:nth-child(2) {
+    margin-top: 1px;
+  }
+
+  .content {
+    order: 1;
+  }
+
+  aside {
+    display: flex;
+    justify-content: center;
+  }
+
+  .extensionText {
+    padding: 0 14px 24px;
+    border-bottom: 1px solid var(--temp-grey-13);
+  }
+
+  .extensionText h3 {
+    padding: 0;
+  }
+
+  .extensionDetails {
+    margin-bottom: 30px;
+    padding: 0 40px;
+    width: 100%;
+  }
+
+  .extensionDetails button {
+    margin-bottom: 8px;
+  }
+
+  .extensionDetails .headerLine {
+    display: none;
+  }
+
+  .buttonWrapper {
+    padding: 0;
+    height: auto;
+    max-height: 48px;
+  }
 }

--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.css.d.ts
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.css.d.ts
@@ -1,3 +1,4 @@
+export const query700: string;
 export const main: string;
 export const headerLine: string;
 export const extensionText: string;
@@ -12,3 +13,4 @@ export const permissions: string;
 export const actionButtons: string;
 export const iconWrapper: string;
 export const contractAddress: string;
+export const content: string;

--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { FormattedDate, defineMessages, FormattedMessage } from 'react-intl';
 import {
   useParams,
@@ -14,6 +14,7 @@ import {
   extensionsIncompatibilityMap,
 } from '@colony/colony-js';
 import isEmpty from 'lodash/isEmpty';
+import { useMediaQuery } from 'react-responsive';
 
 import BreadCrumb, { Crumb } from '~core/BreadCrumb';
 import Heading from '~core/Heading';
@@ -47,6 +48,7 @@ import InvisibleCopyableAddress from '~core/InvisibleCopyableAddress';
 import { getAllUserRoles } from '~modules/transformers';
 import { hasRoot } from '~modules/users/checks';
 
+import { query700 as query } from '~styles/queries.css';
 import styles from './ExtensionDetails.css';
 import ExtensionActionButton from './ExtensionActionButton';
 import ExtensionSetup from './ExtensionSetup';
@@ -241,6 +243,19 @@ const ExtensionDetails = ({
       )
     : false;
 
+  const isMobile = useMediaQuery({ query });
+
+  /*
+   * @NOTE: The following useEffect scrolls the user to the top
+   * of the page on mobile so that they don't have to do it themselves
+   * when moving from a scrolled position on the `Extensions` page
+   * to `ExtensionDetails`.
+   */
+
+  useEffect(() => {
+    if (isMobile) window.scrollTo(0, 0);
+  }, [isMobile]);
+
   let tableData;
 
   if (installedExtension) {
@@ -334,11 +349,18 @@ const ExtensionDetails = ({
     },
   };
 
+  const ExtnHeading = () => (
+    <>
+      <BreadCrumb elements={breadCrumbs} />
+      <hr className={styles.headerLine} />
+    </>
+  );
+
   return (
     <div className={styles.main}>
-      <div>
-        <BreadCrumb elements={breadCrumbs} />
-        <hr className={styles.headerLine} />
+      {isMobile && <ExtnHeading />}
+      <div className={styles.content}>
+        {!isMobile && <ExtnHeading />}
         <div>
           {!extensionCompatible && (
             <Warning

--- a/src/modules/dashboard/components/Extensions/ExtensionSetup.css
+++ b/src/modules/dashboard/components/Extensions/ExtensionSetup.css
@@ -1,3 +1,5 @@
+@value query700 from '~styles/queries.css';
+
 .main {
   max-width: 600px;
 }
@@ -126,4 +128,49 @@
   font-size: var(--size-tiny);
   font-weight: var(--weight-bold);
   color: var(--danger);
+}
+
+@media screen and query700 {
+  .main {
+    padding: 0 14px;
+  }
+
+  .main h3 {
+    padding: 0;
+  }
+
+  .tokenSelectorContainer {
+    height: auto;
+  }
+
+  .input {
+    max-width: none;
+  }
+
+  /* For Coin Machine Setup */
+  .inputContainer .extraParams:nth-child(3) .tokenSelectorContainer {
+    margin-top: 10px;
+  }
+
+  .inputWrapper {
+    display: flex;
+    align-items: center;
+    column-gap: 10px;
+  }
+
+  .inputWrapper > div {
+    width: 100%;
+  }
+
+  .inputWrapper > span {
+    margin-bottom: 14px;
+  }
+
+  .complementaryLabel {
+    position: static;
+  }
+
+  .textArea label {
+    column-gap: 10px;
+  }
 }

--- a/src/modules/dashboard/components/Extensions/ExtensionSetup.css.d.ts
+++ b/src/modules/dashboard/components/Extensions/ExtensionSetup.css.d.ts
@@ -1,3 +1,4 @@
+export const query700: string;
 export const main: string;
 export const extensionDescription: string;
 export const descriptionExtended: string;
@@ -14,3 +15,4 @@ export const tokenAddessLink: string;
 export const extraParams: string;
 export const divider: string;
 export const tokenErrors: string;
+export const inputWrapper: string;

--- a/src/modules/dashboard/components/Extensions/ExtensionSetup.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionSetup.tsx
@@ -8,6 +8,7 @@ import { Extension } from '@colony/colony-js';
 import Decimal from 'decimal.js';
 import { bigNumberify } from 'ethers/utils';
 import { AddressZero } from 'ethers/constants';
+import { useMediaQuery } from 'react-responsive';
 
 import { IconButton, ActionButton } from '~core/Button';
 import {
@@ -32,6 +33,7 @@ import { Address } from '~types/index';
 
 import { ColonyPolicySelector } from '../Whitelist';
 
+import { query700 as query } from '~styles/queries.css';
 import styles from './ExtensionSetup.css';
 
 import {
@@ -298,6 +300,7 @@ const ExtensionSetup = ({
     whitelistAddress,
   ]);
 
+  const isMobile = useMediaQuery({ query });
   const showInputField = useCallback(
     (paramName) => {
       return (
@@ -358,137 +361,145 @@ const ExtensionSetup = ({
         disabled,
         complementaryLabel,
         tokenLabel,
-      }) => (
-        <div
-          key={paramName}
-          className={isExtraParams ? styles.extraParams : ''}
-        >
-          {type === ExtensionParamType.Input && showInputField(paramName) && (
-            <div
-              className={`${styles.input} ${
-                paramName.endsWith('Address') ? styles.addressInput : ''
-              }`}
-            >
-              <Input
-                appearance={{ size: 'medium', theme: 'minimal' }}
-                label={title}
-                name={paramName}
-                onChange={(newValue) =>
-                  handleCoinMachineTargetValidation(
-                    paramName,
-                    newValue,
-                    formikBag,
-                  )
-                }
-                forcedFieldError={
-                  formikBag?.status?.[paramName]
-                    ? MSG[`${paramName}Error`]
-                    : undefined
-                }
-                disabled={formikBag.isSubmitting}
-              />
-              <p className={styles.inputsDescription}>
-                <FormattedMessage
-                  {...description}
-                  values={{
-                    span: (chunks) => (
-                      <span className={styles.descriptionExample}>
-                        {chunks}
-                      </span>
-                    ),
-                  }}
-                />
-              </p>
-              {(complementaryLabel || tokenLabel) && (
-                <span className={styles.complementaryLabel}>
-                  {complementaryLabel ? (
-                    <FormattedMessage {...MSG[complementaryLabel]} />
-                  ) : (
-                    getToken(formikBag.values[tokenLabel])?.symbol
-                  )}
-                </span>
+      }) => {
+        const Label = () =>
+          (complementaryLabel || tokenLabel) && (
+            <span className={styles.complementaryLabel}>
+              {complementaryLabel ? (
+                <FormattedMessage {...MSG[complementaryLabel]} />
+              ) : (
+                getToken(formikBag.values[tokenLabel])?.symbol
               )}
-            </div>
-          )}
-          {type === ExtensionParamType.Textarea && (
-            <div className={styles.textArea}>
-              <Textarea
-                appearance={{ colorSchema: 'grey' }}
-                label={title}
-                name={paramName}
-                disabled={
-                  (disabled && disabled(formikBag.values)) ||
-                  formikBag.isSubmitting
-                }
-                extra={
-                  description && (
-                    <p className={styles.textAreaDescription}>
-                      <FormattedMessage {...description} />
-                    </p>
-                  )
-                }
-              />
-            </div>
-          )}
-          {type === ExtensionParamType.ColonyPolicySelector && (
-            <ColonyPolicySelector
-              name={paramName}
-              title={title}
-              options={options || []}
-            />
-          )}
-          {type === ExtensionParamType.TokenSelector && (
-            <div>
-              <InputLabel
-                label={title}
-                appearance={{
-                  theme: 'minimal',
-                  size: 'medium',
-                }}
-              />
-              <div className={styles.tokenSelectorContainer}>
-                {fieldName && (
-                  <p>
-                    <FormattedMessage {...fieldName} />
-                  </p>
-                )}
-                <TokenSymbolSelector
-                  tokens={tokens}
+            </span>
+          );
+
+        return (
+          <div
+            key={paramName}
+            className={isExtraParams ? styles.extraParams : ''}
+          >
+            {type === ExtensionParamType.Input && showInputField(paramName) && (
+              <div
+                className={`${styles.input} ${
+                  paramName.endsWith('Address') ? styles.addressInput : ''
+                }`}
+              >
+                <div className={styles.inputWrapper}>
+                  <Input
+                    appearance={{ size: 'medium', theme: 'minimal' }}
+                    label={title}
+                    name={paramName}
+                    onChange={(newValue) =>
+                      handleCoinMachineTargetValidation(
+                        paramName,
+                        newValue,
+                        formikBag,
+                      )
+                    }
+                    forcedFieldError={
+                      formikBag?.status?.[paramName]
+                        ? MSG[`${paramName}Error`]
+                        : undefined
+                    }
+                    disabled={formikBag.isSubmitting}
+                  />
+                  {isMobile && <Label />}
+                </div>
+                <p className={styles.inputsDescription}>
+                  <FormattedMessage
+                    {...description}
+                    values={{
+                      span: (chunks) => (
+                        <span className={styles.descriptionExample}>
+                          {chunks}
+                        </span>
+                      ),
+                    }}
+                  />
+                </p>
+                {!isMobile && <Label />}
+              </div>
+            )}
+            {type === ExtensionParamType.Textarea && (
+              <div className={styles.textArea}>
+                <Textarea
+                  appearance={{ colorSchema: 'grey' }}
+                  label={title}
                   name={paramName}
-                  appearance={{ alignOptions: 'right', theme: 'grey' }}
-                  elementOnly
-                  label={paramName}
-                  onChange={(newValue) =>
-                    handleCoinMachineTokenValidation(
-                      paramName,
-                      newValue,
-                      formikBag,
+                  disabled={
+                    (disabled && disabled(formikBag.values)) ||
+                    formikBag.isSubmitting
+                  }
+                  extra={
+                    description && (
+                      <p className={styles.textAreaDescription}>
+                        <FormattedMessage {...description} />
+                      </p>
                     )
                   }
-                  disabled={formikBag.isSubmitting}
                 />
               </div>
-              <div className={styles.tokenAddessLink}>
-                {tokenContractAddress &&
-                  tokenContractAddress(formikBag.values[paramName])}
-                <div>
-                  <MaskedAddress address={formikBag.values[paramName]} full />
+            )}
+            {type === ExtensionParamType.ColonyPolicySelector && (
+              <ColonyPolicySelector
+                name={paramName}
+                title={title}
+                options={options || []}
+              />
+            )}
+            {type === ExtensionParamType.TokenSelector && (
+              <div>
+                <InputLabel
+                  label={title}
+                  appearance={{
+                    theme: 'minimal',
+                    size: 'medium',
+                  }}
+                />
+                <div className={styles.tokenSelectorContainer}>
+                  {fieldName && (
+                    <p>
+                      <FormattedMessage {...fieldName} />
+                    </p>
+                  )}
+                  <TokenSymbolSelector
+                    tokens={tokens}
+                    name={paramName}
+                    appearance={{ alignOptions: 'right', theme: 'grey' }}
+                    elementOnly
+                    label={paramName}
+                    onChange={(newValue) =>
+                      handleCoinMachineTokenValidation(
+                        paramName,
+                        newValue,
+                        formikBag,
+                      )
+                    }
+                    disabled={formikBag.isSubmitting}
+                  />
                 </div>
+                <div className={styles.tokenAddessLink}>
+                  {tokenContractAddress &&
+                    tokenContractAddress(formikBag.values[paramName])}
+                  <div>
+                    <MaskedAddress address={formikBag.values[paramName]} full />
+                  </div>
+                </div>
+                {description && (
+                  <p className={styles.inputsDescription}>
+                    <FormattedMessage {...description} />
+                  </p>
+                )}
+                {formikBag?.status?.[`${paramName}Error`] && (
+                  <p className={styles.tokenErrors}>
+                    <FormattedMessage {...MSG.tokenValidationError} />
+                  </p>
+                )}
               </div>
-              {description && (
-                <p className={styles.inputsDescription}>
-                  <FormattedMessage {...description} />
-                </p>
-              )}
-              {formikBag?.status?.[`${paramName}Error`] && (
-                <p className={styles.tokenErrors}>
-                  <FormattedMessage {...MSG.tokenValidationError} />
-                </p>
-              )}
-            </div>
-          )}
-        </div>
-      ),
+            )}
+          </div>
+        );
+      },
     );
 
   return (
@@ -511,6 +522,7 @@ const ExtensionSetup = ({
           <Heading
             appearance={{ size: 'medium', margin: 'none' }}
             text={MSG.title}
+            id="enableExtnTitle"
           />
           <div
             className={descriptionExtended ? styles.extensionDescription : ''}

--- a/src/modules/dashboard/components/Extensions/ExtensionUninstallConfirmDialog/ExtensionUninstallConfirmDialog.css
+++ b/src/modules/dashboard/components/Extensions/ExtensionUninstallConfirmDialog/ExtensionUninstallConfirmDialog.css
@@ -1,4 +1,5 @@
 @value wideButton: 160px;
+@value query700 from '~styles/queries.css';
 
 .title {
   font-size: var(--size-medium-l);
@@ -37,5 +38,11 @@
     font-size: var(--size-normal);
     color: var(--text-disabled);
     letter-spacing: var(--spacing-normal);
+  }
+}
+
+@media screen and query700 {
+  .input {
+    margin-top: 20px;
   }
 }

--- a/src/modules/dashboard/components/Extensions/ExtensionUninstallConfirmDialog/ExtensionUninstallConfirmDialog.css.d.ts
+++ b/src/modules/dashboard/components/Extensions/ExtensionUninstallConfirmDialog/ExtensionUninstallConfirmDialog.css.d.ts
@@ -1,4 +1,5 @@
 export const wideButton: string;
+export const query700: string;
 export const title: string;
 export const content: string;
 export const inputContainer: string;

--- a/src/modules/dashboard/components/Whitelist/ColonyPolicySelector/ColonyPolicySelector.css
+++ b/src/modules/dashboard/components/Whitelist/ColonyPolicySelector/ColonyPolicySelector.css
@@ -1,4 +1,12 @@
+@value query700 from '~styles/queries.css';
+
 .container {
   margin-top: 50px;
   width: 340px;
+}
+
+@media screen and query700 {
+  .container {
+    width: auto;
+  }
 }

--- a/src/modules/dashboard/components/Whitelist/ColonyPolicySelector/ColonyPolicySelector.css.d.ts
+++ b/src/modules/dashboard/components/Whitelist/ColonyPolicySelector/ColonyPolicySelector.css.d.ts
@@ -1,1 +1,2 @@
+export const query700: string;
 export const container: string;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,5 +1,6 @@
 @import 'variables.css';
 @import 'fonts.css';
+@value query700 from '~styles/queries.css';
 
 /*! minireset.css v0.0.3 | MIT License | github.com/jgthms/minireset.css */
 html,
@@ -208,5 +209,19 @@ table {
     vertical-align: top;
     border-color: inherit;
     text-align: left;
+  }
+}
+
+@media screen and query700 {
+  /*
+  * @NOTE: The following makes it possible to reset
+  * the window's scroll position programatically.
+  * This is useful on mobile to prevent the user having to
+  * manually scroll back to the top of a new page after clicking
+  * on a link at the bottom of the previous page (e.g. Extensions).
+  */
+  body {
+    height: auto;
+    overflow-y: scroll;
   }
 }

--- a/src/styles/main.css.d.ts
+++ b/src/styles/main.css.d.ts
@@ -1,1 +1,1 @@
-export {};
+export const query700: string;

--- a/src/utils/dom/index.ts
+++ b/src/utils/dom/index.ts
@@ -1,0 +1,21 @@
+export const waitForElement = (selector: string) => {
+  return new Promise<HTMLElement>((resolve) => {
+    // If element is in the DOM, resolve straight away
+    if (document.querySelector(selector)) {
+      resolve(document.querySelector(selector) as HTMLElement);
+    }
+
+    // Else, observe the DOM and return only when element has mounted.
+    const observer = new MutationObserver(() => {
+      if (document.querySelector(selector)) {
+        resolve(document.querySelector(selector) as HTMLElement);
+        observer.disconnect();
+      }
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+  });
+};


### PR DESCRIPTION
## Description

Relates to #3549 

This PR is for the `ExtensionDetails` page on mobile. On mobile, when you click on an extension to view its details/install it etc., the details page should adapt to the screen.

**Additions**

* Add utility function that waits for a given selector to become present in the DOM. (This is so when you click the "enable" button there's a smooth transition to the start of that section) 

**Changes** 🏗

* Adapt `ExtensionDetails` for mobile
* Adapt `ExtensionSetup` for mobile

Resolves #3557 

**_Extension details_**
![extn](https://user-images.githubusercontent.com/64402732/176497955-aca46e4b-89c3-46ae-90df-a9179f51a703.png)

**_Extension setup_**
![enable-extn](https://user-images.githubusercontent.com/64402732/176497980-4de19000-8564-425d-99a6-ec737442f06c.png)

