### PR TITLE
Add: actions menus mobile

### DIFF
--- a/src/modules/core/components/Dialog/DialogSection.css
+++ b/src/modules/core/components/Dialog/DialogSection.css
@@ -1,4 +1,5 @@
 @value borderColor: var(--grey-blue-0);
+@value query700 from '~styles/queries.css';
 
 .main {
   padding: 20px;
@@ -43,4 +44,24 @@
 .borderGrey {
   border: 1px solid var(--grey-blue-0);
   border-radius: var(--radius-tiny);
+}
+
+@media screen and query700 {
+  .main {
+    padding: 20px 14px;
+  }
+
+  .themeFooter {
+    display: flex;
+    justify-content: flex-end;
+    padding: 20px 14px;
+  }
+
+  .themeFooter > button:first-child {
+    padding: 9px 22px;
+  }
+
+  .themeSidePadding {
+    padding: 0 14px;
+  }
 }

--- a/src/modules/core/components/Dialog/DialogSection.css.d.ts
+++ b/src/modules/core/components/Dialog/DialogSection.css.d.ts
@@ -1,4 +1,5 @@
 export const borderColor: string;
+export const query700: string;
 export const main: string;
 export const themeHeading: string;
 export const themeSidePadding: string;

--- a/src/modules/core/components/DomainDropdown/DomainDropdownItem.css.d.ts
+++ b/src/modules/core/components/DomainDropdown/DomainDropdownItem.css.d.ts
@@ -1,3 +1,4 @@
+export const query700: string;
 export const main: string;
 export const childDomainIcon: string;
 export const mainContent: string;
@@ -9,4 +10,3 @@ export const editButtonCol: string;
 export const editButton: string;
 export const headingWrapper: string;
 export const activeDomain: string;
-export const query700: string;

--- a/src/modules/core/components/Fields/SelectOption/SelectOption.css
+++ b/src/modules/core/components/Fields/SelectOption/SelectOption.css
@@ -1,3 +1,5 @@
+@value query700 from '~styles/queries.css';
+
 .main {
   padding: 0 30px 0 15px;
   overflow: hidden;
@@ -51,4 +53,10 @@
 .value {
   composes: inlineEllipsis from '~styles/text.css';
   display: block;
+}
+
+@media screen and query700 {
+  .main {
+    padding: 0px 6px;
+  }
 }

--- a/src/modules/core/components/Fields/SelectOption/SelectOption.css.d.ts
+++ b/src/modules/core/components/Fields/SelectOption/SelectOption.css.d.ts
@@ -1,3 +1,4 @@
+export const query700: string;
 export const main: string;
 export const checkedMsg: string;
 export const selectedHelpText: string;

--- a/src/modules/core/components/IndexModal/IndexModal.css
+++ b/src/modules/core/components/IndexModal/IndexModal.css
@@ -43,7 +43,7 @@
 
 @media screen and query700 {
   .header {
-    padding-top: secondaryPadding;
+    padding: secondaryPadding 24px 24px;
   }
 
   .header::after {

--- a/src/modules/core/components/IndexModal/IndexModalItem.css
+++ b/src/modules/core/components/IndexModal/IndexModalItem.css
@@ -120,4 +120,10 @@
     right: 20px;
     left: 20px;
   }
+
+  .coming {
+    padding: 2px;
+    height: auto;
+    min-height: 20px;
+  }
 }

--- a/src/modules/core/components/MemberReputation/MemberReputation.css
+++ b/src/modules/core/components/MemberReputation/MemberReputation.css
@@ -1,4 +1,5 @@
 @value reputationColor: rgb(255, 176, 0);
+@value query700 from '~styles/queries.css';
 
 .reputationWrapper {
   display: flex;
@@ -40,4 +41,25 @@
   fill: transparent;
   stroke-width: 3px;
   stroke: reputationColor;
+}
+
+@media screen and query700 {
+  .reputationWrapper {
+    display: flex;
+    align-items: center;
+    padding-top: 2px;
+    padding-right: 0;
+    column-gap: 3px;
+  }
+
+  .reputationWrapper svg {
+    position: static;
+  }
+
+  .reputationWrapper i {
+    display: flex;
+    align-items: center;
+    position: static;
+    transform: none;
+  }
 }

--- a/src/modules/core/components/MemberReputation/MemberReputation.css.d.ts
+++ b/src/modules/core/components/MemberReputation/MemberReputation.css.d.ts
@@ -1,4 +1,5 @@
 export const reputationColor: string;
+export const query700: string;
 export const reputationWrapper: string;
 export const reputation: string;
 export const reputationPointsContainer: string;

--- a/src/modules/core/components/SingleUserPicker/SingleUserPicker.css
+++ b/src/modules/core/components/SingleUserPicker/SingleUserPicker.css
@@ -1,7 +1,7 @@
 @value query700 from '~styles/queries.css';
 
 .main {
-  composes: field from '~styles/fields.css';
+  composes: field from "~styles/fields.css";
   width: 100%;
 }
 
@@ -169,7 +169,10 @@
   }
 
   .arrowIcon {
+    display: flex;
+    padding: 11px 0;
     position: static;
+    border-bottom: 1px solid var(--temp-grey-blue-7);
   }
 
   .widthWide input {
@@ -183,5 +186,15 @@
   .input:placeholder-shown {
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+
+  .arrowIconActive {
+    border-bottom-color: var(--primary);
+  }
+
+  .baseInput,
+  .omniPickerContainer,
+  .recipientName {
+    max-width: none;
   }
 }

--- a/src/modules/dashboard/components/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.css
+++ b/src/modules/dashboard/components/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.css
@@ -1,4 +1,5 @@
 @value wideButton: 160px;
+@value query700 from '~styles/queries.css';
 
 .inputContainer {
   margin-bottom: 20px;
@@ -107,4 +108,53 @@
   height: 1px;
   width: 100%;
   background-color: color-mod(var(--temp-grey-blue-7) alpha(15%));
+}
+
+@media screen and query700 {
+  .percentageSign {
+    padding-top: 45px;
+    position: static;
+  }
+
+  .inputText {
+    margin-top: 0;
+    padding-right: 28px;
+    float: none;
+    text-align: right;
+  }
+
+  .inputContainer {
+    margin-bottom: -10px; /* Necessary (because of the min-height) to reduce distance from next section */
+    min-height: 127px;
+    width: auto;
+    column-gap: 6px;
+  }
+
+  .inputContainer > div {
+    display: flex;
+    column-gap: 5px;
+  }
+
+  .inputContainer div > p {
+    justify-content: flex-end;
+    text-align: right;
+  }
+
+  .inputContainer > div > div:first-child {
+    flex: 1;
+  }
+
+  .inputContainer label {
+    margin-top: 0px;
+    position: static;
+  }
+
+  .inputContainer label span {
+    display: inline-block;
+    min-height: 34px;
+  }
+
+  .inputContainer input {
+    padding-right: 0px;
+  }
 }

--- a/src/modules/dashboard/components/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.css
+++ b/src/modules/dashboard/components/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.css
@@ -112,20 +112,23 @@
 
 @media screen and query700 {
   .percentageSign {
-    padding-top: 45px;
+    /*
+     * Negative margin maintains the container above the input
+     * instead of to the side, same as on desktop.
+     */
+    margin-left: -28px;
+    padding-top: 38px;
     position: static;
   }
 
   .inputText {
     margin-top: 0;
-    padding-right: 28px;
+    padding-top: 5px;
     float: none;
     text-align: right;
   }
 
   .inputContainer {
-    margin-bottom: -10px; /* Necessary (because of the min-height) to reduce distance from next section */
-    min-height: 127px;
     width: auto;
     column-gap: 6px;
   }
@@ -155,6 +158,6 @@
   }
 
   .inputContainer input {
-    padding-right: 0px;
+    padding-right: 28px;
   }
 }

--- a/src/modules/dashboard/components/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.css.d.ts
@@ -1,4 +1,5 @@
 export const wideButton: string;
+export const query700: string;
 export const inputContainer: string;
 export const domainSelects: string;
 export const singleUserContainer: string;

--- a/src/modules/dashboard/components/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.tsx
@@ -5,7 +5,6 @@ import sortBy from 'lodash/sortBy';
 import { AddressZero } from 'ethers/constants';
 import { ROOT_DOMAIN_ID, ColonyRole } from '@colony/colony-js';
 import Decimal from 'decimal.js';
-import { useMediaQuery } from 'react-responsive';
 
 import Button from '~core/Button';
 import { ItemDataType } from '~core/OmniPicker';
@@ -43,7 +42,6 @@ import { userHasRole } from '~modules/users/checks';
 import { ManageReputationDialogFormValues } from '../types';
 import TeamDropdownItem from './TeamDropdownItem';
 
-import { query700 as query } from '~styles/queries.css';
 import styles from './ManageReputationDialogForm.css';
 
 const MSG = defineMessages({
@@ -282,8 +280,6 @@ const ManageReputationDialogForm = ({
     [setFieldValue],
   );
 
-  const isMobile = useMediaQuery({ query });
-
   return (
     <>
       <DialogSection appearance={{ theme: 'sidePadding' }}>
@@ -397,7 +393,7 @@ const ManageReputationDialogForm = ({
                 tailPrefix: true,
                 numeralDecimalScale: 10,
               }}
-              elementOnly={!isMobile}
+              elementOnly
               maxButtonParams={
                 isSmiteAction
                   ? {

--- a/src/modules/dashboard/components/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.tsx
@@ -5,6 +5,7 @@ import sortBy from 'lodash/sortBy';
 import { AddressZero } from 'ethers/constants';
 import { ROOT_DOMAIN_ID, ColonyRole } from '@colony/colony-js';
 import Decimal from 'decimal.js';
+import { useMediaQuery } from 'react-responsive';
 
 import Button from '~core/Button';
 import { ItemDataType } from '~core/OmniPicker';
@@ -42,6 +43,7 @@ import { userHasRole } from '~modules/users/checks';
 import { ManageReputationDialogFormValues } from '../types';
 import TeamDropdownItem from './TeamDropdownItem';
 
+import { query700 as query } from '~styles/queries.css';
 import styles from './ManageReputationDialogForm.css';
 
 const MSG = defineMessages({
@@ -280,6 +282,8 @@ const ManageReputationDialogForm = ({
     [setFieldValue],
   );
 
+  const isMobile = useMediaQuery({ query });
+
   return (
     <>
       <DialogSection appearance={{ theme: 'sidePadding' }}>
@@ -378,34 +382,36 @@ const ManageReputationDialogForm = ({
       </DialogSection>
       <DialogSection>
         <div className={styles.inputContainer}>
-          <Input
-            name="amount"
-            label={MSG.amount}
-            labelValues={{ isSmiteAction }}
-            appearance={{
-              theme: 'minimal',
-              align: 'right',
-            }}
-            formattingOptions={{
-              numeral: true,
-              // @ts-ignore
-              tailPrefix: true,
-              numeralDecimalScale: 10,
-            }}
-            elementOnly
-            maxButtonParams={
-              isSmiteAction
-                ? {
-                    fieldName: 'amount',
-                    maxAmount: String(unformattedUserReputationAmount),
-                    setFieldValue,
-                  }
-                : undefined
-            }
-            disabled={inputDisabled}
-            dataTest="reputationAmountInput"
-          />
-          <div className={styles.percentageSign}>pts</div>
+          <div>
+            <Input
+              name="amount"
+              label={MSG.amount}
+              labelValues={{ isSmiteAction }}
+              appearance={{
+                theme: 'minimal',
+                align: 'right',
+              }}
+              formattingOptions={{
+                numeral: true,
+                // @ts-ignore
+                tailPrefix: true,
+                numeralDecimalScale: 10,
+              }}
+              elementOnly={!isMobile}
+              maxButtonParams={
+                isSmiteAction
+                  ? {
+                      fieldName: 'amount',
+                      maxAmount: String(unformattedUserReputationAmount),
+                      setFieldValue,
+                    }
+                  : undefined
+              }
+              disabled={inputDisabled}
+              dataTest="reputationAmountInput"
+            />
+            <div className={styles.percentageSign}>pts</div>
+          </div>
           <p className={styles.inputText}>
             <FormattedMessage
               {...MSG.maxReputation}

--- a/src/modules/dashboard/components/Dialogs/CreateDomainDialog/CreateDomainDialogForm.css
+++ b/src/modules/dashboard/components/Dialogs/CreateDomainDialog/CreateDomainDialogForm.css
@@ -1,4 +1,5 @@
 @value wideButton: 160px;
+@value query700 from '~styles/queries.css';
 
 .nameAndColorContainer {
   display: flex;
@@ -41,4 +42,10 @@
 
 .motionVoteDomain {
   margin: 6px 0;
+}
+
+@media screen and query700 {
+  .domainName > div:first-child {
+    min-height: 85px;
+  }
 }

--- a/src/modules/dashboard/components/Dialogs/CreateDomainDialog/CreateDomainDialogForm.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/CreateDomainDialog/CreateDomainDialogForm.css.d.ts
@@ -1,4 +1,5 @@
 export const wideButton: string;
+export const query700: string;
 export const nameAndColorContainer: string;
 export const title: string;
 export const domainName: string;

--- a/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.css
+++ b/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.css
@@ -1,4 +1,5 @@
 @value wideButton: 160px;
+@value query700 from '~styles/queries.css';
 
 .tokenAmount {
   display: flex;
@@ -99,4 +100,24 @@
 
 .warningLabel {
   color: var(--danger);
+}
+
+@media screen and query700 {
+  .domainPotBalance {
+    position: static;
+  }
+
+  .tokenAmountContainer {
+    margin-top: 0px;
+    padding-top: 10px;
+  }
+
+  .tokenAmount {
+    display: flex;
+    min-height: 91px;
+  }
+
+  .networkFee {
+    position: static;
+  }
 }

--- a/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.css.d.ts
@@ -1,4 +1,5 @@
 export const wideButton: string;
+export const query700: string;
 export const tokenAmount: string;
 export const tokenAmountSelect: string;
 export const tokenAmountContainer: string;

--- a/src/modules/dashboard/components/Dialogs/EditDomainDialog/EditDomainDialogForm.css
+++ b/src/modules/dashboard/components/Dialogs/EditDomainDialog/EditDomainDialogForm.css
@@ -1,4 +1,5 @@
 @value wideButton: 160px;
+@value query700 from '~styles/queries.css';
 
 .nameAndColorContainer {
   display: flex;
@@ -34,4 +35,11 @@
 
 .motionVoteDomain {
   margin: 6px 0;
+}
+
+@media screen and query700 {
+  .nameAndColorContainer > div:nth-child(2) {
+    align-self: flex-end;
+    padding-bottom: 5px;
+  }
 }

--- a/src/modules/dashboard/components/Dialogs/EditDomainDialog/EditDomainDialogForm.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/EditDomainDialog/EditDomainDialogForm.css.d.ts
@@ -1,4 +1,5 @@
 export const wideButton: string;
+export const query700: string;
 export const nameAndColorContainer: string;
 export const domainName: string;
 export const noPermissionFromMessage: string;

--- a/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/NoWhitelistedAddressesState/NoWhitelistedAddressesState.css
+++ b/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/NoWhitelistedAddressesState/NoWhitelistedAddressesState.css
@@ -1,3 +1,5 @@
+@value query700 from '~styles/queries.css';
+
 .main {
   display: flex;
   align-items: center;
@@ -15,4 +17,10 @@
 .desc {
   font-size: var(--size-normal);
   color: var(--temp-grey-blue-7);
+}
+
+@media screen and query700 {
+  .main {
+    align-items: flex-start;
+  }
 }

--- a/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/NoWhitelistedAddressesState/NoWhitelistedAddressesState.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/NoWhitelistedAddressesState/NoWhitelistedAddressesState.css.d.ts
@@ -1,3 +1,4 @@
+export const query700: string;
 export const main: string;
 export const title: string;
 export const desc: string;

--- a/src/modules/dashboard/components/Dialogs/NetworkContractUpgradeDialog/NetworkContractUpgradeDialogForm.css
+++ b/src/modules/dashboard/components/Dialogs/NetworkContractUpgradeDialog/NetworkContractUpgradeDialogForm.css
@@ -1,4 +1,5 @@
 @value wideButton: 160px;
+@value query700 from '~styles/queries.css';
 
 .title {
   font-size: var(--size-medium-l);
@@ -84,4 +85,14 @@
 
 .motionVoteDomain {
   margin: 6px 0;
+}
+
+@media screen and query700 {
+  .contractVersionLine {
+    padding: 15px 0;
+  }
+
+  .divider {
+    margin: 0px;
+  }
 }

--- a/src/modules/dashboard/components/Dialogs/NetworkContractUpgradeDialog/NetworkContractUpgradeDialogForm.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/NetworkContractUpgradeDialog/NetworkContractUpgradeDialogForm.css.d.ts
@@ -1,4 +1,5 @@
 export const wideButton: string;
+export const query700: string;
 export const title: string;
 export const noPermissionMessage: string;
 export const contractVersionLine: string;

--- a/src/modules/dashboard/components/Dialogs/TokenMintDialog/TokenMintForm.css
+++ b/src/modules/dashboard/components/Dialogs/TokenMintDialog/TokenMintForm.css
@@ -55,7 +55,11 @@
 }
 
 @media screen and query700 {
+  .inputContainer > div {
+    min-height: 75px;
+  }
+
   .nativeToken {
-    padding: 0 10px 10px;
+    padding: 15px 10px 10px;
   }
 }

--- a/src/modules/dashboard/components/Dialogs/TokenMintDialog/TokenMintForm.css
+++ b/src/modules/dashboard/components/Dialogs/TokenMintDialog/TokenMintForm.css
@@ -1,4 +1,5 @@
 @value wideButton: 160px;
+@value query700 from '~styles/queries.css';
 
 .modalHeading {
   padding: 32px 0 20px;
@@ -51,4 +52,10 @@
 
 .motionVoteDomain {
   margin: 6px 0;
+}
+
+@media screen and query700 {
+  .nativeToken {
+    padding: 0 10px 10px;
+  }
 }

--- a/src/modules/dashboard/components/Dialogs/TokenMintDialog/TokenMintForm.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/TokenMintDialog/TokenMintForm.css.d.ts
@@ -1,4 +1,5 @@
 export const wideButton: string;
+export const query700: string;
 export const modalHeading: string;
 export const headingContainer: string;
 export const inputContainer: string;

--- a/src/modules/dashboard/components/Dialogs/TransferFundsDialog/TransferFundsDialogForm.css
+++ b/src/modules/dashboard/components/Dialogs/TransferFundsDialog/TransferFundsDialogForm.css
@@ -1,4 +1,5 @@
 @value wideButton: 160px;
+@value query700 from '~styles/queries.css';
 
 .tokenAmount {
   display: flex;
@@ -95,4 +96,29 @@
 
 .motionVoteDomain {
   margin: 6px 0;
+}
+
+@media screen and query700 {
+  .domainPotBalance {
+    margin-top: 0px;
+    padding-left: 1px;
+  }
+
+  .tokenAmountContainer {
+    margin-top: 0px;
+    padding-top: 10px;
+  }
+
+  .tokenAmount {
+    display: flex;
+    min-height: 91px;
+  }
+
+  .domainSelects {
+    min-height: 105px;
+  }
+
+  .transferIcon {
+    transform: translateY(-8px);
+  }
 }

--- a/src/modules/dashboard/components/Dialogs/TransferFundsDialog/TransferFundsDialogForm.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/TransferFundsDialog/TransferFundsDialogForm.css.d.ts
@@ -1,4 +1,5 @@
 export const wideButton: string;
+export const query700: string;
 export const tokenAmount: string;
 export const amountContainer: string;
 export const tokenAmountSelect: string;


### PR DESCRIPTION
## Description

This PR covers the work for making the actions menus (e.g. mint tokens or smite reputation) responsive on mobile. To test, go to home page, click `New Action`, and go through every possible option in the menus and ensure all behave on mobile.

**Changes** 🏗

* Styling all the components connected to the Actions menus for mobile

## Screenshot

**_The menus I'm talking about_**

![action-menus](https://user-images.githubusercontent.com/64402732/179623243-cd2f0d90-65a1-4ece-8381-aa91ec234b64.png)

Resolves #3651
