### PR TITLE
Update useCallback dependency array in ManageWhiteListDialog

### DIFF
--- a/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/ManageWhitelistDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/ManageWhitelistDialog/ManageWhitelistDialog.tsx
@@ -157,7 +157,7 @@ const ManageWhitelistDialog = ({
       ),
       withMeta({ history }),
     ),
-    [tabIndex],
+    [tabIndex, storedVerifiedRecipients],
   );
 
   return (


### PR DESCRIPTION
## Description

A while ago, a noticed a bug when adding a member to the address book. It would override any previous members I had added, such that I could only have one verified member at a time. While working on another issue I stumbled across what I believe is the fix for this. 


**Changes** 🏗

* Ensure useCallback dependency array is complete in transform function.

## Before
**Adding a new member replaces existing**
![one-mem-only](https://user-images.githubusercontent.com/64402732/184189041-49e31839-c523-4958-bec5-bfb899446389.gif)

## After
**Adding a new member does not replace existing**
![multiple-members](https://user-images.githubusercontent.com/64402732/184189053-3ba14e5b-4540-4653-b784-8ab3a7adfb51.gif)

Resolves #3588 
