### PR TITLE
Protect event metadata version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@apollo/client": "^3.0.2",
-        "@colony/colony-event-metadata-parser": "^1.0.4",
+        "@colony/colony-event-metadata-parser": "^1.0.5",
         "@colony/colony-js": "^4.2.0",
         "@colony/redux-promise-listener": "^1.2.0",
         "@colony/unicode-confusables-noascii": "^0.1.2",
@@ -192,7 +192,7 @@
     },
     "../ColonyEventMetadataParser": {
       "name": "@colony/colony-event-metadata-parser",
-      "version": "1.0.1",
+      "version": "1.0.5",
       "extraneous": true,
       "license": "GPL-3.0-only",
       "dependencies": {
@@ -4056,9 +4056,9 @@
       }
     },
     "node_modules/@colony/colony-event-metadata-parser": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@colony/colony-event-metadata-parser/-/colony-event-metadata-parser-1.0.4.tgz",
-      "integrity": "sha512-r/pFyQeqecw4b5BsgQHbrUxCcEooYrj4hd2gsol0jv+o03TYpeACYVZsxZd+E8Dw4jov1G5Q2nZpOLBRG1Wvug==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@colony/colony-event-metadata-parser/-/colony-event-metadata-parser-1.0.5.tgz",
+      "integrity": "sha512-DHvgur5VgULMM0bAjMriRWob7+3nja15MNEV7F5l1AgKodYqiebapeoT/wJI3UMlCbR75V5GPu32QYpTCbDQiw==",
       "dependencies": {
         "lint-staged": "^13.0.3",
         "react-intl": "^6.0.4",
@@ -4070,16 +4070,16 @@
       }
     },
     "node_modules/@colony/colony-event-metadata-parser/node_modules/@formatjs/intl": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.3.0.tgz",
-      "integrity": "sha512-mE8zGqP+Flrd8tS3AsdvSucnblqwR5gsGM4Bd5711abkabrz52F2TDrU88rVvVfCdHV4dFHFYEmUBVZZ4pATtg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.3.1.tgz",
+      "integrity": "sha512-f06qZ/ukpeN24gc01qFjh3P+r3FU/ikY4yG+fDJu6dPNvpUQzDy98lYogA1dr6ig2UtrnoEk3xncyFPL1e9cZw==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.11.7",
+        "@formatjs/ecma402-abstract": "1.11.8",
         "@formatjs/fast-memoize": "1.2.4",
-        "@formatjs/icu-messageformat-parser": "2.1.3",
-        "@formatjs/intl-displaynames": "6.0.2",
-        "@formatjs/intl-listformat": "7.0.2",
-        "intl-messageformat": "10.1.0",
+        "@formatjs/icu-messageformat-parser": "2.1.4",
+        "@formatjs/intl-displaynames": "6.0.3",
+        "@formatjs/intl-listformat": "7.0.3",
+        "intl-messageformat": "10.1.1",
         "tslib": "2.4.0"
       },
       "peerDependencies": {
@@ -4092,21 +4092,21 @@
       }
     },
     "node_modules/@colony/colony-event-metadata-parser/node_modules/@formatjs/intl-displaynames": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-6.0.2.tgz",
-      "integrity": "sha512-h9Id/6vbSHpARHKMVsjWag3KMZJpop9s67CZTd+AMxhjHb5xDG2b5rlSRJKx/UdIDQ+GzESK7a4fv32yylG3cw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-6.0.3.tgz",
+      "integrity": "sha512-Mxh6W1VOlmiEvO/QPBrBQHlXrIn5VxjJWyyEI0V7ZHNGl0ee8AjSlq7vIJG8GodRJqGUuutF6N3OB/6qFv0YWg==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.11.7",
+        "@formatjs/ecma402-abstract": "1.11.8",
         "@formatjs/intl-localematcher": "0.2.28",
         "tslib": "2.4.0"
       }
     },
     "node_modules/@colony/colony-event-metadata-parser/node_modules/@formatjs/intl-listformat": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-7.0.2.tgz",
