### PR TITLE
Add decisions page UI

### DIFF
--- a/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.css
+++ b/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.css
@@ -1,0 +1,38 @@
+.emptyState {
+  margin-top: 90px;
+  width: 100%;
+  text-align: center;
+}
+
+.filter {
+  display: inline-block;
+}
+
+.filter button > div {
+  height: 18px;
+}
+
+.filter span {
+  font-size: var(--size-small);
+}
+
+.loadingSpinner {
+  margin-top: 100px;
+}
+
+.bar {
+  display: flex;
+  align-items: center;
+
+  /* The Select component (sorting dropdown) already has 10px top and bottom padding
+  So we are adding the rest as margins to follow the spec */
+  margin-top: 11px;
+  margin-bottom: 2px;
+}
+
+.title {
+  flex-grow: 2;
+  font-size: var(--size-smallish);
+  font-weight: var(--weight-bold);
+  color: var(--dark);
+}

--- a/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.css.d.ts
+++ b/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.css.d.ts
@@ -1,0 +1,5 @@
+export const emptyState: string;
+export const filter: string;
+export const loadingSpinner: string;
+export const bar: string;
+export const title: string;

--- a/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
+++ b/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
@@ -45,7 +45,7 @@ type Props = {
 const ColonyDecisions = ({ colony }: Props) => {
   // temp values, to be removed when queries are wired in
   const isLoading = false;
-  const data = ['m'];
+  const data = ['placeholder'];
 
   if (isLoading) {
     return (
@@ -82,6 +82,9 @@ const ColonyDecisions = ({ colony }: Props) => {
               </div>
             </Form>
           </div>
+          {data.map((item) => (
+            <div>{item}</div>
+          ))}
         </>
       ) : (
         <div className={styles.emptyState}>

--- a/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
+++ b/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
@@ -1,6 +1,36 @@
 import React from 'react';
+import { defineMessages, FormattedMessage } from 'react-intl';
+
+import { Select, Form } from '~core/Fields';
+import { SpinnerLoader } from '~core/Preloaders';
 
 import { Colony } from '~data/index';
+
+import { SortOptions, SortSelectOptions } from './constants';
+import styles from './ColonyDecisions.css';
+
+const MSG = defineMessages({
+  decisionsTitle: {
+    id: 'dashboard.ColonyDecisions.decisionsTitle',
+    defaultMessage: 'Decisions',
+  },
+  labelFilter: {
+    id: 'dashboard.ColonyDecisions.labelFilter',
+    defaultMessage: 'Filter',
+  },
+  placeholderFilter: {
+    id: 'dashboard.ColonyDecisions.placeholderFilter',
+    defaultMessage: 'Filter',
+  },
+  noDecisionsFound: {
+    id: 'dashboard.ColonyDecisions.noDecisionsFound',
+    defaultMessage: 'No decisions exist',
+  },
+  loading: {
+    id: 'dashboard.ColonyDecisions.loading',
+    defaultMessage: 'Loading decisions',
+  },
+});
 
 type Props = {
   colony: Colony;
@@ -13,7 +43,53 @@ type Props = {
 /* Temporary disable */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const ColonyDecisions = ({ colony }: Props) => {
-  return <div>DECISIONS</div>;
+  // temp values, to be removed when queries are wired in
+  const isLoading = false;
+  const data = ['m'];
+
+  if (isLoading) {
+    return (
+      <div className={styles.loadingSpinner}>
+        <SpinnerLoader
+          loadingText={MSG.loading}
+          appearance={{ theme: 'primary', size: 'massive' }}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {data.length > 0 ? (
+        <>
+          <div className={styles.bar}>
+            <div className={styles.title}>
+              <FormattedMessage {...MSG.decisionsTitle} />
+            </div>
+            <Form
+              initialValues={{ filter: SortOptions.ENDING_SOONEST }}
+              onSubmit={() => undefined}
+            >
+              <div className={styles.filter}>
+                <Select
+                  appearance={{ alignOptions: 'left', theme: 'alt' }}
+                  elementOnly
+                  label={MSG.labelFilter}
+                  name="filter"
+                  options={SortSelectOptions}
+                  placeholder={MSG.placeholderFilter}
+                />
+              </div>
+            </Form>
+          </div>
+        </>
+      ) : (
+        <div className={styles.emptyState}>
+          <FormattedMessage {...MSG.noDecisionsFound} />
+        </div>
+      )}
+    </div>
+  );
 };
 
 export default ColonyDecisions;

--- a/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
+++ b/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import { Colony } from '~data/index';
+
+type Props = {
+  colony: Colony;
+  /*
+   * @NOTE Needed for filtering based on domain
+   */
+  ethDomainId?: number;
+};
+
+/* Temporary disable */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const ColonyDecisions = ({ colony }: Props) => {
+  return <div>DECISIONS</div>;
+};
+
+export default ColonyDecisions;

--- a/src/modules/dashboard/components/ColonyDecisions/constants.ts
+++ b/src/modules/dashboard/components/ColonyDecisions/constants.ts
@@ -2,11 +2,11 @@ import { defineMessages } from 'react-intl';
 
 const SORT_MSG = defineMessages({
   soonest: {
-    id: 'dashboard.Sort.soonest',
+    id: 'dashboard.ColonyDecisions.soonest',
     defaultMessage: 'Ending soonest',
   },
   latest: {
-    id: 'dashboard.Sort.latest',
+    id: 'dashboard.ColonyDecisions.latest',
     defaultMessage: 'Ending latest',
   },
 });

--- a/src/modules/dashboard/components/ColonyDecisions/constants.ts
+++ b/src/modules/dashboard/components/ColonyDecisions/constants.ts
@@ -1,0 +1,28 @@
+import { defineMessages } from 'react-intl';
+
+const SORT_MSG = defineMessages({
+  soonest: {
+    id: 'dashboard.Sort.soonest',
+    defaultMessage: 'Ending soonest',
+  },
+  latest: {
+    id: 'dashboard.Sort.latest',
+    defaultMessage: 'Ending latest',
+  },
+});
+
+export enum SortOptions {
+  ENDING_SOONEST = 'ENDING_SOONEST',
+  ENDING_LATEST = 'ENDING_LATEST',
+}
+
+export const SortSelectOptions = [
+  {
+    label: SORT_MSG.soonest,
+    value: SortOptions.ENDING_SOONEST,
+  },
+  {
+    label: SORT_MSG.latest,
+    value: SortOptions.ENDING_LATEST,
+  },
+];

--- a/src/modules/dashboard/components/ColonyDecisions/index.ts
+++ b/src/modules/dashboard/components/ColonyDecisions/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ColonyDecisions';

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
@@ -15,13 +15,10 @@ import ColonyHomeActions from '~dashboard/ColonyHomeActions';
 import ColonyActions from '~dashboard/ColonyActions';
 import ColonyEvents from '~dashboard/ColonyEvents';
 import ColonyDecisions from '~dashboard/ColonyDecisions';
+import ColonyNewDecision from '~dashboard/ColonyNewDecision';
 
 import { COLONY_TOTAL_BALANCE_DOMAIN_ID } from '~constants';
 import { useColonyFromNameQuery } from '~data/index';
-
-import ColonyHomeLayout from './ColonyHomeLayout';
-import styles from './ColonyHomeLayout.css';
-
 import {
   COLONY_EVENTS_ROUTE,
   COLONY_DECISIONS_ROUTE,
@@ -31,6 +28,9 @@ import {
   COLONY_HOME_ROUTE,
   NOT_FOUND_ROUTE,
 } from '~routes/index';
+
+import ColonyHomeLayout from './ColonyHomeLayout';
+import styles from './ColonyHomeLayout.css';
 
 const MSG = defineMessages({
   loadingText: {
@@ -98,7 +98,7 @@ const ColonyHome = ({ match, location }: Props) => {
                 filteredDomainId={filteredDomainId}
                 onDomainChange={setDomainIdFilter}
                 newItemButton={
-                  <ColonyHomeActions
+                  <ColonyNewDecision
                     colony={colony}
                     ethDomainId={filteredDomainId}
                   />

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
@@ -11,16 +11,15 @@ import { parse as parseQS } from 'query-string';
 
 import LoadingTemplate from '~pages/LoadingTemplate';
 import Extensions, { ExtensionDetails } from '~dashboard/Extensions';
-
-import { COLONY_TOTAL_BALANCE_DOMAIN_ID } from '~constants';
-import { useColonyFromNameQuery } from '~data/index';
-
+import ColonyHomeActions from '~dashboard/ColonyHomeActions';
 import ColonyActions from '~dashboard/ColonyActions';
 import ColonyEvents from '~dashboard/ColonyEvents';
 import ColonyDecisions from '~dashboard/ColonyDecisions';
 
-import ColonyHomeLayout from './ColonyHomeLayout';
+import { COLONY_TOTAL_BALANCE_DOMAIN_ID } from '~constants';
+import { useColonyFromNameQuery } from '~data/index';
 
+import ColonyHomeLayout from './ColonyHomeLayout';
 import styles from './ColonyHomeLayout.css';
 
 import {
@@ -86,7 +85,6 @@ const ColonyHome = ({ match, location }: Props) => {
                 colony={colony}
                 filteredDomainId={filteredDomainId}
                 onDomainChange={setDomainIdFilter}
-                showActions={false}
               >
                 <ColonyEvents colony={colony} ethDomainId={filteredDomainId} />
               </ColonyHomeLayout>
@@ -99,7 +97,12 @@ const ColonyHome = ({ match, location }: Props) => {
                 colony={colony}
                 filteredDomainId={filteredDomainId}
                 onDomainChange={setDomainIdFilter}
-                showActions={false}
+                newItemButton={
+                  <ColonyHomeActions
+                    colony={colony}
+                    ethDomainId={filteredDomainId}
+                  />
+                }
               >
                 <ColonyDecisions
                   colony={colony}
@@ -148,7 +151,12 @@ const ColonyHome = ({ match, location }: Props) => {
                 colony={colony}
                 filteredDomainId={filteredDomainId}
                 onDomainChange={setDomainIdFilter}
-                ethDomainId={filteredDomainId}
+                newItemButton={
+                  <ColonyHomeActions
+                    colony={colony}
+                    ethDomainId={filteredDomainId}
+                  />
+                }
               >
                 <ColonyActions colony={colony} ethDomainId={filteredDomainId} />
               </ColonyHomeLayout>

--- a/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHome.tsx
@@ -17,6 +17,7 @@ import { useColonyFromNameQuery } from '~data/index';
 
 import ColonyActions from '~dashboard/ColonyActions';
 import ColonyEvents from '~dashboard/ColonyEvents';
+import ColonyDecisions from '~dashboard/ColonyDecisions';
 
 import ColonyHomeLayout from './ColonyHomeLayout';
 
@@ -24,6 +25,7 @@ import styles from './ColonyHomeLayout.css';
 
 import {
   COLONY_EVENTS_ROUTE,
+  COLONY_DECISIONS_ROUTE,
   COLONY_EXTENSIONS_ROUTE,
   COLONY_EXTENSION_DETAILS_ROUTE,
   COLONY_EXTENSION_SETUP_ROUTE,
@@ -87,6 +89,22 @@ const ColonyHome = ({ match, location }: Props) => {
                 showActions={false}
               >
                 <ColonyEvents colony={colony} ethDomainId={filteredDomainId} />
+              </ColonyHomeLayout>
+            )}
+          />
+          <Route
+            path={COLONY_DECISIONS_ROUTE}
+            component={() => (
+              <ColonyHomeLayout
+                colony={colony}
+                filteredDomainId={filteredDomainId}
+                onDomainChange={setDomainIdFilter}
+                showActions={false}
+              >
+                <ColonyDecisions
+                  colony={colony}
+                  ethDomainId={filteredDomainId}
+                />
               </ColonyHomeLayout>
             )}
           />

--- a/src/modules/dashboard/components/ColonyHome/ColonyHomeLayout.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHomeLayout.tsx
@@ -1,9 +1,7 @@
 import React, { ReactChild, useEffect } from 'react';
 
 import { useDialog } from '~core/Dialog';
-
 import ColonyDomainSelector from '~dashboard/ColonyHome/ColonyDomainSelector';
-import ColonyHomeActions from '~dashboard/ColonyHomeActions';
 import ColonyTotalFunds from '~dashboard/ColonyTotalFunds';
 import WrongNetworkDialog from '~dialogs/WrongNetworkDialog';
 
@@ -35,8 +33,7 @@ type Props = {
   showControls?: boolean;
   showNavigation?: boolean;
   showSidebar?: boolean;
-  showActions?: boolean;
-  ethDomainId?: number;
+  newItemButton?: ReactChild;
 };
 
 const displayName = 'dashboard.ColonyHome.ColonyHomeLayout';
@@ -48,9 +45,8 @@ const ColonyHomeLayout = ({
   showControls = true,
   showNavigation = true,
   showSidebar = true,
-  showActions = true,
   onDomainChange = () => null,
-  ethDomainId,
+  newItemButton,
 }: Props) => {
   const { ethereal, networkId } = useLoggedInUser();
   const isNetworkAllowed = checkIfNetworkIsAllowed(networkId);
@@ -83,12 +79,13 @@ const ColonyHomeLayout = ({
                     colony={colony}
                   />
                 </div>
-                {showActions && (
+                {newItemButton}
+                {/* {showActions && (
                   <ColonyHomeActions
                     colony={colony}
                     ethDomainId={ethDomainId}
                   />
-                )}
+                )} */}
               </div>
             </>
           )}

--- a/src/modules/dashboard/components/ColonyHome/ColonyHomeLayout.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyHomeLayout.tsx
@@ -1,4 +1,4 @@
-import React, { ReactChild, useEffect } from 'react';
+import React, { ReactChild, ReactElement, useEffect } from 'react';
 
 import { useDialog } from '~core/Dialog';
 import ColonyDomainSelector from '~dashboard/ColonyHome/ColonyDomainSelector';
@@ -33,7 +33,7 @@ type Props = {
   showControls?: boolean;
   showNavigation?: boolean;
   showSidebar?: boolean;
-  newItemButton?: ReactChild;
+  newItemButton?: ReactElement;
 };
 
 const displayName = 'dashboard.ColonyHome.ColonyHomeLayout';
@@ -80,12 +80,6 @@ const ColonyHomeLayout = ({
                   />
                 </div>
                 {newItemButton}
-                {/* {showActions && (
-                  <ColonyHomeActions
-                    colony={colony}
-                    ethDomainId={ethDomainId}
-                  />
-                )} */}
               </div>
             </>
           )}

--- a/src/modules/dashboard/components/ColonyHome/ColonyNavigation/ColonyNavigation.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyNavigation/ColonyNavigation.tsx
@@ -55,6 +55,7 @@ const ColonyNavigation = ({ colony: { colonyName } }: Props) => {
    * Problem is I couldn't get @client resolvers to work with subgrap queries :(
    */
   const hasNewActions = false;
+  const hasNewDecisions = false;
   const hasNewExtensions = false;
 
   const items = useMemo<ComponentProps<typeof NavItem>[]>(() => {
@@ -66,6 +67,13 @@ const ColonyNavigation = ({ colony: { colonyName } }: Props) => {
       },
       {
         exact: false,
+        linkTo: `/colony/${colonyName}/decisions`,
+        showDot: hasNewDecisions,
+        text: MSG.linkTextDecisions,
+        dataTest: 'decisionsNavigationButton',
+      },
+      {
+        exact: false,
         linkTo: `/colony/${colonyName}/extensions`,
         showDot: hasNewExtensions,
         text: MSG.linkTextExtensions,
@@ -74,7 +82,7 @@ const ColonyNavigation = ({ colony: { colonyName } }: Props) => {
     ];
 
     return navigationItems;
-  }, [colonyName, hasNewActions, hasNewExtensions]);
+  }, [colonyName, hasNewActions, hasNewExtensions, hasNewDecisions]);
 
   return (
     <nav role="navigation" className={styles.main}>

--- a/src/modules/dashboard/components/ColonyNewDecision/ColonyNewDecision.tsx
+++ b/src/modules/dashboard/components/ColonyNewDecision/ColonyNewDecision.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react';
+import { defineMessages } from 'react-intl';
+import { useSelector } from 'react-redux';
+
+import Button from '~core/Button';
+import { useDialog } from '~core/Dialog';
+import NewDecisionDialog from '~dialogs/NewDecisionDialog';
+import { SpinnerLoader } from '~core/Preloaders';
+
+import { useEnabledExtensions } from '~utils/hooks/useEnabledExtensions';
+import { Colony, useLoggedInUser, useNetworkContracts } from '~data/index';
+import { checkIfNetworkIsAllowed } from '~utils/networks';
+import { colonyMustBeUpgraded } from '~modules/dashboard/checks';
+
+const displayName = 'dashboard.ColonyHomeCreateActionsButton';
+
+const MSG = defineMessages({
+  newDecision: {
+    id: 'dashboard.ColonyNewDecision.newDecision',
+    defaultMessage: 'New Decision',
+  },
+});
+
+interface Props {
+  colony: Colony;
+  ethDomainId?: number;
+}
+
+interface RootState {
+  users: {
+    wallet: {
+      isUserConnected: boolean;
+    };
+  };
+}
+
+const ColonyNewDecision = ({ colony }: Props) => {
+  const { networkId, username, ethereal } = useLoggedInUser();
+  const { version: networkVersion } = useNetworkContracts();
+
+  const [isLoadingUser, setIsLoadingUser] = useState<boolean>(!ethereal);
+
+  const {
+    isVotingExtensionEnabled,
+    isLoadingExtensions,
+  } = useEnabledExtensions({
+    colonyAddress: colony.colonyAddress,
+  });
+
+  useSelector((state: RootState) => {
+    const { isUserConnected } = state.users.wallet;
+    if (!ethereal && isUserConnected && isLoadingUser) {
+      setIsLoadingUser(false);
+    } else if (ethereal && isUserConnected && !isLoadingUser) {
+      setIsLoadingUser(true);
+    }
+  });
+
+  const openNewDecisionDialog = useDialog(NewDecisionDialog);
+
+  const hasRegisteredProfile = !!username && !ethereal;
+  const isNetworkAllowed = checkIfNetworkIsAllowed(networkId);
+  const mustUpgrade = colonyMustBeUpgraded(colony, networkVersion as string);
+  const isLoadingData = isLoadingExtensions || isLoadingUser;
+
+  return (
+    <>
+      {isLoadingData && <SpinnerLoader appearance={{ size: 'medium' }} />}
+      {!isLoadingData && (
+        <Button
+          appearance={{ theme: 'primary', size: 'large' }}
+          text={MSG.newDecision}
+          onClick={() => openNewDecisionDialog({ colony })}
+          disabled={
+            mustUpgrade ||
+            !isNetworkAllowed ||
+            !hasRegisteredProfile ||
+            !colony?.isDeploymentFinished ||
+            !isVotingExtensionEnabled
+          }
+          data-test="newDecisionButton"
+        />
+      )}
+    </>
+  );
+};
+
+export default ColonyNewDecision;
+
+ColonyNewDecision.displayName = displayName;

--- a/src/modules/dashboard/components/ColonyNewDecision/index.ts
+++ b/src/modules/dashboard/components/ColonyNewDecision/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ColonyNewDecision';

--- a/src/modules/dashboard/components/Dialogs/NewDecisionDialog/NewDecisionDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/NewDecisionDialog/NewDecisionDialog.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import Dialog, { DialogProps } from '~core/Dialog';
+import { Colony } from '~data/index';
+
+const displayName = 'dashboard.NewDecisionDialog';
+
+interface Props extends DialogProps {
+  colony: Colony;
+}
+
+const NewDecisionDialog = ({ cancel }: Props) => {
+  return <Dialog cancel={cancel}>NEW DECISION PLACEHOLDER DIALOG</Dialog>;
+};
+
+NewDecisionDialog.displayName = displayName;
+
+export default NewDecisionDialog;

--- a/src/modules/dashboard/components/Dialogs/NewDecisionDialog/index.ts
+++ b/src/modules/dashboard/components/Dialogs/NewDecisionDialog/index.ts
@@ -1,0 +1,1 @@
+export { default } from './NewDecisionDialog';

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -28,6 +28,7 @@ import { ActionTypes } from '~redux/index';
 
 import {
   COLONY_EVENTS_ROUTE,
+  COLONY_DECISIONS_ROUTE,
   COLONY_EXTENSIONS_ROUTE,
   COLONY_EXTENSION_DETAILS_ROUTE,
   COLONY_EXTENSION_SETUP_ROUTE,
@@ -164,6 +165,7 @@ const Routes = () => {
           path={[
             COLONY_HOME_ROUTE,
             COLONY_EVENTS_ROUTE,
+            COLONY_DECISIONS_ROUTE,
             COLONY_EXTENSIONS_ROUTE,
             COLONY_EXTENSION_DETAILS_ROUTE,
             COLONY_EXTENSION_SETUP_ROUTE,

--- a/src/routes/routeConstants.ts
+++ b/src/routes/routeConstants.ts
@@ -4,6 +4,7 @@
 export const CONNECT_ROUTE = '/connect';
 export const COLONY_HOME_ROUTE = '/colony/:colonyName';
 export const COLONY_EVENTS_ROUTE = `${COLONY_HOME_ROUTE}/events`;
+export const COLONY_DECISIONS_ROUTE = `${COLONY_HOME_ROUTE}/decisions`;
 export const COLONY_FUNDING_ROUTE = `${COLONY_HOME_ROUTE}/funds`;
 export const COLONY_EXTENSIONS_ROUTE = `${COLONY_HOME_ROUTE}/extensions`;
 export const COLONY_EXTENSION_DETAILS_ROUTE = `${COLONY_HOME_ROUTE}/extensions/:extensionId`;

--- a/src/utils/hooks/useTitle.ts
+++ b/src/utils/hooks/useTitle.ts
@@ -23,6 +23,7 @@ import {
   ACTIONS_PAGE_ROUTE,
   USER_ROUTE,
   MEMBERS_ROUTE,
+  COLONY_DECISIONS_ROUTE,
   COLONY_EXTENSION_SETUP_ROUTE,
   COLONY_EXTENSION_DETAILS_ROUTE,
   COLONY_EXTENSIONS_ROUTE,
@@ -84,6 +85,11 @@ const MSG = defineMessages({
   colonyFunds: {
     id: 'utils.hooks.useTitle.colonyFunds',
     defaultMessage: `Funds | Colony - {colonyName}`,
+  },
+
+  colonyDecisions: {
+    id: 'utils.hooks.useTitle.colonyDecisions',
+    defaultMessage: `Decisions | Colony - {colonyName}`,
   },
 
   colonyExtensions: {
@@ -150,6 +156,7 @@ const routeMessages: Record<string, MessageDescriptor> = {
   [COLONY_HOME_ROUTE]: MSG.colonyHome,
   [COLONY_EVENTS_ROUTE]: MSG.colonyEvents,
   [COLONY_FUNDING_ROUTE]: MSG.colonyFunds,
+  [COLONY_DECISIONS_ROUTE]: MSG.colonyDecisions,
   [COLONY_EXTENSIONS_ROUTE]: MSG.colonyExtensions,
   [COLONY_EXTENSION_DETAILS_ROUTE]: MSG.colonyExtensionDetails,
   [COLONY_EXTENSION_SETUP_ROUTE]: MSG.colonyExtensionSetup,


### PR DESCRIPTION
## Description

This PR adds the backbone UI of the decisions page with a placeholder for a New Decision dialog.

There are placeholder values for isLoading & data that you can play with to see different states of the page.

If there are any minor discrepancies with the figma specs that's because I made the same ui as on the actions page - for consistency purpose (except no decisions part)

The decisions list by item & wiring are done in different issues.

resolves #3706
