### PR TITLE
Fix Broadcaster Human Readable Error Generator

### DIFF
--- a/src/modules/core/sagas/utils/errorMessages.ts
+++ b/src/modules/core/sagas/utils/errorMessages.ts
@@ -1,5 +1,6 @@
 import { createIntl } from 'react-intl';
-import { parseBytes32String, isHexString } from 'ethers/utils';
+import { isHexString } from 'ethers/utils';
+import { hexSequenceNormalizer } from '@purser/core';
 
 import { TRANSACTION_METHODS } from '~immutable/index';
 import { ContractRevertErrors } from '~types/index';
@@ -23,6 +24,7 @@ export const generateBroadcasterHumanReadableError = (
 ): string => {
   let errorMessage =
     error?.reason ||
+    response?.reason ||
     response?.payload ||
     intl.formatMessage({ id: 'error.unknown' });
 
@@ -33,7 +35,10 @@ export const generateBroadcasterHumanReadableError = (
   const [, foundHexString] = response?.reason?.match(/(0x.*)/) || [];
   const isHexReason = foundHexString && isHexString(foundHexString);
   const hexReasonValue = isHexReason
-    ? parseBytes32String(foundHexString.padEnd(66, '0'))
+    ? Buffer.from(
+        hexSequenceNormalizer(foundHexString, false),
+        'hex',
+      ).toString()
     : '';
 
   if (

--- a/src/modules/core/sagas/utils/errorMessages.ts
+++ b/src/modules/core/sagas/utils/errorMessages.ts
@@ -60,5 +60,14 @@ export const generateBroadcasterHumanReadableError = (
     return errorMessage;
   }
 
+  /*
+   * @NOTE If the error in unknown _(we didn't trigger the previous logic checks)_
+   * make sure to log it out so we can debug it
+   */
+  console.error(
+    errorMessage,
+    `Reponse: ${response?.payload} ${response?.reason}`,
+    `Decoded: ${hexReasonValue}`,
+  );
   return errorMessage;
 };


### PR DESCRIPTION
This fixes the human readable error generator `generateBroadcasterHumanReadableError` for broadcaster that return the error reason as an encoded hex string _(Nethermind does this, and we're using it on Gnosis Chain, both for QA and Production)_

Note that the original implementation was incorrect as it was abusing `parseBytes32String` which expected a 32bit hex string, but if a longer hex string was provided _(which it could, hex strings have no length enforcement)_, it would crash

![Screenshot from 2022-07-14 16-55-24](https://user-images.githubusercontent.com/1193222/178999377-012cf5ab-84e3-4afd-9224-69d7da7403ef.png)

![Screenshot from 2022-07-14 16-55-29](https://user-images.githubusercontent.com/1193222/178999382-4f1e02a8-96c7-4301-a663-8c324f8b547c.png)

This fixes the problem by removing reliance on external libraries, and instead using native functions to do the Hex to ASCII convestion