### PR TITLE
Add delay to `GasStationPopover`

### DIFF
--- a/src/modules/core/components/Popover/Popover.tsx
+++ b/src/modules/core/components/Popover/Popover.tsx
@@ -134,15 +134,19 @@ const Popover = ({
     [onClose],
   );
 
-  const requestOpen = useCallback(() => {
-    if (isOpen) {
-      return;
-    }
+  useEffect(() => {
     if (closeAfterDelay) {
       closeTimeoutRef.current = setTimeout(() => {
         close();
       }, 3000 + (openDelay || 0));
     }
+  }, [close, openDelay, closeAfterDelay]);
+
+  const requestOpen = useCallback(() => {
+    if (isOpen) {
+      return;
+    }
+
     if (openDelay) {
       openTimeoutRef.current = setTimeout(() => {
         _setIsOpen(true);
@@ -150,7 +154,7 @@ const Popover = ({
       return;
     }
     _setIsOpen(true);
-  }, [isOpen, openDelay, closeAfterDelay]);
+  }, [isOpen, openDelay]);
 
   const handleWrapperFocus = useCallback(() => {
     if (retainRefFocus && referenceElement instanceof HTMLInputElement) {

--- a/src/modules/core/components/Popover/Popover.tsx
+++ b/src/modules/core/components/Popover/Popover.tsx
@@ -150,7 +150,7 @@ const Popover = ({
       return;
     }
     _setIsOpen(true);
-  }, [close, isOpen, openDelay, closeAfterDelay]);
+  }, [isOpen, openDelay, closeAfterDelay]);
 
   const handleWrapperFocus = useCallback(() => {
     if (retainRefFocus && referenceElement instanceof HTMLInputElement) {
@@ -260,20 +260,6 @@ const Popover = ({
       _setIsOpen(!!isOpenProp);
     }
   }, [close, isOpen, isOpenProp, lastIsOpenProp, requestOpen]);
-
-  // Timeouts
-  useEffect(() => {
-    const currentOpenTimeoutRef = openTimeoutRef && openTimeoutRef.current;
-    const currentCloseTimeoutRef = closeTimeoutRef && closeTimeoutRef.current;
-    return () => {
-      if (currentOpenTimeoutRef) {
-        clearTimeout(currentOpenTimeoutRef);
-      }
-      if (currentCloseTimeoutRef) {
-        clearTimeout(currentCloseTimeoutRef);
-      }
-    };
-  }, []);
 
   return (
     <>

--- a/src/modules/core/components/Popover/Popover.tsx
+++ b/src/modules/core/components/Popover/Popover.tsx
@@ -104,8 +104,8 @@ const Popover = ({
   const [popperElement, setPopperElement] = useState<HTMLElement | null>(null);
   const [arrowElement, setArrowElement] = useState<HTMLElement | null>(null);
 
-  const openTimeoutRef = useRef<number>();
-  const closeTimeoutRef = useRef<number>();
+  const openTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
   const { current: elementId } = useRef<string>(nanoid());
 
   const { attributes, styles, state } = usePopper(
@@ -122,9 +122,11 @@ const Popover = ({
 
   const close = useCallback(
     (data?: any, modifiers?: { cancelled: boolean }) => {
-      if (window) {
-        window.clearTimeout(openTimeoutRef.current);
-        window.clearTimeout(closeTimeoutRef.current);
+      if (openTimeoutRef.current) {
+        clearTimeout(openTimeoutRef.current);
+      }
+      if (closeTimeoutRef.current) {
+        clearTimeout(closeTimeoutRef.current);
       }
       _setIsOpen(false);
       if (typeof onClose == 'function') onClose(data, modifiers);
@@ -136,13 +138,13 @@ const Popover = ({
     if (isOpen) {
       return;
     }
-    if (closeAfterDelay && window) {
-      closeTimeoutRef.current = window.setTimeout(() => {
+    if (closeAfterDelay) {
+      closeTimeoutRef.current = setTimeout(() => {
         close();
       }, 3000 + (openDelay || 0));
     }
-    if (openDelay && window) {
-      openTimeoutRef.current = window.setTimeout(() => {
+    if (openDelay) {
+      openTimeoutRef.current = setTimeout(() => {
         _setIsOpen(true);
       }, openDelay);
       return;
@@ -264,11 +266,11 @@ const Popover = ({
     const currentOpenTimeoutRef = openTimeoutRef && openTimeoutRef.current;
     const currentCloseTimeoutRef = closeTimeoutRef && closeTimeoutRef.current;
     return () => {
-      if (window && currentOpenTimeoutRef) {
-        window.clearTimeout(currentOpenTimeoutRef);
+      if (currentOpenTimeoutRef) {
+        clearTimeout(currentOpenTimeoutRef);
       }
-      if (window && currentCloseTimeoutRef) {
-        window.clearTimeout(currentCloseTimeoutRef);
+      if (currentCloseTimeoutRef) {
+        clearTimeout(currentCloseTimeoutRef);
       }
     };
   }, []);

--- a/src/modules/core/components/Popover/Popover.tsx
+++ b/src/modules/core/components/Popover/Popover.tsx
@@ -129,7 +129,7 @@ const Popover = ({
       _setIsOpen(false);
       if (typeof onClose == 'function') onClose(data, modifiers);
     },
-    [isOpen, onClose],
+    [onClose],
   );
 
   const requestOpen = useCallback(() => {

--- a/src/modules/core/components/Popover/Popover.tsx
+++ b/src/modules/core/components/Popover/Popover.tsx
@@ -54,6 +54,8 @@ interface Props {
   onClose?: (data?: any, modifiers?: { cancelled: boolean }) => void;
   /** Delay opening of popover for `openDelay` ms */
   openDelay?: number;
+  /** Delay closing of popover for `closeDelay` ms */
+  closeDelay?: number;
   /** Should close popover after delay */
   closeAfterDelay?: boolean;
   /** Popover placement */
@@ -89,6 +91,7 @@ const Popover = ({
   isOpen: isOpenProp = false,
   onClose,
   openDelay,
+  closeDelay,
   closeAfterDelay,
   placement: placementProp = 'auto',
   popperOptions = {},
@@ -97,7 +100,7 @@ const Popover = ({
   trigger = 'click',
 }: Props) => {
   // Use dangle to encourage use of callbackFn for setting state
-  const [isOpen, _setIsOpen] = useState<boolean>(isOpenProp);
+  const [isOpen, setIsOpen] = useState<boolean>(isOpenProp);
   const [referenceElement, setReferenceElement] = useState<Element | null>(
     null,
   );
@@ -128,8 +131,10 @@ const Popover = ({
       if (closeTimeoutRef.current) {
         clearTimeout(closeTimeoutRef.current);
       }
-      _setIsOpen(false);
-      if (typeof onClose == 'function') onClose(data, modifiers);
+      setIsOpen(false);
+      if (typeof onClose == 'function') {
+        onClose(data, modifiers);
+      }
     },
     [onClose],
   );
@@ -138,9 +143,9 @@ const Popover = ({
     if (closeAfterDelay) {
       closeTimeoutRef.current = setTimeout(() => {
         close();
-      }, 3000 + (openDelay || 0));
+      }, (closeDelay || 0) + (openDelay || 0));
     }
-  }, [close, openDelay, closeAfterDelay]);
+  }, [close, openDelay, closeDelay, closeAfterDelay]);
 
   const requestOpen = useCallback(() => {
     if (isOpen) {
@@ -149,11 +154,11 @@ const Popover = ({
 
     if (openDelay) {
       openTimeoutRef.current = setTimeout(() => {
-        _setIsOpen(true);
+        setIsOpen(true);
       }, openDelay);
       return;
     }
-    _setIsOpen(true);
+    setIsOpen(true);
   }, [isOpen, openDelay]);
 
   const handleWrapperFocus = useCallback(() => {
@@ -261,7 +266,7 @@ const Popover = ({
       } else {
         close();
       }
-      _setIsOpen(!!isOpenProp);
+      setIsOpen(!!isOpenProp);
     }
   }, [close, isOpen, isOpenProp, lastIsOpenProp, requestOpen]);
 

--- a/src/modules/users/components/GasStation/GasStationPopover.tsx
+++ b/src/modules/users/components/GasStation/GasStationPopover.tsx
@@ -26,6 +26,7 @@ const GasStationPopover = ({
   transactionAndMessageGroups,
 }: Props) => {
   const [isOpen, setOpen] = useState(false);
+  const [useCloseDelay, setUseCloseDelay] = useState(false);
   const [txNeedsSigning, setTxNeedsSigning] = useState(false);
   const txCount = useMemo(() => transactionCount(transactionAndMessageGroups), [
     transactionAndMessageGroups,
@@ -37,8 +38,9 @@ const GasStationPopover = ({
     if (prevTxCount != null && txCount > prevTxCount) {
       setOpen(true);
       setTxNeedsSigning(true);
+      setUseCloseDelay(true);
     }
-  }, [txCount, prevTxCount, setTxNeedsSigning]);
+  }, [txCount, prevTxCount, setTxNeedsSigning, useCloseDelay]);
 
   /*
    * @NOTE Offset Calculations
@@ -71,10 +73,11 @@ const GasStationPopover = ({
       placement="bottom-end"
       showArrow={false}
       isOpen={isOpen}
-      closeDelay={4000}
+      closeAfterDelay={useCloseDelay}
       onClose={() => {
         setOpen(false);
         setTxNeedsSigning(false);
+        setUseCloseDelay(false);
       }}
       popperOptions={{
         modifiers: [

--- a/src/modules/users/components/GasStation/GasStationPopover.tsx
+++ b/src/modules/users/components/GasStation/GasStationPopover.tsx
@@ -95,6 +95,7 @@ const GasStationPopover = ({
       placement="bottom-end"
       showArrow={false}
       isOpen={isOpen}
+      closeDelay={3000}
       closeAfterDelay={useCloseDelay}
       onClose={() => {
         setOpen(false);

--- a/src/modules/users/components/GasStation/GasStationPopover.tsx
+++ b/src/modules/users/components/GasStation/GasStationPopover.tsx
@@ -30,7 +30,7 @@ const GasStationPopover = ({
   transactionAndMessageGroups,
 }: Props) => {
   const [isOpen, setOpen] = useState(false);
-  const [useCloseDelay, setUseCloseDelay] = useState(false);
+  const [hasCloseDelay, setHasCloseDelay] = useState(false);
   const [txNeedsSigning, setTxNeedsSigning] = useState(false);
   const [groupStatus, setGroupStatus] = useState(TRANSACTION_STATUSES.READY);
 
@@ -58,9 +58,9 @@ const GasStationPopover = ({
 
   useEffect(() => {
     if (groupStatus === TRANSACTION_STATUSES.SUCCEEDED) {
-      setUseCloseDelay(true);
+      setHasCloseDelay(true);
     } else {
-      setUseCloseDelay(false);
+      setHasCloseDelay(false);
     }
   }, [groupStatus]);
 
@@ -96,11 +96,11 @@ const GasStationPopover = ({
       showArrow={false}
       isOpen={isOpen}
       closeDelay={3000}
-      closeAfterDelay={useCloseDelay}
+      closeAfterDelay={hasCloseDelay}
       onClose={() => {
         setOpen(false);
         setTxNeedsSigning(false);
-        setUseCloseDelay(false);
+        setHasCloseDelay(false);
       }}
       popperOptions={{
         modifiers: [

--- a/src/modules/users/components/GasStation/GasStationPopover.tsx
+++ b/src/modules/users/components/GasStation/GasStationPopover.tsx
@@ -71,6 +71,7 @@ const GasStationPopover = ({
       placement="bottom-end"
       showArrow={false}
       isOpen={isOpen}
+      closeDelay={4000}
       onClose={() => {
         setOpen(false);
         setTxNeedsSigning(false);

--- a/src/modules/users/components/GasStation/GasStationPopover.tsx
+++ b/src/modules/users/components/GasStation/GasStationPopover.tsx
@@ -9,7 +9,11 @@ import { removeValueUnits } from '~utils/css';
 import {
   TransactionOrMessageGroups,
   transactionCount,
+  findNewestGroup,
+  getGroupStatus,
 } from './transactionGroup';
+
+import { TRANSACTION_STATUSES } from '~immutable/index';
 
 import GasStationContent from './GasStationContent';
 
@@ -28,9 +32,20 @@ const GasStationPopover = ({
   const [isOpen, setOpen] = useState(false);
   const [useCloseDelay, setUseCloseDelay] = useState(false);
   const [txNeedsSigning, setTxNeedsSigning] = useState(false);
+  const [groupStatus, setGroupStatus] = useState(TRANSACTION_STATUSES.READY);
+
   const txCount = useMemo(() => transactionCount(transactionAndMessageGroups), [
     transactionAndMessageGroups,
   ]);
+
+  useEffect(() => {
+    if (transactionAndMessageGroups.length > 0) {
+      setGroupStatus(
+        getGroupStatus(findNewestGroup(transactionAndMessageGroups)),
+      );
+    }
+  }, [transactionAndMessageGroups]);
+
   const prevTxCount: number | void = usePrevious(txCount);
   const isMobile = useMediaQuery({ query });
 
@@ -38,9 +53,16 @@ const GasStationPopover = ({
     if (prevTxCount != null && txCount > prevTxCount) {
       setOpen(true);
       setTxNeedsSigning(true);
-      setUseCloseDelay(true);
     }
-  }, [txCount, prevTxCount, setTxNeedsSigning, useCloseDelay]);
+  }, [txCount, prevTxCount, setTxNeedsSigning]);
+
+  useEffect(() => {
+    if (groupStatus === TRANSACTION_STATUSES.SUCCEEDED) {
+      setUseCloseDelay(true);
+    } else {
+      setUseCloseDelay(false);
+    }
+  }, [groupStatus]);
 
   /*
    * @NOTE Offset Calculations


### PR DESCRIPTION
## Description

This PR uses setTimeout to close the GasStationPopover after a delay only when the GasStationPopover is opened automatically.

To test, this make sure the GasStationPopover closes after a 3 sec delay when opened automatically. The GasStationPopover should remain open when opened from the wallet. 

**Changes** 🏗
`closeAfterDelay` - Created a new prop to tell the popover to close after a 3 sec delay.


**To Test**
- Please make sure you test transactions with MetaMask.

## TODO

- [x]  Add a prop to close the popover after a delay.

Resolves #3505