### PR TITLE
Fix 99% staking bug

### DIFF
--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
@@ -135,13 +135,21 @@ const StakingWidget = ({
     pipe(
       mapPayload(({ amount }) => {
         if (data?.motionStakes) {
-          const { minUserStake } = data.motionStakes;
+          const { minUserStake, maxUserStake } = data.motionStakes;
+
+          let finalStake;
           const stake = getDecimalStake(amount);
-          const stakeWithMin = new Decimal(minUserStake).gte(stake)
-            ? new Decimal(minUserStake)
-            : stake;
+
+          if (amount === 100) {
+            finalStake = maxUserStake;
+          } else if (amount === 0 || new Decimal(minUserStake).gte(stake)) {
+            finalStake = minUserStake;
+          } else {
+            finalStake = stake.toString();
+          }
+
           return {
-            amount: stakeWithMin.round().toString(),
+            amount: finalStake,
             userAddress: walletAddress,
             colonyAddress,
             motionId: bigNumberify(motionId),

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
@@ -18,6 +18,7 @@ import {
 } from '~data/index';
 import { ActionTypes } from '~redux/index';
 import { mapPayload, pipe } from '~utils/actions';
+import { log } from '~utils/debug';
 
 import styles from './StakingWidget.css';
 import StakingSlider, { StakingAmounts } from './StakingSlider';
@@ -135,7 +136,12 @@ const StakingWidget = ({
     pipe(
       mapPayload(({ amount }) => {
         if (data?.motionStakes) {
-          const { minUserStake, maxUserStake } = data.motionStakes;
+          const {
+            minUserStake,
+            maxUserStake,
+            remainingToFullyNayStaked,
+            remainingToFullyYayStaked,
+          } = data.motionStakes;
 
           let finalStake;
           const stake = getDecimalStake(amount);
@@ -147,6 +153,15 @@ const StakingWidget = ({
           } else {
             finalStake = stake.toString();
           }
+
+          log.verbose('Staking values: ', {
+            minUserStake,
+            maxUserStake,
+            remainingToFullyNayStaked,
+            remainingToFullyYayStaked,
+            stake: stake.toString(),
+            finalStake,
+          });
 
           return {
             amount: finalStake,

--- a/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialog.tsx
@@ -10,6 +10,7 @@ import { ActionForm } from '~core/Fields';
 import { useLoggedInUser } from '~data/index';
 import { ActionTypes } from '~redux/index';
 import { pipe, mapPayload } from '~utils/actions';
+import { log } from '~utils/debug';
 
 import DialogForm, { Props as FormProps } from './RaiseObjectionDialogForm';
 
@@ -64,6 +65,14 @@ const RaiseObjectionDialog = ({
         } else {
           finalStake = stake.toString();
         }
+
+        log.verbose('Objection staking values: ', {
+          minUserStake,
+          maxUserStake,
+          remainingToFullyNayStaked,
+          stake: stake.toString(),
+          finalStake,
+        });
 
         return {
           amount: finalStake,

--- a/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialog.tsx
@@ -47,17 +47,26 @@ const RaiseObjectionDialog = ({
   const transform = useCallback(
     pipe(
       mapPayload(({ amount, annotation: annotationMessage }) => {
-        const { remainingToFullyNayStaked } = props;
+        const { remainingToFullyNayStaked, maxUserStake } = props;
         const remainingToStake = new Decimal(remainingToFullyNayStaked);
+
+        let finalStake;
+
         const stake = new Decimal(amount)
           .div(100)
           .times(remainingToStake.minus(minUserStake))
           .plus(minUserStake);
-        const stakeWithMin = new Decimal(minUserStake).gte(stake)
-          ? new Decimal(minUserStake)
-          : stake;
+
+        if (amount === 100) {
+          finalStake = maxUserStake;
+        } else if (amount === 0 || new Decimal(minUserStake).gte(stake)) {
+          finalStake = minUserStake;
+        } else {
+          finalStake = stake.toString();
+        }
+
         return {
-          amount: stakeWithMin.round().toString(),
+          amount: finalStake,
           userAddress: walletAddress,
           colonyAddress,
           motionId: bigNumberify(motionId),


### PR DESCRIPTION
## Description

This PR fixes the max staking in slider that in some cases produced only 99% staked.

It has been decided not to implement min and max buttons as it wouldn't help the bug and then the UI would get confusing and the slider logic would be even more complicated.

The bug is caused by rounding calculations in `Decimal`. I've added a direct check if the slider is 100% staked.

I've also added `log.verbose` with all the relevant staking values in case the bug persists and we need to investigate further in production.

This bug is hard to replicate, but what worked for me is either really large mounts or really small amounts and a combination of both (for reputation, so basically paying a user). I paid 1 billion and then 2 more tokens. You can try these amounts to replicate.

I'll try to replicate on QA, will add a link to the colony/motion if I manage to.

Resolves #3739 
