### PR TITLE
Add: `/create-colony` mobile styles

### DIFF
--- a/src/modules/core/components/DecisionHub/DecisionHub.tsx
+++ b/src/modules/core/components/DecisionHub/DecisionHub.tsx
@@ -9,15 +9,23 @@ interface Props {
   options: DecisionOptionType[];
   /** Html input `name` attribute */
   name: string;
+  isMobile?: boolean;
 }
 
-const DecisionHub = ({ options, name }: Props) => (
-  <div data-test="hubOptions">
-    {options.map((option) => (
-      <DecisionOption name={name} option={option} key={`row-${option.value}`} />
-    ))}
-  </div>
-);
+const DecisionHub = ({ options, name, isMobile = false }: Props) => {
+  return (
+    <div data-test="hubOptions">
+      {options.map((option) => (
+        <DecisionOption
+          name={name}
+          option={option}
+          key={`row-${option.value}`}
+          isMobile={isMobile}
+        />
+      ))}
+    </div>
+  );
+};
 
 DecisionHub.displayName = displayName;
 

--- a/src/modules/core/components/DecisionHub/DecisionOption.css
+++ b/src/modules/core/components/DecisionHub/DecisionOption.css
@@ -11,14 +11,14 @@
   background: none;
   text-align: left;
   cursor: pointer;
+}
 
-  &:only-of-type {
-    border-bottom-color: transparent;
-  }
+.wrapper:only-of-type {
+  border-bottom-color: transparent;
+}
 
