### PR TITLE
Add permissions to gnosis dialogs

### DIFF
--- a/src/modules/dashboard/components/Dialogs/AdvancedDialog/AdvancedDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/AdvancedDialog/AdvancedDialog.tsx
@@ -95,7 +95,7 @@ const MSG = defineMessages({
   },
   adminFundingPermissions: {
     id: 'dashboard.AdvancedDialog.gnosisPermissionsList',
-    defaultMessage: 'administration and funding ',
+    defaultMessage: 'funding and administration or root',
   },
 });
 

--- a/src/modules/dashboard/components/Dialogs/AdvancedDialog/AdvancedDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/AdvancedDialog/AdvancedDialog.tsx
@@ -94,7 +94,7 @@ const MSG = defineMessages({
     defaultMessage: 'Control a safe to interact with external contracts.',
   },
   adminFundingPermissions: {
-    id: 'dashboard.AdvancedDialog.gnosisPermissionsList',
+    id: 'dashboard.AdvancedDialog.adminFundingPermissions',
     defaultMessage: 'funding and administration or root',
   },
 });

--- a/src/modules/dashboard/components/Dialogs/AdvancedDialog/AdvancedDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/AdvancedDialog/AdvancedDialog.tsx
@@ -12,6 +12,8 @@ import {
   canEnterRecoveryMode,
   hasRoot,
   canArchitect,
+  canFund,
+  canAdminister,
 } from '~modules/users/checks';
 
 const MSG = defineMessages({
@@ -91,6 +93,10 @@ const MSG = defineMessages({
     id: 'dashboard.AdvancedDialog.manageGnosisSafeDescription',
     defaultMessage: 'Control a safe to interact with external contracts.',
   },
+  adminFundingPermissions: {
+    id: 'dashboard.AdvancedDialog.gnosisPermissionsList',
+    defaultMessage: 'administration and funding ',
+  },
 });
 
 interface CustomWizardDialogProps extends ActionDialogProps {
@@ -135,6 +141,11 @@ const AdvancedDialog = ({
 
   const canEnterPermissionManagement =
     (hasRegisteredProfile && canArchitect(allUserRoles)) || hasRootPermission;
+
+  const canManageGnosisSafes =
+    hasRegisteredProfile &&
+    canFund(allUserRoles) &&
+    canAdminister(allUserRoles);
 
   const items = [
     {
@@ -197,6 +208,11 @@ const AdvancedDialog = ({
       icon: 'gnosis-logo',
       dataTest: 'manageGnosisSafeItem',
       onClick: () => callStep(nextStepManageGnosisSafe),
+      permissionRequired: !canManageGnosisSafes,
+      permissionInfoText: MSG.permissionsText,
+      permissionInfoTextValues: {
+        permissionsList: <FormattedMessage {...MSG.adminFundingPermissions} />,
+      },
     },
     {
       title: MSG.makeArbitraryTransactionTitle,

--- a/src/modules/dashboard/components/Dialogs/AdvancedDialog/AdvancedDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/AdvancedDialog/AdvancedDialog.tsx
@@ -145,7 +145,7 @@ const AdvancedDialog = ({
   const canManageGnosisSafes =
     hasRegisteredProfile &&
     canFund(allUserRoles) &&
-    canAdminister(allUserRoles);
+    (canAdminister(allUserRoles) || hasRoot(allUserRoles));
 
   const items = [
     {

--- a/src/modules/dashboard/components/Dialogs/ManageGnosisSafeDialog/ManageGnosisSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/ManageGnosisSafeDialog/ManageGnosisSafeDialog.tsx
@@ -75,9 +75,14 @@ const ManageGnosisSafeDialog = ({
   const allUserRoles = useTransformer(getAllUserRoles, [colony, walletAddress]);
 
   const hasRegisteredProfile = !!username && !ethereal;
-  const canManageGnosisSafes =
+  const canAddRemoveSafes =
     hasRegisteredProfile &&
     userHasRole(allUserRoles, ColonyRole.Administration) &&
+    userHasRole(allUserRoles, ColonyRole.Funding);
+
+  const canControlSafes =
+    hasRegisteredProfile &&
+    userHasRole(allUserRoles, ColonyRole.Root) &&
     userHasRole(allUserRoles, ColonyRole.Funding);
 
   const items = [
@@ -87,7 +92,7 @@ const ManageGnosisSafeDialog = ({
       icon: 'plus-heavy',
       dataTest: 'gnosisAddExistingItem',
       onClick: () => callStep(nextStepAddExistingSafe),
-      permissionRequired: !canManageGnosisSafes,
+      permissionRequired: !canAddRemoveSafes,
       permissionInfoText: MSG.permissionText,
       permissionInfoTextValues: {
         permissionsList: <FormattedMessage {...MSG.adminFundingPermissions} />,
@@ -99,7 +104,7 @@ const ManageGnosisSafeDialog = ({
       icon: 'trash-can',
       dataTest: 'gnosisRemoveSafeItem',
       onClick: () => callStep(nextStepRemoveSafe),
-      permissionRequired: !canManageGnosisSafes,
+      permissionRequired: !canAddRemoveSafes,
       permissionInfoText: MSG.permissionText,
       permissionInfoTextValues: {
         permissionsList: <FormattedMessage {...MSG.adminFundingPermissions} />,
@@ -111,7 +116,7 @@ const ManageGnosisSafeDialog = ({
       icon: 'joystick',
       dataTest: 'gnosisControlSafeItem',
       onClick: () => callStep(nextStepControlSafe),
-      permissionRequired: !canManageGnosisSafes,
+      permissionRequired: !canControlSafes,
       permissionInfoText: MSG.permissionText,
       permissionInfoTextValues: {
         permissionsList: <FormattedMessage {...MSG.adminFundingPermissions} />,

--- a/src/modules/dashboard/components/Dialogs/ManageGnosisSafeDialog/ManageGnosisSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/ManageGnosisSafeDialog/ManageGnosisSafeDialog.tsx
@@ -48,6 +48,10 @@ const MSG = defineMessages({
     id: 'dashboard.AdvancedDialog.gnosisPermissionsList',
     defaultMessage: 'administration and funding ',
   },
+  rootFundingPermissions: {
+    id: 'dashboard.AdvancedDialog.rootFundingPermissions',
+    defaultMessage: 'root and funding ',
+  },
 });
 
 interface CustomWizardDialogProps extends ActionDialogProps {
@@ -119,7 +123,7 @@ const ManageGnosisSafeDialog = ({
       permissionRequired: !canControlSafes,
       permissionInfoText: MSG.permissionText,
       permissionInfoTextValues: {
-        permissionsList: <FormattedMessage {...MSG.adminFundingPermissions} />,
+        permissionsList: <FormattedMessage {...MSG.rootFundingPermissions} />,
       },
     },
   ];

--- a/src/modules/dashboard/components/Dialogs/ManageGnosisSafeDialog/ManageGnosisSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/ManageGnosisSafeDialog/ManageGnosisSafeDialog.tsx
@@ -1,6 +1,6 @@
 import { ColonyRole } from '@colony/colony-js';
 import React from 'react';
-import { defineMessages, useIntl } from 'react-intl';
+import { defineMessages, FormattedMessage } from 'react-intl';
 
 import { DialogProps, ActionDialogProps } from '~core/Dialog';
 import IndexModal from '~core/IndexModal';
@@ -41,8 +41,12 @@ const MSG = defineMessages({
   },
   permissionText: {
     id: 'dashboard.ManageGnosisSafeDialog.permissionsText',
-    defaultMessage: `You must have the {permission} permissions in the
+    defaultMessage: `You must have the {permissionsList} permissions in the
       relevant teams, in order to take this action`,
+  },
+  adminFundingPermissions: {
+    id: 'dashboard.AdvancedDialog.gnosisPermissionsList',
+    defaultMessage: 'administration and funding ',
   },
 });
 
@@ -68,14 +72,14 @@ const ManageGnosisSafeDialog = ({
   nextStepControlSafe,
 }: Props) => {
   const { walletAddress, username, ethereal } = useLoggedInUser();
-  const { formatMessage } = useIntl();
   const allUserRoles = useTransformer(getAllUserRoles, [colony, walletAddress]);
 
   const hasRegisteredProfile = !!username && !ethereal;
   const canManageGnosisSafes =
-    (hasRegisteredProfile &&
-      userHasRole(allUserRoles, ColonyRole.Administration)) ||
+    hasRegisteredProfile &&
+    userHasRole(allUserRoles, ColonyRole.Administration) &&
     userHasRole(allUserRoles, ColonyRole.Funding);
+
   const items = [
     {
       title: MSG.addExistingSafeTitle,
@@ -86,11 +90,7 @@ const ManageGnosisSafeDialog = ({
       permissionRequired: !canManageGnosisSafes,
       permissionInfoText: MSG.permissionText,
       permissionInfoTextValues: {
-        permission: `${formatMessage({
-          id: `role.${ColonyRole.Administration}`,
-        }).toLowerCase()} and ${formatMessage({
-          id: `role.${ColonyRole.Funding}`,
-        }).toLowerCase()}`,
+        permissionsList: <FormattedMessage {...MSG.adminFundingPermissions} />,
       },
     },
     {
@@ -102,11 +102,7 @@ const ManageGnosisSafeDialog = ({
       permissionRequired: !canManageGnosisSafes,
       permissionInfoText: MSG.permissionText,
       permissionInfoTextValues: {
-        permission: `${formatMessage({
-          id: `role.${ColonyRole.Administration}`,
-        }).toLowerCase()} and ${formatMessage({
-          id: `role.${ColonyRole.Funding}`,
-        }).toLowerCase()}`,
+        permissionsList: <FormattedMessage {...MSG.adminFundingPermissions} />,
       },
     },
     {
@@ -115,6 +111,11 @@ const ManageGnosisSafeDialog = ({
       icon: 'joystick',
       dataTest: 'gnosisControlSafeItem',
       onClick: () => callStep(nextStepControlSafe),
+      permissionRequired: !canManageGnosisSafes,
+      permissionInfoText: MSG.permissionText,
+      permissionInfoTextValues: {
+        permissionsList: <FormattedMessage {...MSG.adminFundingPermissions} />,
+      },
     },
   ];
   return (

--- a/src/modules/dashboard/components/Dialogs/ManageGnosisSafeDialog/ManageGnosisSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/ManageGnosisSafeDialog/ManageGnosisSafeDialog.tsx
@@ -45,11 +45,11 @@ const MSG = defineMessages({
       relevant teams, in order to take this action`,
   },
   adminFundingPermissions: {
-    id: 'dashboard.AdvancedDialog.gnosisPermissionsList',
+    id: 'dashboard.ManageGnosisSafeDialog.adminFundingPermissions',
     defaultMessage: 'administration and funding ',
   },
   rootFundingPermissions: {
-    id: 'dashboard.AdvancedDialog.rootFundingPermissions',
+    id: 'dashboard.ManageGnosisSafeDialog.rootFundingPermissions',
     defaultMessage: 'root and funding ',
   },
 });


### PR DESCRIPTION
## Description

This PR adds permissions to the Advanced dialog (gnosis part) and to the `GnosisManagementDialog` (gnosisControlSafeItem part). 

It also fixes what I thought was a bug in permissions logic. It used to be `administration` or `funding` permission in logic but the text suggested otherwise. It says `administration and funding` so I updated the logic to reflect that. @ArmandoGraterol, please, let me know if it should be `or` and I will update accordingly.

resolves #3691 
