### PR TITLE
Make display name & unique username inline in members list item

### DIFF
--- a/src/modules/core/components/MembersList/MembersListItem.css
+++ b/src/modules/core/components/MembersList/MembersListItem.css
@@ -17,7 +17,10 @@
   composes: section;
   flex-grow: 0.5;
   margin-right: auto;
-  max-width: 200px;
+  width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .displayName {
@@ -26,6 +29,7 @@
 }
 
 .displayName + .username {
+  display: inline-flex;
   margin-left: 5px;
 }
 


### PR DESCRIPTION
## Description

This PR makes display name & unique username inline in members list item so that they are all of the same height.

Also added ellipsis for the longer display name.

<img width="848" alt="Screenshot 2022-07-13 at 16 23 25" src="https://user-images.githubusercontent.com/34057551/178744025-7f391997-9e44-443e-bf9c-e93ec5ff4f9d.png">

<img width="837" alt="Screenshot 2022-07-13 at 16 23 58" src="https://user-images.githubusercontent.com/34057551/178744130-a7f707ee-76e7-4c97-852c-18aa33962094.png">

resolves 3616