### PR TITLE
Dapp support for Colony v10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@apollo/client": "^3.0.2",
-        "@colony/colony-js": "^4.2.0",
+        "@colony/colony-js": "^4.2.1-beta.0",
         "@colony/redux-promise-listener": "^1.2.0",
         "@colony/unicode-confusables-noascii": "^0.1.2",
         "@formatjs/intl-pluralrules": "^1.5.7",
@@ -4015,16 +4015,12 @@
       }
     },
     "node_modules/@colony/colony-js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-4.2.0.tgz",
-      "integrity": "sha512-wZOz4ExACaVxsAXq2OQOqPDp/PzUwUM0k/PbKtc2R1sbJW667ya34bywTUMLFJk3oH8G/Iyz8lhH2JBRS1/adQ==",
+      "version": "4.2.1-beta.0",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-4.2.1-beta.0.tgz",
+      "integrity": "sha512-xoHGzn1FOqgfdCE0Py/L7jp6ez3mC117LjfbTt7SMhH4UbTCeXyIvukfOMNKkH/xfPw1m4QW92C5MV2uaM94MQ==",
       "dependencies": {
         "isomorphic-fetch": "^2.2.1",
         "lodash.isequal": "^4.5.0"
-      },
-      "engines": {
-        "node": "14.18",
-        "npm": "^8"
       },
       "peerDependencies": {
         "ethers": "^4.0.47"
@@ -57046,9 +57042,9 @@
       }
     },
     "@colony/colony-js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-4.2.0.tgz",
-      "integrity": "sha512-wZOz4ExACaVxsAXq2OQOqPDp/PzUwUM0k/PbKtc2R1sbJW667ya34bywTUMLFJk3oH8G/Iyz8lhH2JBRS1/adQ==",
+      "version": "4.2.1-beta.0",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-4.2.1-beta.0.tgz",
+      "integrity": "sha512-xoHGzn1FOqgfdCE0Py/L7jp6ez3mC117LjfbTt7SMhH4UbTCeXyIvukfOMNKkH/xfPw1m4QW92C5MV2uaM94MQ==",
       "requires": {
         "isomorphic-fetch": "^2.2.1",
         "lodash.isequal": "^4.5.0"

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.0.2",
-    "@colony/colony-js": "^4.2.0",
+    "@colony/colony-js": "^4.2.1-beta.0",
     "@colony/redux-promise-listener": "^1.2.0",
     "@colony/unicode-confusables-noascii": "^0.1.2",
     "@formatjs/intl-pluralrules": "^1.5.7",


### PR DESCRIPTION
As the title suggests this PR adds support for the new Colony v10 contract upgrade.

Most of the work supporting this was done on the `colonyJS` side, in https://github.com/JoinColony/colonyJS/pull/528

Even though it seems benign, a important update here is the update of `colonyNetwork` since we're using a very "special" branch from the network repo:
- it's downgraded to node v14
- it has the recent (production) changes to the broadcaster
- it has the v10 colony contract

_NOTE: that this branch is a requirement for both https://github.com/JoinColony/colonyDapp/pull/3541 and **Simple Decisions** without which these two features can't be wired in_