-      "integrity": "sha512-K+HXrYIvEcAH/dS8XXnSHQYC/z4w0eHjPlDx43HOoDY87/xV7rpHxFVXWXTgwLYC6iAPUO72Y/AaT9iq873juw==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-7.0.3.tgz",
+      "integrity": "sha512-ampNLRGZl/08epHa3i5sRmcHGLneC6JrknexbbgnexYFNSmJ6AbL/dCzgrQzw2Efl+5AZK7UbNFxcDYY3RePvw==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.11.7",
+        "@formatjs/ecma402-abstract": "1.11.8",
         "@formatjs/intl-localematcher": "0.2.28",
         "tslib": "2.4.0"
       }
@@ -4189,9 +4189,9 @@
       "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ=="
     },
     "node_modules/@colony/colony-event-metadata-parser/node_modules/commander": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.3.0.tgz",
-      "integrity": "sha512-hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
+      "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -4272,13 +4272,13 @@
       }
     },
     "node_modules/@colony/colony-event-metadata-parser/node_modules/intl-messageformat": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.1.0.tgz",
-      "integrity": "sha512-diGMDv9Zo2Mggf6AkJszq/BIR5+rarkwcr4g5JGgREwbwAHY9hR/dYd8FbIgQx2RTxhJsABfAWCiENFLbaTZjg==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.1.1.tgz",
+      "integrity": "sha512-FeJne2oooYW6shLPbrqyjRX6hTELVrQ90Dn88z7NomLk/xZBCLxLPAkgaYaTQJBRBV78nZ933d8APHHkTQrD9Q==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.11.7",
+        "@formatjs/ecma402-abstract": "1.11.8",
         "@formatjs/fast-memoize": "1.2.4",
-        "@formatjs/icu-messageformat-parser": "2.1.3",
+        "@formatjs/icu-messageformat-parser": "2.1.4",
         "tslib": "2.4.0"
       }
     },
@@ -4637,19 +4637,19 @@
       }
     },
     "node_modules/@colony/colony-event-metadata-parser/node_modules/react-intl": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.0.4.tgz",
-      "integrity": "sha512-eBIP4QuFOdr67+ZmNOA7WGzJ6dj0qgsGQbx3phzcel2B0kVLvfojTJuvYiFuLgbZTrRJMjHwYJZO5zsmibsfug==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.0.5.tgz",
+      "integrity": "sha512-nDZ3BosuE8WdovcGxsrjj1aIgJZklSL5aORs5oah+5tLQTzUdOEstzJEYQPM+sxl1dkDOu7RCuw0z9oI9ENf9g==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.11.7",
-        "@formatjs/icu-messageformat-parser": "2.1.3",
-        "@formatjs/intl": "2.3.0",
-        "@formatjs/intl-displaynames": "6.0.2",
-        "@formatjs/intl-listformat": "7.0.2",
+        "@formatjs/ecma402-abstract": "1.11.8",
+        "@formatjs/icu-messageformat-parser": "2.1.4",
+        "@formatjs/intl": "2.3.1",
+        "@formatjs/intl-displaynames": "6.0.3",
+        "@formatjs/intl-listformat": "7.0.3",
         "@types/hoist-non-react-statics": "^3.3.1",
         "@types/react": "16 || 17 || 18",
         "hoist-non-react-statics": "^3.3.2",
-        "intl-messageformat": "10.1.0",
+        "intl-messageformat": "10.1.1",
         "tslib": "2.4.0"
       },
       "peerDependencies": {
@@ -4697,9 +4697,9 @@
       }
     },
     "node_modules/@colony/colony-event-metadata-parser/node_modules/rxjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
-      "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.6.tgz",
+      "integrity": "sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -5122,9 +5122,9 @@
       }
     },
     "node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.11.7",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.7.tgz",
-      "integrity": "sha512-uNaok4XWMJBtPZk/veTDamFCm5HeWJUk2jwoVfH5/+wenQ60QHjH6T3UQ0GOOCz9jpKmed7vqOri7xSf//Dt7g==",
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.8.tgz",
+      "integrity": "sha512-fgLqyWlwmTEuqV/TSLEL/t9JOmHNLFvCdgzXB0jc2w+WOItPCOJ1T0eyN6fQBQKRPfSqqNlu+kWj7ijcOVTVVQ==",
       "dependencies": {
         "@formatjs/intl-localematcher": "0.2.28",
         "tslib": "2.4.0"
@@ -5149,12 +5149,12 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.1.3.tgz",
-      "integrity": "sha512-hsdAn1dXcujW/G8DHw0iiIy7357pw10yOulCrL6xrQOKJAxT7m7EgpG0Hm1OW9xqaLEzqWyE/jA2AGVnOCaCQw==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.1.4.tgz",
+      "integrity": "sha512-3PqMvKWV1oyok0BuiXUAHIaotdhdTJw6OICqCZbfUgKT+ZRwRWO4IlCgvXJeCITaKS5p+PY0XXKjf/vUyIpWjQ==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.11.7",
-        "@formatjs/icu-skeleton-parser": "1.3.9",
+        "@formatjs/ecma402-abstract": "1.11.8",
+        "@formatjs/icu-skeleton-parser": "1.3.10",
         "tslib": "2.4.0"
       }
     },
