### PR TITLE
Update colonymetadata destructuring

### DIFF
--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -907,7 +907,7 @@ export type ColonyAction = {
   newVersion: Scalars['String'];
   colonyDisplayName: Scalars['String'];
   colonyAvatarHash: Scalars['String'];
-  colonyTokens: Array<Maybe<Scalars['String']>>;
+  colonyTokens: Array<Scalars['String']>;
   domainName: Scalars['String'];
   domainPurpose: Scalars['String'];
   domainColor: Scalars['String'];

--- a/src/data/graphql/typeDefs.ts
+++ b/src/data/graphql/typeDefs.ts
@@ -115,7 +115,7 @@ export default gql`
     newVersion: String!
     colonyDisplayName: String!
     colonyAvatarHash: String!
-    colonyTokens: [String]!
+    colonyTokens: [String!]!
     domainName: String!
     domainPurpose: String!
     domainColor: String!

--- a/src/i18n/en-actions.ts
+++ b/src/i18n/en-actions.ts
@@ -35,6 +35,7 @@ const actionsMessageDescriptors = {
   [`action.${ColonyActions.SetUserRoles}.assignAndRemove`]: `{roles} in {fromDomain} to/from {recipient}`,
   [`action.${ColonyMotions.SetUserRolesMotion}.assignAndRemove`]: `{roles} in {fromDomain} to/from {recipient}`,
   [`action.${ColonyActions.ColonyEdit}.verifiedAddresses`]: `Address book was updated`,
+  [`action.${ColonyActions.ColonyEdit}.tokens`]: `Colony tokens were updated`,
   'action.type': `{actionType, select,
       ${ColonyActions.WrongColony} {Not part of the Colony}
       ${ColonyActions.Payment} {Payment}

--- a/src/modules/core/components/ActionsList/ActionsListItem.tsx
+++ b/src/modules/core/components/ActionsList/ActionsListItem.tsx
@@ -130,11 +130,11 @@ const ActionsListItem = ({
   const [fetchTokenInfo, { data: tokenData }] = useTokenInfoLazyQuery();
 
   const colonyObject = parseColonyMetadata(metadataJSON);
-  const colonyMetadataChecks = useColonyMetadataChecks(
+  const { tokensChanged, verifiedAddressesChanged } = useColonyMetadataChecks(
     actionType,
     colony,
     transactionHash,
-    { verifiedAddresses: colonyObject.verifiedAddresses || [] },
+    colonyObject,
   );
   useEffect(() => {
     if (transactionTokenAddress) {
@@ -294,8 +294,10 @@ const ActionsListItem = ({
             <span className={styles.title}>
               <FormattedMessage
                 id={
-                  (colonyMetadataChecks.verifiedAddressesChanged &&
+                  (verifiedAddressesChanged &&
                     `action.${ColonyActions.ColonyEdit}.verifiedAddresses`) ||
+                  (tokensChanged &&
+                    `action.${ColonyActions.ColonyEdit}.tokens`) ||
                   roleMessageDescriptorId ||
                   'action.title'
                 }

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultAction.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultAction.tsx
@@ -97,7 +97,7 @@ const DefaultAction = ({
   );
 
   let domainMetadata;
-  const colonyMetadataChecks = useColonyMetadataChecks(
+  const { verifiedAddressesChanged, tokensChanged } = useColonyMetadataChecks(
     actionType,
     colony,
     transactionHash,
@@ -247,8 +247,10 @@ const DefaultAction = ({
           <h1 className={styles.heading} data-test="actionHeading">
             <FormattedMessage
               id={
-                (colonyMetadataChecks.verifiedAddressesChanged &&
+                (verifiedAddressesChanged &&
                   `action.${ColonyActions.ColonyEdit}.verifiedAddresses`) ||
+                (tokensChanged &&
+                  `action.${ColonyActions.ColonyEdit}.tokens`) ||
                 roleMessageDescriptorId ||
                 'action.title'
               }

--- a/src/modules/dashboard/hooks/useColonyMetadataChecks.ts
+++ b/src/modules/dashboard/hooks/useColonyMetadataChecks.ts
@@ -13,6 +13,7 @@ import {
   getSpecificActionValuesCheck,
   sortMetadataHistory,
   parseColonyMetadata,
+  ColonyMetadata,
 } from '~utils/colonyActions';
 import { useDataFetcher } from '~utils/hooks';
 
@@ -24,7 +25,7 @@ const useColonyMetadataChecks = (
   eventName: string,
   colony: Colony,
   transactionHash: string,
-  actionData: Partial<ColonyAction>,
+  actionData: ColonyMetadata | Partial<ColonyAction>,
 ) => {
   let metadataJSON: string | null = null;
   const [metadataIpfsHash, setMetadataIpfsHash] = useState<string>('');

--- a/src/utils/colonyActions.ts
+++ b/src/utils/colonyActions.ts
@@ -203,15 +203,18 @@ export const getAssignmentEventDescriptorsIds = (
     : `${eventMessageType}.${eventName}.remove`;
 };
 
-export const parseColonyMetadata = (
-  jsonMetadata: string,
-): {
+export interface ColonyMetadata {
   colonyDisplayName: string | null;
   colonyAvatarHash: string | null;
   colonyTokens: string[] | null;
   verifiedAddresses: string[] | null;
   isWhitelistActivated: boolean | null;
-} => {
+  domainName?: string;
+  domainPurpose?: string;
+  domainColor?: string;
+}
+
+export const parseColonyMetadata = (jsonMetadata: string): ColonyMetadata => {
   try {
     if (jsonMetadata) {
       const {
@@ -301,7 +304,7 @@ export const getSpecificActionValuesCheck = (
     domainColor: currentDomainColor,
     verifiedAddresses: currentVerifiedAddresses,
     isWhitelistActivated: currentIsWhitelistActivated,
-  }: Partial<ColonyAction>,
+  }: Partial<ColonyAction> | ColonyMetadata,
   {
     colonyDisplayName: prevColonyDisplayName,
     colonyAvatarHash: prevColonyAvatarHash,
@@ -329,9 +332,9 @@ export const getSpecificActionValuesCheck = (
 
       const verifiedAddressesChanged =
         !isEqual(prevVerifiedAddresses, currentVerifiedAddresses) ||
-        // purposely using loose equality here to compare IsWhitelistActivated flags
-        // eslint-disable-next-line eqeqeq
-        prevIsWhitelistActivated != currentIsWhitelistActivated;
+        // @NOTE casting to Boolean as IsWhitelistActivated could have a value, null, undefined.
+        Boolean(prevIsWhitelistActivated) !==
+          Boolean(currentIsWhitelistActivated);
 
       /*
        * Tokens arrays might come from a subgraph query, in which case


### PR DESCRIPTION
## Description

This PR fixes the bug that whenever you have any colony edit actions (update tokens list, edit colony details) that happens int he colony for the first time, it will always show the title as `Address book updated`. It also adds a specific title to the colony tokens update action.

resolves #3699 
