### PR TITLE
Refactor: remove decimal styles from padding

### DIFF
--- a/src/modules/core/components/Fields/Select/Select.css
+++ b/src/modules/core/components/Fields/Select/Select.css
@@ -101,7 +101,7 @@
 
 .themeGrey {
   composes: baseSelect;
-  padding: 10.5px 15px 10.5px 15px;
+  padding: 10px 15px 10px 15px;
   height: 45px;
   border: 1px solid rgb(200, 214, 245);
   border-radius: var(--radius-tiny);


### PR DESCRIPTION
## Description

Remove the decimal pixels for the padding in the themeGrey css styles for the `Select` component.


(Resolves | Contributes to) #3637