### PR TITLE
Fix: Network fee and Available funds positioning

### DIFF
--- a/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.css
+++ b/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.css
@@ -14,7 +14,7 @@
   flex-direction: column;
   align-items: flex-start;
   margin-top: 20px;
-  gap: 20px;
+  gap: 5px;
 }
 
 .tokenAmountUsd {
@@ -25,6 +25,7 @@
 }
 
 .domainPotBalance, .networkFee {
+  margin-top: -16px;
   font-size: var(--size-tiny);
   font-weight: var(--weight-bold);
   text-align: right;

--- a/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.css
+++ b/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.css
@@ -25,7 +25,8 @@
 }
 
 .domainPotBalance, .networkFee {
-  margin-top: -16px;
+  position: relative;
+  bottom: 14px;
   font-size: var(--size-tiny);
   font-weight: var(--weight-bold);
   text-align: right;

--- a/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
@@ -501,10 +501,9 @@ const CreatePaymentDialogForm = ({
               dataTest="paymentAmountInput"
             />
             {networkFeeInverse &&
+              customAmountError === undefined &&
               values.amount &&
-              values.amount !== '0' &&
-              values.amount !== '0.' &&
-              values.amount !== '.' && (
+              Number(values.amount) > 0 && (
                 <div className={styles.networkFee}>
                   <FormattedMessage
                     {...MSG.fee}


### PR DESCRIPTION
## Description

This PR fixes the "Network fee" and "Available Funds" margin/positioning under inputs.

**TODO:**

- The "Network fee" and "Available Funds" should be positioned correctly below their respective inputs, as per the design.
- The input error messages and the "Network fee" message do not need to be visible at the same time.
 
**Changes** 🏗

- Updated margin for `domainPotBalance` and `networkFee`.
<img width="489" alt="Screen Shot 2022-06-29 at 10 16 56 PM" src="https://user-images.githubusercontent.com/71563622/176539427-0a892bbd-e8df-4e9d-a6f8-1d928094baf2.png">

- Adjusted the `tokenAmountContainer` gap to match the above changes. Previously the gap was too big as well.
<img width="490" alt="Screen Shot 2022-06-29 at 10 17 49 PM" src="https://user-images.githubusercontent.com/71563622/176539966-8b91ccf0-887a-482f-836a-782e27df308c.png">

- The inputs error messages and the "Network fee" message do not need to be visible at the same time.

**Previously**
<img width="488" alt="Screen Shot 2022-06-29 at 3 49 52 PM" src="https://user-images.githubusercontent.com/71563622/176540374-b06e5a15-3dfb-41a3-ab14-a8a4e5209a52.png">

<img width="484" alt="Screen Shot 2022-06-29 at 4 57 52 PM" src="https://user-images.githubusercontent.com/71563622/176540400-faa987b7-019f-4992-bece-79f5a8ad79b7.png">

**After**
<img width="487" alt="Screen Shot 2022-06-29 at 10 18 17 PM" src="https://user-images.githubusercontent.com/71563622/176540530-98dd0d14-8cfd-4a7b-a00e-d6d129654b2c.png">

<img width="488" alt="Screen Shot 2022-06-29 at 10 40 50 PM" src="https://user-images.githubusercontent.com/71563622/176540656-67a40a17-6e25-4529-a757-b624d1fbbb06.png">


- Added new logic in the `createPaymentDialogForm` that better handles 0 or negative numbers. 


Resolves #3504