### PR TITLE
Add decisions list UI with filtering, sorting & pagination

### DIFF
--- a/src/modules/core/components/ActionsList/ActionsListItem.tsx
+++ b/src/modules/core/components/ActionsList/ActionsListItem.tsx
@@ -105,6 +105,8 @@ const ActionsListItem = ({
     requiredStake,
     transactionTokenAddress,
     reputationChange,
+    title,
+    isDecision,
   },
   colony,
   handleOnClick,
@@ -143,7 +145,7 @@ const ActionsListItem = ({
   }, [fetchTokenInfo, transactionTokenAddress]);
 
   const initiatorUserProfile = useUser(createAddress(initiator || AddressZero));
-  const recipientAddress = createAddress(recipient);
+  const recipientAddress = createAddress(recipient || AddressZero);
   const isColonyAddress = recipientAddress === colony.colonyAddress;
   const fallbackRecipientProfile = useUser(
     isColonyAddress ? '' : recipientAddress,
@@ -194,11 +196,13 @@ const ActionsListItem = ({
   }
   const motionStyles =
     MOTION_TAG_MAP[
-      motionState ||
-        (isVotingExtensionEnabled &&
-          !actionType?.endsWith('Motion') &&
-          MotionState.Forced) ||
-        MotionState.Invalid
+      isDecision && motionState === MotionState.Staked
+        ? MotionState.Notice
+        : motionState ||
+          (isVotingExtensionEnabled &&
+            !actionType?.endsWith('Motion') &&
+            MotionState.Forced) ||
+          MotionState.Invalid
     ];
 
   const decimals =
@@ -292,60 +296,64 @@ const ActionsListItem = ({
         <div className={styles.content}>
           <div className={styles.titleWrapper}>
             <span className={styles.title}>
-              <FormattedMessage
-                id={
-                  (verifiedAddressesChanged &&
-                    `action.${ColonyActions.ColonyEdit}.verifiedAddresses`) ||
-                  (tokensChanged &&
-                    `action.${ColonyActions.ColonyEdit}.tokens`) ||
-                  roleMessageDescriptorId ||
-                  'action.title'
-                }
-                values={{
-                  actionType,
-                  initiator: (
-                    <span className={styles.titleDecoration}>
-                      <FriendlyName
-                        user={initiatorUserProfile}
-                        autoShrinkAddress
+              {isDecision && title ? (
+                title
+              ) : (
+                <FormattedMessage
+                  id={
+                    (verifiedAddressesChanged &&
+                      `action.${ColonyActions.ColonyEdit}.verifiedAddresses`) ||
+                    (tokensChanged &&
+                      `action.${ColonyActions.ColonyEdit}.tokens`) ||
+                    roleMessageDescriptorId ||
+                    'action.title'
+                  }
+                  values={{
+                    actionType,
+                    initiator: (
+                      <span className={styles.titleDecoration}>
+                        <FriendlyName
+                          user={initiatorUserProfile}
+                          autoShrinkAddress
+                        />
+                      </span>
+                    ),
+                    /*
+                     * @TODO Add user mention popover back in
+                     */
+                    recipient: (
+                      <span className={styles.titleDecoration}>
+                        <FriendlyName
+                          user={fallbackRecipientProfile}
+                          autoShrinkAddress
+                          colony={colony}
+                        />
+                      </span>
+                    ),
+                    amount: (
+                      <Numeral
+                        value={
+                          actionType === ColonyActions.Payment ||
+                          actionType === ColonyMotions.PaymentMotion
+                            ? paymentReceivedFn(amount)
+                            : amount
+                        }
+                        unit={getTokenDecimalsWithFallback(decimals)}
                       />
-                    </span>
-                  ),
-                  /*
-                   * @TODO Add user mention popover back in
-                   */
-                  recipient: (
-                    <span className={styles.titleDecoration}>
-                      <FriendlyName
-                        user={fallbackRecipientProfile}
-                        autoShrinkAddress
-                        colony={colony}
-                      />
-                    </span>
-                  ),
-                  amount: (
-                    <Numeral
-                      value={
-                        actionType === ColonyActions.Payment ||
-                        actionType === ColonyMotions.PaymentMotion
-                          ? paymentReceivedFn(amount)
-                          : amount
-                      }
-                      unit={getTokenDecimalsWithFallback(decimals)}
-                    />
-                  ),
-                  tokenSymbol: symbol,
-                  decimals: getTokenDecimalsWithFallback(decimals),
-                  fromDomain: domainName || fromDomain?.name || '',
-                  toDomain: toDomain?.name || '',
-                  roles: roleTitle,
-                  newVersion: newVersion || '0',
-                  reputationChange: formattedReputationChange,
-                  reputationChangeNumeral: (
-                    <Numeral value={formattedReputationChange} />
-                  ),
-                }}
-              />
+                    ),
+                    tokenSymbol: symbol,
+                    decimals: getTokenDecimalsWithFallback(decimals),
+                    fromDomain: domainName || fromDomain?.name || '',
+                    toDomain: toDomain?.name || '',
+                    roles: roleTitle,
+                    newVersion: newVersion || '0',
+                    reputationChange: formattedReputationChange,
+                    reputationChangeNumeral: (
+                      <Numeral value={formattedReputationChange} />
+                    ),
+                  }}
+                />
+              )}
             </span>
             {(motionState || isVotingExtensionEnabled) && (
               <>

--- a/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
+++ b/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
@@ -7,6 +7,7 @@ import ActionsList, {
   ClickHandlerProps as RedirectHandlerProps,
 } from '~core/ActionsList';
 import { Select, Form } from '~core/Fields';
+import LoadMoreButton from '~core/LoadMoreButton';
 import { SpinnerLoader } from '~core/Preloaders';
 
 import { Colony } from '~data/index';
@@ -128,6 +129,8 @@ const data = [
   },
 ];
 
+const ITEMS_PER_PAGE = 1;
+
 const ColonyDecisions = ({
   colony,
   colony: { colonyName },
@@ -136,6 +139,8 @@ const ColonyDecisions = ({
   const [sortOption, setSortOption] = useState<string>(
     SortOptions.ENDING_SOONEST,
   );
+  const [dataPage, setDataPage] = useState<number>(1);
+
   // temp values, to be removed when queries are wired in
   const isLoading = false;
 
@@ -162,7 +167,7 @@ const ColonyDecisions = ({
     [ethDomainId],
   );
 
-  const sortedActions = useMemo(
+  const sortedDecisions = useMemo(
     () =>
       filteredDecisions.sort((first, second) =>
         sortOption === SortOptions.ENDING_SOONEST
@@ -170,6 +175,11 @@ const ColonyDecisions = ({
           : second.ending.getTime() - first.ending.getTime(),
       ),
     [sortOption, filteredDecisions],
+  );
+
+  const paginatedDecisions = useMemo(
+    () => sortedDecisions.slice(0, ITEMS_PER_PAGE * dataPage),
+    [dataPage, sortedDecisions],
   );
 
   if (isLoading) {
@@ -209,10 +219,16 @@ const ColonyDecisions = ({
             </Form>
           </div>
           <ActionsList
-            items={sortedActions}
+            items={paginatedDecisions}
             handleItemClick={handleActionRedirect}
             colony={colony}
           />
+          {ITEMS_PER_PAGE * dataPage < data.length && (
+            <LoadMoreButton
+              onClick={() => setDataPage(dataPage + 1)}
+              isLoadingData={isLoading}
+            />
+          )}
         </>
       ) : (
         <div className={styles.emptyState}>

--- a/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
+++ b/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
@@ -1,6 +1,10 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
+import { useHistory } from 'react-router-dom';
 
+import ActionsList, {
+  ClickHandlerProps as RedirectHandlerProps,
+} from '~core/ActionsList';
 import { Select, Form } from '~core/Fields';
 import { SpinnerLoader } from '~core/Preloaders';
 
@@ -40,12 +44,91 @@ type Props = {
   ethDomainId?: number;
 };
 
-/* Temporary disable */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const ColonyDecisions = ({ colony }: Props) => {
+/* temp data */
+const data = [
+  {
+    id: `0xeabe562c979679dc4023dd23e8c6aa782448c2e7_motion_0xa1e73506f3ef6dc19dc27b750adf585fd0f30c63_2`,
+    initiator: '0xb77d57f4959eafa0339424b83fcfaf9c15407461',
+    recipient: '0x0000000000000000000000000000000000000000',
+    title: 'I want to add dark mode to the Dapp',
+    motionState: 'Passed',
+    isDecision: true,
+    motionId: '2',
+    createdAt: new Date(
+      'Sun Aug 17 2022 12:48:59 GMT+0300 (Eastern European Summer Time)',
+    ),
+  },
+  {
+    title: 'Update the logo design',
+    isDecision: true,
+    actionType: undefined,
+    amount: '0',
+    blockNumber: 853,
+    commentCount: 0,
+    createdAt: new Date(
+      'Sun Aug 14 2022 12:48:59 GMT+0300 (Eastern European Summer Time)',
+    ),
+    decimals: '18',
+    fromDomain: '1',
+    id: `0xeabe562c979679dc4023dd23e8c6aa782448c2e7_motion_0xa1e73506f3ef6dc19dc27b750adf585fd0f30c63_1`,
+    initiator: '0xb77d57f4959eafa0339424b83fcfaf9c15407461',
+    motionId: '1',
+    motionState: 'Staking',
+    recipient: '0x0000000000000000000000000000000000000000',
+    reputationChange: '0',
+    requiredStake: '1010101010101010101',
+    status: undefined,
+    symbol: '???',
+    timeoutPeriods: undefined,
+    toDomain: '1',
+    tokenAddress: '0x0000000000000000000000000000000000000000',
+    totalNayStake: '0',
+    transactionHash:
+      '0x9c742b1392fadb48c0bc0d2cebdd518e7b11c0c1ab426c084a06c68ea77f8f70',
+    transactionTokenAddress: undefined,
+  },
+  {
+    title: 'Update the actions design',
+    isDecision: true,
+    actionType: undefined,
+    amount: '0',
+    blockNumber: 853,
+    commentCount: 0,
+    createdAt: new Date(
+      'Sun Aug 18 2022 12:48:59 GMT+0300 (Eastern European Summer Time)',
+    ),
+    decimals: '18',
+    fromDomain: '2',
+    id: `0xeabe562c979679dc4023dd23e8c6aa782448c2e7_motion_0xa1e73506f3ef6dc19dc27b750adf585fd0f30c63_3`,
+    initiator: '0xb77d57f4959eafa0339424b83fcfaf9c15407461',
+    motionId: '1',
+    motionState: 'Staked',
+    recipient: '0x0000000000000000000000000000000000000000',
+    reputationChange: '0',
+    requiredStake: '1010101010101010101',
+    status: undefined,
+    symbol: '???',
+    timeoutPeriods: undefined,
+    toDomain: '1',
+    tokenAddress: '0x0000000000000000000000000000000000000000',
+    totalNayStake: '0',
+    transactionHash:
+      '0x9c742b1392fadb48c0bc0d2cebdd518e7b11c0c1ab426c084a06c68ea77f8f70',
+    transactionTokenAddress: undefined,
+  },
+];
+
+const ColonyDecisions = ({ colony, colony: { colonyName } }: Props) => {
   // temp values, to be removed when queries are wired in
   const isLoading = false;
-  const data = ['placeholder'];
+
+  const history = useHistory();
+
+  const handleActionRedirect = useCallback(
+    ({ transactionHash }: RedirectHandlerProps) =>
+      history.push(`/colony/${colonyName}/tx/${transactionHash}`),
+    [colonyName, history],
+  );
 
   if (isLoading) {
     return (
@@ -82,9 +165,11 @@ const ColonyDecisions = ({ colony }: Props) => {
               </div>
             </Form>
           </div>
-          {data.map((item) => (
-            <div>{item}</div>
-          ))}
+          <ActionsList
+            items={data}
+            handleItemClick={handleActionRedirect}
+            colony={colony}
+          />
         </>
       ) : (
         <div className={styles.emptyState}>

--- a/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
+++ b/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { useHistory } from 'react-router-dom';
 
@@ -58,6 +58,9 @@ const data = [
     createdAt: new Date(
       'Sun Aug 17 2022 12:48:59 GMT+0300 (Eastern European Summer Time)',
     ),
+    ending: new Date(
+      'Sun Aug 27 2022 12:48:59 GMT+0300 (Eastern European Summer Time)',
+    ),
   },
   {
     title: 'Update the logo design',
@@ -68,6 +71,9 @@ const data = [
     commentCount: 0,
     createdAt: new Date(
       'Sun Aug 14 2022 12:48:59 GMT+0300 (Eastern European Summer Time)',
+    ),
+    ending: new Date(
+      'Sun Aug 24 2022 12:48:59 GMT+0300 (Eastern European Summer Time)',
     ),
     decimals: '18',
     fromDomain: '1',
@@ -98,6 +104,9 @@ const data = [
     createdAt: new Date(
       'Sun Aug 18 2022 12:48:59 GMT+0300 (Eastern European Summer Time)',
     ),
+    ending: new Date(
+      'Sun Aug 28 2022 12:48:59 GMT+0300 (Eastern European Summer Time)',
+    ),
     decimals: '18',
     fromDomain: '2',
     id: `0xeabe562c979679dc4023dd23e8c6aa782448c2e7_motion_0xa1e73506f3ef6dc19dc27b750adf585fd0f30c63_3`,
@@ -124,6 +133,9 @@ const ColonyDecisions = ({
   colony: { colonyName },
   ethDomainId,
 }: Props) => {
+  const [sortOption, setSortOption] = useState<string>(
+    SortOptions.ENDING_SOONEST,
+  );
   // temp values, to be removed when queries are wired in
   const isLoading = false;
 
@@ -140,13 +152,24 @@ const ColonyDecisions = ({
       !ethDomainId || ethDomainId === ROOT_DOMAIN_ID
         ? data
         : data.filter(
-            (item) =>
-              item.toDomain === ethDomainId.toString() ||
-              item.fromDomain === ethDomainId.toString() ||
+            (decision) =>
+              decision.toDomain === ethDomainId.toString() ||
+              decision.fromDomain === ethDomainId.toString() ||
               /* when no specific domain in the action it is displayed in Root */
-              (ethDomainId === ROOT_DOMAIN_ID && item.fromDomain === undefined),
+              (ethDomainId === ROOT_DOMAIN_ID &&
+                decision.fromDomain === undefined),
           ),
     [ethDomainId],
+  );
+
+  const sortedActions = useMemo(
+    () =>
+      filteredDecisions.sort((first, second) =>
+        sortOption === SortOptions.ENDING_SOONEST
+          ? first.ending.getTime() - second.ending.getTime()
+          : second.ending.getTime() - first.ending.getTime(),
+      ),
+    [sortOption, filteredDecisions],
   );
 
   if (isLoading) {
@@ -180,12 +203,13 @@ const ColonyDecisions = ({
                   name="filter"
                   options={SortSelectOptions}
                   placeholder={MSG.placeholderFilter}
+                  onChange={setSortOption}
                 />
               </div>
             </Form>
           </div>
           <ActionsList
-            items={filteredDecisions}
+            items={sortedActions}
             handleItemClick={handleActionRedirect}
             colony={colony}
           />

--- a/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
+++ b/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
@@ -1,7 +1,8 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { useHistory } from 'react-router-dom';
 
+import { ROOT_DOMAIN_ID } from '@colony/colony-js';
 import ActionsList, {
   ClickHandlerProps as RedirectHandlerProps,
 } from '~core/ActionsList';
@@ -109,7 +110,7 @@ const data = [
     status: undefined,
     symbol: '???',
     timeoutPeriods: undefined,
-    toDomain: '1',
+    toDomain: '2',
     tokenAddress: '0x0000000000000000000000000000000000000000',
     totalNayStake: '0',
     transactionHash:
@@ -118,7 +119,11 @@ const data = [
   },
 ];
 
-const ColonyDecisions = ({ colony, colony: { colonyName } }: Props) => {
+const ColonyDecisions = ({
+  colony,
+  colony: { colonyName },
+  ethDomainId,
+}: Props) => {
   // temp values, to be removed when queries are wired in
   const isLoading = false;
 
@@ -128,6 +133,20 @@ const ColonyDecisions = ({ colony, colony: { colonyName } }: Props) => {
     ({ transactionHash }: RedirectHandlerProps) =>
       history.push(`/colony/${colonyName}/tx/${transactionHash}`),
     [colonyName, history],
+  );
+
+  const filteredDecisions = useMemo(
+    () =>
+      !ethDomainId || ethDomainId === ROOT_DOMAIN_ID
+        ? data
+        : data.filter(
+            (item) =>
+              item.toDomain === ethDomainId.toString() ||
+              item.fromDomain === ethDomainId.toString() ||
+              /* when no specific domain in the action it is displayed in Root */
+              (ethDomainId === ROOT_DOMAIN_ID && item.fromDomain === undefined),
+          ),
+    [ethDomainId],
   );
 
   if (isLoading) {
@@ -166,7 +185,7 @@ const ColonyDecisions = ({ colony, colony: { colonyName } }: Props) => {
             </Form>
           </div>
           <ActionsList
-            items={data}
+            items={filteredDecisions}
             handleItemClick={handleActionRedirect}
             colony={colony}
           />

--- a/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
+++ b/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
@@ -186,9 +186,9 @@ const ColonyDecisions = ({
     [sortOption, filteredDecisions],
   );
 
-  const paginatedDecisions = useMemo(
-    () => sortedDecisions.slice(0, ITEMS_PER_PAGE * dataPage),
-    [dataPage, sortedDecisions],
+  const paginatedDecisions = sortedDecisions.slice(
+    0,
+    ITEMS_PER_PAGE * dataPage,
   );
 
   if (!isVotingExtensionEnabled) {

--- a/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
+++ b/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
@@ -11,6 +11,7 @@ import LoadMoreButton from '~core/LoadMoreButton';
 import { SpinnerLoader } from '~core/Preloaders';
 
 import { Colony } from '~data/index';
+import { useEnabledExtensions } from '~utils/hooks/useEnabledExtensions';
 
 import { SortOptions, SortSelectOptions } from './constants';
 import styles from './ColonyDecisions.css';
@@ -35,6 +36,10 @@ const MSG = defineMessages({
   loading: {
     id: 'dashboard.ColonyDecisions.loading',
     defaultMessage: 'Loading decisions',
+  },
+  installExtension: {
+    id: 'dashboard.ColonyDecisions.loading',
+    defaultMessage: `You need to install Governance extension to use Decisions feature`,
   },
 });
 
@@ -129,7 +134,7 @@ const data = [
   },
 ];
 
-const ITEMS_PER_PAGE = 1;
+const ITEMS_PER_PAGE = 10;
 
 const ColonyDecisions = ({
   colony,
@@ -140,6 +145,10 @@ const ColonyDecisions = ({
     SortOptions.ENDING_SOONEST,
   );
   const [dataPage, setDataPage] = useState<number>(1);
+
+  const { isVotingExtensionEnabled } = useEnabledExtensions({
+    colonyAddress: colony.colonyAddress,
+  });
 
   // temp values, to be removed when queries are wired in
   const isLoading = false;
@@ -181,6 +190,14 @@ const ColonyDecisions = ({
     () => sortedDecisions.slice(0, ITEMS_PER_PAGE * dataPage),
     [dataPage, sortedDecisions],
   );
+
+  if (!isVotingExtensionEnabled) {
+    return (
+      <div>
+        <FormattedMessage {...MSG.installExtension} />
+      </div>
+    );
+  }
 
   if (isLoading) {
     return (

--- a/src/types/colonyActions.ts
+++ b/src/types/colonyActions.ts
@@ -145,6 +145,9 @@ export interface FormattedAction {
   totalNayStake?: string;
   requiredStake?: string;
   reputationChange?: string;
+  /* This is potentially temporary. Will depend on what data we get from a query */
+  isDecision?: boolean;
+  title?: string;
 }
 
 export interface FormattedEvent {

--- a/src/utils/colonyMotions.ts
+++ b/src/utils/colonyMotions.ts
@@ -21,6 +21,7 @@ export enum MotionState {
   Invalid = 'Invalid',
   Escalation = 'Escalation',
   Forced = 'Forced',
+  Notice = 'Notice',
 }
 
 export enum MotionVote {
@@ -73,6 +74,10 @@ const MSG = defineMessage({
     id: 'dashboard.ActionsPage.forcedTag',
     defaultMessage: 'Forced',
   },
+  noticeTag: {
+    id: 'dashboard.ActionsPage.noticeTag',
+    defaultMessage: 'Notice',
+  },
 });
 
 export const MOTION_TAG_MAP = {
@@ -80,6 +85,12 @@ export const MOTION_TAG_MAP = {
     theme: 'primary',
     colorSchema: 'fullColor',
     name: MSG.stakedTag,
+    tagName: 'motionTag',
+  },
+  [MotionState.Notice]: {
+    theme: 'blue',
+    colorSchema: 'fullColor',
+    name: MSG.noticeTag,
     tagName: 'motionTag',
   },
   [MotionState.Staking]: {


### PR DESCRIPTION
## Description

This PR adds UI for the decisions list page including filtering, sorting and pagination functionality.

I've added props to the ActionsListItem component as it seems only logical to reuse it. 

I've added `Notice` motions state. It is a state that will be given only for the `Notice` tag. It means that the decision has been staked.

<img width="761" alt="Screenshot 2022-08-09 at 17 04 43" src="https://user-images.githubusercontent.com/34057551/183669691-68b6de5b-9a68-4189-be62-30d3ab36e4e8.png">
 
resolves #3707
