### PR TITLE
Update tooltip positioning for `MembersListItem`

### DIFF
--- a/src/modules/core/components/MembersList/MembersListItem.css
+++ b/src/modules/core/components/MembersList/MembersListItem.css
@@ -15,7 +15,6 @@
 
 .usernameSection {
   composes: section;
-  composes: inlineEllipsis from '~styles/text.css';
   flex-grow: 0.5;
   margin-right: auto;
   max-width: 200px;
@@ -39,13 +38,6 @@
 .address span {
   font-size: var(--size-normal);
   font-weight: 500;
-}
-
-/* We need position fixed for this case and because of the way
-  styles are applied in the `Tooltip` component !important is the only way
-  to override them without refactoring the whole `Tootltip` */
-.address > div > div {
-  position: fixed !important;
 }
 
 .reputationSection {
@@ -75,5 +67,5 @@
 }
 
 .whitelistedIconTooltip {
-  width: initial;
+  width: 130px;
 }

--- a/src/modules/core/components/MembersList/MembersListItem.css
+++ b/src/modules/core/components/MembersList/MembersListItem.css
@@ -41,6 +41,13 @@
   font-weight: 500;
 }
 
+/* We need position fixed for this case and because of the way
+  styles are applied in the `Tooltip` component !important is the only way
+  to override them without refactoring the whole `Tootltip` */
+.address > div > div {
+  position: fixed !important;
+}
+
 .reputationSection {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Description

This PR fixes the tooltip position that appears when we hover over the greenish checkmark of the verified sign.
<img width="635" alt="Screenshot 2022-07-07 at 15 30 05" src="https://user-images.githubusercontent.com/34057551/177773561-530c6d83-5dd3-4b04-8375-45f90bfb9e4f.png">

resolves #3574 