### PR TITLE
Add missing Metatransactions Gas Station Annotation Message Descriptor

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -410,6 +410,8 @@
     "metatransaction.WrappedToken.withdraw.description": "Unwrap Token",
     "metatransaction.VestingSimple.claimGrant.title": "Claim Colony Grant",
     "metatransaction.VestingSimple.claimGrant.description": "Claim Colony Grant",
+    "metatransaction.ColonyClient.annotateTransaction.title": "Annotate Transaction",
+    "metatransaction.ColonyClient.annotateTransaction.description": "Annotate Transaction",
 
     "message.generic.title": "Generic Message",
     "message.generic.description": "This needs your wallet's signature",


### PR DESCRIPTION
Apparently in my rush to get Metatransactions merged, I've missed the message descriptor declaration for when annotating transactions via Metatransactions. 

This PR now fixes that.