### PR TITLE
Add: check if safe already exists in colony

### DIFF
--- a/src/modules/constants.ts
+++ b/src/modules/constants.ts
@@ -235,3 +235,5 @@ export const ALLDOMAINS_DOMAIN_SELECTION = {
 };
 
 export const SMALL_TOKEN_AMOUNT_FORMAT = '0.00000...';
+
+export const SAFE_ALREADY_EXISTS = 'alreadyExists';

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
@@ -67,6 +67,8 @@ const ColonyHome = ({ match, location }: Props) => {
     // We have to define an empty address here for type safety, will be replaced by the query
     variables: { name: colonyName, address: '' },
     pollInterval: 5000,
+    fetchPolicy: 'network-only',
+    nextFetchPolicy: 'cache-first',
   });
 
   if (error) console.error(error);

--- a/src/modules/dashboard/components/Dialogs/AddExistingSafeDialog/AddExistingSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/AddExistingSafeDialog/AddExistingSafeDialog.tsx
@@ -27,7 +27,7 @@ type Props = Required<DialogProps> &
 const displayName = 'dashboard.AddExistingSafeDialog';
 
 const AddExistingSafeDialog = ({
-  colony: { colonyAddress, colonyName },
+  colony: { colonyAddress, colonyName, safes },
   callStep,
   prevStep,
   cancel,
@@ -98,6 +98,7 @@ const AddExistingSafeDialog = ({
             <DialogForm
               {...formProps}
               networkOptions={networkOptions}
+              colonySafes={safes}
               back={() => callStep(prevStep)}
             />
           </Dialog>


### PR DESCRIPTION
## Description

This PR adds a check to the AddExistingSafeDialog form for if the safe already exists in the colony, and won't permit form completion if so.

To test, add a safe via the Add Existing Safe option in the UAC. 
Then try to add the same safe again. You should see the following error :
![safe-already-exists](https://user-images.githubusercontent.com/64402732/180665324-6e70a31d-9224-434e-a6ee-ff10ab35a621.png)

**Changes** 🏗

* AddExistingSafeDialogForm: Check whether safe already exists in colony and show error if so.

Resolves #3643
