### PR TITLE
Update `useContributorsAndWatchersQuery` fetch policy

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.tsx
@@ -43,6 +43,8 @@ const ColonyMembers = ({
       colonyName,
       domainId: currentDomainId,
     },
+    fetchPolicy: 'network-only',
+    nextFetchPolicy: 'cache-first',
   });
 
   if (loadingMembers) {

--- a/src/modules/dashboard/components/Members/Members.tsx
+++ b/src/modules/dashboard/components/Members/Members.tsx
@@ -88,6 +88,8 @@ const Members = ({
       colonyName,
       domainId: selectedDomain,
     },
+    fetchPolicy: 'network-only',
+    nextFetchPolicy: 'cache-first',
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Description

This PR updates the fetch policies of two instances of the `useContributorsAndWatchersQuery`, one in the `ColonyMembers` page component and the other in the `ColonyMembers` sidebar on the `ColonyHome` page. 

This is so that when you interact with the address book, e.g. by adding a new user to it, the next time you navigate to one of these components, the query will fetch over the network and therefore return updated data, instead of fetching from the cache and returning the previous query result (which has not been updated). The advantage of this is that the user doesn't have to refresh the browser to see the latest members data. 


**Changes** 🏗

* `useContributorsAndWatchersQuery` fetch policy in `ColonyMembers` page component and sidebar  component in ColonyHome


Resolves #3747 