-  &:last-of-type:not(.themeAlt) {
-    border-bottom: 1px solid var(--grey-blue-0);
-  }
+.wrapper:last-of-type:not(.themeAlt) {
+  border-bottom: 1px solid var(--grey-blue-0);
 }
 
 .stateDisabled {
@@ -48,5 +48,25 @@
 @media screen and query700 {
   .main {
     height: auto;
+    border: none;
+
+    &:last-of-type:not(.themeAlt) {
+      border-bottom: 0px;
+    }
+  }
+
+  .wrapper {
+    display: flex;
+    align-items: center;
+    border: none;
+    border-top: 1px solid var(--grey-blue-0);
+
+    &:only-of-type {
+      border-bottom-color: transparent;
+    }
+
+    &:last-of-type:not(.themeAlt) {
+      border-bottom: 1px solid var(--grey-blue-0);
+    }
   }
 }

--- a/src/modules/core/components/DecisionHub/DecisionOption.css.d.ts
+++ b/src/modules/core/components/DecisionHub/DecisionOption.css.d.ts
@@ -1,5 +1,6 @@
 export const query700: string;
 export const main: string;
+export const wrapper: string;
 export const themeAlt: string;
 export const stateDisabled: string;
 export const rowContent: string;

--- a/src/modules/core/components/DecisionHub/DecisionOption.tsx
+++ b/src/modules/core/components/DecisionHub/DecisionOption.tsx
@@ -5,13 +5,14 @@ import {
   FormattedMessage,
 } from 'react-intl';
 import { useField } from 'formik';
-
 import { LinkProps } from 'react-router-dom';
+
 import { getMainClasses } from '~utils/css';
 import Icon from '../Icon';
 import Link from '../Link';
 import { Tooltip } from '../Popover';
 import Heading from '../Heading';
+
 import styles from './DecisionOption.css';
 
 const MSG = defineMessages({
@@ -40,22 +41,46 @@ interface Props {
   option: DecisionOptionType;
   link?: string;
   name: string;
+  isMobile?: boolean;
 }
+
+type IconProps = Props['option'] & {
+  isMobile?: boolean;
+};
 
 const displayName = 'DecisionOption';
 
-const DecisionOptionIcon = ({ icon, tooltip, title }: Props['option']) => {
+const DecisionOptionIcon = ({
+  icon,
+  tooltip,
+  title,
+  isMobile = false,
+}: IconProps) => {
+  const popperOptions = isMobile
+    ? {
+        modifiers: [
+          {
+            name: 'offset',
+            options: {
+              offset: [118, 0],
+            },
+          },
+        ],
+      }
+    : undefined;
+
   if (icon) {
     // Wrap the icon in a Tooltip wrapper only if the tooltip property exists
     return tooltip ? (
       <Tooltip
-        placement="left"
-        trigger="hover"
+        placement={isMobile ? 'bottom' : 'left'}
+        trigger={isMobile ? 'click' : 'hover'}
         content={
           <span className={styles.tooltip}>
             <FormattedMessage {...tooltip} />
           </span>
         }
+        popperOptions={popperOptions}
       >
         <div className={styles.rowIcon}>
           <Icon name={icon} title={title} appearance={{ size: 'small' }} />
@@ -76,6 +101,7 @@ const DecisionOption = ({
   option: { title, subtitle, disabled, value },
   option,
   link,
+  isMobile = false,
 }: Props) => {
   const [, , { setValue }] = useField(name);
   const makeDecision = useCallback(() => {
@@ -92,24 +118,27 @@ const DecisionOption = ({
       } as ButtonHTMLAttributes<HTMLButtonElement>);
 
   return (
-    <Element
-      className={getMainClasses(appearance, styles, { disabled: !!disabled })}
-      {...(elmProps as any)}
-      data-test={option.dataTest}
-    >
-      <DecisionOptionIcon {...option} />
-      <div className={styles.rowContent}>
-        <Heading
-          appearance={{ size: 'small', weight: 'bold', margin: 'small' }}
-          text={title}
-        />
-        <Heading
-          appearance={{ size: 'tiny', weight: 'thin', margin: 'small' }}
-          text={subtitle}
-        />
-      </div>
-      <Icon name="caret-right" title={MSG.iconTitle} />
-    </Element>
+    <div className={styles.wrapper}>
+      {isMobile && <DecisionOptionIcon {...option} isMobile />}
+      <Element
+        className={getMainClasses(appearance, styles, { disabled: !!disabled })}
+        {...(elmProps as any)}
+        data-test={option.dataTest}
+      >
+        {!isMobile && <DecisionOptionIcon {...option} />}
+        <div className={styles.rowContent}>
+          <Heading
+            appearance={{ size: 'small', weight: 'bold', margin: 'small' }}
+            text={title}
+          />
+          <Heading
+            appearance={{ size: 'tiny', weight: 'thin', margin: 'small' }}
+            text={subtitle}
+          />
+        </div>
+        <Icon name="caret-right" title={MSG.iconTitle} />
+      </Element>
+    </div>
   );
 };
 

--- a/src/modules/core/components/DecisionHub/__tests__/__snapshots__/DecisionHub.test.tsx.snap
+++ b/src/modules/core/components/DecisionHub/__tests__/__snapshots__/DecisionHub.test.tsx.snap
@@ -38,6 +38,7 @@ exports[`DecisionHub component Renders initial component 1`] = `
       data-test="hubOptions"
     >
       <DecisionOption
+        isMobile={false}
         key="row-create"
         name="decisionHubTest"
         option={
@@ -54,97 +55,100 @@ exports[`DecisionHub component Renders initial component 1`] = `
           }
         }
       >
-        <button
-          className=""
-          onClick={[Function]}
-          type="submit"
-        >
-          <DecisionOptionIcon
-            subtitle={
-              Object {
-                "defaultMessage": "Collaborate with others",
-                "id": "ComponentName.exceptional",
-              }
-            }
-            title={
-              Object {
-                "defaultMessage": "Rule the world",
-                "id": "ComponentName.special",
-              }
-            }
-            value="create"
-          />
-          <div>
-            <Heading
-              appearance={
-                Object {
-                  "margin": "small",
-                  "size": "small",
-                  "weight": "bold",
-                }
-              }
-              text={
-                Object {
-                  "defaultMessage": "Rule the world",
-                  "id": "ComponentName.special",
-                }
-              }
-            >
-              <h5
-                className=""
-                title="Rule the world"
-              >
-                Rule the world
-              </h5>
-            </Heading>
-            <Heading
-              appearance={
-                Object {
-                  "margin": "small",
-                  "size": "tiny",
-                  "weight": "thin",
-                }
-              }
-              text={
+        <div>
+          <button
+            className=""
+            onClick={[Function]}
+            type="submit"
+          >
+            <DecisionOptionIcon
+              subtitle={
                 Object {
                   "defaultMessage": "Collaborate with others",
                   "id": "ComponentName.exceptional",
                 }
               }
-            >
-              <h6
-                className=""
-                title="Collaborate with others"
-              >
-                Collaborate with others
-              </h6>
-            </Heading>
-          </div>
-          <Icon
-            name="caret-right"
-            title={
-              Object {
-                "defaultMessage": "Choose this option",
-                "id": "DecisionOption.iconTitle",
+              title={
+                Object {
+                  "defaultMessage": "Rule the world",
+                  "id": "ComponentName.special",
+                }
               }
-            }
-          >
-            <i
-              className=""
-              title="Choose this option"
-            >
-              <svg
-                viewBox="0 0 30 30"
+              value="create"
+            />
+            <div>
+              <Heading
+                appearance={
+                  Object {
+                    "margin": "small",
+                    "size": "small",
+                    "weight": "bold",
+                  }
+                }
+                text={
+                  Object {
+                    "defaultMessage": "Rule the world",
+                    "id": "ComponentName.special",
+                  }
+                }
               >
-                <use
-                  xlinkHref="#undefined"
-                />
-              </svg>
-            </i>
-          </Icon>
-        </button>
+                <h5
+                  className=""
+                  title="Rule the world"
+                >
+                  Rule the world
+                </h5>
+              </Heading>
+              <Heading
+                appearance={
+                  Object {
+                    "margin": "small",
+                    "size": "tiny",
+                    "weight": "thin",
+                  }
+                }
+                text={
+                  Object {
+                    "defaultMessage": "Collaborate with others",
+                    "id": "ComponentName.exceptional",
+                  }
+                }
+              >
+                <h6
+                  className=""
+                  title="Collaborate with others"
+                >
+                  Collaborate with others
+                </h6>
+              </Heading>
+            </div>
+            <Icon
+              name="caret-right"
+              title={
+                Object {
+                  "defaultMessage": "Choose this option",
+                  "id": "DecisionOption.iconTitle",
+                }
+              }
+            >
+              <i
+                className=""
+                title="Choose this option"
+              >
+                <svg
+                  viewBox="0 0 30 30"
+                >
+                  <use
+                    xlinkHref="#undefined"
+                  />
+                </svg>
+              </i>
+            </Icon>
+          </button>
+        </div>
       </DecisionOption>
       <DecisionOption
+        isMobile={false}
         key="row-select"
         name="decisionHubTest"
         option={
@@ -161,95 +165,97 @@ exports[`DecisionHub component Renders initial component 1`] = `
           }
         }
       >
-        <button
-          className=""
-          onClick={[Function]}
-          type="submit"
-        >
-          <DecisionOptionIcon
-            subtitle={
-              Object {
-                "defaultMessage": "Collaborate with others",
-                "id": "ComponentName.exceptional",
-              }
-            }
-            title={
-              Object {
-                "defaultMessage": "Rule the world",
-                "id": "ComponentName.special",
-              }
-            }
-            value="select"
-          />
-          <div>
-            <Heading
-              appearance={
-                Object {
-                  "margin": "small",
-                  "size": "small",
-                  "weight": "bold",
-                }
-              }
-              text={
-                Object {
-                  "defaultMessage": "Rule the world",
-                  "id": "ComponentName.special",
-                }
-              }
-            >
-              <h5
-                className=""
-                title="Rule the world"
-              >
-                Rule the world
-              </h5>
-            </Heading>
-            <Heading
-              appearance={
-                Object {
-                  "margin": "small",
-                  "size": "tiny",
-                  "weight": "thin",
-                }
-              }
-              text={
+        <div>
+          <button
+            className=""
+            onClick={[Function]}
+            type="submit"
+          >
+            <DecisionOptionIcon
+              subtitle={
                 Object {
                   "defaultMessage": "Collaborate with others",
                   "id": "ComponentName.exceptional",
                 }
               }
-            >
-              <h6
-                className=""
-                title="Collaborate with others"
-              >
-                Collaborate with others
-              </h6>
-            </Heading>
-          </div>
-          <Icon
-            name="caret-right"
-            title={
-              Object {
-                "defaultMessage": "Choose this option",
-                "id": "DecisionOption.iconTitle",
+              title={
+                Object {
+                  "defaultMessage": "Rule the world",
+                  "id": "ComponentName.special",
+                }
               }
-            }
-          >
-            <i
-              className=""
-              title="Choose this option"
-            >
-              <svg
-                viewBox="0 0 30 30"
+              value="select"
+            />
+            <div>
+              <Heading
+                appearance={
+                  Object {
+                    "margin": "small",
+                    "size": "small",
+                    "weight": "bold",
+                  }
+                }
+                text={
+                  Object {
+                    "defaultMessage": "Rule the world",
+                    "id": "ComponentName.special",
+                  }
+                }
               >
-                <use
-                  xlinkHref="#undefined"
-                />
-              </svg>
-            </i>
-          </Icon>
-        </button>
+                <h5
+                  className=""
+                  title="Rule the world"
+                >
+                  Rule the world
+                </h5>
+              </Heading>
+              <Heading
+                appearance={
+                  Object {
+                    "margin": "small",
+                    "size": "tiny",
+                    "weight": "thin",
+                  }
+                }
+                text={
+                  Object {
+                    "defaultMessage": "Collaborate with others",
+                    "id": "ComponentName.exceptional",
+                  }
+                }
+              >
+                <h6
+                  className=""
+                  title="Collaborate with others"
+                >
+                  Collaborate with others
+                </h6>
+              </Heading>
+            </div>
+            <Icon
+              name="caret-right"
+              title={
+                Object {
+                  "defaultMessage": "Choose this option",
+                  "id": "DecisionOption.iconTitle",
+                }
+              }
+            >
+              <i
+                className=""
+                title="Choose this option"
+              >
+                <svg
+                  viewBox="0 0 30 30"
+                >
+                  <use
+                    xlinkHref="#undefined"
+                  />
+                </svg>
+              </i>
+            </Icon>
+          </button>
+        </div>
       </DecisionOption>
     </div>
   </DecisionHub>

--- a/src/modules/core/components/ExternalLink/ExternalLink.css
+++ b/src/modules/core/components/ExternalLink/ExternalLink.css
@@ -1,6 +1,3 @@
-@value queries: "~styles/queries.css";
-@value query700 from queries;
-
 .main {
   font-size: var(--size-small);
   font-weight: var(--weight-bold);
@@ -10,11 +7,4 @@
 .main:hover {
   text-decoration: underline;
   color: var(--dark-blue);
-}
-@media screen and query700 {
-  .main {
-    font-size: inherit;
-    font-weight: inherit;
-    color: inherit;
-  }
 }

--- a/src/modules/core/components/ExternalLink/ExternalLink.css.d.ts
+++ b/src/modules/core/components/ExternalLink/ExternalLink.css.d.ts
@@ -1,3 +1,1 @@
-export const queries: string;
-export const query700: string;
 export const main: string;

--- a/src/modules/core/components/Fields/InputStatus/InputStatus.css
+++ b/src/modules/core/components/Fields/InputStatus/InputStatus.css
@@ -1,3 +1,5 @@
+@value query700 from '~styles/queries.css';
+
 .main {
   margin-top: 4px;
   height: 15px;
@@ -54,4 +56,17 @@
   height: 38px;
   line-height: 18px;
   white-space: pre-wrap;
+}
+
+@media screen and query700 {
+  .main {
+    display: flex;
+    height: auto;
+    white-space: normal;
+  }
+
+  .main::before {
+    margin-top: 4px;
+    min-width: 8px;
+  }
 }

--- a/src/modules/core/components/Fields/InputStatus/InputStatus.css.d.ts
+++ b/src/modules/core/components/Fields/InputStatus/InputStatus.css.d.ts
@@ -1,3 +1,4 @@
+export const query700: string;
 export const main: string;
 export const statusSchemaInfo: string;
 export const directionHorizontal: string;

--- a/src/modules/dashboard/components/CreateColonyWizard/StepColonyName.css
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepColonyName.css
@@ -41,4 +41,8 @@
   .main {
     padding-bottom: 40px;
   }
+
+  .main h3 span {
+    overflow-wrap: anywhere;
+  }
 }

--- a/src/modules/dashboard/components/CreateColonyWizard/StepColonyName.css
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepColonyName.css
@@ -1,3 +1,5 @@
+@value query700 from '~styles/queries.css';
+
 .main {
   padding-top: 155px;
   width: 100%;
@@ -33,4 +35,10 @@
 
 .tooltipContent {
   min-width: 280px;
+}
+
+@media screen and query700 {
+  .main {
+    padding-bottom: 40px;
+  }
 }

--- a/src/modules/dashboard/components/CreateColonyWizard/StepColonyName.css
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepColonyName.css
@@ -45,4 +45,17 @@
   .main h3 span {
     overflow-wrap: anywhere;
   }
+
+  .nameForm > div:not(:last-child) {
+    min-height: 87px;
+  }
+
+  /* Tooltip popover */
+  .nameForm > div:nth-child(2) span > div:not(:only-child) {
+    max-width: calc(100vw - 50px);
+  }
+
+  .tooltipContent {
+    min-width: 0px;
+  }
 }

--- a/src/modules/dashboard/components/CreateColonyWizard/StepColonyName.css.d.ts
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepColonyName.css.d.ts
@@ -1,3 +1,4 @@
+export const query700: string;
 export const main: string;
 export const paragraph: string;
 export const nameForm: string;

--- a/src/modules/dashboard/components/CreateColonyWizard/StepColonyName.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepColonyName.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import * as yup from 'yup';
 import { useApolloClient } from '@apollo/client';
+import { useMediaQuery } from 'react-responsive';
 
 import { WizardProps } from '~core/Wizard';
 import { Form, Input } from '~core/Fields';
@@ -20,6 +21,7 @@ import {
 import { DEFAULT_NETWORK_INFO } from '~constants';
 import { checkIfNetworkIsAllowed } from '~utils/networks';
 
+import { query700 as query } from '~styles/queries.css';
 import styles from './StepColonyName.css';
 
 interface FormValues {
@@ -151,7 +153,7 @@ const StepColonyName = ({
   );
 
   const isNetworkAllowed = checkIfNetworkIsAllowed(networkId);
-
+  const isMobile = useMediaQuery({ query });
   return (
     <Form
       onSubmit={nextStep}
@@ -222,6 +224,13 @@ const StepColonyName = ({
                     }}
                     className={styles.iconContainer}
                     tooltipClassName={styles.tooltipContent}
+                    tooltipPopperOptions={
+                      isMobile
+                        ? {
+                            placement: 'left',
+                          }
+                        : undefined
+                    }
                   />
                 }
               />

--- a/src/modules/dashboard/components/CreateColonyWizard/StepConfirmAllInput.css
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepConfirmAllInput.css
@@ -49,4 +49,8 @@
   .finalContainer {
     width: 100%;
   }
+
+  .cardRow span {
+    max-width: 208px;
+  }
 }

--- a/src/modules/dashboard/components/CreateColonyWizard/StepConfirmAllInput.css
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepConfirmAllInput.css
@@ -1,3 +1,5 @@
+@value query700 from '~styles/queries.css';
+
 .main {
   padding-top: 146px;
   width: 100%;
@@ -37,4 +39,14 @@
   display: flex;
   justify-content: flex-end;
   margin-top: 22px;
+}
+
+@media screen and query700 {
+  .main {
+    padding-bottom: 30px;
+  }
+
+  .finalContainer {
+    width: 100%;
+  }
 }

--- a/src/modules/dashboard/components/CreateColonyWizard/StepConfirmAllInput.css.d.ts
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepConfirmAllInput.css.d.ts
@@ -1,3 +1,4 @@
+export const query700: string;
 export const main: string;
 export const paragraph: string;
 export const finalContainer: string;

--- a/src/modules/dashboard/components/CreateColonyWizard/StepConfirmTransactions.css
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepConfirmTransactions.css
@@ -1,3 +1,5 @@
+@value query700 from '~styles/queries.css';
+
 .main {
   padding-top: 100px;
   width: 500px;
@@ -34,4 +36,10 @@
 .linkToColony {
   font-weight: var(--weight-bold);
   text-decoration: underline;
+}
+
+@media screen and query700 {
+  .container {
+    padding: 22px 0px 18px 0px;
+  }
 }

--- a/src/modules/dashboard/components/CreateColonyWizard/StepConfirmTransactions.css.d.ts
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepConfirmTransactions.css.d.ts
@@ -1,3 +1,4 @@
+export const query700: string;
 export const main: string;
 export const container: string;
 export const containerGasPrice: string;

--- a/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.css
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.css
@@ -1,3 +1,5 @@
+@value query700 from '~styles/queries.css';
+
 .main {
   width: 460px;
 }
@@ -31,4 +33,14 @@
   font-weight: var(--weight-bold);
   color: var(--sky-blue);
   cursor: pointer;
+}
+
+@media screen and query700 {
+  .main {
+    width: 100%;
+  }
+
+  .titleSection {
+    margin-top: 155px;
+  }
 }

--- a/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.css
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.css
@@ -37,10 +37,27 @@
 
 @media screen and query700 {
   .main {
+    padding-bottom: 40px;
     width: 100%;
   }
 
   .titleSection {
     margin-top: 155px;
+  }
+
+  .inputFields > div {
+    min-height: 87px;
+  }
+
+  .inputFields > div:first-child {
+    min-height: 109px;
+  }
+
+  .inputFieldWrapper {
+    margin-bottom: 25px;
+  }
+
+  .actionsContainer {
+    margin-top: 25px;
   }
 }

--- a/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.css.d.ts
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepCreateToken.css.d.ts
@@ -1,3 +1,4 @@
+export const query700: string;
 export const main: string;
 export const titleSection: string;
 export const inputFields: string;

--- a/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.css
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.css
@@ -1,3 +1,5 @@
+@value query700 from '~styles/queries.css';
+
 .main {
   width: 100%;
   max-width: 460px;
@@ -43,4 +45,14 @@
   font-weight: var(--weight-bold);
   color: var(--sky-blue);
   cursor: pointer;
+}
+
+@media screen and query700 {
+  .tokenDetails, .buttons {
+    margin-top: 25px;
+  }
+
+  .main form {
+    padding-bottom: 40px;
+  }
 }

--- a/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.css.d.ts
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepSelectToken.css.d.ts
@@ -1,3 +1,4 @@
+export const query700: string;
 export const main: string;
 export const header: string;
 export const labelContainer: string;

--- a/src/modules/dashboard/components/CreateColonyWizard/StepTokenChoice.tsx
+++ b/src/modules/dashboard/components/CreateColonyWizard/StepTokenChoice.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
+import { useMediaQuery } from 'react-responsive';
 
 import { WizardProps } from '~core/Wizard';
 import Heading from '~core/Heading';
@@ -8,6 +9,7 @@ import DecisionHub from '~core/DecisionHub';
 import { Form } from '~core/Fields';
 import { multiLineTextEllipsis } from '~utils/strings';
 
+import { query700 as query } from '~styles/queries.css';
 import styles from './StepTokenChoice.css';
 
 const LEARN_MORE_URL = `https://colony.gitbook.io/colony/create-a-colony/select-native-token`;
@@ -95,60 +97,64 @@ type Props = WizardProps<FormValues>;
 
 const displayName = 'dashboard.CreateColonyWizard.StepTokenChoice';
 
-const StepTokenChoice = ({ nextStep, wizardForm, wizardValues }: Props) => (
-  <Form onSubmit={nextStep} {...wizardForm}>
-    <section className={styles.content}>
-      <div className={styles.title}>
-        <Heading appearance={{ size: 'medium', weight: 'bold' }}>
-          <FormattedMessage
-            {...MSG.heading}
-            values={{
-              /*
-               * @NOTE We need to use a JS string truncate here, rather then CSS,
-               * since we're dealing with a string that needs to be truncated,
-               * inside a sentence that does not
-               */
-              colony: (
-                <span title={wizardValues.displayName}>
-                  {multiLineTextEllipsis(wizardValues.displayName, 120)}
-                </span>
-              ),
-            }}
+const StepTokenChoice = ({ nextStep, wizardForm, wizardValues }: Props) => {
+  const isMobile = useMediaQuery({ query });
+
+  return (
+    <Form onSubmit={nextStep} {...wizardForm}>
+      <section className={styles.content}>
+        <div className={styles.title}>
+          <Heading appearance={{ size: 'medium', weight: 'bold' }}>
+            <FormattedMessage
+              {...MSG.heading}
+              values={{
+                /*
+                 * @NOTE We need to use a JS string truncate here, rather then CSS,
+                 * since we're dealing with a string that needs to be truncated,
+                 * inside a sentence that does not
+                 */
+                colony: (
+                  <span title={wizardValues.displayName}>
+                    {multiLineTextEllipsis(wizardValues.displayName, 120)}
+                  </span>
+                ),
+              }}
+            />
+          </Heading>
+        </div>
+        <div className={styles.subtitle}>
+          <Heading
+            appearance={{ size: 'normal', weight: 'thin' }}
+            text={MSG.subtitle}
           />
-        </Heading>
-      </div>
-      <div className={styles.subtitle}>
-        <Heading
-          appearance={{ size: 'normal', weight: 'thin' }}
-          text={MSG.subtitle}
-        />
-      </div>
-      <div className={styles.subtitleWithExampleBox}>
-        <Heading
-          className={styles.subtitleWithExample}
-          appearance={{ size: 'normal', weight: 'thin' }}
-          text={MSG.subtitleWithExample}
-        />
-      </div>
-      <DecisionHub name="tokenChoice" options={options} />
-      <div className={styles.titleAndButton}>
-        <Heading
-          appearance={{
-            size: 'tiny',
-            weight: 'bold',
-            margin: 'none',
-          }}
-          text={MSG.notSure}
-        />
-        <ExternalLink
-          className={styles.link}
-          text={{ id: 'text.learnMore' }}
-          href={LEARN_MORE_URL}
-        />
-      </div>
-    </section>
-  </Form>
-);
+        </div>
+        <div className={styles.subtitleWithExampleBox}>
+          <Heading
+            className={styles.subtitleWithExample}
+            appearance={{ size: 'normal', weight: 'thin' }}
+            text={MSG.subtitleWithExample}
+          />
+        </div>
+        <DecisionHub name="tokenChoice" options={options} isMobile={isMobile} />
+        <div className={styles.titleAndButton}>
+          <Heading
+            appearance={{
+              size: 'tiny',
+              weight: 'bold',
+              margin: 'none',
+            }}
+            text={MSG.notSure}
+          />
+          <ExternalLink
+            className={styles.link}
+            text={{ id: 'text.learnMore' }}
+            href={LEARN_MORE_URL}
+          />
+        </div>
+      </section>
+    </Form>
+  );
+};
 
 StepTokenChoice.displayName = displayName;
 


### PR DESCRIPTION
## Description

This PR tracks the work required for making the `/create-colony` route mobile responsive. No specific design for this route, however should follow the same pattern as other designs in this project. 

**Changes** 🏗

* `StepCreateToken` : add mobile styles
* `StepConfirmAllInput`:  add mobile styles
* `StepColonyName`:  add mobile styles

## Screenshots

**_`/create-colony`: Step 1_**

![create-col-1](https://user-images.githubusercontent.com/64402732/177548480-84bf9484-946c-4da6-a940-bc427e79c21a.png)

**_`/create-colony`: Step 2_**

![create-col-6](https://user-images.githubusercontent.com/64402732/177549047-424cad1b-99c9-4c8f-a572-f948f9605cd6.png)

**_`/create-colony` : Create new token_**

![create-col-2](https://user-images.githubusercontent.com/64402732/177548501-2b73c093-a33d-4829-b63a-b8f0f2293e15.png)

**_`/create-colony` : Confirm_**

![create-col-3](https://user-images.githubusercontent.com/64402732/177548509-97be0227-bb0e-466c-ad75-25fcfb8147fe.png)

**_`/create-colony` : Transactions_**

![create-col-4](https://user-images.githubusercontent.com/64402732/177548528-afe00422-e928-44b6-9cca-bcbfefde1114.png)

**_`/create-colony` : Use existing token_**

![create-col-5](https://user-images.githubusercontent.com/64402732/177548541-61444e6e-056d-4f35-9f00-d602c5d086b2.png)

Resolves #3576
