### PR TITLE
Fix: Rendering error for threshold and alignment of help icons

### DIFF
--- a/src/modules/core/components/ProgressBar/ProgressBar.tsx
+++ b/src/modules/core/components/ProgressBar/ProgressBar.tsx
@@ -42,9 +42,10 @@ const ProgressBar = ({
 }: Props) => {
   const { formatMessage } = useIntl();
   const titleText = formatMessage(MSG.titleProgress, { value, max });
+  const shouldDisplayThreshold = !!(threshold && threshold > 0);
   return (
     <div className={`${styles.wrapper} ${getMainClasses(appearance, styles)}`}>
-      {threshold && (
+      {shouldDisplayThreshold && (
         <div
           style={{
             left: `calc(${threshold}% - 12px)`,

--- a/src/modules/core/components/ProgressBar/ProgressBar.tsx
+++ b/src/modules/core/components/ProgressBar/ProgressBar.tsx
@@ -48,7 +48,7 @@ const ProgressBar = ({
       {shouldDisplayThreshold && (
         <div
           style={{
-            left: `calc(${threshold}% - 12px)`,
+            left: `calc(${threshold}% - 14px)`,
           }}
           className={styles.threshold}
         >

--- a/src/modules/core/components/ProgressBar/ProgressBar.tsx
+++ b/src/modules/core/components/ProgressBar/ProgressBar.tsx
@@ -42,10 +42,10 @@ const ProgressBar = ({
 }: Props) => {
   const { formatMessage } = useIntl();
   const titleText = formatMessage(MSG.titleProgress, { value, max });
-  const shouldDisplayThreshold = !!(threshold && threshold > 0);
+
   return (
     <div className={`${styles.wrapper} ${getMainClasses(appearance, styles)}`}>
-      {shouldDisplayThreshold && (
+      {!!threshold && (
         <div
           style={{
             left: `calc(${threshold}% - 14px)`,

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.css
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.css
@@ -16,11 +16,11 @@
 
 .progressStateContainer {
   display: flex;
-  align-items: baseline;
 }
 
 .progressBarContainer {
   margin-left: 2px;
+  padding-top: 5px;
   width: 116px;
 }
 

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.css
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.css
@@ -43,7 +43,7 @@
 
 .helpProgressBar {
   align-self: flex-end;
-  margin-left: 8px;
+  margin-left: 15px;
   cursor: pointer;
 }
 

--- a/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.css
@@ -30,6 +30,10 @@
   color: var(--dark);
 }
 
+.itemWithForcedBorder .helpIcon {
+  padding-top: 5px;
+}
+
 .title {
   composes: item;
 }

--- a/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.css.d.ts
@@ -3,6 +3,7 @@ export const stateMargin: string;
 export const item: string;
 export const itemWithForcedBorder: string;
 export const label: string;
+export const helpIcon: string;
 export const title: string;
 export const value: string;
 export const help: string;

--- a/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
@@ -323,8 +323,8 @@ const FinalizeMotionAndClaimWidget = ({
             <>
               <div className={styles.itemWithForcedBorder}>
                 <div className={styles.label}>
-                  <div>
-                    <FormattedMessage {...MSG.finalizeLabel} />
+                  <FormattedMessage {...MSG.finalizeLabel} />
+                  <div className={styles.helpIcon}>
                     <QuestionMarkTooltip
                       tooltipText={MSG.finalizeTooltip}
                       className={styles.help}

--- a/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteDetails.tsx
+++ b/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteDetails.tsx
@@ -108,17 +108,15 @@ const VoteDetails = ({
     <div>
       <div className={styles.item}>
         <div className={styles.label}>
-          <div>
-            <FormattedMessage {...MSG.votingMethodLabel} />
-            <QuestionMarkTooltip
-              tooltipText={MSG.votingMethodTooltip}
-              className={styles.help}
-              tooltipClassName={styles.tooltip}
-              tooltipPopperOptions={{
-                placement: 'right',
-              }}
-            />
-          </div>
+          <FormattedMessage {...MSG.votingMethodLabel} />
+          <QuestionMarkTooltip
+            tooltipText={MSG.votingMethodTooltip}
+            className={styles.help}
+            tooltipClassName={styles.tooltip}
+            tooltipPopperOptions={{
+              placement: 'right',
+            }}
+          />
         </div>
         <div className={styles.value}>
           {/*
@@ -134,17 +132,15 @@ const VoteDetails = ({
         <>
           <div className={styles.item}>
             <div className={styles.label}>
-              <div>
-                <FormattedMessage {...MSG.reputationTeamLabel} />
-                <QuestionMarkTooltip
-                  tooltipText={MSG.reputationTeamTooltip}
-                  className={styles.help}
-                  tooltipClassName={styles.tooltip}
-                  tooltipPopperOptions={{
-                    placement: 'right',
-                  }}
-                />
-              </div>
+              <FormattedMessage {...MSG.reputationTeamLabel} />
+              <QuestionMarkTooltip
+                tooltipText={MSG.reputationTeamTooltip}
+                className={styles.help}
+                tooltipClassName={styles.tooltip}
+                tooltipPopperOptions={{
+                  placement: 'right',
+                }}
+              />
             </div>
             <div className={styles.value}>
               <div className={styles.reputation}>
@@ -157,17 +153,15 @@ const VoteDetails = ({
           </div>
           <div className={styles.item}>
             <div className={styles.label}>
-              <div>
-                <FormattedMessage {...MSG.rewardLabel} />
-                <QuestionMarkTooltip
-                  tooltipText={MSG.rewardTooltip}
-                  className={styles.help}
-                  tooltipClassName={styles.tooltip}
-                  tooltipPopperOptions={{
-                    placement: 'right',
-                  }}
-                />
-              </div>
+              <FormattedMessage {...MSG.rewardLabel} />
+              <QuestionMarkTooltip
+                tooltipText={MSG.rewardTooltip}
+                className={styles.help}
+                tooltipClassName={styles.tooltip}
+                tooltipPopperOptions={{
+                  placement: 'right',
+                }}
+              />
             </div>
             <div className={styles.value}>
               {voterReward?.motionVoterReward && (
@@ -239,17 +233,15 @@ const VoteDetails = ({
       {buttonComponent && (
         <div className={styles.item}>
           <div className={styles.label}>
-            <div>
-              <FormattedMessage {...MSG.rulesLabel} />
-              <QuestionMarkTooltip
-                tooltipText={MSG.rulesTooltip}
-                className={styles.help}
-                tooltipClassName={styles.tooltip}
-                tooltipPopperOptions={{
-                  placement: 'right',
-                }}
-              />
-            </div>
+            <FormattedMessage {...MSG.rulesLabel} />
+            <QuestionMarkTooltip
+              tooltipText={MSG.rulesTooltip}
+              className={styles.help}
+              tooltipClassName={styles.tooltip}
+              tooltipPopperOptions={{
+                placement: 'right',
+              }}
+            />
           </div>
           <div className={styles.value}>{buttonComponent}</div>
         </div>


### PR DESCRIPTION
## Description

This PR fixes the issue with a 0 rendering error for the threshold progress bar. As well as the alignment of the help icons in the `VoteDetails` component. 

##Story
The threshold value was 0, so when it was being evaluated it kept returning a 0 in the tsx and rendered by React to the screen. In this situation, it is better to use a boolean.

[Figma link](https://www.figma.com/file/CCgGsBzhX3BUENS1IvgP7N/Motions-%26-Disputes?node-id=3756%3A1)

**Before**
<img width="964" alt="Screen Shot 2022-07-04 at 3 27 22 PM" src="https://user-images.githubusercontent.com/71563622/178029342-07c93a35-4cdd-464e-b006-c3e5eb7224e3.png">

**Changes** 🏗

* Removed unnecessary divs in the `VoteDetails` component that were causing the issue with the misalignment of the help icons.

* Created a new variable that would handle the threshold as a boolean instead of a number.  

**After**
<img width="1061" alt="Screen Shot 2022-07-08 at 6 55 36 PM" src="https://user-images.githubusercontent.com/71563622/178032307-501774b3-d9c4-4e6e-b615-3f88cb2c6bbe.png">

## TODO
- [x] Fix the 0 rendering error for the threshold progress bar.
- [x] Fix alignment of help icons

Resolves #3572