### PR TITLE
Add:  `/create-user` mobile styles

### DIFF
--- a/src/modules/pages/components/WizardTemplateColony/WizardTemplateColony.css
+++ b/src/modules/pages/components/WizardTemplateColony/WizardTemplateColony.css
@@ -1,3 +1,5 @@
+@value query700 from '~styles/queries.css';
+
 .layoutMain {
   composes: stretchVertical stretchHorizontal from '~styles/layout.css';
   overflow: auto;
@@ -75,4 +77,17 @@
 
 .copy {
   margin-left: 8px;
+}
+
+@media screen and query700 {
+  .content section {
+    padding-left: 14px;
+    padding-right: 14px;
+    width: 100%;
+    max-width: 500px;
+  }
+
+  .content section h3 {
+    white-space: normal;
+  }
 }

--- a/src/modules/pages/components/WizardTemplateColony/WizardTemplateColony.css.d.ts
+++ b/src/modules/pages/components/WizardTemplateColony/WizardTemplateColony.css.d.ts
@@ -1,3 +1,4 @@
+export const query700: string;
 export const layoutMain: string;
 export const header: string;
 export const steps: string;


### PR DESCRIPTION
## Description

This PR tracks the work required to make the `/create-user` route mobile responsive. A short one. 

**Changes** 🏗

* `WizardTemplateColony`: adding mobile styles

## Screenshot

**_Create user screen 1_**

![create-user](https://user-images.githubusercontent.com/64402732/177327872-50c5aaef-4ebe-45d8-8874-c8a52aa0083b.png)

**_Screen 2 (the metmask fox does show up here too, but he's too quick for me)_**

![create-user-1](https://user-images.githubusercontent.com/64402732/177327887-b1b649f9-e428-4b5c-a8d1-3c281e891e68.png)

Resolves  #3512 
