### PR TITLE
Fix: Updated logic for funds links

### DIFF
--- a/src/modules/dashboard/components/ColonyFundingMenu/ColonyFundingMenu.tsx
+++ b/src/modules/dashboard/components/ColonyFundingMenu/ColonyFundingMenu.tsx
@@ -108,9 +108,9 @@ const ColonyFundingMenu = ({
   const mustUpgradeOneTx = oneTxMustBeUpgraded(oneTxPaymentExtension);
 
   const canEdit =
-    userHasRole(rootRoles, ColonyRole.Root) ||
-    userHasRole(rootRoles, ColonyRole.Administration);
-  const canMoveTokens = userHasRole(rootRoles, ColonyRole.Funding);
+    isVotingExtensionEnabled || userHasRole(rootRoles, ColonyRole.Root);
+  const canMoveTokens =
+    isVotingExtensionEnabled || userHasRole(rootRoles, ColonyRole.Funding);
   const canUserMintNativeToken = isVotingExtensionEnabled
     ? colony.canColonyMintNativeToken
     : userHasRole(rootRoles, ColonyRole.Root) &&

--- a/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.tsx
@@ -5,11 +5,7 @@ import { SpinnerLoader } from '~core/Preloaders';
 import Heading from '~core/Heading';
 import InfoPopover from '~core/InfoPopover';
 import NavLink from '~core/NavLink';
-import {
-  useLoggedInUser,
-  Colony,
-  useTokenBalancesForDomainsQuery,
-} from '~data/index';
+import { Colony, useTokenBalancesForDomainsQuery } from '~data/index';
 
 import TokenItem from './TokenItem';
 
@@ -30,10 +26,6 @@ interface Props {
 const displayName = 'dashboard.ColonyHome.ColonyFunding';
 
 const ColonyFunding = ({ colony, currentDomainId }: Props) => {
-  const { ethereal, username } = useLoggedInUser();
-
-  const canMoveFunds = !!username && !ethereal;
-
   const {
     colonyAddress,
     tokens: colonyTokens,
@@ -57,13 +49,9 @@ const ColonyFunding = ({ colony, currentDomainId }: Props) => {
   return (
     <div className={styles.main}>
       <Heading appearance={{ size: 'normal', weight: 'bold' }}>
-        {canMoveFunds ? (
-          <NavLink to={`/colony/${colonyName}/funds`}>
-            <FormattedMessage {...MSG.title} />
-          </NavLink>
-        ) : (
+        <NavLink to={`/colony/${colonyName}/funds`}>
           <FormattedMessage {...MSG.title} />
-        )}
+        </NavLink>
       </Heading>
       {data && !isLoadingTokenBalances ? (
         <ul data-test="availableFunds">

--- a/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyFunding/ColonyFunding.tsx
@@ -10,9 +10,6 @@ import {
   Colony,
   useTokenBalancesForDomainsQuery,
 } from '~data/index';
-import { useTransformer } from '~utils/hooks';
-import { canFund } from '~modules/users/checks';
-import { getAllUserRoles } from '~modules/transformers';
 
 import TokenItem from './TokenItem';
 
@@ -33,11 +30,9 @@ interface Props {
 const displayName = 'dashboard.ColonyHome.ColonyFunding';
 
 const ColonyFunding = ({ colony, currentDomainId }: Props) => {
-  const { walletAddress, ethereal, username } = useLoggedInUser();
+  const { ethereal, username } = useLoggedInUser();
 
-  const allUserRoles = useTransformer(getAllUserRoles, [colony, walletAddress]);
-
-  const canMoveFunds = !!username && !ethereal && canFund(allUserRoles);
+  const canMoveFunds = !!username && !ethereal;
 
   const {
     colonyAddress,


### PR DESCRIPTION
## Description
This PR fixes the "Available Funds" link that should take the user to the funds page and be enabled regardless of permissions but it is currently inactive.

Additionally, once you go inside the funds page, the Move funds, Mint Tokens, Manage Tokens links should all be active depending on the following:

1. If Governance Extension is enabled:
- Move Funds - visible
- Mint Tokens - visible
- Manage Tokens - visible

2. If Governance Extension is NOT enabled:
- Move Funds - needs the Funding role
- Mint Tokens - needs the Root role
- Manage Tokens - needs the Root role 

**Changes** 🏗
* Removed permissions requirement for available funds link.
<img width="993" alt="Screen Shot 2022-07-12 at 11 42 40 PM" src="https://user-images.githubusercontent.com/71563622/178591777-e63eb31a-ba94-4741-b989-10d189265389.png">

* Made the Move funds, Mint Tokens, Manage Tokens links enabled when the governance extension is active. 
<img width="1008" alt="Screen Shot 2022-07-12 at 11 39 26 PM" src="https://user-images.githubusercontent.com/71563622/178591363-c3518018-9cc1-4da6-97c1-abafa498be62.png">

## TODO
- [x] Activate the "Available Funds" link.
- [x] Make the Move funds, Mint Tokens, Manage Tokens links enabled when the governance extension is active.

Resolves #3550