### PR TITLE
Add Gnosis Safe event message

### DIFF
--- a/src/i18n/en-actions.ts
+++ b/src/i18n/en-actions.ts
@@ -33,6 +33,7 @@ const actionsMessageDescriptors = {
       ${ColonyExtendedActions.AddressBookUpdated} {Address book was updated}
       ${ColonyExtendedActions.TokensUpdated} {Colony tokens were updated}
       ${ColonyExtendedActions.SafeRemoved} {Remove Safe}
+      ${ColonyExtendedActions.SafeAdded} {Add Safe from {chainName}}
       other {Generic action we don't have information about}
     }`,
   [`action.${ColonyActions.SetUserRoles}.assign`]: `Assign the {roles} in {fromDomain} to {recipient}`,
@@ -55,6 +56,7 @@ const actionsMessageDescriptors = {
       ${ColonyActions.Recovery} {Recovery}
       ${ColonyActions.EmitDomainReputationPenalty} {Smite}
       ${ColonyActions.EmitDomainReputationReward} {Award}
+      ${ColonyExtendedActions.SafeAdded} {Add Safe}
       ${ColonyExtendedActions.SafeRemoved} {Remove Safe}
       ${ColonyExtendedActions.TokensUpdated} {Update Tokens}
       ${ColonyExtendedActions.AddressBookUpdated} {Update Address Book}

--- a/src/i18n/en-events.ts
+++ b/src/i18n/en-events.ts
@@ -30,6 +30,7 @@ const eventsMessageDescriptors = {
   [`event.${ColonyAndExtensionsEvents.ColonyMetadata}.tokens`]: `{initiator} changed this colony's tokens`,
   [`event.${ColonyAndExtensionsEvents.ColonyMetadata}.verifiedAddresses`]: `{initiator} updated this colony's address book`,
   [`event.${ColonyAndExtensionsEvents.ColonyMetadata}.safeRemoved`]: `{initiator} removed {removedSafesString} using the Administration and Funding permissions.`,
+  [`event.${ColonyAndExtensionsEvents.ColonyMetadata}.safeAdded`]: `{initiator} added the Safe {addedSafeAddress} from {chainName} using the Administration and Funding permissions`,
   [`event.${ColonyAndExtensionsEvents.ColonyMetadata}.fallback`]: `{initiator} changed this colony's metadata, but the values are the same`,
   [`event.${ColonyAndExtensionsEvents.DomainMetadata}.all`]: `{initiator} changed teams's name, description, color from {oldName}, {oldDescription}, {oldColor} to {domainName}, {domainPurpose}, {domainColor}`,
   [`event.${ColonyAndExtensionsEvents.DomainMetadata}.nameDescription`]: `{initiator} changed teams's name and description from {oldName}, {oldDescription} to {domainName}, {domainPurpose}`,

--- a/src/modules/core/components/ActionsList/ActionsListItem.tsx
+++ b/src/modules/core/components/ActionsList/ActionsListItem.tsx
@@ -40,7 +40,11 @@ import {
   MotionState,
   MOTION_TAG_MAP,
 } from '~utils/colonyMotions';
-import { useExtendedColonyActionType } from '~modules/dashboard/hooks';
+import {
+  useColonyMetadataChecks,
+  useExtendedColonyActionType,
+} from '~modules/dashboard/hooks';
+import { GNOSIS_SAFE_NAMES_MAP } from '~constants';
 
 import { ipfsDataFetcher } from '../../../core/fetchers';
 
@@ -131,6 +135,13 @@ const ActionsListItem = ({
   const [fetchTokenInfo, { data: tokenData }] = useTokenInfoLazyQuery();
 
   const colonyObject = parseColonyMetadata(metadataJSON);
+  const { addedSafe } = useColonyMetadataChecks(
+    actionType,
+    colony,
+    transactionHash,
+    colonyObject,
+  );
+
   const extendedActionType = useExtendedColonyActionType(
     actionType,
     colony,
@@ -339,6 +350,8 @@ const ActionsListItem = ({
                   reputationChangeNumeral: (
                     <Numeral value={formattedReputationChange} />
                   ),
+                  chainName:
+                    addedSafe && GNOSIS_SAFE_NAMES_MAP[addedSafe.chainId],
                 }}
               />
             </span>

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultAction.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultAction.tsx
@@ -103,7 +103,7 @@ const DefaultAction = ({
   );
 
   let domainMetadata;
-  const { removedSafes } = useColonyMetadataChecks(
+  const { removedSafes, addedSafe } = useColonyMetadataChecks(
     actionType,
     colony,
     transactionHash,
@@ -231,10 +231,15 @@ const DefaultAction = ({
     isSmiteAction: new Decimal(reputationChange).isNegative(),
     removedSafes,
     removedSafesString,
+    addedSafeAddress: addedSafe && (
+      <MaskedAddress address={addedSafe.contractAddress} />
+    ),
+    chainName: addedSafe && GNOSIS_SAFE_NAMES_MAP[addedSafe.chainId],
+    safeName: addedSafe?.safeName,
   };
 
   const actionAndEventValuesForDocumentTitle = {
-    actionType,
+    actionType: extendedActionType,
     initiator:
       initiator.profile?.displayName ??
       initiator.profile?.username ??
@@ -252,6 +257,7 @@ const DefaultAction = ({
     roles: roleTitle,
     reputationChange: actionAndEventValues.reputationChange,
     reputationChangeNumeral: actionAndEventValues.reputationChangeNumeral,
+    chainName: addedSafe && GNOSIS_SAFE_NAMES_MAP[addedSafe.chainId],
   };
 
   const motionStyles = MOTION_TAG_MAP[MotionState.Forced];

--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.tsx
@@ -78,6 +78,18 @@ const MSG = defineMessages({
     id: 'dashboard.ActionsPage.DetailsWidget.safe',
     defaultMessage: 'Safe',
   },
+  chain: {
+    id: 'dashboard.ActionsPage.DetailsWidget.chain',
+    defaultMessage: 'Chain',
+  },
+  safeAddress: {
+    id: 'dashboard.ActionsPage.DetailsWidget.safeAddress',
+    defaultMessage: 'Safe Address',
+  },
+  safeName: {
+    id: 'dashboard.ActionsPage.DetailsWidget.safeName',
+    defaultMessage: 'Safe Name',
+  },
 });
 
 interface Props {
@@ -155,6 +167,36 @@ const DetailsWidget = ({
           </div>
           <div className={styles.value}>
             <DetailsWidgetTeam domain={values.motionDomain} />
+          </div>
+        </div>
+      )}
+      {detailsForAction.Chain && values?.chainName && (
+        <div className={styles.item}>
+          <div className={styles.label}>
+            <FormattedMessage {...MSG.chain} />
+          </div>
+          <div className={styles.value}>
+            <span>{values.chainName}</span>
+          </div>
+        </div>
+      )}
+      {detailsForAction.SafeAddress && values?.addedSafeAddress && (
+        <div className={styles.item}>
+          <div className={styles.label}>
+            <FormattedMessage {...MSG.safeAddress} />
+          </div>
+          <div className={styles.value}>
+            <span>{values.addedSafeAddress}</span>
+          </div>
+        </div>
+      )}
+      {detailsForAction.SafeName && values?.safeName && (
+        <div className={styles.item}>
+          <div className={styles.label}>
+            <FormattedMessage {...MSG.safeName} />
+          </div>
+          <div className={styles.value}>
+            <span>{values.safeName}</span>
           </div>
         </div>
       )}

--- a/src/modules/dashboard/components/ActionsPage/staticMaps.ts
+++ b/src/modules/dashboard/components/ActionsPage/staticMaps.ts
@@ -20,6 +20,9 @@ export enum ActionPageDetails {
   Permissions = 'Permissions',
   ReputationChange = 'ReputationChange',
   Safe = 'Safe',
+  Chain = 'Chain',
+  SafeAddress = 'SafeAddress',
+  SafeName = 'SafeName',
 }
 
 type EventRolesMap = Partial<
@@ -103,6 +106,7 @@ export const ACTION_TYPES_ICONS_MAP: {
   [ColonyExtendedActions.AddressBookUpdated]: 'emoji-edit-tools',
   [ColonyExtendedActions.TokensUpdated]: 'emoji-edit-tools',
   [ColonyExtendedActions.SafeRemoved]: 'gnosis-logo',
+  [ColonyExtendedActions.SafeAdded]: 'gnosis-logo',
   [ColonyActions.Generic]: 'circle-check-primary',
 };
 
@@ -251,6 +255,11 @@ export const DETAILS_FOR_ACTION: ActionsDetailsMap = {
   [ColonyExtendedActions.SafeRemoved]: [ActionPageDetails.Safe],
   [ColonyExtendedActions.TokensUpdated]: [ActionPageDetails.Name],
   [ColonyExtendedActions.AddressBookUpdated]: [ActionPageDetails.Name],
+  [ColonyExtendedActions.SafeAdded]: [
+    ActionPageDetails.Chain,
+    ActionPageDetails.SafeName,
+    ActionPageDetails.SafeAddress,
+  ],
   [ColonyMotions.MintTokensMotion]: [ActionPageDetails.Amount],
   [ColonyMotions.PaymentMotion]: [
     ActionPageDetails.FromDomain,

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeed.tsx
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeed.tsx
@@ -71,6 +71,9 @@ export interface EventValues {
   reputationChange?: string;
   isSmiteAction?: boolean;
   removedSafes?: ColonySafe[];
+  addedSafeAddress?: JSX.Element | null;
+  chainName?: string | null;
+  safeName?: string;
 }
 
 export type FeedItemWithId<T> = T & { uniqueId: string };

--- a/src/modules/dashboard/hooks/useColonyMetadataChecks.ts
+++ b/src/modules/dashboard/hooks/useColonyMetadataChecks.ts
@@ -20,6 +20,7 @@ import { useDataFetcher } from '~utils/hooks';
 
 export interface ColonyMetadataChecks {
   removedSafes?: ColonySafe[];
+  addedSafe?: ColonySafe | null;
   nameChanged?: boolean;
   logoChanged?: boolean;
   tokensChanged?: boolean;
@@ -45,6 +46,7 @@ const useColonyMetadataChecks = (
     tokensChanged: false,
     verifiedAddressesChanged: false,
     removedSafes: [],
+    addedSafe: null,
   });
 
   const colonyMetadataHistory = useSubgraphColonyMetadataQuery({
@@ -129,6 +131,7 @@ const useColonyMetadataChecks = (
             tokensChanged: !!actionColonyTokens?.length,
             verifiedAddressesChanged: !!actionVerifiedAddresses?.length,
             removedSafes: [],
+            addedSafe: null,
           };
 
           if (!isEqual(newMetadataValues, metadataChecks)) {

--- a/src/modules/dashboard/hooks/useExtendedColonyActionType.ts
+++ b/src/modules/dashboard/hooks/useExtendedColonyActionType.ts
@@ -17,6 +17,7 @@ const useExtendedColonyActionType = (
     verifiedAddressesChanged,
     tokensChanged,
     removedSafes,
+    addedSafe,
   } = useColonyMetadataChecks(
     actionType,
     colony,
@@ -37,9 +38,19 @@ const useExtendedColonyActionType = (
       if ((removedSafes || []).length > 0) {
         return ColonyExtendedActions.SafeRemoved;
       }
+
+      if (addedSafe) {
+        return ColonyExtendedActions.SafeAdded;
+      }
     }
     return actionType;
-  }, [actionType, verifiedAddressesChanged, tokensChanged, removedSafes]);
+  }, [
+    actionType,
+    verifiedAddressesChanged,
+    tokensChanged,
+    removedSafes,
+    addedSafe,
+  ]);
 };
 
 export default useExtendedColonyActionType;

--- a/src/modules/dashboard/sagas/colonyCreate.ts
+++ b/src/modules/dashboard/sagas/colonyCreate.ts
@@ -301,6 +301,7 @@ function* colonyCreate({
             colonyDisplayName: displayName,
             colonyAvatarHash: null,
             colonyTokens: [],
+            colonySafes: [],
           }),
         );
       } catch (error) {
@@ -317,6 +318,7 @@ function* colonyCreate({
             colonyDisplayName: displayName,
             colonyAvatarHash: null,
             colonyTokens: [],
+            colonySafes: [],
           }),
         );
       }

--- a/src/redux/types/actions/colonyActions.ts
+++ b/src/redux/types/actions/colonyActions.ts
@@ -13,6 +13,7 @@ import {
   MetaWithHistory,
   ActionType,
 } from './index';
+import { ColonySafe } from '~data/index';
 
 /*
  * @NOTE About naming
@@ -254,7 +255,7 @@ export type ColonyActionsActionTypes =
       {
         colonyName: string;
         colonyAddress: Address;
-        safeAddresses: Address[];
+        safeAddresses: ColonySafe[] | Address[];
         annotationMessage?: string;
         isRemovingSafes?: boolean;
       },

--- a/src/types/colonyActions.ts
+++ b/src/types/colonyActions.ts
@@ -28,6 +28,7 @@ export enum AddedActions {
   AddressBookUpdated = 'AddressBookUpdated',
   TokensUpdated = 'TokensUpdated',
   SafeRemoved = 'SafeRemoved',
+  SafeAdded = 'SafeAdded',
 }
 
 export const ColonyExtendedActions = { ...ColonyActions, ...AddedActions };

--- a/src/utils/colonyActions.ts
+++ b/src/utils/colonyActions.ts
@@ -142,6 +142,7 @@ export const getColonyMetadataMessageDescriptorsIds = (
     nameChanged,
     logoChanged,
     tokensChanged,
+    addedSafe,
     verifiedAddressesChanged,
     removedSafes,
   }: ColonyMetadataChecks,
@@ -165,6 +166,9 @@ export const getColonyMetadataMessageDescriptorsIds = (
 
     if ((removedSafes || []).length > 0) {
       return `event.${ColonyAndExtensionsEvents.ColonyMetadata}.safeRemoved`;
+    }
+    if (addedSafe) {
+      return `event.${ColonyAndExtensionsEvents.ColonyMetadata}.safeAdded`;
     }
   }
   return `event.${ColonyAndExtensionsEvents.ColonyMetadata}.fallback`;
@@ -317,9 +321,9 @@ export const getSpecificActionValuesCheck = (
     domainName: currentDomainName,
     domainPurpose: currentDomainPurpose,
     domainColor: currentDomainColor,
-    verifiedAddresses: currentVerifiedAddresses,
+    verifiedAddresses: currentVerifiedAddresses = [],
     isWhitelistActivated: currentIsWhitelistActivated,
-    colonySafes: currentColonySafes,
+    colonySafes: currentColonySafes = [],
   }: Partial<ColonyAction> | ColonyMetadata,
   {
     colonyDisplayName: prevColonyDisplayName,
@@ -328,9 +332,9 @@ export const getSpecificActionValuesCheck = (
     domainName: prevDomainName,
     domainPurpose: prevDomainPurpose,
     domainColor: prevDomainColor,
-    verifiedAddresses: prevVerifiedAddresses,
+    verifiedAddresses: prevVerifiedAddresses = [],
     isWhitelistActivated: prevIsWhitelistActivated,
-    colonySafes: prevColonySafes,
+    colonySafes: prevColonySafes = [],
   }: {
     colonyDisplayName?: string | null;
     colonyAvatarHash?: string | null;
@@ -364,6 +368,14 @@ export const getSpecificActionValuesCheck = (
         currentColonyTokens?.slice(0).sort() || [],
       );
 
+      const addedSafe =
+        currentColonySafes.length > prevColonySafes.length
+          ? currentColonySafes.find(
+              (safe) =>
+                !prevColonySafes.some((prevSafe) => isEqual(prevSafe, safe)),
+            )
+          : null;
+
       const removedSafes =
         (currentColonySafes || []).length < (prevColonySafes || []).length
           ? (prevColonySafes || []).filter(
@@ -381,6 +393,7 @@ export const getSpecificActionValuesCheck = (
         tokensChanged,
         verifiedAddressesChanged,
         removedSafes,
+        addedSafe,
       };
     }
     case ColonyAndExtensionsEvents.DomainMetadata: {

--- a/src/utils/events/index.ts
+++ b/src/utils/events/index.ts
@@ -18,7 +18,7 @@ import {
   FormattedAction,
   ActionUserRoles,
 } from '~types/index';
-import { ParsedEvent } from '~data/index';
+import { ColonySafe, ParsedEvent } from '~data/index';
 import { ProcessedEvent } from '~data/resolvers/colonyActions';
 
 import {
@@ -466,7 +466,7 @@ const getColonyEditActionValues = async (
     colonyTokens?: string[];
     isWhitelistActivated?: boolean;
     verifiedAddresses?: string[];
-    colonySafes?: string[];
+    colonySafes: ColonySafe[] | null;
   } = {
     address,
     colonyDisplayName: null,
@@ -506,7 +506,7 @@ const getColonyEditActionValues = async (
       colonyEditValues.colonyTokens = colonyTokens;
       colonyEditValues.isWhitelistActivated = isWhitelistActivated;
       colonyEditValues.verifiedAddresses = verifiedAddresses;
-      colonyEditValues.colonySafes = colonySafes;
+      colonyEditValues.colonySafes = colonySafes || [];
     }
   } catch (error) {
     log.verbose(


### PR DESCRIPTION
## Description

This PR tracks the work involved with ensuring that the correct messages appear on the Action Event page when a new safe is added, and that the correct `ActionListItem` titles appear in the Colony Actions list. 

Design: https://www.figma.com/file/LlVmeMQxHVA04evfrgZyuN/Safe-Control?node-id=727%3A15054

**Changes** 🏗

* DefaultAction & ActionsListItem: Show 'Add Gnosis Safe' title when safe added
* Details Widget: Add AddSafe view when safe added
* Updating `staticMaps`, the i18n files, and various other files to account for the AddSafe action

## Screenshot

![add-gnosis-safe](https://user-images.githubusercontent.com/64402732/180331605-a81cbb2e-9480-44af-b549-10353059edda.png)

![actionsList](https://user-images.githubusercontent.com/64402732/180656265-35d92abe-06ef-4fd0-9156-0c992f8bb741.png)


## TODO

- [x] Event title says 'Add Gnosis Safe'
- [x] Event text accurately describes the added safe
- [x] Details Widget displays correct data 
- [x] ActionsList on ColonyHome displays correct titles 

Resolves #3657