### PR TITLE
Add gnosis transaction preview dialog

### DIFF
--- a/src/modules/core/components/Fields/Form/ActionForm.tsx
+++ b/src/modules/core/components/Fields/Form/ActionForm.tsx
@@ -43,6 +43,7 @@ interface ExtendedFormikConfig {
   onSubmit?: (values: any, formikActions: FormikHelpers<any>) => void;
   validationSchema?: any | (() => any);
   validate?: (values: any) => void | object | Promise<FormikErrors<any>>;
+  validateOnMount?: boolean;
 }
 
 interface Props extends ExtendedFormikConfig {

--- a/src/modules/core/components/Fields/Input/InputComponent.tsx
+++ b/src/modules/core/components/Fields/Input/InputComponent.tsx
@@ -171,6 +171,7 @@ const InputComponent = ({
           placeholder={placeholder}
           onInit={(cleaveInstance) => setCleave(cleaveInstance)}
           data-test={dataTest}
+          value={value || ''}
         />
       </div>
     );

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/DetailsItem/DetailsItem.css
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/DetailsItem/DetailsItem.css
@@ -1,0 +1,18 @@
+.detailsItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 46px;
+  width: 100%;
+  border-bottom: 1px solid color-mod(var(--temp-grey-blue-7) alpha(15%));
+  font-size: var(--size-smallish);
+  font-weight: var(--weight-bold);
+}
+
+.detailsItemLabel {
+  color: var(--temp-grey-blue-7);
+}
+
+.detailsItemValue {
+  color: var(--dark);
+}

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/DetailsItem/DetailsItem.css
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/DetailsItem/DetailsItem.css
@@ -2,7 +2,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  height: 46px;
+  min-height: 46px;
   width: 100%;
   border-bottom: 1px solid color-mod(var(--temp-grey-blue-7) alpha(15%));
   font-size: var(--size-smallish);

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/DetailsItem/DetailsItem.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/DetailsItem/DetailsItem.css.d.ts
@@ -1,0 +1,3 @@
+export const detailsItem: string;
+export const detailsItemLabel: string;
+export const detailsItemValue: string;

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/DetailsItem/DetailsItem.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/DetailsItem/DetailsItem.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { FormattedMessage, MessageDescriptor } from 'react-intl';
+
+import styles from './DetailsItem.css';
+
+const DetailsItem = ({
+  label,
+  value,
+}: {
+  label: MessageDescriptor;
+  value: JSX.Element;
+}) => (
+  <div className={styles.detailsItem}>
+    <div className={styles.detailsItemLabel}>
+      <FormattedMessage {...label} />
+    </div>
+    <div className={styles.detailsItemValue}>{value}</div>
+  </div>
+);
+
+export default DetailsItem;

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/DetailsItem/index.ts
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/DetailsItem/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DetailsItem';

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
@@ -175,7 +175,7 @@ const GnosisControlSafeDialog = ({
             safes={safes}
             isVotingExtensionEnabled={isVotingExtensionEnabled}
             showPreview={showPreview}
-            handleSHowPreview={setShowPreview}
+            handleShowPreview={setShowPreview}
           />
         </Dialog>
       )}

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
@@ -11,7 +11,9 @@ import { ActionForm } from '~core/Fields';
 import { ActionTypes } from '~redux/index';
 import { WizardDialogType } from '~utils/hooks';
 
-import GnosisControlSafeForm from './GnosisControlSafeForm';
+import GnosisControlSafeForm, {
+  TransactionTypes,
+} from './GnosisControlSafeForm';
 
 const MSG = defineMessages({
   requiredFieldError: {
@@ -52,25 +54,6 @@ export interface FormValues {
   safe: string;
   forceAction: boolean;
 }
-
-export const transactionOptions = [
-  {
-    value: 'transferFunds',
-    label: 'Transfer funds',
-  },
-  {
-    value: 'transferNft',
-    label: 'Transfer NFT',
-  },
-  {
-    value: 'contractInteraction',
-    label: 'Contract interaction',
-  },
-  {
-    value: 'rawTransaction',
-    label: 'Raw transaction',
-  },
-];
 
 const displayName = 'dashboard.GnosisControlSafeDialog';
 

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
@@ -50,7 +50,6 @@ export interface FormValues {
     contract?: string;
     abi?: string;
     contractFunction?: string;
-    nft?: string;
   }[];
   safe: string;
   forceAction: boolean;
@@ -164,6 +163,7 @@ const GnosisControlSafeDialog = ({
       submit={ActionTypes.COLONY_ACTION_GENERIC}
       success={ActionTypes.COLONY_ACTION_GENERIC_SUCCESS}
       error={ActionTypes.COLONY_ACTION_GENERIC_ERROR}
+      validateOnMount
     >
       {(formValues: FormikProps<FormValues>) => (
         <Dialog cancel={cancel}>

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
@@ -53,7 +53,7 @@ export interface FormValues {
   }[];
   safe: string;
   forceAction: boolean;
-  transactionSetTitle: string;
+  transactionsTitle: string;
 }
 
 const displayName = 'dashboard.GnosisControlSafeDialog';
@@ -65,7 +65,7 @@ type Props = DialogProps &
 const validationSchema = (isPreview) =>
   yup.object().shape({
     safe: yup.string().required(() => MSG.requiredFieldError),
-    ...(isPreview ? { transactionSetTitle: yup.string().required() } : {}),
+    ...(isPreview ? { transactionsTitle: yup.string().required() } : {}),
     transactions: yup.array(
       yup.object().shape({
         transactionType: yup.string().required(() => MSG.requiredFieldError),
@@ -146,7 +146,7 @@ const GnosisControlSafeDialog = ({
     <ActionForm
       initialValues={{
         safe: '',
-        transactionSetTitle: undefined,
+        transactionsTitle: undefined,
         transactions: [
           {
             transactionType: '',

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
@@ -12,9 +12,8 @@ import { ActionTypes } from '~redux/index';
 import { WizardDialogType } from '~utils/hooks';
 import { Address } from '~types/index';
 
-import GnosisControlSafeForm, {
-  TransactionTypes,
-} from './GnosisControlSafeForm';
+import { TransactionTypes } from './constants';
+import GnosisControlSafeForm from './GnosisControlSafeForm';
 
 const MSG = defineMessages({
   requiredFieldError: {

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
@@ -71,7 +71,8 @@ const validationSchema = yup.object().shape({
       recipient: yup.object().shape({
         profile: yup.object().shape({
           walletAddress: yup.string().when('transactionType', {
-            is: (transactionType) => transactionType === 'transferFunds',
+            is: (transactionType) =>
+              transactionType === TransactionTypes.TRANSFER_FUNDS,
             then: yup
               .string()
               .address()
@@ -82,8 +83,8 @@ const validationSchema = yup.object().shape({
       }),
       amount: yup.number().when('transactionType', {
         is: (transactionType) =>
-          transactionType === 'transferFunds' ||
-          transactionType === 'rawTransaction',
+          transactionType === TransactionTypes.TRANSFER_FUNDS ||
+          transactionType === TransactionTypes.RAW_TRANSACTION,
         then: yup
           .number()
           .transform((value) => toFinite(value))
@@ -92,7 +93,8 @@ const validationSchema = yup.object().shape({
         otherwise: false,
       }),
       tokenAddress: yup.string().when('transactionType', {
-        is: (transactionType) => transactionType === 'transferFunds',
+        is: (transactionType) =>
+          transactionType === TransactionTypes.TRANSFER_FUNDS,
         then: yup
           .string()
           .address()
@@ -100,12 +102,14 @@ const validationSchema = yup.object().shape({
         otherwise: false,
       }),
       data: yup.string().when('transactionType', {
-        is: (transactionType) => transactionType === 'rawTransaction',
+        is: (transactionType) =>
+          transactionType === TransactionTypes.RAW_TRANSACTION,
         then: yup.string().required(() => MSG.requiredFieldError),
         otherwise: false,
       }),
       contract: yup.string().when('transactionType', {
-        is: (transactionType) => transactionType === 'contractInteraction',
+        is: (transactionType) =>
+          transactionType === TransactionTypes.CONTRACT_INTERACTION,
         then: yup
           .string()
           .address()
@@ -113,12 +117,14 @@ const validationSchema = yup.object().shape({
         otherwise: false,
       }),
       abi: yup.string().when('transactionType', {
-        is: (transactionType) => transactionType === 'contractInteraction',
+        is: (transactionType) =>
+          transactionType === TransactionTypes.CONTRACT_INTERACTION,
         then: yup.string().required(() => MSG.requiredFieldError),
         otherwise: false,
       }),
       contractFunction: yup.string().when('transactionType', {
-        is: (transactionType) => transactionType === 'contractInteraction',
+        is: (transactionType) =>
+          transactionType === TransactionTypes.CONTRACT_INTERACTION,
         then: yup.string().required(() => MSG.requiredFieldError),
         otherwise: false,
       }),

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
@@ -10,6 +10,7 @@ import { ActionForm } from '~core/Fields';
 
 import { ActionTypes } from '~redux/index';
 import { WizardDialogType } from '~utils/hooks';
+import { Address } from '~types/index';
 
 import GnosisControlSafeForm, {
   TransactionTypes,
@@ -50,6 +51,7 @@ export interface FormValues {
     contract?: string;
     abi?: string;
     contractFunction?: string;
+    nft?: string;
   }[];
   safe: string;
   forceAction: boolean;

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
@@ -53,6 +53,7 @@ export interface FormValues {
   }[];
   safe: string;
   forceAction: boolean;
+  transactionSetTitle: string;
 }
 
 const displayName = 'dashboard.GnosisControlSafeDialog';

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
@@ -44,7 +44,7 @@ const safes = [
 export interface FormValues {
   transactions: {
     transactionType: string;
-    tokenAddress?: string;
+    tokenAddress?: Address;
     amount?: number;
     recipient?: AnyUser;
     data?: string;

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css
@@ -117,26 +117,48 @@
 }
 
 .transactionTitle {
-  font-size: var(--size-normal);
-  color: var(dark);
   margin-bottom: 20px;
+  font-size: var(--size-normal);
   font-weight: var(--weight-bold);
+  color: var(dark);
 }
 
 .detailsItem {
   display: flex;
+  justify-content: space-between;
+  align-items: center;
   height: 46px;
   width: 100%;
-  align-items: center;
-  justify-content: space-between;
   border-bottom: 1px solid color-mod(var(--temp-grey-blue-7) alpha(15%));
   font-size: var(--size-smallish);
+  font-weight: var(--weight-bold);
 }
 
 .detailsItemLabel {
   color: var(--temp-grey-blue-7);
 }
 
+.nftValue {
+  color: var(--pink);
+}
+
 .detailsItemValue {
-  color: var(dark);
+  color: var(--dark);
+}
+
+.tokenAmount {
+  display: flex;
+  align-items: center;
+}
+
+.tokenAmount > figure {
+  margin-right: 8px;
+}
+
+.tokenAmount > span {
+  font-size: var(--size-smallish);
+}
+
+.tokenAmount > figure > div {
+  border-radius: 0;
 }

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css
@@ -120,7 +120,7 @@
   margin-bottom: 20px;
   font-size: var(--size-normal);
   font-weight: var(--weight-bold);
-  color: var(dark);
+  color: var(--dark);
 }
 
 .detailsItem {

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css
@@ -143,3 +143,10 @@
 .tokenAmount > figure > div {
   border-radius: 0;
 }
+
+.rawTransactionValues {
+  padding: 10px 0;
+  max-width: 270px;
+  font-weight: var(--weight-normal);
+  overflow-wrap: anywhere;
+}

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css
@@ -115,3 +115,28 @@
 .transactionHeadingOpen .toggleTabIcon {
   transform: none;
 }
+
+.transactionTitle {
+  font-size: var(--size-normal);
+  color: var(dark);
+  margin-bottom: 20px;
+  font-weight: var(--weight-bold);
+}
+
+.detailsItem {
+  display: flex;
+  height: 46px;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid color-mod(var(--temp-grey-blue-7) alpha(15%));
+  font-size: var(--size-smallish);
+}
+
+.detailsItemLabel {
+  color: var(--temp-grey-blue-7);
+}
+
+.detailsItemValue {
+  color: var(dark);
+}

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css
@@ -144,9 +144,12 @@
   border-radius: 0;
 }
 
+.transactionDetailsSection {
+  padding-bottom: 20px;
+}
+
 .rawTransactionValues {
   padding: 10px 0;
   max-width: 270px;
-  font-weight: var(--weight-normal);
   overflow-wrap: anywhere;
 }

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css
@@ -123,27 +123,8 @@
   color: var(--dark);
 }
 
-.detailsItem {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  height: 46px;
-  width: 100%;
-  border-bottom: 1px solid color-mod(var(--temp-grey-blue-7) alpha(15%));
-  font-size: var(--size-smallish);
-  font-weight: var(--weight-bold);
-}
-
-.detailsItemLabel {
-  color: var(--temp-grey-blue-7);
-}
-
 .nftValue {
   color: var(--pink);
-}
-
-.detailsItemValue {
-  color: var(--dark);
 }
 
 .tokenAmount {

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css
@@ -151,5 +151,6 @@
 .rawTransactionValues {
   padding: 10px 0;
   max-width: 270px;
+  text-align: right;
   overflow-wrap: anywhere;
 }

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css.d.ts
@@ -13,8 +13,5 @@ export const toggleTabIcon: string;
 export const tabContentClosed: string;
 export const transactionHeadingOpen: string;
 export const transactionTitle: string;
-export const detailsItem: string;
-export const detailsItemLabel: string;
 export const nftValue: string;
-export const detailsItemValue: string;
 export const tokenAmount: string;

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css.d.ts
@@ -15,4 +15,6 @@ export const transactionHeadingOpen: string;
 export const transactionTitle: string;
 export const detailsItem: string;
 export const detailsItemLabel: string;
+export const nftValue: string;
 export const detailsItemValue: string;
+export const tokenAmount: string;

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css.d.ts
@@ -15,4 +15,5 @@ export const transactionHeadingOpen: string;
 export const transactionTitle: string;
 export const nftValue: string;
 export const tokenAmount: string;
+export const transactionDetailsSection: string;
 export const rawTransactionValues: string;

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css.d.ts
@@ -12,3 +12,7 @@ export const deleteTabTooltip: string;
 export const toggleTabIcon: string;
 export const tabContentClosed: string;
 export const transactionHeadingOpen: string;
+export const transactionTitle: string;
+export const detailsItem: string;
+export const detailsItemLabel: string;
+export const detailsItemValue: string;

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css.d.ts
@@ -15,3 +15,4 @@ export const transactionHeadingOpen: string;
 export const transactionTitle: string;
 export const nftValue: string;
 export const tokenAmount: string;
+export const rawTransactionValues: string;

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
@@ -203,7 +203,7 @@ const GnosisControlSafeForm = ({
   /* This is necessary as the form validation doesn't work on the first render
   when we switch to showing preview */
   useEffect(() => {
-    if (showPreview && values.transactionSetTitle === undefined) {
+    if (showPreview && values.transactionsTitle === undefined) {
       setHasTitle(false);
     } else {
       setHasTitle(true);

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { FieldArray, FieldArrayRenderProps, FormikProps } from 'formik';
 import { ColonyRole, ROOT_DOMAIN_ID } from '@colony/colony-js';
@@ -127,6 +127,7 @@ const GnosisControlSafeForm = ({
   handleSHowPreview,
 }: Props & FormikProps<FormValues>) => {
   const [transactionTabStatus, setTransactionTabStatus] = useState([true]);
+  const [hasTitle, setHasTitle] = useState(true);
 
   const { walletAddress } = useLoggedInUser();
   const fromDomainRoles = useTransformer(getUserRolesForDomain, [
@@ -198,6 +199,16 @@ const GnosisControlSafeForm = ({
     () => [...new Array(values.transactions.length)].map(nanoid),
     [values.transactions.length],
   );
+
+  /* This is necessary as the form validation doesn't work on the first render
+  when we switch to showing preview */
+  useEffect(() => {
+    if (showPreview && values.transactionSetTitle === undefined) {
+      setHasTitle(false);
+    } else {
+      setHasTitle(true);
+    }
+  }, [values, showPreview]);
 
   return (
     <>
@@ -370,7 +381,7 @@ const GnosisControlSafeForm = ({
           }
           text={MSG.buttonCreateTransaction}
           loading={isSubmitting}
-          disabled={!isValid || isSubmitting}
+          disabled={!isValid || isSubmitting || !hasTitle}
           style={{ width: styles.wideButton }}
         />
       </DialogSection>

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
@@ -7,7 +7,7 @@ import { nanoid } from 'nanoid';
 
 import Avatar from '~core/Avatar';
 import { DialogSection } from '~core/Dialog';
-import { Select } from '~core/Fields';
+import { Annotations, Input, Select } from '~core/Fields';
 import Heading from '~core/Heading';
 import ExternalLink from '~core/ExternalLink';
 import Button, { AddItemButton } from '~core/Button';
@@ -82,6 +82,10 @@ const MSG = defineMessages({
     id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.deleteTransactionTooltipText`,
     defaultMessage: `Delete transaction.\nBe careful, data can be lost.`,
   },
+  previewTitle: {
+    id: 'dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.previewTitle',
+    defaultMessage: 'Confirm transaction details',
+  },
 });
 
 const displayName = 'dashboard.GnosisControlSafeDialog.GnosisControlSafeForm';
@@ -121,6 +125,8 @@ const GnosisControlSafeForm = ({
   setFieldValue,
 }: Props & FormikProps<FormValues>) => {
   const [transactionTabStatus, setTransactionTabStatus] = useState([true]);
+  const [showPreview, setShowPreview] = useState(false);
+
   const { walletAddress } = useLoggedInUser();
   const fromDomainRoles = useTransformer(getUserRolesForDomain, [
     colony,
@@ -190,7 +196,7 @@ const GnosisControlSafeForm = ({
     [values.transactions.length],
   );
 
-  return (
+  return !showPreview ? (
     <>
       <DialogSection>
         <div className={styles.heading}>
@@ -348,8 +354,45 @@ const GnosisControlSafeForm = ({
         />
         <Button
           appearance={{ theme: 'primary', size: 'large' }}
-          onClick={() => handleSubmit()}
+          onClick={() => setShowPreview(!showPreview)}
+          // onClick={() => handleSubmit()}
           text={MSG.buttonCreateTransaction}
+          // loading={isSubmitting}
+          disabled={!isValid || isSubmitting}
+          style={{ width: styles.wideButton }}
+        />
+      </DialogSection>
+    </>
+  ) : (
+    <>
+      <DialogSection>
+        <div className={styles.heading}>
+          <Heading
+            appearance={{ size: 'medium', margin: 'none', theme: 'dark' }}
+            text={MSG.previewTitle}
+          />
+        </div>
+      </DialogSection>
+      <DialogSection>
+        <div>1. Subtitle</div>
+        <div>transaction details</div>
+      </DialogSection>
+      <DialogSection>
+        <Input label="Set title" name="transactionSetTitle" disabled={false} />
+      </DialogSection>
+      <DialogSection>
+        <Annotations label="Explain why" name="annotation" />
+      </DialogSection>
+      <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
+        <Button
+          appearance={{ theme: 'secondary', size: 'large' }}
+          onClick={() => setShowPreview(!showPreview)}
+          text={{ id: 'button.back' }}
+        />
+        <Button
+          appearance={{ theme: 'primary', size: 'large' }}
+          onClick={() => handleSubmit()}
+          text={{ id: 'button.confirm' }}
           loading={isSubmitting}
           disabled={!isValid || isSubmitting}
           style={{ width: styles.wideButton }}

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
@@ -97,6 +97,14 @@ const MSG = defineMessages({
     id: 'dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.previewTitle',
     defaultMessage: 'Confirm transaction details',
   },
+  transactionsSetTitle: {
+    id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.transactionsSetTitle`,
+    defaultMessage: 'Title of the set of all the arbitrary transactions',
+  },
+  explainWhy: {
+    id: 'dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.explainWhy',
+    defaultMessage: `Explain why you’re making arbitrary transaction (optional)`,
+  },
   targetContract: {
     id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.targetContract`,
     defaultMessage: 'Target contract',
@@ -566,13 +574,13 @@ const GnosisControlSafeForm = ({
       <DialogSection>
         <Input
           appearance={{ colorSchema: 'grey', theme: 'fat' }}
-          label="Set title"
+          label={MSG.transactionsSetTitle}
           name="transactionSetTitle"
           disabled={false}
         />
       </DialogSection>
       <DialogSection>
-        <Annotations label="Explain why" name="annotation" />
+        <Annotations label={MSG.explainWhy} name="annotation" />
       </DialogSection>
       <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
         <Button

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
@@ -167,18 +167,22 @@ export const transactionOptions = [
   {
     value: TransactionTypes.TRANSFER_FUNDS,
     label: MSG[TransactionTypes.TRANSFER_FUNDS],
+    labelString: 'Transfer funds',
   },
   {
     value: TransactionTypes.TRANSFER_NFT,
     label: MSG[TransactionTypes.TRANSFER_NFT],
+    labelString: 'Transfer NFT',
   },
   {
     value: TransactionTypes.CONTRACT_INTERACTION,
     label: MSG[TransactionTypes.CONTRACT_INTERACTION],
+    labelString: 'Contract interaction',
   },
   {
     value: TransactionTypes.RAW_TRANSACTION,
     label: MSG[TransactionTypes.RAW_TRANSACTION],
+    labelString: 'Raw transaction',
   },
 ];
 
@@ -333,7 +337,7 @@ const GnosisControlSafeForm = ({
       const transactionType = transactionOptions.find(
         (transaction) => transaction.value === transactionTypeValue,
       );
-      return transactionType?.label;
+      return transactionType?.labelString;
     },
     [],
   );
@@ -476,7 +480,7 @@ const GnosisControlSafeForm = ({
                     </div>
                   </DialogSection>
                   {values.transactions[index]?.transactionType ===
-                    'transferFunds' && (
+                    TransactionTypes.TRANSFER_FUNDS && (
                     <TransferFundsSection
                       colony={colony}
                       disabledInput={!userHasPermission || isSubmitting}
@@ -486,7 +490,7 @@ const GnosisControlSafeForm = ({
                     />
                   )}
                   {values.transactions[index]?.transactionType ===
-                    'rawTransaction' && (
+                    TransactionTypes.RAW_TRANSACTION && (
                     <RawTransactionSection
                       colony={colony}
                       disabledInput={!userHasPermission || isSubmitting}
@@ -494,7 +498,7 @@ const GnosisControlSafeForm = ({
                     />
                   )}
                   {values.transactions[index]?.transactionType ===
-                    'contractInteraction' && (
+                    TransactionTypes.CONTRACT_INTERACTION && (
                     <ContractInteractionSection
                       disabledInput={!userHasPermission || isSubmitting}
                       transactionFormIndex={index}

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
@@ -30,7 +30,7 @@ import {
   RawTransactionSection,
   ContractInteractionSection,
 } from './TransactionTypesSection';
-import { TransactionTypes } from './constants';
+import { TransactionTypes, transactionOptions } from './constants';
 
 import styles from './GnosisControlSafeForm.css';
 
@@ -84,98 +84,7 @@ const MSG = defineMessages({
     id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.deleteTransactionTooltipText`,
     defaultMessage: `Delete transaction.\nBe careful, data can be lost.`,
   },
-  previewTitle: {
-    id: 'dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.previewTitle',
-    defaultMessage: 'Confirm transaction details',
-  },
-  transactionsSetTitle: {
-    id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.transactionsSetTitle`,
-    defaultMessage: 'Title of the set of all the arbitrary transactions',
-  },
-  explainWhy: {
-    id: 'dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.explainWhy',
-    defaultMessage: `Explain why you’re making arbitrary transaction (optional)`,
-  },
-  targetContract: {
-    id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.targetContract`,
-    defaultMessage: 'Target contract',
-  },
-  function: {
-    id: 'dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.function',
-    defaultMessage: 'Function',
-  },
-  to: {
-    id: 'dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.to',
-    defaultMessage: 'To',
-  },
-  amount: {
-    id: 'dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.amount',
-    defaultMessage: 'Amount',
-  },
-  contract: {
-    id: 'dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.contract',
-    defaultMessage: 'Contract',
-  },
-  abi: {
-    id: 'dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.abi',
-    defaultMessage: 'ABI',
-  },
-  nft: {
-    id: 'dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.nft',
-    defaultMessage: 'NFT',
-  },
-  data: {
-    id: 'dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.data',
-    defaultMessage: 'Data',
-  },
-  contractFunction: {
-    id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.contractFunction`,
-    defaultMessage: 'Contract function',
-  },
-  value: {
-    id: 'dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.value',
-    defaultMessage: 'Value',
-  },
-  [TransactionTypes.TRANSFER_FUNDS]: {
-    id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.${TransactionTypes.TRANSFER_FUNDS}`,
-    defaultMessage: 'Transfer funds',
-  },
-  [TransactionTypes.TRANSFER_NFT]: {
-    id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.${TransactionTypes.TRANSFER_NFT}`,
-    defaultMessage: 'Transfer NFT',
-  },
-  [TransactionTypes.CONTRACT_INTERACTION]: {
-    id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.${TransactionTypes.CONTRACT_INTERACTION}`,
-    defaultMessage: 'Contract interaction',
-  },
-  [TransactionTypes.RAW_TRANSACTION]: {
-    id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.${TransactionTypes.RAW_TRANSACTION}`,
-    defaultMessage: 'Raw transaction',
-  },
 });
-
-export const transactionOptions = [
-  {
-    value: TransactionTypes.TRANSFER_FUNDS,
-    label: MSG[TransactionTypes.TRANSFER_FUNDS],
-    labelString: 'Transfer funds',
-  },
-  {
-    value: TransactionTypes.TRANSFER_NFT,
-    label: MSG[TransactionTypes.TRANSFER_NFT],
-    labelString: 'Transfer NFT',
-  },
-  {
-    value: TransactionTypes.CONTRACT_INTERACTION,
-    label: MSG[TransactionTypes.CONTRACT_INTERACTION],
-    labelString: 'Contract interaction',
-  },
-  {
-    value: TransactionTypes.RAW_TRANSACTION,
-    label: MSG[TransactionTypes.RAW_TRANSACTION],
-    labelString: 'Raw transaction',
-  },
-];
 
 const displayName = 'dashboard.GnosisControlSafeDialog.GnosisControlSafeForm';
 

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
@@ -23,7 +23,7 @@ import { GNOSIS_SAFE_INTEGRATION_LEARN_MORE } from '~externalUrls';
 import { Colony, useLoggedInUser } from '~data/index';
 import { Address } from '~types/index';
 
-import { FormValues, transactionOptions } from './GnosisControlSafeDialog';
+import { FormValues } from './GnosisControlSafeDialog';
 import {
   TransferFundsSection,
   RawTransactionSection,
@@ -31,6 +31,13 @@ import {
 } from './TransactionTypesSection';
 
 import styles from './GnosisControlSafeForm.css';
+
+export enum TransactionTypes {
+  TRANSFER_FUNDS = 'transferFunds',
+  TRANSFER_NFT = 'transferNft',
+  CONTRACT_INTERACTION = 'contractInteraction',
+  RAW_TRANSACTION = 'rawTransaction',
+}
 
 const MSG = defineMessages({
   title: {
@@ -86,7 +93,42 @@ const MSG = defineMessages({
     id: 'dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.previewTitle',
     defaultMessage: 'Confirm transaction details',
   },
+  [TransactionTypes.TRANSFER_FUNDS]: {
+    id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.${TransactionTypes.TRANSFER_FUNDS}`,
+    defaultMessage: 'Transfer funds',
+  },
+  [TransactionTypes.TRANSFER_NFT]: {
+    id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.${TransactionTypes.TRANSFER_NFT}`,
+    defaultMessage: 'Transfer NFT',
+  },
+  [TransactionTypes.CONTRACT_INTERACTION]: {
+    id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.${TransactionTypes.CONTRACT_INTERACTION}`,
+    defaultMessage: 'Contract interaction',
+  },
+  [TransactionTypes.RAW_TRANSACTION]: {
+    id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.${TransactionTypes.RAW_TRANSACTION}`,
+    defaultMessage: 'Raw transaction',
+  },
 });
+
+export const transactionOptions = [
+  {
+    value: TransactionTypes.TRANSFER_FUNDS,
+    label: MSG[TransactionTypes.TRANSFER_FUNDS],
+  },
+  {
+    value: TransactionTypes.TRANSFER_NFT,
+    label: MSG[TransactionTypes.TRANSFER_NFT],
+  },
+  {
+    value: TransactionTypes.CONTRACT_INTERACTION,
+    label: MSG[TransactionTypes.CONTRACT_INTERACTION],
+  },
+  {
+    value: TransactionTypes.RAW_TRANSACTION,
+    label: MSG[TransactionTypes.RAW_TRANSACTION],
+  },
+];
 
 const displayName = 'dashboard.GnosisControlSafeDialog.GnosisControlSafeForm';
 
@@ -374,11 +416,18 @@ const GnosisControlSafeForm = ({
         </div>
       </DialogSection>
       <DialogSection>
-        <div>1. Subtitle</div>
+        <div>
+          1. <FormattedMessage {...MSG[values.transactionType]} />
+        </div>
         <div>transaction details</div>
       </DialogSection>
       <DialogSection>
-        <Input label="Set title" name="transactionSetTitle" disabled={false} />
+        <Input
+          appearance={{ colorSchema: 'grey', theme: 'fat' }}
+          label="Set title"
+          name="transactionSetTitle"
+          disabled={false}
+        />
       </DialogSection>
       <DialogSection>
         <Annotations label="Explain why" name="annotation" />

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
@@ -125,6 +125,7 @@ const GnosisControlSafeForm = ({
   setFieldValue,
   showPreview,
   handleShowPreview,
+  validateForm,
 }: Props & FormikProps<FormValues>) => {
   const [transactionTabStatus, setTransactionTabStatus] = useState([true]);
   const [hasTitle, setHasTitle] = useState(true);
@@ -209,6 +210,12 @@ const GnosisControlSafeForm = ({
       setHasTitle(true);
     }
   }, [values, showPreview]);
+
+  useEffect(() => {
+    if (!showPreview) {
+      validateForm();
+    }
+  }, [showPreview, validateForm]);
 
   return (
     <>

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
@@ -99,6 +99,8 @@ interface Props {
   safes: GnosisSafe[];
   isVotingExtensionEnabled: boolean;
   back?: () => void;
+  showPreview: boolean;
+  handleSHowPreview: (showPreview: boolean) => void;
 }
 
 const renderAvatar = (address: string, item) => (
@@ -121,9 +123,10 @@ const GnosisControlSafeForm = ({
   values,
   isVotingExtensionEnabled,
   setFieldValue,
+  showPreview,
+  handleSHowPreview,
 }: Props & FormikProps<FormValues>) => {
   const [transactionTabStatus, setTransactionTabStatus] = useState([true]);
-  const [showPreview, setShowPreview] = useState(false);
 
   const { walletAddress } = useLoggedInUser();
   const fromDomainRoles = useTransformer(getUserRolesForDomain, [
@@ -357,13 +360,13 @@ const GnosisControlSafeForm = ({
       <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
         <Button
           appearance={{ theme: 'secondary', size: 'large' }}
-          onClick={showPreview ? () => setShowPreview(!showPreview) : back}
+          onClick={showPreview ? () => handleSHowPreview(!showPreview) : back}
           text={{ id: 'button.back' }}
         />
         <Button
           appearance={{ theme: 'primary', size: 'large' }}
           onClick={() =>
-            showPreview ? handleSubmit() : setShowPreview(!showPreview)
+            showPreview ? handleSubmit() : handleSHowPreview(!showPreview)
           }
           text={MSG.buttonCreateTransaction}
           loading={isSubmitting}

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
@@ -93,6 +93,14 @@ const MSG = defineMessages({
     id: 'dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.previewTitle',
     defaultMessage: 'Confirm transaction details',
   },
+  targetContract: {
+    id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.targetContract`,
+    defaultMessage: 'Target contract',
+  },
+  function: {
+    id: 'dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.function',
+    defaultMessage: 'Function',
+  },
   [TransactionTypes.TRANSFER_FUNDS]: {
     id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.${TransactionTypes.TRANSFER_FUNDS}`,
     defaultMessage: 'Transfer funds',
@@ -238,7 +246,17 @@ const GnosisControlSafeForm = ({
     [values.transactions.length],
   );
 
-  return !showPreview ? (
+  const DetailsItem = ({ label, value }) => (
+    <div className={styles.detailsItem}>
+      <div className={styles.detailsItemLabel}>
+        <FormattedMessage {...label} />
+      </div>
+      <div className={styles.detailsItemValue}>{value}</div>
+    </div>
+  );
+
+  // return !showPreview ? (
+  return false ? (
     <>
       <DialogSection>
         <div className={styles.heading}>
@@ -416,10 +434,14 @@ const GnosisControlSafeForm = ({
         </div>
       </DialogSection>
       <DialogSection>
-        <div>
+        <div className={styles.transactionTitle}>
           1. <FormattedMessage {...MSG[values.transactionType]} />
         </div>
-        <div>transaction details</div>
+        <DetailsItem label={MSG.targetContract} value={values.safe} />
+        <DetailsItem
+          label={MSG.function}
+          value={<FormattedMessage {...MSG[values.transactionType]} />}
+        />
       </DialogSection>
       <DialogSection>
         <Input

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
@@ -100,7 +100,7 @@ interface Props {
   isVotingExtensionEnabled: boolean;
   back?: () => void;
   showPreview: boolean;
-  handleSHowPreview: (showPreview: boolean) => void;
+  handleShowPreview: (showPreview: boolean) => void;
 }
 
 const renderAvatar = (address: string, item) => (
@@ -124,7 +124,7 @@ const GnosisControlSafeForm = ({
   isVotingExtensionEnabled,
   setFieldValue,
   showPreview,
-  handleSHowPreview,
+  handleShowPreview,
 }: Props & FormikProps<FormValues>) => {
   const [transactionTabStatus, setTransactionTabStatus] = useState([true]);
   const [hasTitle, setHasTitle] = useState(true);
@@ -371,13 +371,13 @@ const GnosisControlSafeForm = ({
       <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
         <Button
           appearance={{ theme: 'secondary', size: 'large' }}
-          onClick={showPreview ? () => handleSHowPreview(!showPreview) : back}
+          onClick={showPreview ? () => handleShowPreview(!showPreview) : back}
           text={{ id: 'button.back' }}
         />
         <Button
           appearance={{ theme: 'primary', size: 'large' }}
           onClick={() =>
-            showPreview ? handleSubmit() : handleSHowPreview(!showPreview)
+            showPreview ? handleSubmit() : handleShowPreview(!showPreview)
           }
           text={MSG.buttonCreateTransaction}
           loading={isSubmitting}

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
@@ -343,12 +343,15 @@ const GnosisControlSafeForm = ({
   );
 
   const transactionDetails = useMemo(
-    () => transactionTypeFieldsMap[values.transactionType],
+    () => transactionTypeFieldsMap[values.transactions[0].transactionType],
     [values],
   );
 
   const token = useMemo(
-    () => tokens.find((item) => item.address === values.tokenAddress),
+    () =>
+      tokens.find(
+        (item) => item.address === values.transactions[0].tokenAddress,
+      ),
     [values, tokens],
   );
 
@@ -541,7 +544,8 @@ const GnosisControlSafeForm = ({
       </DialogSection>
       <DialogSection>
         <div className={styles.transactionTitle}>
-          1. <FormattedMessage {...MSG[values.transactionType]} />
+          1.{' '}
+          <FormattedMessage {...MSG[values.transactions[0].transactionType]} />
         </div>
         <DetailsItem
           label={MSG.targetContract}
@@ -554,21 +558,30 @@ const GnosisControlSafeForm = ({
         />
         <DetailsItem
           label={MSG.function}
-          value={<FormattedMessage {...MSG[values.transactionType]} />}
+          value={
+            <FormattedMessage
+              {...MSG[values.transactions[0].transactionType]}
+            />
+          }
         />
-        {values.transactionType !== TransactionTypes.CONTRACT_INTERACTION && (
+        {values.transactions[0].transactionType !==
+          TransactionTypes.CONTRACT_INTERACTION && (
           <DetailsItem
             label={MSG.to}
             value={
               <AddressDetailsView
-                item={(values.recipient as never) as AnyUser}
+                item={(values.transactions[0].recipient as never) as AnyUser}
                 isSafeItem={false}
               />
             }
           />
         )}
         {transactionDetails.map(({ key, label, value }) => (
-          <DetailsItem label={label} value={value(values[key], token)} />
+          <DetailsItem
+            key={key}
+            label={label}
+            value={value(values.transactions[0][key], token)}
+          />
         ))}
       </DialogSection>
       <DialogSection>

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/SafeTransactionPreview.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/SafeTransactionPreview.tsx
@@ -84,6 +84,12 @@ const transactionTypeFieldsMap = {
     },
   ],
   [TransactionTypes.TRANSFER_NFT]: [
+    // To be finished once NFT part of the form is merged
+    {
+      key: 'function',
+      label: MSG.function,
+      value: () => <FormattedMessage {...ConstantsMSG.transferNft} />,
+    },
     {
       key: 'nft',
       label: MSG.nft,
@@ -91,21 +97,7 @@ const transactionTypeFieldsMap = {
     },
   ],
   [TransactionTypes.CONTRACT_INTERACTION]: [
-    {
-      key: 'contract',
-      label: MSG.contract,
-      value: (contract) => contract,
-    },
-    {
-      key: 'abi',
-      label: MSG.abi,
-      value: (abi) => abi,
-    },
-    {
-      key: 'contractFunction',
-      label: MSG.contractFunction,
-      value: (contractFunction) => contractFunction,
-    },
+    // To be finished once NFT part of the form is merged
   ],
   [TransactionTypes.RAW_TRANSACTION]: [
     {
@@ -169,14 +161,6 @@ const SafeTransactionPreview = ({ colony: { tokens }, values }: Props) => {
             <AddressDetailsView
               item={(values.safe as never) as AnyUser}
               isSafeItem
-            />
-          }
-        />
-        <DetailsItem
-          label={MSG.function}
-          value={
-            <FormattedMessage
-              {...ConstantsMSG[values.transactions[0].transactionType]}
             />
           }
         />

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/SafeTransactionPreview.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/SafeTransactionPreview.tsx
@@ -190,6 +190,7 @@ const SafeTransactionPreview = ({ colony: { tokens }, values }: Props) => {
           label={MSG.transactionsSetTitle}
           name="transactionSetTitle"
           disabled={false}
+          placeholder=""
         />
       </DialogSection>
       <DialogSection>

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/SafeTransactionPreview.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/SafeTransactionPreview.tsx
@@ -1,0 +1,312 @@
+import React, { useMemo } from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import { DialogSection } from '~core/Dialog';
+import { Annotations, Input } from '~core/Fields';
+import Heading from '~core/Heading';
+import Numeral from '~core/Numeral';
+import TokenIcon from '~dashboard/HookedTokenIcon';
+
+import { Colony, AnyUser } from '~data/index';
+
+import AddressDetailsView from './TransactionPreview/AddressDetailsView';
+
+import { FormValues } from './GnosisControlSafeDialog';
+
+import { TransactionTypes } from './constants';
+import styles from './GnosisControlSafeForm.css';
+
+const MSG = defineMessages({
+  title: {
+    id: 'dashboard.GnosisControlSafeDialog.SafeTransactionPreview.title',
+    defaultMessage: 'Control Safe',
+  },
+  description: {
+    id: 'dashboard.GnosisControlSafeDialog.SafeTransactionPreview.description',
+    defaultMessage: `You can use Control Safe to interact with other third party smart contracts. Be careful. <a>Learn more</a>`,
+  },
+  selectSafe: {
+    id: 'dashboard.GnosisControlSafeDialog.SafeTransactionPreview.selectSafe',
+    defaultMessage: 'Select Safe',
+  },
+  safePickerPlaceholder: {
+    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.safePickerPlaceholder`,
+    defaultMessage: 'Select Safe to control',
+  },
+  transactionLabel: {
+    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.transactionLabel`,
+    defaultMessage: 'Select transaction type',
+  },
+  transactionPlaceholder: {
+    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.transactionPlaceholder`,
+    defaultMessage: 'Select transaction',
+  },
+  buttonTransaction: {
+    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.buttonTransaction`,
+    defaultMessage: 'Add another transaction',
+  },
+  buttonCreateTransaction: {
+    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.buttonCreateTransaction`,
+    defaultMessage: 'Create transaction',
+  },
+  transactionTitle: {
+    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.transactionTitle`,
+    defaultMessage: `Transaction #{transactionNumber} {transactionType, select, undefined {} other {({transactionType})}}`,
+  },
+  toggleTransaction: {
+    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.toggleTransaction`,
+    defaultMessage:
+      '{tabToggleStatus, select, true {Expand} false {Close}} transaction',
+  },
+  deleteTransaction: {
+    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.deleteTransaction`,
+    defaultMessage: 'Delete transaction',
+  },
+  deleteTransactionTooltipText: {
+    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.deleteTransactionTooltipText`,
+    defaultMessage: `Delete transaction.\nBe careful, data can be lost.`,
+  },
+  previewTitle: {
+    id: 'dashboard.GnosisControlSafeDialog.SafeTransactionPreview.previewTitle',
+    defaultMessage: 'Confirm transaction details',
+  },
+  transactionsSetTitle: {
+    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.transactionsSetTitle`,
+    defaultMessage: 'Title of the set of all the arbitrary transactions',
+  },
+  explainWhy: {
+    id: 'dashboard.GnosisControlSafeDialog.SafeTransactionPreview.explainWhy',
+    defaultMessage: `Explain why you’re making arbitrary transaction (optional)`,
+  },
+  targetContract: {
+    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.targetContract`,
+    defaultMessage: 'Target contract',
+  },
+  function: {
+    id: 'dashboard.GnosisControlSafeDialog.SafeTransactionPreview.function',
+    defaultMessage: 'Function',
+  },
+  to: {
+    id: 'dashboard.GnosisControlSafeDialog.SafeTransactionPreview.to',
+    defaultMessage: 'To',
+  },
+  amount: {
+    id: 'dashboard.GnosisControlSafeDialog.SafeTransactionPreview.amount',
+    defaultMessage: 'Amount',
+  },
+  contract: {
+    id: 'dashboard.GnosisControlSafeDialog.SafeTransactionPreview.contract',
+    defaultMessage: 'Contract',
+  },
+  abi: {
+    id: 'dashboard.GnosisControlSafeDialog.SafeTransactionPreview.abi',
+    defaultMessage: 'ABI',
+  },
+  nft: {
+    id: 'dashboard.GnosisControlSafeDialog.SafeTransactionPreview.nft',
+    defaultMessage: 'NFT',
+  },
+  data: {
+    id: 'dashboard.GnosisControlSafeDialog.SafeTransactionPreview.data',
+    defaultMessage: 'Data',
+  },
+  contractFunction: {
+    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.contractFunction`,
+    defaultMessage: 'Contract function',
+  },
+  value: {
+    id: 'dashboard.GnosisControlSafeDialog.SafeTransactionPreview.value',
+    defaultMessage: 'Value',
+  },
+  [TransactionTypes.TRANSFER_FUNDS]: {
+    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.${TransactionTypes.TRANSFER_FUNDS}`,
+    defaultMessage: 'Transfer funds',
+  },
+  [TransactionTypes.TRANSFER_NFT]: {
+    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.${TransactionTypes.TRANSFER_NFT}`,
+    defaultMessage: 'Transfer NFT',
+  },
+  [TransactionTypes.CONTRACT_INTERACTION]: {
+    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.${TransactionTypes.CONTRACT_INTERACTION}`,
+    defaultMessage: 'Contract interaction',
+  },
+  [TransactionTypes.RAW_TRANSACTION]: {
+    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.${TransactionTypes.RAW_TRANSACTION}`,
+    defaultMessage: 'Raw transaction',
+  },
+});
+
+export const transactionOptions = [
+  {
+    value: TransactionTypes.TRANSFER_FUNDS,
+    label: MSG[TransactionTypes.TRANSFER_FUNDS],
+    labelString: 'Transfer funds',
+  },
+  {
+    value: TransactionTypes.TRANSFER_NFT,
+    label: MSG[TransactionTypes.TRANSFER_NFT],
+    labelString: 'Transfer NFT',
+  },
+  {
+    value: TransactionTypes.CONTRACT_INTERACTION,
+    label: MSG[TransactionTypes.CONTRACT_INTERACTION],
+    labelString: 'Contract interaction',
+  },
+  {
+    value: TransactionTypes.RAW_TRANSACTION,
+    label: MSG[TransactionTypes.RAW_TRANSACTION],
+    labelString: 'Raw transaction',
+  },
+];
+
+const transactionTypeFieldsMap = {
+  [TransactionTypes.TRANSFER_FUNDS]: [
+    {
+      key: 'amount',
+      label: MSG.amount,
+      value: (amount, token) => (
+        <div className={styles.tokenAmount}>
+          <TokenIcon token={token} size="xxs" />
+          <Numeral value={amount} suffix={token.symbol} />
+        </div>
+      ),
+    },
+  ],
+  [TransactionTypes.TRANSFER_NFT]: [
+    {
+      key: 'nft',
+      label: MSG.nft,
+      value: (nft) => <span>{`${nft.name} #${nft.number}`}</span>,
+    },
+  ],
+  [TransactionTypes.CONTRACT_INTERACTION]: [
+    {
+      key: 'contract',
+      label: MSG.contract,
+      value: (contract) => contract,
+    },
+    {
+      key: 'abi',
+      label: MSG.abi,
+      value: (abi) => abi,
+    },
+    {
+      key: 'contractFunction',
+      label: MSG.contractFunction,
+      value: (contractFunction) => contractFunction,
+    },
+  ],
+  [TransactionTypes.RAW_TRANSACTION]: [
+    {
+      key: 'value',
+      label: MSG.value,
+      value: (value) => value,
+    },
+    {
+      key: 'data',
+      label: MSG.data,
+      value: (data) => data,
+    },
+  ],
+};
+
+const displayName = 'dashboard.GnosisControlSafeDialog.SafeTransactionPreview';
+
+interface Props {
+  colony: Colony;
+  values: FormValues;
+}
+
+const SafeTransactionPreview = ({ colony: { tokens }, values }: Props) => {
+  const transactionDetails = useMemo(
+    () => transactionTypeFieldsMap[values.transactions[0].transactionType],
+    [values],
+  );
+
+  const token = useMemo(
+    () =>
+      tokens.find(
+        (item) => item.address === values.transactions[0].tokenAddress,
+      ),
+    [values, tokens],
+  );
+
+  const DetailsItem = ({ label, value }: { label: any; value: any }) => (
+    <div className={styles.detailsItem}>
+      <div className={styles.detailsItemLabel}>
+        <FormattedMessage {...label} />
+      </div>
+      <div className={styles.detailsItemValue}>{value}</div>
+    </div>
+  );
+
+  return (
+    <>
+      <DialogSection>
+        <div className={styles.heading}>
+          <Heading
+            appearance={{ size: 'medium', margin: 'none', theme: 'dark' }}
+            text={MSG.previewTitle}
+          />
+        </div>
+      </DialogSection>
+      <DialogSection>
+        <div className={styles.transactionTitle}>
+          1.{' '}
+          <FormattedMessage {...MSG[values.transactions[0].transactionType]} />
+        </div>
+        <DetailsItem
+          label={MSG.targetContract}
+          value={
+            <AddressDetailsView
+              item={(values.safe as never) as AnyUser}
+              isSafeItem
+            />
+          }
+        />
+        <DetailsItem
+          label={MSG.function}
+          value={
+            <FormattedMessage
+              {...MSG[values.transactions[0].transactionType]}
+            />
+          }
+        />
+        {values.transactions[0].transactionType !==
+          TransactionTypes.CONTRACT_INTERACTION && (
+          <DetailsItem
+            label={MSG.to}
+            value={
+              <AddressDetailsView
+                item={(values.transactions[0].recipient as never) as AnyUser}
+                isSafeItem={false}
+              />
+            }
+          />
+        )}
+        {transactionDetails.map(({ key, label, value }) => (
+          <DetailsItem
+            key={key}
+            label={label}
+            value={value(values.transactions[0][key], token)}
+          />
+        ))}
+      </DialogSection>
+      <DialogSection>
+        <Input
+          appearance={{ colorSchema: 'grey', theme: 'fat' }}
+          label={MSG.transactionsSetTitle}
+          name="transactionSetTitle"
+          disabled={false}
+        />
+      </DialogSection>
+      <DialogSection>
+        <Annotations label={MSG.explainWhy} name="annotation" />
+      </DialogSection>
+    </>
+  );
+};
+
+SafeTransactionPreview.displayName = displayName;
+
+export default SafeTransactionPreview;

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/SafeTransactionPreview.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/SafeTransactionPreview.tsx
@@ -11,7 +11,7 @@ import { Colony, AnyUser } from '~data/index';
 
 import AddressDetailsView from './TransactionPreview/AddressDetailsView';
 import { FormValues } from './GnosisControlSafeDialog';
-import { TransactionTypes } from './constants';
+import { TransactionTypes, MSG as ConstantsMSG } from './constants';
 import DetailsItem from './DetailsItem';
 import styles from './GnosisControlSafeForm.css';
 
@@ -155,7 +155,9 @@ const SafeTransactionPreview = ({ colony: { tokens }, values }: Props) => {
       <DialogSection>
         <div className={styles.transactionTitle}>
           1.{' '}
-          <FormattedMessage {...MSG[values.transactions[0].transactionType]} />
+          <FormattedMessage
+            {...ConstantsMSG[values.transactions[0].transactionType]}
+          />
         </div>
         <DetailsItem
           label={MSG.targetContract}
@@ -170,7 +172,7 @@ const SafeTransactionPreview = ({ colony: { tokens }, values }: Props) => {
           label={MSG.function}
           value={
             <FormattedMessage
-              {...MSG[values.transactions[0].transactionType]}
+              {...ConstantsMSG[values.transactions[0].transactionType]}
             />
           }
         />

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/SafeTransactionPreview.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/SafeTransactionPreview.tsx
@@ -17,55 +17,6 @@ import { TransactionTypes } from './constants';
 import styles from './GnosisControlSafeForm.css';
 
 const MSG = defineMessages({
-  title: {
-    id: 'dashboard.GnosisControlSafeDialog.SafeTransactionPreview.title',
-    defaultMessage: 'Control Safe',
-  },
-  description: {
-    id: 'dashboard.GnosisControlSafeDialog.SafeTransactionPreview.description',
-    defaultMessage: `You can use Control Safe to interact with other third party smart contracts. Be careful. <a>Learn more</a>`,
-  },
-  selectSafe: {
-    id: 'dashboard.GnosisControlSafeDialog.SafeTransactionPreview.selectSafe',
-    defaultMessage: 'Select Safe',
-  },
-  safePickerPlaceholder: {
-    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.safePickerPlaceholder`,
-    defaultMessage: 'Select Safe to control',
-  },
-  transactionLabel: {
-    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.transactionLabel`,
-    defaultMessage: 'Select transaction type',
-  },
-  transactionPlaceholder: {
-    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.transactionPlaceholder`,
-    defaultMessage: 'Select transaction',
-  },
-  buttonTransaction: {
-    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.buttonTransaction`,
-    defaultMessage: 'Add another transaction',
-  },
-  buttonCreateTransaction: {
-    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.buttonCreateTransaction`,
-    defaultMessage: 'Create transaction',
-  },
-  transactionTitle: {
-    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.transactionTitle`,
-    defaultMessage: `Transaction #{transactionNumber} {transactionType, select, undefined {} other {({transactionType})}}`,
-  },
-  toggleTransaction: {
-    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.toggleTransaction`,
-    defaultMessage:
-      '{tabToggleStatus, select, true {Expand} false {Close}} transaction',
-  },
-  deleteTransaction: {
-    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.deleteTransaction`,
-    defaultMessage: 'Delete transaction',
-  },
-  deleteTransactionTooltipText: {
-    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.deleteTransactionTooltipText`,
-    defaultMessage: `Delete transaction.\nBe careful, data can be lost.`,
-  },
   previewTitle: {
     id: 'dashboard.GnosisControlSafeDialog.SafeTransactionPreview.previewTitle',
     defaultMessage: 'Confirm transaction details',
@@ -118,46 +69,7 @@ const MSG = defineMessages({
     id: 'dashboard.GnosisControlSafeDialog.SafeTransactionPreview.value',
     defaultMessage: 'Value',
   },
-  [TransactionTypes.TRANSFER_FUNDS]: {
-    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.${TransactionTypes.TRANSFER_FUNDS}`,
-    defaultMessage: 'Transfer funds',
-  },
-  [TransactionTypes.TRANSFER_NFT]: {
-    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.${TransactionTypes.TRANSFER_NFT}`,
-    defaultMessage: 'Transfer NFT',
-  },
-  [TransactionTypes.CONTRACT_INTERACTION]: {
-    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.${TransactionTypes.CONTRACT_INTERACTION}`,
-    defaultMessage: 'Contract interaction',
-  },
-  [TransactionTypes.RAW_TRANSACTION]: {
-    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.${TransactionTypes.RAW_TRANSACTION}`,
-    defaultMessage: 'Raw transaction',
-  },
 });
-
-export const transactionOptions = [
-  {
-    value: TransactionTypes.TRANSFER_FUNDS,
-    label: MSG[TransactionTypes.TRANSFER_FUNDS],
-    labelString: 'Transfer funds',
-  },
-  {
-    value: TransactionTypes.TRANSFER_NFT,
-    label: MSG[TransactionTypes.TRANSFER_NFT],
-    labelString: 'Transfer NFT',
-  },
-  {
-    value: TransactionTypes.CONTRACT_INTERACTION,
-    label: MSG[TransactionTypes.CONTRACT_INTERACTION],
-    labelString: 'Contract interaction',
-  },
-  {
-    value: TransactionTypes.RAW_TRANSACTION,
-    label: MSG[TransactionTypes.RAW_TRANSACTION],
-    labelString: 'Raw transaction',
-  },
-];
 
 const transactionTypeFieldsMap = {
   [TransactionTypes.TRANSFER_FUNDS]: [

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/SafeTransactionPreview.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/SafeTransactionPreview.tsx
@@ -126,7 +126,10 @@ interface Props {
 
 const SafeTransactionPreview = ({ colony: { tokens }, values }: Props) => {
   const transactionDetails = useMemo(
-    () => transactionTypeFieldsMap[values.transactions[0].transactionType],
+    () =>
+      values.transactions[0].transactionType === ''
+        ? []
+        : transactionTypeFieldsMap[values.transactions[0].transactionType],
     [values],
   );
 
@@ -149,12 +152,14 @@ const SafeTransactionPreview = ({ colony: { tokens }, values }: Props) => {
         </div>
       </DialogSection>
       <DialogSection>
-        <div className={styles.transactionTitle}>
-          1.{' '}
-          <FormattedMessage
-            {...ConstantsMSG[values.transactions[0].transactionType]}
-          />
-        </div>
+        {values.transactions[0].transactionType !== '' && (
+          <div className={styles.transactionTitle}>
+            1.{' '}
+            <FormattedMessage
+              {...ConstantsMSG[values.transactions[0].transactionType]}
+            />
+          </div>
+        )}
         <DetailsItem
           label={MSG.targetContract}
           value={
@@ -176,7 +181,7 @@ const SafeTransactionPreview = ({ colony: { tokens }, values }: Props) => {
             }
           />
         )}
-        {transactionDetails.map(({ key, label, value }) => (
+        {transactionDetails?.map(({ key, label, value }) => (
           <DetailsItem
             key={key}
             label={label}

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/SafeTransactionPreview.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/SafeTransactionPreview.tsx
@@ -147,44 +147,46 @@ const SafeTransactionPreview = ({ colony: { tokens }, values }: Props) => {
         </div>
       </DialogSection>
       <DialogSection>
-        {values.transactions[0].transactionType !== '' && (
-          <div className={styles.transactionTitle}>
-            1.{' '}
-            <FormattedMessage
-              {...ConstantsMSG[values.transactions[0].transactionType]}
-            />
-          </div>
-        )}
-        <DetailsItem
-          label={MSG.safe}
-          value={
-            <AddressDetailsView
-              item={(values.safe as never) as AnyUser}
-              isSafeItem
-            />
-          }
-        />
-        {values.transactions[0].transactionType !==
-          TransactionTypes.CONTRACT_INTERACTION && (
+        <div className={styles.transactionDetailsSection}>
+          {values.transactions[0].transactionType !== '' && (
+            <div className={styles.transactionTitle}>
+              1.{' '}
+              <FormattedMessage
+                {...ConstantsMSG[values.transactions[0].transactionType]}
+              />
+            </div>
+          )}
           <DetailsItem
-            label={MSG.to}
+            label={MSG.safe}
             value={
               <AddressDetailsView
-                item={(values.transactions[0].recipient as never) as AnyUser}
-                isSafeItem={false}
+                item={(values.safe as never) as AnyUser}
+                isSafeItem
               />
             }
           />
-        )}
-        {transactionDetails?.map(({ key, label, value }) => (
-          <DetailsItem
-            key={key}
-            label={label}
-            value={value(values.transactions[0][key], token)}
-          />
-        ))}
+          {values.transactions[0].transactionType !==
+            TransactionTypes.CONTRACT_INTERACTION && (
+            <DetailsItem
+              label={MSG.to}
+              value={
+                <AddressDetailsView
+                  item={(values.transactions[0].recipient as never) as AnyUser}
+                  isSafeItem={false}
+                />
+              }
+            />
+          )}
+          {transactionDetails?.map(({ key, label, value }) => (
+            <DetailsItem
+              key={key}
+              label={label}
+              value={value(values.transactions[0][key], token)}
+            />
+          ))}
+        </div>
       </DialogSection>
-      <DialogSection>
+      <DialogSection appearance={{ theme: 'sidePadding' }}>
         <Input
           appearance={{ colorSchema: 'grey', theme: 'fat' }}
           label={MSG.transactionsTitle}

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/SafeTransactionPreview.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/SafeTransactionPreview.tsx
@@ -10,10 +10,9 @@ import TokenIcon from '~dashboard/HookedTokenIcon';
 import { Colony, AnyUser } from '~data/index';
 
 import AddressDetailsView from './TransactionPreview/AddressDetailsView';
-
 import { FormValues } from './GnosisControlSafeDialog';
-
 import { TransactionTypes } from './constants';
+import DetailsItem from './DetailsItem';
 import styles from './GnosisControlSafeForm.css';
 
 const MSG = defineMessages({
@@ -141,15 +140,6 @@ const SafeTransactionPreview = ({ colony: { tokens }, values }: Props) => {
         (item) => item.address === values.transactions[0].tokenAddress,
       ),
     [values, tokens],
-  );
-
-  const DetailsItem = ({ label, value }: { label: any; value: any }) => (
-    <div className={styles.detailsItem}>
-      <div className={styles.detailsItemLabel}>
-        <FormattedMessage {...label} />
-      </div>
-      <div className={styles.detailsItemValue}>{value}</div>
-    </div>
   );
 
   return (

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/SafeTransactionPreview.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/SafeTransactionPreview.tsx
@@ -190,8 +190,7 @@ const SafeTransactionPreview = ({ colony: { tokens }, values }: Props) => {
         <Input
           appearance={{ colorSchema: 'grey', theme: 'fat' }}
           label={MSG.transactionsTitle}
-          name="transactionSetTitle"
-          disabled={false}
+          name="transactionsTitle"
           placeholder=""
         />
       </DialogSection>

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/SafeTransactionPreview.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/SafeTransactionPreview.tsx
@@ -20,17 +20,17 @@ const MSG = defineMessages({
     id: 'dashboard.GnosisControlSafeDialog.SafeTransactionPreview.previewTitle',
     defaultMessage: 'Confirm transaction details',
   },
-  transactionsSetTitle: {
-    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.transactionsSetTitle`,
-    defaultMessage: 'Title of the set of all the arbitrary transactions',
+  transactionsTitle: {
+    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.transactionsTitle`,
+    defaultMessage: 'Title',
   },
-  explainWhy: {
-    id: 'dashboard.GnosisControlSafeDialog.SafeTransactionPreview.explainWhy',
-    defaultMessage: `Explain why you’re making arbitrary transaction (optional)`,
+  description: {
+    id: 'dashboard.GnosisControlSafeDialog.SafeTransactionPreview.description',
+    defaultMessage: 'Description (optional)',
   },
-  targetContract: {
-    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.targetContract`,
-    defaultMessage: 'Target contract',
+  safe: {
+    id: `dashboard.GnosisControlSafeDialog.SafeTransactionPreview.safe`,
+    defaultMessage: 'Safe',
   },
   function: {
     id: 'dashboard.GnosisControlSafeDialog.SafeTransactionPreview.function',
@@ -156,7 +156,7 @@ const SafeTransactionPreview = ({ colony: { tokens }, values }: Props) => {
           </div>
         )}
         <DetailsItem
-          label={MSG.targetContract}
+          label={MSG.safe}
           value={
             <AddressDetailsView
               item={(values.safe as never) as AnyUser}
@@ -187,14 +187,14 @@ const SafeTransactionPreview = ({ colony: { tokens }, values }: Props) => {
       <DialogSection>
         <Input
           appearance={{ colorSchema: 'grey', theme: 'fat' }}
-          label={MSG.transactionsSetTitle}
+          label={MSG.transactionsTitle}
           name="transactionSetTitle"
           disabled={false}
           placeholder=""
         />
       </DialogSection>
       <DialogSection>
-        <Annotations label={MSG.explainWhy} name="annotation" />
+        <Annotations label={MSG.description} name="annotation" />
       </DialogSection>
     </>
   );

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/SafeTransactionPreview.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/SafeTransactionPreview.tsx
@@ -90,11 +90,6 @@ const transactionTypeFieldsMap = {
       label: MSG.function,
       value: () => <FormattedMessage {...ConstantsMSG.transferNft} />,
     },
-    {
-      key: 'nft',
-      label: MSG.nft,
-      value: (nft) => <span>{`${nft.name} #${nft.number}`}</span>,
-    },
   ],
   [TransactionTypes.CONTRACT_INTERACTION]: [
     // To be finished once NFT part of the form is merged

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/SafeTransactionPreview.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/SafeTransactionPreview.tsx
@@ -66,7 +66,7 @@ const MSG = defineMessages({
   },
   value: {
     id: 'dashboard.GnosisControlSafeDialog.SafeTransactionPreview.value',
-    defaultMessage: 'Value',
+    defaultMessage: 'Value (wei)',
   },
 });
 
@@ -109,14 +109,18 @@ const transactionTypeFieldsMap = {
   ],
   [TransactionTypes.RAW_TRANSACTION]: [
     {
-      key: 'value',
+      key: 'amount',
       label: MSG.value,
-      value: (value) => value,
+      value: (value) => (
+        <div className={styles.rawTransactionValues}>{value}</div>
+      ),
     },
     {
       key: 'data',
       label: MSG.data,
-      value: (data) => data,
+      value: (data) => (
+        <div className={styles.rawTransactionValues}>{data}</div>
+      ),
     },
   ],
 };

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/TransactionPreview/AddressDetailsView/AddressDetailsView.css
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/TransactionPreview/AddressDetailsView/AddressDetailsView.css
@@ -1,0 +1,18 @@
+.main {
+  display: flex;
+  align-items: center;
+}
+
+.name {
+  margin: 0 10px;
+  font-size: var(--size-normal);
+  font-weight: var(--weight-bold);
+  color: var(--pink);
+}
+
+.main > span:last-child {
+  margin-top: 3px;
+  font-size: var(--size-small);
+  font-weight: var(--weight-medium);
+  color: var(--temp-grey-blue-7);
+}

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/TransactionPreview/AddressDetailsView/AddressDetailsView.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/TransactionPreview/AddressDetailsView/AddressDetailsView.css.d.ts
@@ -1,0 +1,2 @@
+export const main: string;
+export const name: string;

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/TransactionPreview/AddressDetailsView/AddressDetailsView.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/TransactionPreview/AddressDetailsView/AddressDetailsView.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import MaskedAddress from '~core/MaskedAddress';
+import Avatar from '~core/Avatar';
+import { AnyUser } from '~data/index';
+
+import styles from './AddressDetailsView.css';
+
+const MSG = defineMessages({
+  contract: {
+    id: 'dashboard.GnosisControlSafeDialog.AddressDetailsView.contract',
+    defaultMessage: 'Contract',
+  },
+});
+
+interface Props {
+  item: AnyUser;
+  isSafeItem: boolean;
+}
+
+const AddressDetailsView = ({ item, isSafeItem }: Props) => {
+  const userDisplayName = item?.profile?.displayName;
+  const username = item?.profile?.username;
+
+  return (
+    <div className={styles.main}>
+      <Avatar
+        seed={item.id.toLowerCase()}
+        size="xs"
+        avatarURL={item?.profile?.avatarHash || ''}
+        title="avatar"
+        placeholderIcon={isSafeItem ? 'gnosis-logo' : 'circle-person'}
+      />
+      <span className={styles.name}>
+        {isSafeItem ? (
+          <FormattedMessage {...MSG.contract} />
+        ) : (
+          userDisplayName || `@${username}`
+        )}
+      </span>
+      <MaskedAddress address={item.id} />
+    </div>
+  );
+};
+
+export default AddressDetailsView;

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/TransactionPreview/AddressDetailsView/AddressDetailsView.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/TransactionPreview/AddressDetailsView/AddressDetailsView.tsx
@@ -1,18 +1,10 @@
 import React from 'react';
-import { defineMessages, FormattedMessage } from 'react-intl';
 
 import MaskedAddress from '~core/MaskedAddress';
 import Avatar from '~core/Avatar';
 import { AnyUser } from '~data/index';
 
 import styles from './AddressDetailsView.css';
-
-const MSG = defineMessages({
-  contract: {
-    id: 'dashboard.GnosisControlSafeDialog.AddressDetailsView.contract',
-    defaultMessage: 'Contract',
-  },
-});
 
 interface Props {
   item: AnyUser;
@@ -32,13 +24,7 @@ const AddressDetailsView = ({ item, isSafeItem }: Props) => {
         title="avatar"
         placeholderIcon={isSafeItem ? 'gnosis-logo' : 'circle-person'}
       />
-      <span className={styles.name}>
-        {isSafeItem ? (
-          <FormattedMessage {...MSG.contract} />
-        ) : (
-          userDisplayName || `@${username}`
-        )}
-      </span>
+      <span className={styles.name}>{userDisplayName || `@${username}`}</span>
       <MaskedAddress address={item.id} />
     </div>
   );

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/TransactionPreview/AddressDetailsView/AddressDetailsView.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/TransactionPreview/AddressDetailsView/AddressDetailsView.tsx
@@ -18,14 +18,14 @@ const AddressDetailsView = ({ item, isSafeItem }: Props) => {
   return (
     <div className={styles.main}>
       <Avatar
-        seed={item.id.toLowerCase()}
+        seed={item?.id?.toLowerCase()}
         size="xs"
         avatarURL={item?.profile?.avatarHash || ''}
         title="avatar"
         placeholderIcon={isSafeItem ? 'gnosis-logo' : 'circle-person'}
       />
       <span className={styles.name}>{userDisplayName || `@${username}`}</span>
-      <MaskedAddress address={item.id} />
+      <MaskedAddress address={item?.id} />
     </div>
   );
 };

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/TransactionPreview/AddressDetailsView/index.ts
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/TransactionPreview/AddressDetailsView/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AddressDetailsView';

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/constants.ts
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/constants.ts
@@ -1,6 +1,49 @@
+import { defineMessages } from 'react-intl';
+
 export enum TransactionTypes {
   TRANSFER_FUNDS = 'transferFunds',
   TRANSFER_NFT = 'transferNft',
   CONTRACT_INTERACTION = 'contractInteraction',
   RAW_TRANSACTION = 'rawTransaction',
 }
+const MSG = defineMessages({
+  [TransactionTypes.TRANSFER_FUNDS]: {
+    id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.${TransactionTypes.TRANSFER_FUNDS}`,
+    defaultMessage: 'Transfer funds',
+  },
+  [TransactionTypes.TRANSFER_NFT]: {
+    id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.${TransactionTypes.TRANSFER_NFT}`,
+    defaultMessage: 'Transfer NFT',
+  },
+  [TransactionTypes.CONTRACT_INTERACTION]: {
+    id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.${TransactionTypes.CONTRACT_INTERACTION}`,
+    defaultMessage: 'Contract interaction',
+  },
+  [TransactionTypes.RAW_TRANSACTION]: {
+    id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.${TransactionTypes.RAW_TRANSACTION}`,
+    defaultMessage: 'Raw transaction',
+  },
+});
+
+export const transactionOptions = [
+  {
+    value: TransactionTypes.TRANSFER_FUNDS,
+    label: MSG[TransactionTypes.TRANSFER_FUNDS],
+    labelString: 'Transfer funds',
+  },
+  {
+    value: TransactionTypes.TRANSFER_NFT,
+    label: MSG[TransactionTypes.TRANSFER_NFT],
+    labelString: 'Transfer NFT',
+  },
+  {
+    value: TransactionTypes.CONTRACT_INTERACTION,
+    label: MSG[TransactionTypes.CONTRACT_INTERACTION],
+    labelString: 'Contract interaction',
+  },
+  {
+    value: TransactionTypes.RAW_TRANSACTION,
+    label: MSG[TransactionTypes.RAW_TRANSACTION],
+    labelString: 'Raw transaction',
+  },
+];

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/constants.ts
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/constants.ts
@@ -1,0 +1,6 @@
+export enum TransactionTypes {
+  TRANSFER_FUNDS = 'transferFunds',
+  TRANSFER_NFT = 'transferNft',
+  CONTRACT_INTERACTION = 'contractInteraction',
+  RAW_TRANSACTION = 'rawTransaction',
+}

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/constants.ts
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/constants.ts
@@ -6,7 +6,8 @@ export enum TransactionTypes {
   CONTRACT_INTERACTION = 'contractInteraction',
   RAW_TRANSACTION = 'rawTransaction',
 }
-const MSG = defineMessages({
+
+export const MSG = defineMessages({
   [TransactionTypes.TRANSFER_FUNDS]: {
     id: `dashboard.GnosisControlSafeDialog.GnosisControlSafeForm.${TransactionTypes.TRANSFER_FUNDS}`,
     defaultMessage: 'Transfer funds',
@@ -29,21 +30,17 @@ export const transactionOptions = [
   {
     value: TransactionTypes.TRANSFER_FUNDS,
     label: MSG[TransactionTypes.TRANSFER_FUNDS],
-    labelString: 'Transfer funds',
   },
   {
     value: TransactionTypes.TRANSFER_NFT,
     label: MSG[TransactionTypes.TRANSFER_NFT],
-    labelString: 'Transfer NFT',
   },
   {
     value: TransactionTypes.CONTRACT_INTERACTION,
     label: MSG[TransactionTypes.CONTRACT_INTERACTION],
-    labelString: 'Contract interaction',
   },
   {
     value: TransactionTypes.RAW_TRANSACTION,
     label: MSG[TransactionTypes.RAW_TRANSACTION],
-    labelString: 'Raw transaction',
   },
 ];


### PR DESCRIPTION
## Description

This PR adds transaction preview logic for the gnosis safe control dialog. I've already added preview for transfer funds & for raw transaction. NFT & arbitrary transactions are not finished so there is a separate issue to add them when they are.

I've also added a fix for another issue - validate on load.

I've also added `TransactionTypes` enum across the dialog.
<img width="551" alt="Screenshot 2022-07-22 at 13 37 27" src="https://user-images.githubusercontent.com/34057551/180422038-a09a57bb-0fff-40b2-8645-3018d354995f.png">
<img width="546" alt="Screenshot 2022-07-22 at 13 37 56" src="https://user-images.githubusercontent.com/34057551/180422139-1648b726-8ea9-44f3-bcf6-a50449a17fe6.png">



Resolves #3543 
Resolves #3664 