### PR TITLE
Add: Landing page mobile styles

### DIFF
--- a/src/modules/pages/components/LandingPage/LandingPage.css
+++ b/src/modules/pages/components/LandingPage/LandingPage.css
@@ -1,3 +1,5 @@
+@value query700 from '~styles/queries.css';
+
 .main {
   /*
    * @NOTE Center vertically and horizontally
@@ -59,4 +61,15 @@
 .itemLoading {
   composes: itemLink;
   text-align: center;
+}
+
+@media screen and query700 {
+  .main {
+    padding: 0 14px;
+    height: calc(100vh - 43px); /* @NOTE: 43px is the height of the nav */
+  }
+
+  .itemLink {
+    width: auto;
+  }
 }

--- a/src/modules/pages/components/LandingPage/LandingPage.css.d.ts
+++ b/src/modules/pages/components/LandingPage/LandingPage.css.d.ts
@@ -1,3 +1,4 @@
+export const query700: string;
 export const main: string;
 export const title: string;
 export const item: string;


### PR DESCRIPTION
## Description

Ensuring the `/landing` route is mobile responsive.

**Changes** 🏗

* `LandingPage`: adding mobile styles

## Screenshot

![landing](https://user-images.githubusercontent.com/64402732/178515742-4e012ac9-4ec9-4667-acf9-d92d200f47f3.png)

Resolves #3594 
