### PR TITLE
Remove references to showWhiteListWarning

### DIFF
--- a/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialog.tsx
@@ -121,15 +121,6 @@ const CreatePaymentDialog = ({
     return getVerifiedUsers(colony.whitelistedAddresses, subscribedUsers) || [];
   }, [subscribedUsers, colony]);
 
-  const showWarningForAddress = (walletAddress) => {
-    if (!walletAddress) return false;
-    return isWhitelistActivated
-      ? !colonyData?.processedColony?.whitelistedAddresses.some(
-          (el) => el.toLowerCase() === walletAddress.toLowerCase(),
-        )
-      : false;
-  };
-
   const transform = useCallback(
     pipe(
       mapPayload((payload) => {
@@ -214,9 +205,6 @@ const CreatePaymentDialog = ({
                 isWhitelistActivated ? verifiedUsers : subscribedUsers
               }
               ethDomainId={ethDomainId}
-              showWhitelistWarning={showWarningForAddress(
-                formValues.values?.recipient?.profile?.walletAddress,
-              )}
             />
           </Dialog>
         );

--- a/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.css
+++ b/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.css
@@ -82,21 +82,3 @@
 .motionVoteDomain {
   margin: 6px 0;
 }
-
-.warningContainer {
-  margin-top: 20px;
-  padding: 20px 15px;
-  border-radius: var(--radius-normal);
-  background-color: color-mod(var(--danger) alpha(15%));
-}
-
-.warningText {
-  font-size: var(--size-smallish);
-  font-weight: var(--weight-bold);
-  line-height: 18px;
-  color: var(--dark);
-}
-
-.warningLabel {
-  color: var(--danger);
-}

--- a/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.css.d.ts
@@ -12,6 +12,3 @@ export const noPermissionFromMessage: string;
 export const modalHeading: string;
 export const headingContainer: string;
 export const motionVoteDomain: string;
-export const warningContainer: string;
-export const warningText: string;
-export const warningLabel: string;

--- a/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.tsx
@@ -109,14 +109,9 @@ const MSG = defineMessages({
     id: `dashboard.CreatePaymentDialog.CreatePaymentDialogForm.userPickerPlaceholder`,
     defaultMessage: 'Search for a user or paste wallet address',
   },
-  warningText: {
-    id: `dashboard.CreatePaymentDialog.CreatePaymentDialogForm.warningText`,
-    defaultMessage: `<span>Warning.</span> You are about to make a payment to an address not on the whitelist. Are you sure the address is correct?`,
-  },
 });
 interface Props extends ActionDialogProps {
   verifiedUsers: AnyUser[];
-  showWhitelistWarning: boolean;
   ethDomainId?: number;
 }
 
@@ -161,7 +156,6 @@ const CreatePaymentDialogForm = ({
   isValid,
   values,
   ethDomainId: preselectedDomainId,
-  showWhitelistWarning,
 }: Props & FormikProps<FormValues>) => {
   const selectedDomain =
     preselectedDomainId === 0 || preselectedDomainId === undefined
@@ -450,20 +444,6 @@ const CreatePaymentDialogForm = ({
             valueDataTest="paymentRecipientName"
           />
         </div>
-        {showWhitelistWarning && (
-          <div className={styles.warningContainer}>
-            <p className={styles.warningText}>
-              <FormattedMessage
-                {...MSG.warningText}
-                values={{
-                  span: (chunks) => (
-                    <span className={styles.warningLabel}>{chunks}</span>
-                  ),
-                }}
-              />
-            </p>
-          </div>
-        )}
         {values.recipient &&
           isConfusing(
             values.recipient.profile.username ||


### PR DESCRIPTION
## Description

When working on #3684, I noticed a small piece of logic that is now reduntant. In the `CreatePaymentDialog`, when the address book is activated, we don't need to check if the selected address is not in the address book, because the SingleUserPicker will only display users in the address book. 

I have removed the related logic and styles.

If you want to verify this, on `master`, try and generate the warning. To do this, you would need the address book to be active, and to select a user that is not on it. However, you can't, because the SingleUserPicker will only show you members in the address book.

**Deletions** ⚰️

* `showWhiteListWarning` and related logic / styles

Resolves #3744
