### PR TITLE
Add: `/events` mobile styles (transactions log)

### DIFF
--- a/src/modules/dashboard/components/ColonyEvents/ColonyEvents.css
+++ b/src/modules/dashboard/components/ColonyEvents/ColonyEvents.css
@@ -1,3 +1,5 @@
+@value query700 from '~styles/queries.css';
+
 .filter {
   display: inline-block;
   margin-right: 10px;
@@ -28,4 +30,14 @@
   font-size: var(--size-small);
   font-weight: var(--weight-bold);
   color: var(--dark-blue);
+}
+
+@media screen and query700 {
+  .main {
+    padding: 0 14px 60px;
+  }
+
+  .bar {
+    margin-top: 0;
+  }
 }

--- a/src/modules/dashboard/components/ColonyEvents/ColonyEvents.css.d.ts
+++ b/src/modules/dashboard/components/ColonyEvents/ColonyEvents.css.d.ts
@@ -1,4 +1,6 @@
+export const query700: string;
 export const filter: string;
 export const bar: string;
 export const title: string;
 export const link: string;
+export const main: string;

--- a/src/modules/dashboard/components/ColonyEvents/ColonyEvents.tsx
+++ b/src/modules/dashboard/components/ColonyEvents/ColonyEvents.tsx
@@ -127,7 +127,7 @@ const ColonyEvents = ({
   );
 
   return (
-    <div>
+    <div className={styles.main}>
       <div className={styles.bar}>
         <div className={styles.title}>
           <FormattedMessage {...MSG.transactionsLogTitle} />

--- a/src/modules/dashboard/components/ColonyEvents/ColonyEventsListItem.css
+++ b/src/modules/dashboard/components/ColonyEvents/ColonyEventsListItem.css
@@ -5,6 +5,8 @@
 @value popoverWidth: 400px;
 @value popoverDistance: 10px;
 
+@value query700 from '~styles/queries.css';
+
 .listItem:first-of-type {
   border-top: 1px solid var(--temp-grey-13);
 }
@@ -92,4 +94,17 @@
   font-size: var(--size-tiny);
   font-weight: var(--weight-bold);
   color: var(--action-secondary);
+}
+
+@media screen and query700 {
+  .title {
+    padding: 15px 0;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+
+  .main {
+    height: auto;
+    min-height: 51px;
+  }
 }

--- a/src/modules/dashboard/components/ColonyEvents/ColonyEventsListItem.css.d.ts
+++ b/src/modules/dashboard/components/ColonyEvents/ColonyEventsListItem.css.d.ts
@@ -1,6 +1,7 @@
 export const mainTextSize: string;
 export const popoverWidth: string;
 export const popoverDistance: string;
+export const query700: string;
 export const listItem: string;
 export const main: string;
 export const avatar: string;


### PR DESCRIPTION
## Description

This PR is for making the route `/{colony_home}/events` mobile responsive. Should follow same pattern as other screens in this project. 

**Changes** 🏗

* `ColonyEvents` and `ColonyEventsListItem`: add mobile styles

## Screenshots

![events-log](https://user-images.githubusercontent.com/64402732/178010882-ce6d317a-319d-4c29-b814-db1207cf9f75.png)

**_Wrapping long messages as below_**

![events-log-2](https://user-images.githubusercontent.com/64402732/178010888-fac69e9a-f140-4da6-a286-1a04ace34481.png)

Resolves  #3589