@@ -5164,11 +5164,11 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.9.tgz",
-      "integrity": "sha512-s9THwwhiiSzbGSk73FP6Ur2MBwEj1vfgYDHKa5FiXGQMfYzdRdRvyH1dgqNgSFJPB6PM3DKtkloJLjpqpSDNUg==",
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.10.tgz",
+      "integrity": "sha512-kXJmtLDqFF5aLTf8IxdJXnhrIX1Qb4Qp3a9jqRecGDYfzOa9hMhi9U0nKyhrJJ4cXxBzptcgb+LWkyeHL6nlBQ==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.11.7",
+        "@formatjs/ecma402-abstract": "1.11.8",
         "tslib": "2.4.0"
       }
     },
@@ -58015,9 +58015,9 @@
       }
     },
     "@colony/colony-event-metadata-parser": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@colony/colony-event-metadata-parser/-/colony-event-metadata-parser-1.0.4.tgz",
-      "integrity": "sha512-r/pFyQeqecw4b5BsgQHbrUxCcEooYrj4hd2gsol0jv+o03TYpeACYVZsxZd+E8Dw4jov1G5Q2nZpOLBRG1Wvug==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@colony/colony-event-metadata-parser/-/colony-event-metadata-parser-1.0.5.tgz",
+      "integrity": "sha512-DHvgur5VgULMM0bAjMriRWob7+3nja15MNEV7F5l1AgKodYqiebapeoT/wJI3UMlCbR75V5GPu32QYpTCbDQiw==",
       "requires": {
         "lint-staged": "^13.0.3",
         "react-intl": "^6.0.4",
@@ -58025,35 +58025,35 @@
       },
       "dependencies": {
         "@formatjs/intl": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.3.0.tgz",
-          "integrity": "sha512-mE8zGqP+Flrd8tS3AsdvSucnblqwR5gsGM4Bd5711abkabrz52F2TDrU88rVvVfCdHV4dFHFYEmUBVZZ4pATtg==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.3.1.tgz",
+          "integrity": "sha512-f06qZ/ukpeN24gc01qFjh3P+r3FU/ikY4yG+fDJu6dPNvpUQzDy98lYogA1dr6ig2UtrnoEk3xncyFPL1e9cZw==",
           "requires": {
-            "@formatjs/ecma402-abstract": "1.11.7",
+            "@formatjs/ecma402-abstract": "1.11.8",
             "@formatjs/fast-memoize": "1.2.4",
-            "@formatjs/icu-messageformat-parser": "2.1.3",
-            "@formatjs/intl-displaynames": "6.0.2",
-            "@formatjs/intl-listformat": "7.0.2",
-            "intl-messageformat": "10.1.0",
+            "@formatjs/icu-messageformat-parser": "2.1.4",
+            "@formatjs/intl-displaynames": "6.0.3",
+            "@formatjs/intl-listformat": "7.0.3",
+            "intl-messageformat": "10.1.1",
             "tslib": "2.4.0"
           }
         },
         "@formatjs/intl-displaynames": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-6.0.2.tgz",
