### PR TITLE
Add: Connect wallet mobile styles

### DIFF
--- a/src/modules/core/components/DecisionHub/DecisionOption.css
+++ b/src/modules/core/components/DecisionHub/DecisionOption.css
@@ -1,3 +1,4 @@
+@value query700 from '~styles/queries.css';
 
 .main {
   display: flex;
@@ -42,4 +43,10 @@
 
 .tooltip {
   max-width: 270px;
+}
+
+@media screen and query700 {
+  .main {
+    height: auto;
+  }
 }

--- a/src/modules/core/components/DecisionHub/DecisionOption.css.d.ts
+++ b/src/modules/core/components/DecisionHub/DecisionOption.css.d.ts
@@ -1,3 +1,4 @@
+export const query700: string;
 export const main: string;
 export const themeAlt: string;
 export const stateDisabled: string;

--- a/src/modules/pages/components/RouteLayouts/UserNavigation.css
+++ b/src/modules/pages/components/RouteLayouts/UserNavigation.css
@@ -213,6 +213,14 @@
     width: 120px;
   }
 
+  .connectWalletButton + div[role="tooltip"] {
+    display: flex;
+    justify-content: center;
+    width: 100vw;
+    background-color: transparent;
+    box-shadow: none;
+  }
+
   .gasStationReference + div {
     display: flex;
     justify-content: center;

--- a/src/modules/pages/components/WizardTemplate/WizardTemplate.css
+++ b/src/modules/pages/components/WizardTemplate/WizardTemplate.css
@@ -1,3 +1,5 @@
+@value query700 from '~styles/queries.css';
+
 .layoutMain {
   composes: stretchVertical stretchHorizontal from '~styles/layout.css';
   overflow: auto;
@@ -30,4 +32,22 @@
 
 .stepBarContainer {
   padding-right: 20px;
+}
+
+@media screen and query700 {
+  .content {
+    padding-bottom: 60px;
+  }
+
+  .content main {
+    padding: 0 14px;
+  }
+
+  .content main > div:first-child {
+    margin-top: 30px;
+  }
+
+  .content main > div:first-child h3 {
+    text-align: left;
+  }
 }

--- a/src/modules/pages/components/WizardTemplate/WizardTemplate.css.d.ts
+++ b/src/modules/pages/components/WizardTemplate/WizardTemplate.css.d.ts
@@ -1,3 +1,4 @@
+export const query700: string;
 export const layoutMain: string;
 export const header: string;
 export const logo: string;

--- a/src/modules/users/components/ConnectWalletWizard/ConnectWalletPopover/ConnectWalletPopover.tsx
+++ b/src/modules/users/components/ConnectWalletWizard/ConnectWalletPopover/ConnectWalletPopover.tsx
@@ -36,7 +36,7 @@ const ConnectWalletPopover = ({ children }: Props) => {
   const popoverOffset = useMemo(() => {
     const skid =
       removeValueUnits(refWidth) + removeValueUnits(horizontalOffset);
-    return isMobile ? [-33, 15] : [-1 * skid, removeValueUnits(verticalOffset)];
+    return isMobile ? [-28, 15] : [-1 * skid, removeValueUnits(verticalOffset)];
   }, [isMobile]);
 
   return (

--- a/src/modules/users/components/ConnectWalletWizard/ConnectWalletPopover/WalletPopoverTemplate.css
+++ b/src/modules/users/components/ConnectWalletWizard/ConnectWalletPopover/WalletPopoverTemplate.css
@@ -9,7 +9,10 @@
 @media screen and query700 {
   .main {
     padding: 30px 25px;
-    width: calc(100vw - 28px);
+    width: calc(100% - 28px);
+    border-radius: 4px;
+    background-color: var(--grey-blue-2);
+    box-shadow: 0px 2px 11px 0px var(--drop-shadow);
   }
 
   .main button {

--- a/src/modules/users/components/ConnectWalletWizard/StepGanache/StepGanache.css
+++ b/src/modules/users/components/ConnectWalletWizard/StepGanache/StepGanache.css
@@ -1,3 +1,5 @@
+@value query700 from '~styles/queries.css';
+
 .content {
   composes: alignCenter from '~styles/text.css';
   composes: marginBottomMedium from '~styles/layout.css';
@@ -17,4 +19,42 @@
 .contentSimplified {
   composes: content;
   margin-top: 30px;
+}
+
+@media screen and query700 {
+  .content, .contentSimplified {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .contentSimplified {
+    padding: 20px 14px;
+  }
+
+  .iconContainer {
+    margin-bottom: 10px;
+  }
+
+  .contentSimplified ul,
+  .content ul {
+    width: 100%;
+  }
+
+  .contentSimplified ul span,
+  .content ul span {
+    width: 100%;
+  }
+
+  .contentSimplified li,
+  .content li {
+    padding-left: 8px;
+    padding-right: 8px;
+  }
+
+  .contentSimplified > div:last-child button span,
+  .content > div:last-child button span {
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
 }

--- a/src/modules/users/components/ConnectWalletWizard/StepGanache/StepGanache.css.d.ts
+++ b/src/modules/users/components/ConnectWalletWizard/StepGanache/StepGanache.css.d.ts
@@ -1,3 +1,4 @@
+export const query700: string;
 export const content: string;
 export const actions: string;
 export const iconContainer: string;

--- a/src/modules/users/components/ConnectWalletWizard/StepStart/StepStart.css
+++ b/src/modules/users/components/ConnectWalletWizard/StepStart/StepStart.css
@@ -52,6 +52,7 @@
 @media screen and query700 {
   .content {
     width: 100%;
+    max-width: 340px;
   }
 
   .title {


### PR DESCRIPTION
## Description

This PR tracks the work for the making the '/connect' route mobile responsive. It also improves the mobile styling for `ConnectWalletPopover`, which shares the `StepGanache` component with the '/connect' route.

**Changes** 🏗

* `WizardTemplate`: adding mobile stlyes
* `ConnectWalletPopover`: adjusting mobile alignment
* `StepGanache`: adding mobile styles
* `StepStart`: adding max-width on mobile to keep it tidy at larger widths

## Screenshot

**_/connect: step 1_**

![connect-1](https://user-images.githubusercontent.com/64402732/177358328-03289c42-735e-458a-ad35-c0d58ca224ea.png)

**_/connect: step 2 (ganache)_**

![dropdown-connect](https://user-images.githubusercontent.com/64402732/177358345-7e69ae87-4cbb-4c20-bd1c-060d00b8d6b6.png)

**_/connect: step 2 (meta-mask)_**

![meta-mask-connect](https://user-images.githubusercontent.com/64402732/177358306-0fff30a5-ed8f-4e27-ae0b-48397400d32c.png)

**_Popover: step 1_**

![wallet-popover-2](https://user-images.githubusercontent.com/64402732/177360260-0a1da032-cbc9-462f-bc70-9003c219f2b0.png)

**_Popover: step 2_ (ganache)**

![popover-dropdown](https://user-images.githubusercontent.com/64402732/177360296-0372939d-97f0-40b5-8bfe-0c6aaf1a9664.png)

**_Popover: step 2 (mm)_**

![mm-wallet-popover](https://user-images.githubusercontent.com/64402732/177360903-27411034-6a6d-48d3-9afa-10da1d8b585f.png)

Resolves to #3577
