### PR TITLE
Fix: memory leak in `SubscribedColoniesList`

### DIFF
--- a/src/modules/dashboard/components/SubscribedColoniesList/SubscribedColoniesList.tsx
+++ b/src/modules/dashboard/components/SubscribedColoniesList/SubscribedColoniesList.tsx
@@ -7,7 +7,7 @@ import { SpinnerLoader } from '~core/Preloaders';
 import NavLink from '~core/NavLink';
 import HookedColonyAvatar from '~dashboard/HookedColonyAvatar';
 
-import { useLoggedInUser, useUserColoniesQuery } from '~data/index';
+import { LoggedInUser, useUserColoniesQuery } from '~data/index';
 import { CREATE_COLONY_ROUTE } from '~routes/index';
 import { checkIfNetworkIsAllowed } from '~utils/networks';
 
@@ -27,12 +27,15 @@ const ColonyAvatar = HookedColonyAvatar({ fetchColony: false });
 
 const displayName = 'dashboard.SubscribedColoniesList';
 
-interface ListProps {
+interface Props {
+  loggedInUser: Pick<
+    LoggedInUser,
+    'walletAddress' | 'networkId' | 'ethereal' | 'balance' | 'username'
+  >;
   path: string;
 }
-
-const SubscribedColoniesList = ({ path }: ListProps) => {
-  const { walletAddress, networkId, ethereal } = useLoggedInUser();
+const SubscribedColoniesList = ({ loggedInUser, path }: Props) => {
+  const { walletAddress, networkId, ethereal } = loggedInUser;
   const { data, loading } = useUserColoniesQuery({
     variables: { address: walletAddress },
   });

--- a/src/modules/pages/components/RouteLayouts/Default/Default.tsx
+++ b/src/modules/pages/components/RouteLayouts/Default/Default.tsx
@@ -4,6 +4,8 @@ import { useMediaQuery } from 'react-responsive';
 
 import { RouteComponentProps } from '~pages/RouteLayouts';
 import SubscribedColoniesList from '~dashboard/SubscribedColoniesList';
+import { useLoggedInUser } from '~data/helpers';
+
 import SimpleNav from '../SimpleNav';
 import HistoryNavigation from '../HistoryNavigation';
 import UserNavigation from '../UserNavigation';
@@ -35,11 +37,15 @@ const Default = ({
       ? location.state && location.state.hasBackLink
       : hasBackLink;
   const isMobile = useMediaQuery({ query });
+  const loggedInUser = useLoggedInUser();
 
   const SubscribedColonies = () =>
     hasSubscribedColonies ? (
       <div className={styles.coloniesList}>
-        <SubscribedColoniesList path={location.pathname} />
+        <SubscribedColoniesList
+          loggedInUser={loggedInUser}
+          path={location.pathname}
+        />
       </div>
     ) : null;
 

--- a/src/modules/pages/components/RouteLayouts/UserLayout/UserLayout.tsx
+++ b/src/modules/pages/components/RouteLayouts/UserLayout/UserLayout.tsx
@@ -11,6 +11,7 @@ import SimpleNav from '../SimpleNav';
 import { query700 as query } from '~styles/queries.css';
 import styles from './UserLayout.css';
 import navStyles from '../SimpleNav/SimpleNav.css';
+import { useLoggedInUser } from '~data/helpers';
 
 interface Props {
   routeProps?: RouteComponentProps;
@@ -22,7 +23,9 @@ const UserLayout = ({
   routeProps: { hasSubscribedColonies = true } = {},
 }: Props) => {
   const isMobile = useMediaQuery({ query });
+  const loggedInUser = useLoggedInUser();
   const { pathname } = useLocation();
+
   return (
     <SimpleNav>
       {isMobile && (
@@ -32,7 +35,10 @@ const UserLayout = ({
           </div>
           {hasSubscribedColonies && (
             <div className={styles.coloniesList}>
-              <SubscribedColoniesList path={pathname} />
+              <SubscribedColoniesList
+                path={pathname}
+                loggedInUser={loggedInUser}
+              />
             </div>
           )}
         </div>


### PR DESCRIPTION
## Description

This PR fixes a memory leak in the `feature/dapp-mobile-responsive` branch. Before, on loading the home page, a memory leak warning appeared in the console and this simple fix removes it.

**Changes** 🏗

* Move `useLoggedInUser` hook to parent component `Default`

## Screenshots

**_This is the error that should not be present in this branch_**

![image](https://user-images.githubusercontent.com/64402732/177729181-b589875b-1172-48b8-8e8d-1781e5395c56.png)

Resolves #3567 