-          "integrity": "sha512-h9Id/6vbSHpARHKMVsjWag3KMZJpop9s67CZTd+AMxhjHb5xDG2b5rlSRJKx/UdIDQ+GzESK7a4fv32yylG3cw==",
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-6.0.3.tgz",
+          "integrity": "sha512-Mxh6W1VOlmiEvO/QPBrBQHlXrIn5VxjJWyyEI0V7ZHNGl0ee8AjSlq7vIJG8GodRJqGUuutF6N3OB/6qFv0YWg==",
           "requires": {
-            "@formatjs/ecma402-abstract": "1.11.7",
+            "@formatjs/ecma402-abstract": "1.11.8",
             "@formatjs/intl-localematcher": "0.2.28",
             "tslib": "2.4.0"
           }
         },
         "@formatjs/intl-listformat": {
-          "version": "7.0.2",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-7.0.2.tgz",
-          "integrity": "sha512-K+HXrYIvEcAH/dS8XXnSHQYC/z4w0eHjPlDx43HOoDY87/xV7rpHxFVXWXTgwLYC6iAPUO72Y/AaT9iq873juw==",
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-7.0.3.tgz",
+          "integrity": "sha512-ampNLRGZl/08epHa3i5sRmcHGLneC6JrknexbbgnexYFNSmJ6AbL/dCzgrQzw2Efl+5AZK7UbNFxcDYY3RePvw==",
           "requires": {
-            "@formatjs/ecma402-abstract": "1.11.7",
+            "@formatjs/ecma402-abstract": "1.11.8",
             "@formatjs/intl-localematcher": "0.2.28",
             "tslib": "2.4.0"
           }
@@ -58109,9 +58109,9 @@
           "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ=="
         },
         "commander": {
-          "version": "9.3.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-9.3.0.tgz",
-          "integrity": "sha512-hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw=="
+          "version": "9.4.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
+          "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw=="
         },
         "cross-spawn": {
           "version": "7.0.3",
@@ -58163,13 +58163,13 @@
           "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ=="
         },
         "intl-messageformat": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.1.0.tgz",
-          "integrity": "sha512-diGMDv9Zo2Mggf6AkJszq/BIR5+rarkwcr4g5JGgREwbwAHY9hR/dYd8FbIgQx2RTxhJsABfAWCiENFLbaTZjg==",
+          "version": "10.1.1",
+          "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.1.1.tgz",
+          "integrity": "sha512-FeJne2oooYW6shLPbrqyjRX6hTELVrQ90Dn88z7NomLk/xZBCLxLPAkgaYaTQJBRBV78nZ933d8APHHkTQrD9Q==",
           "requires": {
-            "@formatjs/ecma402-abstract": "1.11.7",
+            "@formatjs/ecma402-abstract": "1.11.8",
             "@formatjs/fast-memoize": "1.2.4",
-            "@formatjs/icu-messageformat-parser": "2.1.3",
+            "@formatjs/icu-messageformat-parser": "2.1.4",
             "tslib": "2.4.0"
           }
         },
@@ -58406,19 +58406,19 @@
           "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
         },
         "react-intl": {
-          "version": "6.0.4",
-          "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.0.4.tgz",
-          "integrity": "sha512-eBIP4QuFOdr67+ZmNOA7WGzJ6dj0qgsGQbx3phzcel2B0kVLvfojTJuvYiFuLgbZTrRJMjHwYJZO5zsmibsfug==",
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.0.5.tgz",
+          "integrity": "sha512-nDZ3BosuE8WdovcGxsrjj1aIgJZklSL5aORs5oah+5tLQTzUdOEstzJEYQPM+sxl1dkDOu7RCuw0z9oI9ENf9g==",
           "requires": {
-            "@formatjs/ecma402-abstract": "1.11.7",
-            "@formatjs/icu-messageformat-parser": "2.1.3",
-            "@formatjs/intl": "2.3.0",
-            "@formatjs/intl-displaynames": "6.0.2",
-            "@formatjs/intl-listformat": "7.0.2",
+            "@formatjs/ecma402-abstract": "1.11.8",
+            "@formatjs/icu-messageformat-parser": "2.1.4",
+            "@formatjs/intl": "2.3.1",
+            "@formatjs/intl-displaynames": "6.0.3",
+            "@formatjs/intl-listformat": "7.0.3",
             "@types/hoist-non-react-statics": "^3.3.1",
             "@types/react": "16 || 17 || 18",
             "hoist-non-react-statics": "^3.3.2",
-            "intl-messageformat": "10.1.0",
+            "intl-messageformat": "10.1.1",
             "tslib": "2.4.0"
           }
         },
@@ -58447,9 +58447,9 @@
           }
         },
         "rxjs": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
-          "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
+          "version": "7.5.6",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.6.tgz",
+          "integrity": "sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==",
           "requires": {
             "tslib": "^2.1.0"
           }
