### PR TITLE
Fix: confirm button flashing on dialog open

### DIFF
--- a/src/modules/core/components/Comment/Dialogs/BanUser/BanUser.tsx
+++ b/src/modules/core/components/Comment/Dialogs/BanUser/BanUser.tsx
@@ -175,7 +175,12 @@ const BanUser = ({
       onSubmit={handleSubmit}
       enableReinitialize
     >
-      {({ isValid, isSubmitting, submitForm }: FormikProps<FormValues>) => (
+      {({
+        isValid,
+        isSubmitting,
+        values,
+        submitForm,
+      }: FormikProps<FormValues>) => (
         <Dialog cancel={cancel}>
           <DialogSection>
             <Heading
@@ -219,7 +224,7 @@ const BanUser = ({
                   size: 'large',
                 }}
                 text={isBanning ? MSG.banish : MSG.deactivateBan}
-                disabled={!isValid || isSubmitting}
+                disabled={!isValid || isSubmitting || values.userAddress === ''}
                 loading={loadingBanAction || isSubmitting}
                 onClick={submitForm}
               />


### PR DESCRIPTION
## Description

Small pr to fix a small bug with the confirm button of the Ban User form that was flashing upon first open. Now, when opening the dialog via ban / unban address, the confirm button does not flash.

**Changes** 🏗

* Form is now disabled if the input is an empty string.

## Screenshot
_Undesired flashing_

![flashing](https://user-images.githubusercontent.com/64402732/179033271-3f648fea-aa38-4b75-a16c-739e8d184a9a.gif)

Resolves #3632 
