### PR TITLE
Add: My Profile screen (mobile) 

### DIFF
--- a/src/modules/pages/components/ProfileTemplate/ProfileTemplate.css
+++ b/src/modules/pages/components/ProfileTemplate/ProfileTemplate.css
@@ -1,5 +1,6 @@
 @value paddingHorizontal: 60px;
 @value sidebarWidth: 340px;
+@value query700 from '~styles/queries.css';
 
 .main {
   display: flex;
@@ -41,5 +42,38 @@
   & .mainContainer {
     border-left: 2px solid var(--grey-blue-0);
     background-color: transparent;
+  }
+}
+
+@media screen and query700 {
+  .main {
+    flex-direction: column;
+  }
+
+  .mainContainer {
+    background-color: transparent;
+  }
+
+  .sidebar {
+    justify-content: center;
+    padding: 40px 0;
+    height: auto;
+    width: 100%;
+  }
+
+  .sidebar > div > div {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .mainContent {
+    padding: 40px 30px;
+  }
+
+  .mainContent div:nth-child(2) {
+    justify-content: space-around;
+    row-gap: 10px;
   }
 }

--- a/src/modules/pages/components/ProfileTemplate/ProfileTemplate.css.d.ts
+++ b/src/modules/pages/components/ProfileTemplate/ProfileTemplate.css.d.ts
@@ -1,5 +1,6 @@
 export const paddingHorizontal: string;
 export const sidebarWidth: string;
+export const query700: string;
 export const main: string;
 export const sidebar: string;
 export const header: string;

--- a/src/modules/pages/components/RouteLayouts/UserLayout/UserLayout.css
+++ b/src/modules/pages/components/RouteLayouts/UserLayout/UserLayout.css
@@ -1,0 +1,7 @@
+.head {
+  composes: head from '../Default/Default.css';
+}
+
+.coloniesList {
+  composes: coloniesList from '../Default/Default.css';
+}

--- a/src/modules/pages/components/RouteLayouts/UserLayout/UserLayout.css.d.ts
+++ b/src/modules/pages/components/RouteLayouts/UserLayout/UserLayout.css.d.ts
@@ -1,0 +1,2 @@
+export const head: string;
+export const coloniesList: string;

--- a/src/modules/pages/components/RouteLayouts/UserLayout/UserLayout.tsx
+++ b/src/modules/pages/components/RouteLayouts/UserLayout/UserLayout.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { useMediaQuery } from 'react-responsive';
+import { useLocation } from 'react-router';
+
+import SubscribedColoniesList from '~dashboard/SubscribedColoniesList';
+
+import UserNavigation from '../UserNavigation';
+import SimpleNav from '../SimpleNav';
+
+import { query700 as query } from '~styles/queries.css';
+import styles from './UserLayout.css';
+import navStyles from '../SimpleNav/SimpleNav.css';
+
+interface Props {
+  hasSubscribedColonies: boolean;
+  children: React.ReactNode;
+}
+
+const UserLayout = ({ children, hasSubscribedColonies = true }: Props) => {
+  const isMobile = useMediaQuery({ query });
+  const { pathname } = useLocation();
+
+  return (
+    <SimpleNav>
+      {isMobile && (
+        <div className={styles.head}>
+          <div className={navStyles.nav}>
+            <UserNavigation />
+          </div>
+          {hasSubscribedColonies && (
+            <div className={styles.coloniesList}>
+              <SubscribedColoniesList path={pathname} />
+            </div>
+          )}
+        </div>
+      )}
+      {children}
+    </SimpleNav>
+  );
+};
+
+const displayName = 'pages.RouteLayouts.UserLayout';
+UserLayout.displayName = displayName;
+
+export default UserLayout;

--- a/src/modules/pages/components/RouteLayouts/UserLayout/UserLayout.tsx
+++ b/src/modules/pages/components/RouteLayouts/UserLayout/UserLayout.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useMediaQuery } from 'react-responsive';
 import { useLocation } from 'react-router';
 
+import { RouteComponentProps } from '~pages/RouteLayouts';
 import SubscribedColoniesList from '~dashboard/SubscribedColoniesList';
 
 import UserNavigation from '../UserNavigation';
@@ -12,14 +13,16 @@ import styles from './UserLayout.css';
 import navStyles from '../SimpleNav/SimpleNav.css';
 
 interface Props {
-  hasSubscribedColonies: boolean;
+  routeProps?: RouteComponentProps;
   children: React.ReactNode;
 }
 