@@ -58749,9 +58749,9 @@
       }
     },
     "@formatjs/ecma402-abstract": {
-      "version": "1.11.7",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.7.tgz",
-      "integrity": "sha512-uNaok4XWMJBtPZk/veTDamFCm5HeWJUk2jwoVfH5/+wenQ60QHjH6T3UQ0GOOCz9jpKmed7vqOri7xSf//Dt7g==",
+      "version": "1.11.8",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.8.tgz",
+      "integrity": "sha512-fgLqyWlwmTEuqV/TSLEL/t9JOmHNLFvCdgzXB0jc2w+WOItPCOJ1T0eyN6fQBQKRPfSqqNlu+kWj7ijcOVTVVQ==",
       "requires": {
         "@formatjs/intl-localematcher": "0.2.28",
         "tslib": "2.4.0"
@@ -58780,12 +58780,12 @@
       }
     },
     "@formatjs/icu-messageformat-parser": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.1.3.tgz",
-      "integrity": "sha512-hsdAn1dXcujW/G8DHw0iiIy7357pw10yOulCrL6xrQOKJAxT7m7EgpG0Hm1OW9xqaLEzqWyE/jA2AGVnOCaCQw==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.1.4.tgz",
+      "integrity": "sha512-3PqMvKWV1oyok0BuiXUAHIaotdhdTJw6OICqCZbfUgKT+ZRwRWO4IlCgvXJeCITaKS5p+PY0XXKjf/vUyIpWjQ==",
       "requires": {
-        "@formatjs/ecma402-abstract": "1.11.7",
-        "@formatjs/icu-skeleton-parser": "1.3.9",
+        "@formatjs/ecma402-abstract": "1.11.8",
+        "@formatjs/icu-skeleton-parser": "1.3.10",
         "tslib": "2.4.0"
       },
       "dependencies": {
@@ -58797,11 +58797,11 @@
       }
     },
     "@formatjs/icu-skeleton-parser": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.9.tgz",
-      "integrity": "sha512-s9THwwhiiSzbGSk73FP6Ur2MBwEj1vfgYDHKa5FiXGQMfYzdRdRvyH1dgqNgSFJPB6PM3DKtkloJLjpqpSDNUg==",
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.10.tgz",
+      "integrity": "sha512-kXJmtLDqFF5aLTf8IxdJXnhrIX1Qb4Qp3a9jqRecGDYfzOa9hMhi9U0nKyhrJJ4cXxBzptcgb+LWkyeHL6nlBQ==",
       "requires": {
-        "@formatjs/ecma402-abstract": "1.11.7",
+        "@formatjs/ecma402-abstract": "1.11.8",
         "tslib": "2.4.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.0.2",
-    "@colony/colony-event-metadata-parser": "^1.0.4",
+    "@colony/colony-event-metadata-parser": "^1.0.5",
     "@colony/colony-js": "^4.2.0",
     "@colony/redux-promise-listener": "^1.2.0",
     "@colony/unicode-confusables-noascii": "^0.1.2",

--- a/src/data/resolvers/colony.ts
+++ b/src/data/resolvers/colony.ts
@@ -181,19 +181,27 @@ export const getProcessedColony = async (
         try {
           response = await ipfs.getString(avatarHash);
           if (response) {
+            // checking version to be certain
+            const avatarMetadataVersion = getEventMetadataVersion(response);
             avatarObject =
-              metadataVersion === 1
+              avatarMetadataVersion === 1
                 ? JSON.parse(response) // original metadata format
                 : { image: getColonyAvatarImage(response) }; // new metadata format
           }
         } catch (error) {
-          log.verbose('Could not fetch colony avatar', response);
-          log.verbose(
-            `Could not parse IPFS avatar for colony:`,
-            ensName,
-            'with hash:',
-            avatarHash,
-          );
+          /*
+           * @NOTE Silent error if avatar hash is null
+           */
+          if (avatarHash) {
+            log.verbose(error.message);
+            log.verbose('Could not fetch colony avatar', response);
+            log.verbose(
+              `Could not parse IPFS avatar for colony:`,
+              ensName,
+              'with hash:',
+              avatarHash,
+            );
+          }
         }
       }
     }

