### PR TITLE
Fix: syntax errors with spread operator

### DIFF
--- a/src/modules/core/components/Fields/Radio/CustomRadio.tsx
+++ b/src/modules/core/components/Fields/Radio/CustomRadio.tsx
@@ -97,21 +97,19 @@ const CustomRadio = ({
         </div>
       )}
       <div className={styles.content}>
-        {label && (
-          <span className={styles.label}>
-            {label === 'string' ? (
-              label
-            ) : (
-              <FormattedMessage {...label} values={labelValues} />
-            )}
-          </span>
-        )}
+        <span className={styles.label}>
+          {typeof label === 'object' ? (
+            <FormattedMessage {...label} values={labelValues} />
+          ) : (
+            label
+          )}
+        </span>
         {description && (
           <span className={styles.description}>
-            {description === 'string' ? (
-              description
-            ) : (
+            {typeof description === 'object' ? (
               <FormattedMessage {...description} values={descriptionValues} />
+            ) : (
+              description
             )}
           </span>
         )}

--- a/src/modules/core/components/PermissionsLabel/PermissionsLabel.tsx
+++ b/src/modules/core/components/PermissionsLabel/PermissionsLabel.tsx
@@ -68,10 +68,10 @@ const PermissionsLabel = ({
     <Tooltip
       content={
         <div className={styles.tooltip}>
-          {infoMessage && infoMessage === 'string' ? (
-            infoMessage
-          ) : (
+          {infoMessage && typeof infoMessage === 'object' ? (
             <FormattedMessage {...infoMessage} values={infoMessageValues} />
+          ) : (
+            infoMessage
           )}
         </div>
       }

--- a/src/modules/core/components/Preloaders/MiniSpinnerLoader.tsx
+++ b/src/modules/core/components/Preloaders/MiniSpinnerLoader.tsx
@@ -39,7 +39,11 @@ const MiniSpinnerLoader = ({
       <SpinnerLoader appearance={appearance} />
       {loadingText && (
         <span className={loadingTextClassName || styles.loadingText}>
-          <FormattedMessage {...loadingText} />
+          {typeof loadingText === 'object' ? (
+            <FormattedMessage {...loadingText} />
+          ) : (
+            loadingText
+          )}
         </span>
       )}
     </div>

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageSystemInfo/ActionsPageSystemInfo.tsx
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageSystemInfo/ActionsPageSystemInfo.tsx
@@ -14,16 +14,16 @@ export interface Appearance {
 
 interface Props {
   appearance?: Appearance;
-  tip?: MessageDescriptor | string;
+  tip: MessageDescriptor | string;
   tipValues?: UniversalMessageValues;
 }
 
 const ActionsPageSystemInfo = ({ tip, tipValues, appearance }: Props) => (
   <div className={getMainClasses(appearance, styles)}>
-    {tip && tip === 'string' ? (
-      tip
-    ) : (
+    {typeof tip === 'object' ? (
       <FormattedMessage {...tip} values={tipValues} />
+    ) : (
+      tip
     )}
   </div>
 );

--- a/src/modules/dashboard/components/Extensions/ExtensionCard.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionCard.tsx
@@ -50,7 +50,11 @@ const ExtensionCard = ({ extension, installedExtension, dataTest }: Props) => {
             </div>
           </div>
           <div className={styles.cardDescription}>
-            <FormattedMessage {...extension.descriptionShort} />
+            {typeof extension.descriptionShort === 'object' ? (
+              <FormattedMessage {...extension.descriptionShort} />
+            ) : (
+              extension.descriptionShort
+            )}
           </div>
           {installedExtension ? (
             <div className={styles.status}>

--- a/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
+++ b/src/modules/dashboard/components/Extensions/ExtensionDetails.tsx
@@ -363,27 +363,35 @@ const ExtensionDetails = ({
                     }}
                     text={extension.header || extension.name}
                   />
-                  <FormattedMessage
-                    {...extension.descriptionLong}
-                    values={{
-                      h4: (chunks) => (
-                        <Heading
-                          tagName="h4"
-                          appearance={{ size: 'medium', margin: 'small' }}
-                          text={chunks}
-                        />
-                      ),
-                      link0: extension.descriptionLinks?.[0],
-                    }}
-                  />
+                  {typeof extension.descriptionLong === 'object' ? (
+                    <FormattedMessage
+                      {...extension.descriptionLong}
+                      values={{
+                        h4: (chunks) => (
+                          <Heading
+                            tagName="h4"
+                            appearance={{ size: 'medium', margin: 'small' }}
+                            text={chunks}
+                          />
+                        ),
+                        link0: extension.descriptionLinks?.[0],
+                      }}
+                    />
+                  ) : (
+                    extension.descriptionLong
+                  )}
                   {extension.info && (
                     <div className={styles.extensionSubtext}>
-                      <FormattedMessage
-                        {...extension.info}
-                        values={{
-                          link0: extension.descriptionLinks?.[0],
-                        }}
-                      />
+                      {typeof extension.info === 'object' ? (
+                        <FormattedMessage
+                          {...extension.info}
+                          values={{
+                            link0: extension.descriptionLinks?.[0],
+                          }}
+                        />
+                      ) : (
+                        extension.info
+                      )}
                     </div>
                   )}
                   {extensionEnabled &&


### PR DESCRIPTION
## Description

This PR fixes a few syntax errors. If a prop type is `string | MessageDescriptor`, you get an error because you can't spread a string.

**Changes** 🏗

* Implementing \<FormatMessage\> conditionaly if it's an object

Resolves #3662 