-const UserLayout = ({ children, hasSubscribedColonies = true }: Props) => {
+const UserLayout = ({
+  children,
+  routeProps: { hasSubscribedColonies = true } = {},
+}: Props) => {
   const isMobile = useMediaQuery({ query });
   const { pathname } = useLocation();
-
   return (
     <SimpleNav>
       {isMobile && (

--- a/src/modules/users/components/AvatarDropdown/AvatarDropdown.tsx
+++ b/src/modules/users/components/AvatarDropdown/AvatarDropdown.tsx
@@ -68,7 +68,8 @@ const AvatarDropdown = ({
   const popoverContent = isMobile
     ? () =>
         username &&
-        walletAddress && (
+        walletAddress &&
+        colony && (
           <AvatarDropdownPopoverMobile
             {...{
               walletAddress,

--- a/src/modules/users/components/HamburgerDropdown/HamburgerDropdownPopover.tsx
+++ b/src/modules/users/components/HamburgerDropdown/HamburgerDropdownPopover.tsx
@@ -60,7 +60,7 @@ const HamburgerDropdownPopover = ({
       <DropdownMenu onClick={closePopover}>
         {!onlyLogout && (
           <>
-            {username && (
+            {username && colonyName && (
               <DropdownMenuSection>
                 <DropdownMenuItem>
                   <NavLink to={colonyHomePath} text={MSG.actions} exact />

--- a/src/modules/users/components/UserProfile/UserMeta.tsx
+++ b/src/modules/users/components/UserProfile/UserMeta.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { defineMessages } from 'react-intl';
+import { useMediaQuery } from 'react-responsive';
 
 import { AnyUser, useLoggedInUser } from '~data/index';
 
@@ -12,6 +13,7 @@ import UserMention from '~core/UserMention';
 import HookedUserAvatar from '~users/HookedUserAvatar';
 import { stripProtocol } from '~utils/strings';
 
+import { query700 as query } from '~styles/queries.css';
 import styles from './UserMeta.css';
 
 const MSG = defineMessages({
@@ -36,13 +38,14 @@ const UserMeta = ({
   user,
 }: Props) => {
   const { walletAddress: currentUserWalletAddress } = useLoggedInUser();
+  const isMobile = useMediaQuery({ query });
   return (
     <div className={styles.main}>
       <div data-test="userProfileAvatar">
         <UserAvatar
           className={styles.avatar}
           address={walletAddress}
-          size="xl"
+          size={isMobile ? 'm' : 'xl'}
           user={user}
           notSet={false}
         />

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -54,6 +54,7 @@ import AlwaysAccesibleRoute from './AlwaysAccesibleRoute';
 import WalletRequiredRoute from './WalletRequiredRoute';
 import { useTitle } from '~utils/hooks/useTitle';
 import { query700 as query } from '~styles/queries.css';
+import UserLayout from '~pages/RouteLayouts/UserLayout/UserLayout';
 
 const MSG = defineMessages({
   userProfileEditBack: {
@@ -189,9 +190,10 @@ const Routes = () => {
         <AlwaysAccesibleRoute
           path={USER_ROUTE}
           component={UserProfile}
-          layout={SimpleNav}
+          layout={UserLayout}
           routeProps={{
             hasBackLink: false,
+            hasSubscribedColonies: isMobile,
           }}
         />
         <AlwaysAccesibleRoute


### PR DESCRIPTION
## Description

This PR covers making the "My Profile" screen mobile responsive. There's no figma design but it should follow the same pattern as the others (link can be found in the project's To-Do column). 

I've hidden the colony actions in the menu when on this screen, given that colony actions refer to a specific colony and this page doesn't. Same for the user avatar dropdown, which as also been disactivated.

**New stuff** ✨

* `UserLayout` component for the `user` route to handle the mobile logic instead of cluttering `SimpleNav`

**Changes** 🏗

* Made `UserMeta` avatar size medium on mobile. 
*  `ProfileTemplate` mobile styles
* `HamburgerDropdown`: don't show colony-specific menu options
* `AvatarDropdownMobile`: don't show on this page (because it's also colony specific)

## Screenshots

**_My profile page_**
![my-profile](https://user-images.githubusercontent.com/64402732/177149900-12f00c87-2f87-408f-8170-7781ebcaf269.png)

**_My profile menu (without Colony Actions)_**
![my-profile-menu](https://user-images.githubusercontent.com/64402732/177149911-a13087e5-6e3c-4795-a105-ac2acb1fc2b9.png)

Resolves #3509 
