### PR TITLE
COLONY_EXTENSION_DETAILS_ROUTE Handle invalid extension Id 

### DIFF
--- a/src/data/staticData/helpers.ts
+++ b/src/data/staticData/helpers.ts
@@ -1,0 +1,7 @@
+import { extensions } from '@colony/colony-js';
+import extensionData from '~data/staticData/extensionData';
+
+// get all extensions that are allowed to be installed
+export const allAllowedExtensions = extensions.filter(
+  (extensionId) => extensionData[extensionId],
+);

--- a/src/data/staticData/index.ts
+++ b/src/data/staticData/index.ts
@@ -1,0 +1,2 @@
+export { default as extensionData } from './extensionData';
+export { allAllowedExtensions } from './helpers';

--- a/src/modules/dashboard/components/Extensions/Extensions.tsx
+++ b/src/modules/dashboard/components/Extensions/Extensions.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
-import { extensions, getExtensionHash } from '@colony/colony-js';
+import { getExtensionHash } from '@colony/colony-js';
 import camelCase from 'lodash/camelCase';
 
 import BreadCrumb from '~core/BreadCrumb';
@@ -11,7 +11,7 @@ import {
 } from '~data/index';
 import { Address } from '~types/index';
 import { SpinnerLoader } from '~core/Preloaders';
-import extensionData from '~data/staticData/extensionData';
+import { extensionData, allAllowedExtensions } from '~data/staticData/';
 
 import ExtensionCard from './ExtensionCard';
 
@@ -68,11 +68,6 @@ const Extensions = ({ colonyAddress }: Props) => {
   const availableExtensionsData = useMemo(() => {
     if (data?.processedColony?.installedExtensions) {
       const { installedExtensions } = data.processedColony;
-
-      // get all extensions that are allowed to be installed
-      const allAllowedExtensions = extensions.filter(
-        (extensionName) => extensionData[extensionName],
-      );
 
       return allAllowedExtensions.reduce(
         (availableExtensions, extensionName) => {

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -162,11 +162,11 @@ const Routes = () => {
         <AlwaysAccesibleRoute
           exact
           path={[
+            COLONY_EXTENSION_DETAILS_ROUTE,
+            COLONY_EXTENSIONS_ROUTE,
+            COLONY_EXTENSION_SETUP_ROUTE,
             COLONY_HOME_ROUTE,
             COLONY_EVENTS_ROUTE,
-            COLONY_EXTENSIONS_ROUTE,
-            COLONY_EXTENSION_DETAILS_ROUTE,
-            COLONY_EXTENSION_SETUP_ROUTE,
           ]}
           component={ColonyHome}
           layout={Default}


### PR DESCRIPTION
## Description

This PR fixes a bug where providing an invalid exentionId in a URL will crash the dapp. This update implements a check on the exentionId, where a 404 page is display if invalid.

Resolves #3678
