### PR TITLE
Add missing support for V2 metadata in colonyActions

### DIFF
--- a/src/utils/colonyActions.ts
+++ b/src/utils/colonyActions.ts
@@ -1,6 +1,11 @@
 import { ColonyRole } from '@colony/colony-js';
 import sortBy from 'lodash/sortBy';
 import isEqual from 'lodash/isEqual';
+import {
+  getColonyMetadataFromResponse,
+  getDomainMetadataFromResponse,
+  getEventMetadataVersion,
+} from '@colony/colony-event-metadata-parser';
 
 import {
   ColonyActions,
@@ -203,74 +208,105 @@ export const getAssignmentEventDescriptorsIds = (
     : `${eventMessageType}.${eventName}.remove`;
 };
 
-export const parseColonyMetadata = (
-  jsonMetadata: string,
-): {
+interface ColonyMetadata {
   colonyDisplayName: string | null;
   colonyAvatarHash: string | null;
   colonyTokens: string[] | null;
   verifiedAddresses: string[] | null;
   isWhitelistActivated: boolean | null;
-} => {
-  try {
-    if (jsonMetadata) {
-      const {
-        colonyDisplayName = null,
-        colonyAvatarHash = null,
-        colonyTokens = [],
-        verifiedAddresses = [],
-        isWhitelistActivated = null,
-      } = JSON.parse(jsonMetadata);
-      return {
-        colonyDisplayName,
-        colonyAvatarHash,
-        colonyTokens,
-        verifiedAddresses,
-        isWhitelistActivated,
-      };
-    }
-  } catch (error) {
-    console.error('Could not parse colony ipfs json blob', jsonMetadata);
-    console.error(error);
-  }
-  return {
+}
+
+export const parseColonyMetadata = (jsonMetadata: string): ColonyMetadata => {
+  const metadata: ColonyMetadata = {
     colonyDisplayName: null,
     colonyAvatarHash: null,
     colonyTokens: [],
+    isWhitelistActivated: false,
     verifiedAddresses: [],
-    isWhitelistActivated: null,
   };
-};
-
-export const parseDomainMetadata = (
-  jsonMetadata: string,
-): {
-  domainName: string | null;
-  domainPurpose: string | null;
-  domainColor: string | null;
-} => {
   try {
     if (jsonMetadata) {
-      const {
-        domainName = null,
-        domainPurpose = null,
-        domainColor = null,
-      } = JSON.parse(jsonMetadata);
-      return {
-        domainName,
-        domainPurpose,
-        domainColor,
-      };
+      const metadataVersion = getEventMetadataVersion(jsonMetadata);
+      if (metadataVersion === 1) {
+        /*
+         * original metadata format
+         */
+        const {
+          colonyDisplayName,
+          colonyAvatarHash,
+          colonyTokens,
+          isWhitelistActivated,
+          verifiedAddresses,
+        } = JSON.parse(jsonMetadata);
+        metadata.colonyDisplayName = colonyDisplayName;
+        metadata.colonyAvatarHash = colonyAvatarHash;
+        metadata.colonyTokens = colonyTokens;
+        metadata.isWhitelistActivated = isWhitelistActivated;
+        metadata.verifiedAddresses = verifiedAddresses;
+      } else {
+        /*
+         * new metadata format
+         */
+        const colonyMetadata = getColonyMetadataFromResponse(jsonMetadata);
+        metadata.colonyDisplayName = colonyMetadata?.colonyDisplayName || null;
+        metadata.colonyAvatarHash = colonyMetadata?.colonyAvatarHash || null;
+        metadata.colonyTokens = colonyMetadata?.colonyTokens || [];
+        metadata.verifiedAddresses = colonyMetadata?.verifiedAddresses || [];
+        metadata.isWhitelistActivated =
+          colonyMetadata?.isWhitelistActivated || false;
+      }
     }
   } catch (error) {
-    console.error('Could not parse domain ipfs json blob', jsonMetadata);
+    console.error('Could not parse Colony ipfs json data', jsonMetadata);
     console.error(error);
   }
-  return {
+  return metadata;
+};
+
+interface DomainMetadata {
+  domainName: string | null;
+  // @TODO set to string instead of number to follow existing prop,
+  // but this needs to be standardised across the app
+  domainColor: string | null;
+  domainPurpose: string | null;
+}
+export const parseDomainMetadata = (jsonMetadata: string): DomainMetadata => {
+  const domainValues: DomainMetadata = {
     domainName: null,
-    domainPurpose: null,
     domainColor: null,
+    domainPurpose: null,
   };
+  try {
+    if (jsonMetadata) {
+      const metadataVersion = getEventMetadataVersion(jsonMetadata);
+      if (metadataVersion === 1) {
+        /*
+         * original metadata format
+         */
+        const {
+          domainName = null,
+          domainPurpose = null,
+          domainColor = null,
+        } = JSON.parse(jsonMetadata);
+        domainValues.domainName = domainName;
+        domainValues.domainPurpose = domainPurpose;
+        domainValues.domainColor = domainColor;
+      } else {
+        /*
+         * new metadata format
+         */
+        const domainMetadata = getDomainMetadataFromResponse(jsonMetadata);
+        domainValues.domainName = domainMetadata?.domainName || null;
+        domainValues.domainColor =
+          domainMetadata?.domainColor?.toString() || null; // @TODO revert to number during refactor
+        domainValues.domainPurpose = domainMetadata?.domainPurpose || null;
+      }
+    }
+  } catch (error) {
+    console.error('Could not parse domain ipfs json data', jsonMetadata);
+    console.error(error);
+  }
+  return domainValues;
 };
 
 export const sortMetadataHistory = (colonyMetadata) =>
@@ -326,12 +362,11 @@ export const getSpecificActionValuesCheck = (
     case ColonyAndExtensionsEvents.ColonyMetadata: {
       const nameChanged = prevColonyDisplayName !== currentColonyDisplayName;
       const logoChanged = prevColonyAvatarHash !== currentColonyAvatarHash;
-
       const verifiedAddressesChanged =
         !isEqual(prevVerifiedAddresses, currentVerifiedAddresses) ||
-        // purposely using loose equality here to compare IsWhitelistActivated flags
-        // eslint-disable-next-line eqeqeq
-        prevIsWhitelistActivated != currentIsWhitelistActivated;
+        // @NOTE casting to Boolean as IsWhitelistActivated could have a value, null, undefined.
+        Boolean(prevIsWhitelistActivated) !==
+          Boolean(currentIsWhitelistActivated);
 
       /*
        * Tokens arrays might come from a subgraph query, in which case

--- a/src/utils/events/index.ts
+++ b/src/utils/events/index.ts
@@ -536,9 +536,9 @@ const getColonyEditActionValues = async (
         const colonyMetadata = getColonyMetadataFromResponse(ipfsMetadata);
 
         colonyEditValues.colonyDisplayName =
-          colonyMetadata?.colonyDisplayName ?? '';
+          colonyMetadata?.colonyDisplayName || null;
         colonyEditValues.colonyAvatarHash =
-          colonyMetadata?.colonyAvatarHash || '';
+          colonyMetadata?.colonyAvatarHash || null;
         colonyEditValues.colonyTokens = colonyMetadata?.colonyTokens || [];
         colonyEditValues.verifiedAddresses =
           colonyMetadata?.verifiedAddresses || [];


### PR DESCRIPTION
## Description

This PR fixes a bug where addresses could not be added/removed from the address book. This was caused by missing support for parsing V2 metadata in colonyActions.

You can test by editing colony details, and adding/removing addresses from the address book.



Resolves #3697