--- a/src/data/resolvers/colony.ts
+++ b/src/data/resolvers/colony.ts
@@ -198,6 +198,7 @@ export const getProcessedColony = async (
       }
     }
   } catch (error) {
+    log.verbose(error.message);
     log.verbose(
       `Could not parse IPFS metadata for colony:`,
       ensName,
@@ -287,6 +288,7 @@ export const getProcessedDomain = async (
       }
     }
   } catch (error) {
+    log.verbose(error.message);
     log.verbose(
       `Could not parse IPFS metadata for domain:`,
       domainChainId,

--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeedItemWithIPFS/ActionsPageFeedItemWithIPFS.tsx
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageFeedItemWithIPFS/ActionsPageFeedItemWithIPFS.tsx
@@ -51,21 +51,24 @@ const ActionsPageFeedItemWithIPFS = ({
     if (!annotation || !ipfsDataJSON) {
       return undefined;
     }
-
-    const metadataVersion = getEventMetadataVersion(ipfsDataJSON);
-    if (metadataVersion === 1) {
-      /*
-       * original metadata format
-       */
-      const annotationObject = JSON.parse(ipfsDataJSON);
-      if (annotationObject?.annotationMessage) {
-        return annotationObject.annotationMessage;
+    try {
+      const metadataVersion = getEventMetadataVersion(ipfsDataJSON);
+      if (metadataVersion === 1) {
+        /*
+         * original metadata format
+         */
+        const annotationObject = JSON.parse(ipfsDataJSON);
+        if (annotationObject?.annotationMessage) {
+          return annotationObject.annotationMessage;
+        }
+      } else {
+        /*
+         * new metadata format
+         */
+        return getAnnotationMsgFromResponse(ipfsDataJSON);
       }
-    } else {
-      /*
-       * new metadata format
-       */
-      return getAnnotationMsgFromResponse(ipfsDataJSON);
+    } catch (error) {
+      // silently fail
     }
     return undefined;
   }, [annotation, ipfsDataJSON]);

--- a/src/modules/dashboard/components/HookedColonyAvatar/HookedColonyAvatar.ts
+++ b/src/modules/dashboard/components/HookedColonyAvatar/HookedColonyAvatar.ts
@@ -33,7 +33,7 @@ export default withHooks<
   const avatarURL = result.colony ? result.colony.avatarURL : null;
   result.avatarURL = avatarURL;
 
-  if (!avatarURL) {
+  if (!avatarURL && avatarHash) {
     const { data: avatar } = useDataFetcher(
       ipfsDataFetcher,
       [avatarHash as string], // Technically a bug, shouldn't need type override

--- a/src/modules/dashboard/components/HookedColonyAvatar/HookedColonyAvatar.ts
+++ b/src/modules/dashboard/components/HookedColonyAvatar/HookedColonyAvatar.ts
@@ -39,15 +39,16 @@ export default withHooks<
       [avatarHash as string], // Technically a bug, shouldn't need type override
       [avatarHash],
     );
-
-    try {
-      const metadataVersion = getEventMetadataVersion(avatar);
-      avatarObject =
-        metadataVersion === 1
-          ? JSON.parse(avatar) // original metadata format
-          : { image: getColonyAvatarImage(avatar) }; // new metadata format
-    } catch (error) {
-      // silent error
+    if (avatar) {
+      try {
+        const metadataVersion = getEventMetadataVersion(avatar);
+        avatarObject =
+          metadataVersion === 1
+            ? JSON.parse(avatar) // original metadata format
+            : { image: getColonyAvatarImage(avatar) }; // new metadata format
+      } catch (error) {
+        // silent error
+      }
     }
     result.avatarURL = avatarObject?.image || null;
   }

--- a/src/utils/hooks/useUserAvatarImageFromIPFS.ts
+++ b/src/utils/hooks/useUserAvatarImageFromIPFS.ts
@@ -16,6 +16,7 @@ const useUserAvatarImageFromIPFS = (ipfsHash: string): IPFSAvatarImage => {
     [ipfsHash],
   );
 
+  if (!avatar) return avatarObject;
   try {
     const metadataVersion = getEventMetadataVersion(avatar);
     avatarObject =


### PR DESCRIPTION
## Description

This PR adds extra protection when parsing metadata and calling `getEventMetadataVersion`. 

getEventMetadataVersion is now called in a try/catch block.

Resolves #3734
