### PR TITLE
Add "Contract interaction" transaction variation

### DIFF
--- a/src/modules/core/components/Fields/Select/Select.tsx
+++ b/src/modules/core/components/Fields/Select/Select.tsx
@@ -255,11 +255,7 @@ const Select = ({
   }, [handleOutsideClick, isOpen]);
 
   const activeOptionDisplay = useMemo<ReactNode>(() => {
-    /*
-     * @NOTE If the active option is removed by something (ie: filtered out),
-     * fall back to the last entry in the options array
-     */
-    const activeOption = options[checkedOption] || options[options.length - 1];
+    const activeOption = options[checkedOption];
     let activeOptionLabel;
     if (activeOption) {
       if (typeof activeOption.label === 'object') {
@@ -273,7 +269,16 @@ const Select = ({
         activeOptionLabel = activeOption.label;
       }
     }
-    const activeOptionLabelText = activeOptionLabel || placeholder;
+
+    let placeholderText;
+    if (placeholder) {
+      if (typeof placeholder === 'string') {
+        placeholderText = placeholder;
+      } else {
+        placeholderText = formatMessage(placeholder);
+      }
+    }
+    const activeOptionLabelText = activeOptionLabel || placeholderText;
     if (renderActiveOption) {
       return renderActiveOption(activeOption, activeOptionLabelText);
     }

--- a/src/modules/core/components/Fields/Select/Select.tsx
+++ b/src/modules/core/components/Fields/Select/Select.tsx
@@ -111,7 +111,7 @@ const Select = ({
   itemDataTest,
 }: Props) => {
   const [id] = useState<string>(idProp || nanoid());
-  const [, { error, value }, { setValue }] = useField(name);
+  const [, { error, value, touched }, { setValue }] = useField(name);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const { formatMessage } = useIntl();
 
@@ -346,6 +346,7 @@ const Select = ({
           status={status}
           statusValues={statusValues}
           error={error}
+          touched={touched}
         />
       )}
     </div>

--- a/src/modules/core/components/Fields/Select/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/src/modules/core/components/Fields/Select/__tests__/__snapshots__/Select.test.tsx.snap
@@ -118,6 +118,7 @@ exports[`Select component Renders initial component 1`] = `
                   "theme": "minimal",
                 }
               }
+              touched={false}
             >
               <p
                 className=""

--- a/src/modules/core/components/Fields/Select/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/src/modules/core/components/Fields/Select/__tests__/__snapshots__/Select.test.tsx.snap
@@ -83,9 +83,7 @@ exports[`Select component Renders initial component 1`] = `
               >
                 <div>
                   <div>
-                    <span>
-                      Bar
-                    </span>
+                    <span />
                   </div>
                   <span>
                     <Icon

--- a/src/modules/core/components/Fields/Textarea/Textarea.tsx
+++ b/src/modules/core/components/Fields/Textarea/Textarea.tsx
@@ -82,7 +82,7 @@ const Textarea = ({
 }: Props) => {
   const { formatMessage } = useIntl();
   const [id] = useState(idProp || nanoid());
-  const [{ value, ...fieldInputProps }, { error }] = useField<string>({
+  const [{ value, ...fieldInputProps }, { error, touched }] = useField<string>({
     name,
     value: '',
   });
@@ -108,7 +108,7 @@ const Textarea = ({
       <div className={styles.textareaWrapper}>
         <textarea
           {...fieldInputProps}
-          aria-invalid={error ? true : undefined}
+          aria-invalid={touched && error ? true : undefined}
           className={getMainClasses(appearance, styles)}
           id={id}
           maxLength={maxLength}
@@ -135,6 +135,7 @@ const Textarea = ({
           status={status}
           statusValues={statusValues}
           error={error}
+          touched={touched}
         />
       )}
     </div>

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
@@ -99,6 +99,21 @@ const validationSchema = yup.object().shape({
     then: yup.string().required(),
     otherwise: false,
   }),
+  contract: yup.string().when('transactionType', {
+    is: (transactionType) => transactionType === 'contractInteraction',
+    then: yup.string().address().required(),
+    otherwise: false,
+  }),
+  abi: yup.string().when('transactionType', {
+    is: (transactionType) => transactionType === 'contractInteraction',
+    then: yup.string().required(),
+    otherwise: false,
+  }),
+  contractFunction: yup.string().when('transactionType', {
+    is: (transactionType) => transactionType === 'contractInteraction',
+    then: yup.string().required(),
+    otherwise: false,
+  }),
 });
 
 const GnosisControlSafeDialog = ({

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
@@ -74,6 +74,7 @@ const validationSchema = yup.object().shape({
       walletAddress: yup.string().when('transactionType', {
         is: (transactionType) => transactionType === 'transferFunds',
         then: yup.string().address().required(),
+        otherwise: false,
       }),
     }),
   }),
@@ -86,26 +87,32 @@ const validationSchema = yup.object().shape({
       .transform((value) => toFinite(value))
       .required()
       .moreThan(0, () => MSG.amountZero),
+    otherwise: false,
   }),
   tokenAddress: yup.string().when('transactionType', {
     is: (transactionType) => transactionType === 'transferFunds',
     then: yup.string().address().required(),
+    otherwise: false,
   }),
   data: yup.string().when('transactionType', {
     is: (transactionType) => transactionType === 'rawTransaction',
     then: yup.string().required(),
+    otherwise: false,
   }),
   contract: yup.string().when('transactionType', {
     is: (transactionType) => transactionType === 'contractInteraction',
     then: yup.string().address().required(),
+    otherwise: false,
   }),
   abi: yup.string().when('transactionType', {
     is: (transactionType) => transactionType === 'contractInteraction',
     then: yup.string().required(),
+    otherwise: false,
   }),
   contractFunction: yup.string().when('transactionType', {
     is: (transactionType) => transactionType === 'contractInteraction',
     then: yup.string().required(),
+    otherwise: false,
   }),
 });
 
@@ -121,10 +128,9 @@ const GnosisControlSafeDialog = ({
       initialValues={{
         safe: '',
         transactionType: '',
-        forceAction: false,
         tokenAddress: colony.nativeTokenAddress,
-        amount: 0,
-        recipient: '',
+        amount: undefined,
+        recipient: null,
         data: '',
         contract: '',
         abi: '',

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FormikProps } from 'formik';
 import * as yup from 'yup';
-import { toFinite } from 'lodash';
+import toFinite from 'lodash/toFinite';
 import { defineMessages } from 'react-intl';
 
 import Dialog, { DialogProps, ActionDialogProps } from '~core/Dialog';
@@ -74,7 +74,6 @@ const validationSchema = yup.object().shape({
       walletAddress: yup.string().when('transactionType', {
         is: (transactionType) => transactionType === 'transferFunds',
         then: yup.string().address().required(),
-        otherwise: false,
       }),
     }),
   }),
@@ -87,32 +86,26 @@ const validationSchema = yup.object().shape({
       .transform((value) => toFinite(value))
       .required()
       .moreThan(0, () => MSG.amountZero),
-    otherwise: false,
   }),
   tokenAddress: yup.string().when('transactionType', {
     is: (transactionType) => transactionType === 'transferFunds',
     then: yup.string().address().required(),
-    otherwise: false,
   }),
   data: yup.string().when('transactionType', {
     is: (transactionType) => transactionType === 'rawTransaction',
     then: yup.string().required(),
-    otherwise: false,
   }),
   contract: yup.string().when('transactionType', {
     is: (transactionType) => transactionType === 'contractInteraction',
     then: yup.string().address().required(),
-    otherwise: false,
   }),
   abi: yup.string().when('transactionType', {
     is: (transactionType) => transactionType === 'contractInteraction',
     then: yup.string().required(),
-    otherwise: false,
   }),
   contractFunction: yup.string().when('transactionType', {
     is: (transactionType) => transactionType === 'contractInteraction',
     then: yup.string().required(),
-    otherwise: false,
   }),
 });
 
@@ -132,6 +125,10 @@ const GnosisControlSafeDialog = ({
         tokenAddress: colony.nativeTokenAddress,
         amount: 0,
         recipient: '',
+        data: '',
+        contract: '',
+        abi: '',
+        contractFunction: '',
       }}
       validationSchema={validationSchema}
       submit={ActionTypes.COLONY_ACTION_GENERIC}

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
@@ -23,6 +23,7 @@ import { FormValues, transactionOptions } from './GnosisControlSafeDialog';
 import {
   TransferFundsSection,
   RawTransactionSection,
+  ContractInteractionSection,
 } from './TransactionTypesSection';
 
 import styles from './GnosisControlSafeForm.css';
@@ -175,6 +176,11 @@ const GnosisControlSafeForm = ({
       {values.transactionType === 'rawTransaction' && (
         <RawTransactionSection
           colony={colony}
+          disabledInput={!userHasPermission || isSubmitting}
+        />
+      )}
+      {values.transactionType === 'contractInteraction' && (
+        <ContractInteractionSection
           disabledInput={!userHasPermission || isSubmitting}
         />
       )}

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { defineMessages } from 'react-intl';
+
+import { AnyUser } from '~data/index';
+import { Address } from '~types/index';
+import { Select, Textarea } from '~core/Fields';
+import UserAvatar from '~core/UserAvatar';
+import SingleUserPicker, { filterUserSelection } from '~core/SingleUserPicker';
+import { DialogSection } from '~core/Dialog';
+
+import styles from './TransactionTypesSection.css';
+
+const MSG = defineMessages({
+  abiLabel: {
+    id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.ContractInteractionSection.abiLabel`,
+    defaultMessage: 'ABI/JSON',
+  },
+  functionLabel: {
+    id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.ContractInteractionSection.functionLabel`,
+    defaultMessage: 'Select function to interact with',
+  },
+  functionPlaceholder: {
+    id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.ContractInteractionSection.functionPlaceholder`,
+    defaultMessage: 'Select function',
+  },
+  contractLabel: {
+    id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.ContractInteractionSection.contractLabel`,
+    defaultMessage: 'Target contract address',
+  },
+  userPickerPlaceholder: {
+    id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.ContractInteractionSection.userPickerPlaceholder`,
+    defaultMessage: 'Select or paste a contract address',
+  },
+});
+
+const displayName = `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.ContractInteractionSection`;
+
+interface Props {
+  disabledInput: boolean;
+}
+
+const renderAvatar = (address: Address, item: AnyUser) => (
+  <UserAvatar address={address} user={item} size="xs" notSet={false} />
+);
+
+const ContractInteractionSection = ({ disabledInput }: Props) => {
+  return (
+    <>
+      <DialogSection>
+        <div className={styles.singleUserPickerContainer}>
+          {/* @TODO: Connect available contract data with picker */}
+          <SingleUserPicker
+            data={[]}
+            label={MSG.contractLabel}
+            name="contract"
+            filter={filterUserSelection}
+            renderAvatar={renderAvatar}
+            disabled={disabledInput}
+            placeholder={MSG.userPickerPlaceholder}
+          />
+        </div>
+      </DialogSection>
+      <DialogSection>
+        <Textarea
+          label={MSG.abiLabel}
+          name="abi"
+          appearance={{ colorSchema: 'grey', resizable: 'vertical' }}
+          disabled={disabledInput}
+        />
+      </DialogSection>
+      <DialogSection appearance={{ theme: 'sidePadding' }}>
+        <div className={styles.contractFunctionSelectorContainer}>
+          {/* @TODO: Connect available contract functions data with picker */}
+          <Select
+            label={MSG.functionLabel}
+            name="contractFunction"
+            appearance={{ theme: 'grey', width: 'fluid' }}
+            placeholder={MSG.functionPlaceholder}
+            disabled={disabledInput}
+          />
+        </div>
+      </DialogSection>
+    </>
+  );
+};
+
+ContractInteractionSection.displayName = displayName;
+
+export default ContractInteractionSection;

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css
@@ -14,7 +14,8 @@
   padding-left: 0;
 }
 
-.singleUserPickerContainer label {
+.singleUserPickerContainer label,
+.contractFunctionSelectorContainer label {
   color: var(--dark);
 }
 

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css.d.ts
@@ -1,2 +1,3 @@
 export const singleUserPickerContainer: string;
+export const contractFunctionSelectorContainer: string;
 export const labelDescription: string;

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/TransactionTypesSection/index.ts
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/TransactionTypesSection/index.ts
@@ -1,2 +1,3 @@
 export { default as TransferFundsSection } from './TransferFundsSection';
 export { default as RawTransactionSection } from './RawTransactionSection';
+export { default as ContractInteractionSection } from './ContractInteractionSection';


### PR DESCRIPTION
As an extra: 

- Fixed a bug in the `Select` core component that displayed the first option of the `options` array as the placeholder.
- Fixed the `Select` component crashing when the `placeholder` prop was a `MessageDescriptor`

![FireShot Capture 653 - Actions - Colony - wonker - localhost](https://user-images.githubusercontent.com/18473896/177423104-72fe9944-9bc7-41f5-b869-52785593df0a.png)


Resolves #3483 
