### PR TITLE
Sync single user picker with Address Book in award/smite dialogs

### DIFF
--- a/src/modules/dashboard/components/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/AwardAndSmiteDialogs/ManageReputationDialogForm/ManageReputationDialogForm.tsx
@@ -29,7 +29,6 @@ import {
   OneDomain,
   useUserReputationQuery,
   useLoggedInUser,
-  useMembersSubscription,
 } from '~data/index';
 import { useDialogActionPermissions } from '~utils/hooks/useDialogActionPermissions';
 import { useTransformer } from '~utils/hooks';
@@ -108,6 +107,7 @@ const MSG = defineMessages({
 interface Props extends ActionDialogProps {
   isVotingExtensionEnabled: boolean;
   nativeTokenDecimals: number;
+  verifiedUsers: AnyUser[];
   ethDomainId?: number;
   updateReputation?: (
     userPercentageReputation: number,
@@ -135,6 +135,7 @@ const ManageReputationDialogForm = ({
   ethDomainId: preselectedDomainId,
   isVotingExtensionEnabled,
   nativeTokenDecimals,
+  verifiedUsers,
   isSmiteAction = false,
 }: Props & FormikProps<ManageReputationDialogFormValues>) => {
   const { walletAddress, username, ethereal } = useLoggedInUser();
@@ -171,10 +172,6 @@ const ManageReputationDialogForm = ({
   );
 
   const inputDisabled = !userHasPermission || onlyForceAction;
-
-  const { data: colonyMembers } = useMembersSubscription({
-    variables: { colonyAddress },
-  });
 
   const { data: userReputationData } = useUserReputationQuery({
     variables: {
@@ -346,7 +343,7 @@ const ManageReputationDialogForm = ({
         <div className={styles.singleUserContainer}>
           <SingleUserPicker
             appearance={{ width: 'wide' }}
-            data={colonyMembers?.subscribedUsers || []}
+            data={verifiedUsers}
             label={MSG.recipient}
             name="user"
             filter={filterUserSelection}

--- a/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
@@ -115,7 +115,7 @@ const MSG = defineMessages({
   },
 });
 interface Props extends ActionDialogProps {
-  subscribedUsers: AnyUser[];
+  verifiedUsers: AnyUser[];
   showWhitelistWarning: boolean;
   ethDomainId?: number;
 }
@@ -154,7 +154,7 @@ const CreatePaymentDialogForm = ({
   colony,
   colony: { colonyAddress, domains, tokens },
   isVotingExtensionEnabled,
-  subscribedUsers,
+  verifiedUsers,
   handleSubmit,
   setFieldValue,
   isSubmitting,
@@ -438,7 +438,7 @@ const CreatePaymentDialogForm = ({
         <div className={styles.singleUserContainer}>
           <SingleUserPicker
             appearance={{ width: 'wide' }}
-            data={subscribedUsers}
+            data={verifiedUsers}
             label={MSG.to}
             name="recipient"
             filter={filterUserSelection}

--- a/src/utils/hooks/useSelectedUser.ts
+++ b/src/utils/hooks/useSelectedUser.ts
@@ -1,17 +1,12 @@
 import { useMemo } from 'react';
 
-import { useLoggedInUser } from '~data/index';
+import { AnyUser, useLoggedInUser } from '~data/index';
 
-export const useSelectedUser = (colonyMembers) => {
+export const useSelectedUser = (colonyUsers: AnyUser[]) => {
   const { walletAddress: loggedInUserWalletAddress } = useLoggedInUser();
 
   return useMemo(() => {
-    if (!colonyMembers) {
-      return undefined;
-    }
-
-    const [firstSubscriber, secondSubscriber] =
-      colonyMembers?.subscribedUsers || [];
+    const [firstSubscriber, secondSubscriber] = colonyUsers;
 
     if (!secondSubscriber) {
       return firstSubscriber;
@@ -20,5 +15,5 @@ export const useSelectedUser = (colonyMembers) => {
     return firstSubscriber.profile.walletAddress === loggedInUserWalletAddress
       ? secondSubscriber
       : firstSubscriber;
-  }, [colonyMembers, loggedInUserWalletAddress]);
+  }, [colonyUsers, loggedInUserWalletAddress]);
 };

--- a/src/utils/verifiedRecipients.ts
+++ b/src/utils/verifiedRecipients.ts
@@ -1,0 +1,15 @@
+import { AnyUser } from '~data/index';
+
+export const getVerifiedUsers = (
+  verifiedAddresses: string[],
+  subscribedUsers: AnyUser[],
+) => {
+  if (verifiedAddresses.length === 0) {
+    return undefined;
+  }
+  return subscribedUsers.filter((member) =>
+    verifiedAddresses.some(
+      (el) => el.toLowerCase() === member.id.toLowerCase(),
+    ),
+  );
+};


### PR DESCRIPTION
## Description

This PR  ensures that when the Address Book is enabled, the single user picker in the Award/Smite dialogs shows verified members instead of all members. When the Address Book is inactive, or no members have been added, the single user picker in both components should show all colony members. 

Note: this was already happening in the Create Payment dialog. I have extracted this logic for reuse in the Award/Smite components.
 
To test: 

1. With no members added, verify that the `SingleUserPicker` in the Award/Smite show all users in the colony. 
2. Add a member or two to the address book. Now verify the `SingleUserPicker` only shows those members. 
3. Turn off the address book. Now verify that the `SingleUserPicker` is showing all users again.

**Changes** 🏗

`CreatePaymentDialog.tsx`: Extracted the `verifiedUsers` logic for reuse in award/smite.
`ManageReputationContainer.tsx`: Added the `ColonyMembers` prop so that when the component loads, `ColonyMembers` is defined. This ensures that the selected user doesn't rerender after the component has been opened and therefore avoids a "flashing" in the ui. Also added the `verifiedUsers` logic. 
`ColonyHomeActions.tsx`: I moved the ColonyMembers query here because this contains the loading component nearest to the ManageReputation Container.
`useSelectedUser.ts`: updated to take an array of `AnyUser` (making it compatible with an array of verified or subscribed users)


**Additions**

`verifiedRecipients.ts`: Extracted logic for filtering subscribed (i.e. all) users by whether they're verified or not.

Resolves #3641

**Note:** The issue says that this should apply to all `SingleUserPicker` instances however after checking this with Arren we agreed that it should only apply to the Payments and Award/Smite dialogs for now (see issue comments).