### PR TITLE
Fix incorrect spelling in ManageFundsDialog

### DIFF
--- a/src/modules/dashboard/components/Dialogs/ManageFundsDialog/ManageFundsDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/ManageFundsDialog/ManageFundsDialog.tsx
@@ -79,7 +79,7 @@ const MSG = defineMessages({
   unlockTokensDescription: {
     id: 'dashboard.ManageFundsDialog.unlockTokensDescription',
     defaultMessage:
-      'Allow your native token to be transferred between acccounts.',
+      'Allow your native token to be transferred between accounts.',
   },
 });
 


### PR DESCRIPTION
## Description

Very simple PR to correct a spelling issue one of our users picked up and reported.

**Changes** 🏗

* "acccounts" to "accounts" in `ManageFundsDialog`

Resolves #3742
