### PR TITLE
Add: wallet, inbox and coin machine navigation (mobile)

### DIFF
--- a/src/modules/pages/components/RouteLayouts/UserNavigation.css
+++ b/src/modules/pages/components/RouteLayouts/UserNavigation.css
@@ -193,7 +193,7 @@
 }
 
 @media screen and query700 {
-  .elementWrapper, .notificationsIcon, .walletAutoLogin {
+  .elementWrapper, .walletAutoLogin {
     display: none;
   }
 
@@ -213,18 +213,21 @@
     width: 120px;
   }
 
-  .connectWalletButton + div[role="tooltip"] {
+  .gasStationReference + div,
+  .notificationsButton + div,
+  .connectWalletButton + div {
     display: flex;
     justify-content: center;
     width: 100vw;
     background-color: transparent;
-    box-shadow: none;
   }
 
-  .gasStationReference + div {
-    display: flex;
-    justify-content: center;
-    width: 100vw;
-    background-color: transparent;
+  .notificationsIcon {
+    margin-right: 0px;
+  }
+
+  .notificationsButton + div,
+  .connectWalletButton + div {
+    box-shadow: none;
   }
 }

--- a/src/modules/users/components/HamburgerDropdown/HamburgerDropdownPopover.tsx
+++ b/src/modules/users/components/HamburgerDropdown/HamburgerDropdownPopover.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { defineMessages } from 'react-intl';
 
-import { Colony, Maybe } from '~data/index';
+import { Colony, Maybe, useColonyExtensionsQuery } from '~data/index';
 import DropdownMenu, {
   DropdownMenuItem,
   DropdownMenuSection,
@@ -33,6 +33,10 @@ const MSG = defineMessages({
     id: 'users.HamburgerDropdown.HamburgerDropdownPopover.link.extensions',
     defaultMessage: 'Extensions',
   },
+  buyTokens: {
+    id: 'users.HamburgerDropdown.HamburgerDropdownPopover.link.buyTokens',
+    defaultMessage: 'Buy Tokens',
+  },
 });
 
 const displayName = 'users.HamburgerDropdown.HamburgerDropdownPopover';
@@ -55,6 +59,13 @@ const HamburgerDropdownPopover = ({
   isWalletConnected = false,
 }: Props) => {
   const colonyHomePath = `/colony/${colonyName}`;
+  const { data } = useColonyExtensionsQuery({
+    variables: { address: colony?.colonyAddress },
+  });
+  const coinMachineExtn = data?.processedColony.installedExtensions.find(
+    ({ extensionId }) => extensionId === 'CoinMachine',
+  );
+
   return (
     <div className={styles.menu}>
       <DropdownMenu onClick={closePopover}>
@@ -80,6 +91,16 @@ const HamburgerDropdownPopover = ({
                     text={MSG.extensions}
                   />
                 </DropdownMenuItem>
+                {coinMachineExtn &&
+                  coinMachineExtn.details.initialized &&
+                  !coinMachineExtn.details.deprecated && (
+                    <DropdownMenuItem>
+                      <NavLink
+                        to={`${colonyHomePath}/buy-tokens`}
+                        text={MSG.buyTokens}
+                      />
+                    </DropdownMenuItem>
+                  )}
               </DropdownMenuSection>
             )}
             <UserSection colony={colony} username={username} />

--- a/src/modules/users/components/Inbox/InboxContainer/InboxContainer.css
+++ b/src/modules/users/components/Inbox/InboxContainer/InboxContainer.css
@@ -79,4 +79,10 @@
   .contentContainerFull {
     padding: 35px 14px 60px;
   }
+
+  .contentContainerPopup {
+    width: calc(100% - 28px);
+    border-radius: 4px;
+    background-color: var(--grey-blue-2);
+  }
 }

--- a/src/modules/users/components/PopoverSection/UserSection.tsx
+++ b/src/modules/users/components/PopoverSection/UserSection.tsx
@@ -4,7 +4,11 @@ import { defineMessages } from 'react-intl';
 import { DropdownMenuItem, DropdownMenuSection } from '~core/DropdownMenu';
 import NavLink from '~core/NavLink';
 import { Colony, Maybe } from '~data/index';
-import { CREATE_USER_ROUTE, USER_EDIT_ROUTE } from '~routes/routeConstants';
+import {
+  CREATE_USER_ROUTE,
+  USER_EDIT_ROUTE,
+  WALLET_ROUTE,
+} from '~routes/routeConstants';
 
 const MSG = defineMessages({
   buttonGetStarted: {
@@ -18,6 +22,10 @@ const MSG = defineMessages({
   settings: {
     id: 'users.PopoverSection.UserSection.link.settings',
     defaultMessage: 'Settings',
+  },
+  wallet: {
+    id: 'users.PopoverSection.UserSection.link.wallet',
+    defaultMessage: 'Wallet',
   },
 });
 
@@ -59,6 +67,9 @@ const UserSection = ({ colony, username }: Props) => (
             text={MSG.settings}
             data-test="userProfileSettings"
           />
+        </DropdownMenuItem>
+        <DropdownMenuItem>
+          <NavLink to={WALLET_ROUTE} text={MSG.wallet} />
         </DropdownMenuItem>
       </>
     )}


### PR DESCRIPTION
## Description

This PR tracks the work involved in adding Inbox, Wallet and Coin Machine route navigation on mobile. 

**Changes** 🏗

* `UserNavigation`: show mail icon
* `InboxContainer`: style mail icon popover
* `HamburgerDropdownPopover`: Add menu item for "Buy Tokens"
* `UserSection`: Add menu item for "Wallet" 

## Screenshots

**_Mail icon added to top nav_**

![mail-icon-mobile](https://user-images.githubusercontent.com/64402732/178032506-76952433-01fa-49cd-9db5-0ff8614b69ae.png)

**_"Wallet" and "Buy Tokens" added to menu (the latter only when coin machine is enabled)_**
![new-routes-hamburger](https://user-images.githubusercontent.com/64402732/178032495-85a6fa79-30be-4a49-afda-ffb6de9668f4.png)

Resolves #3603
