### PR TITLE
Fix: Changed the colonies list scroll to a fixed position

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyTitle/ColonyTitle.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyTitle/ColonyTitle.css
@@ -1,8 +1,7 @@
 .main {
   display: block;
-  margin: 0 -40px 50px;
+  margin: 0 -40px 50px 0px;
   padding-top: 15px;
-  text-align: right;
 }
 
 .wrapper {

--- a/src/modules/pages/components/RouteLayouts/Default/Default.css
+++ b/src/modules/pages/components/RouteLayouts/Default/Default.css
@@ -10,6 +10,7 @@
 .coloniesList {
   flex: 0 0 auto;
   width: 60px;
+  position: fixed;
   border-right: 1px solid var(--temp-grey-13);
 }
 


### PR DESCRIPTION
## Description

The colonies list (right side of screen) should be static no matter how many colonies you've subscribed to.

**Changes** 🏗

-  The colonies list was changed to a fixed position

![colony](https://user-images.githubusercontent.com/71563622/176757728-d9a285d3-b3c1-4187-bca5-b416f4a1c7f8.gif)


Resolves #3553