### PR TITLE
Implement contract functions parser

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,3 +56,6 @@ SUBGRAPH_WS_ENDPOINT=ws://127.0.0.1:8001/subgraphs/name/joinColony/subgraph
 METATRANSACTIONS=true
 # METATRANSACTIONS BROADCASTER ADDRESS
 BROADCASTER_ENDPOINT=http://127.0.0.1:3004
+
+# Add an etherscan key in order to allow contract interaction parsing
+ETHERSCAN_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -57,5 +57,11 @@ METATRANSACTIONS=true
 # METATRANSACTIONS BROADCASTER ADDRESS
 BROADCASTER_ENDPOINT=http://127.0.0.1:3004
 
-# Add an etherscan key in order to allow contract interaction parsing
+# Add API keys in order to allow contract interaction parsing
 ETHERSCAN_API_KEY=
+
+POLYGONSCAN_API_KEY=
+
+BSCSCAN_API_KEY=
+
+GNOSIS_API_KEY=

--- a/src/modules/constants.ts
+++ b/src/modules/constants.ts
@@ -12,6 +12,7 @@ export type NetworkInfo = {
   name: string;
   chainId: number;
   shortName: string;
+  apiUri: string;
   description?: string;
   displayENSDomain?: string;
   /**
@@ -85,6 +86,7 @@ export const GNOSIS_NETWORK: NetworkInfo = {
   contractAddressLink: 'https://blockscout.com/poa/xdai/address',
   rpcUrl: 'https://rpc.gnosischain.com',
   safeTxService: 'https://safe-transaction.xdai.gnosis.io/',
+  apiUri: 'https://blockscout.com/xdai/mainnet/api',
 };
 
 export const ETHEREUM_NETWORK: NetworkInfo = {
@@ -98,6 +100,7 @@ export const ETHEREUM_NETWORK: NetworkInfo = {
   contractAddressLink: 'https://etherscan.io/address',
   rpcUrl: 'https://mainnet.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161',
   safeTxService: 'https://safe-transaction.mainnet.gnosis.io/',
+  apiUri: 'https://api.etherscan.io/api',
 };
 
 export const GOERLI_NETWORK: NetworkInfo = {
@@ -111,6 +114,7 @@ export const GOERLI_NETWORK: NetworkInfo = {
   contractAddressLink: 'https://goerli.etherscan.io/address',
   rpcUrl: 'https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161',
   safeTxService: 'https://safe-transaction.goerli.gnosis.io/',
+  apiUri: 'https://api-goerli.etherscan.io/api',
 };
 
 const ARBITRUM_NETWORK: NetworkInfo = {
@@ -120,6 +124,7 @@ const ARBITRUM_NETWORK: NetworkInfo = {
   contractAddressLink: '',
   safeTxService: 'https://safe-transaction.arbitrum.gnosis.io/',
   rpcUrl: 'https://rpc.ankr.com/arbitrum',
+  apiUri: 'https://api.arbiscan.io/api',
 };
 
 const AURORA_NETWORK: NetworkInfo = {
@@ -129,6 +134,7 @@ const AURORA_NETWORK: NetworkInfo = {
   contractAddressLink: '',
   safeTxService: 'https://safe-transaction.aurora.gnosis.io/',
   rpcUrl: 'https://testnet.aurora.dev/',
+  apiUri: 'https://api.aurorascan.dev/api',
 };
 
 const AVALANCHE_NETWORK: NetworkInfo = {
@@ -138,15 +144,17 @@ const AVALANCHE_NETWORK: NetworkInfo = {
   contractAddressLink: '',
   safeTxService: 'https://safe-transaction.avalanche.gnosis.io/',
   rpcUrl: 'https://api.avax.network/ext/bc/C/rpc',
+  apiUri: 'https://api.snowtrace.io/api',
 };
 
-const BINANCE_NETWORK: NetworkInfo = {
+export const BINANCE_NETWORK: NetworkInfo = {
   name: 'Binance Smart Chain',
   chainId: 56,
   shortName: 'BNB',
   contractAddressLink: '',
   safeTxService: 'https://safe-transaction.bsc.gnosis.io/',
   rpcUrl: 'https://bsc-dataseed.binance.org/',
+  apiUri: 'https://api.bscscan.com/api',
 };
 
 const OPTIMISM_NETWORK: NetworkInfo = {
@@ -156,15 +164,17 @@ const OPTIMISM_NETWORK: NetworkInfo = {
   contractAddressLink: '',
   safeTxService: 'https://safe-transaction.optimism.gnosis.io/',
   rpcUrl: 'https://mainnet.optimism.io',
+  apiUri: 'https://api-optimistic.etherscan.io/api',
 };
 
-const POLYGON_NETWORK: NetworkInfo = {
+export const POLYGON_NETWORK: NetworkInfo = {
   name: 'Polygon',
   chainId: 137,
   shortName: 'MATIC',
   contractAddressLink: '',
   safeTxService: 'https://safe-transaction.polygon.gnosis.io/',
   rpcUrl: 'https://polygon-rpc.com',
+  apiUri: 'https://api.polygonscan.com/api',
 };
 
 export const RINKEBY_TEST_NETWORK: NetworkInfo = {
@@ -174,6 +184,7 @@ export const RINKEBY_TEST_NETWORK: NetworkInfo = {
   contractAddressLink: '',
   safeTxService: 'https://safe-transaction.rinkeby.gnosis.io/',
   rpcUrl: 'https://rinkeby.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161',
+  apiUri: 'https://api-rinkeby.etherscan.io/api',
 };
 
 /*
@@ -190,6 +201,7 @@ export const GANACHE_NETWORK: NetworkInfo = {
   tokenExplorerLink: 'http://localhost',
   contractAddressLink: 'http://localhost',
   rpcUrl: 'http://localhost:8545',
+  apiUri: '',
 };
 
 export const NETWORK_DATA: { [key: string]: NetworkInfo } = {

--- a/src/modules/core/components/Fields/InputStatus/InputStatus.tsx
+++ b/src/modules/core/components/Fields/InputStatus/InputStatus.tsx
@@ -1,7 +1,8 @@
 import { MessageDescriptor, useIntl } from 'react-intl';
 import React from 'react';
+import isArray from 'lodash/isArray';
+import isNil from 'lodash/isNil';
 
-import { isNil } from 'lodash';
 import { SimpleMessageValues } from '~types/index';
 import { getMainClasses } from '~utils/css';
 
@@ -41,10 +42,17 @@ const InputStatus = ({
   touched,
 }: Props) => {
   const { formatMessage } = useIntl();
-  const errorText = typeof error === 'object' ? formatMessage(error) : error;
+  const getErrorText = () => {
+    switch (typeof error) {
+      case 'object':
+        return formatMessage(isArray(error) ? error[0] : error);
+      default:
+        return error;
+    }
+  };
   const statusText =
     typeof status === 'object' ? formatMessage(status, statusValues) : status;
-  const text = errorText || statusText;
+  const text = getErrorText() || statusText;
   const Element = appearance.direction === 'horizontal' ? 'span' : 'p';
   return (
     <Element

--- a/src/modules/core/components/Fields/InputStatus/InputStatus.tsx
+++ b/src/modules/core/components/Fields/InputStatus/InputStatus.tsx
@@ -45,7 +45,7 @@ const InputStatus = ({
   const getErrorText = () => {
     switch (typeof error) {
       case 'object':
-        return formatMessage(isArray(error) ? error[0] : error);
+        return formatMessage(isArray(error) ? error.find((e) => e) : error);
       default:
         return error;
     }

--- a/src/modules/core/components/Fields/InputStatus/InputStatus.tsx
+++ b/src/modules/core/components/Fields/InputStatus/InputStatus.tsx
@@ -1,7 +1,6 @@
 import { MessageDescriptor, useIntl } from 'react-intl';
 import React from 'react';
 import isArray from 'lodash/isArray';
-import isNil from 'lodash/isNil';
 
 import { SimpleMessageValues } from '~types/index';
 import { getMainClasses } from '~utils/css';
@@ -52,13 +51,22 @@ const InputStatus = ({
   };
   const statusText =
     typeof status === 'object' ? formatMessage(status, statusValues) : status;
-  const text = getErrorText() || statusText;
+  const getText = () => {
+    if (!!error && touched) {
+      return getErrorText();
+    }
+    if (status) {
+      return statusText;
+    }
+    return null;
+  };
+  const text = getText();
   const Element = appearance.direction === 'horizontal' ? 'span' : 'p';
   return (
     <Element
       className={getMainClasses(appearance, styles, {
-        error: !!error,
-        hidden: !text || (!!error && !isNil(touched) && !touched),
+        error: !!error && !!touched,
+        hidden: !text,
       })}
     >
       {text}

--- a/src/modules/core/components/Fields/InputStatus/InputStatus.tsx
+++ b/src/modules/core/components/Fields/InputStatus/InputStatus.tsx
@@ -52,11 +52,11 @@ const InputStatus = ({
   const statusText =
     typeof status === 'object' ? formatMessage(status, statusValues) : status;
   const getText = () => {
-    if (!!error && touched) {
-      return getErrorText();
-    }
     if (status) {
       return statusText;
+    }
+    if (!!error && touched) {
+      return getErrorText();
     }
     return null;
   };
@@ -65,7 +65,7 @@ const InputStatus = ({
   return (
     <Element
       className={getMainClasses(appearance, styles, {
-        error: !!error && !!touched,
+        error: !!error && !!touched && !status,
         hidden: !text,
       })}
     >

--- a/src/modules/core/components/Fields/Textarea/Textarea.tsx
+++ b/src/modules/core/components/Fields/Textarea/Textarea.tsx
@@ -108,7 +108,7 @@ const Textarea = ({
       <div className={styles.textareaWrapper}>
         <textarea
           {...fieldInputProps}
-          aria-invalid={touched && error ? true : undefined}
+          aria-invalid={touched && error && !status ? true : undefined}
           className={getMainClasses(appearance, styles)}
           id={id}
           maxLength={maxLength}

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeDialog.tsx
@@ -38,6 +38,14 @@ const MSG = defineMessages({
     id: 'dashboard.ControlSafeDialog.notHexError',
     defaultMessage: 'Value must be a valid hex string',
   },
+  notAddress: {
+    id: 'dashboard.GnosisControlSafeDialog.notAddress',
+    defaultMessage: 'Address must be formatted correctly',
+  },
+  notBooleanError: {
+    id: 'dashboard.GnosisControlSafeDialog.notBooleanError',
+    defaultMessage: 'Value must be a boolean',
+  },
 });
 
 export interface FormValues {
@@ -52,7 +60,7 @@ export interface FormValues {
     contractFunction?: string;
     nft: NFT;
   }[];
-  safe: string;
+  safe: AnyUser;
   forceAction: boolean;
   transactionsTitle: string;
 }
@@ -115,7 +123,9 @@ const ControlSafeDialog = ({
           },
           then: yup
             .string()
-            .address(() => (isArraySchema ? MSG.notAddressArray : null))
+            .address(() =>
+              isArraySchema ? MSG.notAddressArray : MSG.notAddress,
+            )
             .required(() => MSG.requiredFieldError),
           otherwise: false,
         });
@@ -124,7 +134,10 @@ const ControlSafeDialog = ({
         return yup.bool().when('contractFunction', {
           is: (contractFunction) =>
             contractFunction === contractName || isArraySchema,
-          then: yup.bool().required(() => MSG.requiredFieldError),
+          then: yup
+            .bool()
+            .typeError(() => MSG.notBooleanError)
+            .required(() => MSG.requiredFieldError),
           otherwise: false,
         });
       }

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
@@ -161,6 +161,8 @@ const ControlSafeForm = ({
   values,
   isVotingExtensionEnabled,
   setFieldValue,
+  setStatus,
+  status,
   showPreview,
   handleShowPreview,
   validateForm,
@@ -397,6 +399,8 @@ const ControlSafeForm = ({
                           values={values}
                           safes={safes}
                           setFieldValue={setFieldValue}
+                          setStatus={setStatus}
+                          status={status}
                           selectedContractMethods={selectedContractMethods}
                           handleSelectedContractMethods={
                             handleSelectedContractMethods

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
@@ -22,8 +22,7 @@ import { useDialogActionPermissions } from '~utils/hooks/useDialogActionPermissi
 import { SAFE_INTEGRATION_LEARN_MORE } from '~externalUrls';
 import { Colony, ColonySafe, useLoggedInUser } from '~data/index';
 import { Address, PrimitiveType } from '~types/index';
-
-import { AbiItemExtended } from '../../../hooks/useContractABIParser';
+import { AbiItemExtended } from '~utils/getContractUsefulMethods';
 
 import SafeTransactionPreview from './SafeTransactionPreview';
 import { FormValues } from './ControlSafeDialog';
@@ -129,9 +128,15 @@ interface Props {
   back?: () => void;
   showPreview: boolean;
   handleShowPreview: (showPreview: boolean) => void;
-  selectedContractMethod: AbiItemExtended | undefined;
-  handleSelectedContractMethod: React.Dispatch<
-    React.SetStateAction<AbiItemExtended>
+  selectedContractMethods:
+    | {
+        [key: number]: AbiItemExtended | undefined;
+      }
+    | undefined;
+  handleSelectedContractMethods: React.Dispatch<
+    React.SetStateAction<{
+      [key: number]: AbiItemExtended | undefined;
+    }>
   >;
 }
 
@@ -159,8 +164,8 @@ const ControlSafeForm = ({
   showPreview,
   handleShowPreview,
   validateForm,
-  selectedContractMethod,
-  handleSelectedContractMethod,
+  selectedContractMethods,
+  handleSelectedContractMethods,
 }: Props & FormikProps<FormValues>) => {
   const [transactionTabStatus, setTransactionTabStatus] = useState([true]);
   const [hasTitle, setHasTitle] = useState(true);
@@ -392,10 +397,9 @@ const ControlSafeForm = ({
                           values={values}
                           safes={safes}
                           setFieldValue={setFieldValue}
-                          validateForm={validateForm}
-                          selectedContractMethod={selectedContractMethod}
-                          handleSelectedContractMethod={
-                            handleSelectedContractMethod
+                          selectedContractMethods={selectedContractMethods}
+                          handleSelectedContractMethods={
+                            handleSelectedContractMethods
                           }
                         />
                       )}

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
@@ -390,7 +390,9 @@ const ControlSafeForm = ({
                           disabledInput={!userHasPermission || isSubmitting}
                           transactionFormIndex={index}
                           values={values}
+                          safes={safes}
                           setFieldValue={setFieldValue}
+                          validateForm={validateForm}
                           selectedContractMethod={selectedContractMethod}
                           handleSelectedContractMethod={
                             handleSelectedContractMethod

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
@@ -23,6 +23,8 @@ import { SAFE_INTEGRATION_LEARN_MORE } from '~externalUrls';
 import { Colony, ColonySafe, useLoggedInUser } from '~data/index';
 import { Address, PrimitiveType } from '~types/index';
 
+import { AbiItemExtended } from '../../../hooks/useContractABIParser';
+
 import SafeTransactionPreview from './SafeTransactionPreview';
 import { FormValues } from './ControlSafeDialog';
 import {
@@ -127,6 +129,10 @@ interface Props {
   back?: () => void;
   showPreview: boolean;
   handleShowPreview: (showPreview: boolean) => void;
+  selectedContractMethod: AbiItemExtended | undefined;
+  handleSelectedContractMethod: React.Dispatch<
+    React.SetStateAction<AbiItemExtended>
+  >;
 }
 
 const renderAvatar = (address: string, item) => (
@@ -153,6 +159,8 @@ const ControlSafeForm = ({
   showPreview,
   handleShowPreview,
   validateForm,
+  selectedContractMethod,
+  handleSelectedContractMethod,
 }: Props & FormikProps<FormValues>) => {
   const [transactionTabStatus, setTransactionTabStatus] = useState([true]);
   const [hasTitle, setHasTitle] = useState(true);
@@ -192,7 +200,7 @@ const ControlSafeForm = ({
         amount: undefined,
         recipient: null,
         data: '',
-        contract: '',
+        contract: null,
         abi: '',
         contractFunction: '',
         nft: null,
@@ -381,6 +389,12 @@ const ControlSafeForm = ({
                         <ContractInteractionSection
                           disabledInput={!userHasPermission || isSubmitting}
                           transactionFormIndex={index}
+                          values={values}
+                          setFieldValue={setFieldValue}
+                          selectedContractMethod={selectedContractMethod}
+                          handleSelectedContractMethod={
+                            handleSelectedContractMethod
+                          }
                         />
                       )}
                       {values.transactions[index]?.transactionType ===

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
@@ -234,10 +234,11 @@ const ContractInteractionSection = ({
               disabled={disabledInput}
               placeholder={`${input.name} (${input.type})`}
               formattingOptions={
-                input.type === 'uint256'
+                input.type === 'uint256' || input.type === 'int256'
                   ? {
                       numeral: true,
-                      numeralPositiveOnly: true,
+                      numeralPositiveOnly: input.type === 'uint256',
+                      numeralDecimalScale: 0,
                     }
                   : undefined
               }

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
@@ -11,12 +11,14 @@ import { Input, Select, SelectOption, Textarea } from '~core/Fields';
 import UserAvatar from '~core/UserAvatar';
 import SingleUserPicker, { filterUserSelection } from '~core/SingleUserPicker';
 import { DialogSection } from '~core/Dialog';
-import { AbiItemExtended } from '~utils/useContractUsefulMethods';
+import {
+  getContractUsefulMethods,
+  AbiItemExtended,
+} from '~utils/getContractUsefulMethods';
 
 import { FormValues } from '../GnosisControlSafeDialog';
 
 import styles from './TransactionTypesSection.css';
-import { getContractUsefulMethods } from '~utils/getContractUsefulMethods';
 
 const MSG = defineMessages({
   abiLabel: {

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
@@ -17,7 +17,7 @@ import {
   fetchContractABI,
 } from '~utils/getContractUsefulMethods';
 
-import { FormValues } from '../GnosisControlSafeDialog';
+import { FormValues } from '../ControlSafeDialog';
 
 import styles from './TransactionTypesSection.css';
 import { GNOSIS_NETWORK } from '~constants';

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
@@ -138,19 +138,17 @@ const ContractInteractionSection = ({
 
   const onContractChange = useCallback(
     (contract: AnyUser) => {
-      if (selectedSafe?.chainId) {
-        const contractPromise = fetchContractABI(
-          contract.profile.walletAddress,
-          Number(selectedSafe.chainId),
-        );
-        contractPromise.then((data) => {
-          onContractABIChange(data);
+      const contractPromise = fetchContractABI(
+        contract.profile.walletAddress,
+        Number(selectedSafe?.chainId),
+      );
+      contractPromise.then((data) => {
+        onContractABIChange(data);
 
-          if (Number(selectedSafe.chainId) !== currentSafeChainId) {
-            setCurrentSafeChainId(Number(selectedSafe.chainId));
-          }
-        });
-      }
+        if (Number(selectedSafe?.chainId) !== currentSafeChainId) {
+          setCurrentSafeChainId(Number(selectedSafe?.chainId));
+        }
+      });
     },
     [selectedSafe, currentSafeChainId, onContractABIChange],
   );
@@ -163,7 +161,8 @@ const ContractInteractionSection = ({
   useEffect(() => {
     if (
       transactionValues.contract &&
-      currentSafeChainId !== Number(selectedSafe?.chainId)
+      !isNil(selectedSafe) &&
+      currentSafeChainId !== Number(selectedSafe.chainId)
     ) {
       onContractChange(transactionValues.contract);
     }

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
@@ -20,6 +20,7 @@ import {
 import { FormValues } from '../GnosisControlSafeDialog';
 
 import styles from './TransactionTypesSection.css';
+import { GNOSIS_NETWORK } from '~constants';
 
 const MSG = defineMessages({
   abiLabel: {
@@ -91,10 +92,24 @@ const ContractInteractionSection = ({
 
   const transactionValues = values.transactions[transactionFormIndex];
 
+  const selectedSafe = safes.find(
+    (safe) => safe.contractAddress === values.safe?.profile?.walletAddress,
+  );
+
   const onContractABIChange = useCallback(
     (abiResponse: any) => {
-      if (abiResponse.status === '0' && status !== abiResponse.message) {
-        setStatus(abiResponse.message);
+      if (abiResponse.status === '0') {
+        if (
+          Number(selectedSafe?.chainId) === GNOSIS_NETWORK.chainId &&
+          status !== abiResponse.message
+        ) {
+          setStatus(abiResponse.message);
+        } else if (
+          Number(selectedSafe?.chainId) !== GNOSIS_NETWORK.chainId &&
+          status !== abiResponse.result
+        ) {
+          setStatus(abiResponse.result);
+        }
       } else if (
         !isNil(abiResponse.result) &&
         abiResponse.result !== transactionValues.abi
@@ -129,11 +144,9 @@ const ContractInteractionSection = ({
       status,
       transactionValues.abi,
       selectedContractMethods,
+      selectedSafe,
       handleSelectedContractMethods,
     ],
-  );
-  const selectedSafe = safes.find(
-    (safe) => safe.contractAddress === values.safe?.profile?.walletAddress,
   );
 
   const onContractChange = useCallback(
@@ -162,6 +175,7 @@ const ContractInteractionSection = ({
     if (
       transactionValues.contract &&
       !isNil(selectedSafe) &&
+      !isNil(currentSafeChainId) &&
       currentSafeChainId !== Number(selectedSafe.chainId)
     ) {
       onContractChange(transactionValues.contract);

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css
@@ -31,3 +31,7 @@
 .inputParamContainer input::placeholder {
   color: var(--temp-grey-blue-7) !important;
 }
+
+.inputParamContainer p {
+  margin-bottom: 10px;
+}

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css
@@ -22,3 +22,12 @@
 .labelDescription {
   color: var(--temp-grey-blue-7);
 }
+
+/*
+  I can't think of any other way of overriding the theme styles
+  right now without adding another theme or prop just to change the color
+*/
+.inputParamContainer label span,
+.inputParamContainer input::placeholder {
+  color: var(--temp-grey-blue-7) !important;
+}

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css.d.ts
@@ -1,3 +1,4 @@
 export const singleUserPickerContainer: string;
 export const contractFunctionSelectorContainer: string;
 export const labelDescription: string;
+export const inputParamContainer: string;

--- a/src/modules/dashboard/hooks/useContractABIParser.ts
+++ b/src/modules/dashboard/hooks/useContractABIParser.ts
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react';
+import { AbiItem, keccak256 } from 'web3-utils';
+
+export interface AbiItemExtended extends AbiItem {
+  name: string;
+  type: 'function';
+  action: string;
+  methodSignature: string;
+  signatureHash: string;
+}
+
+export const fetchContractABI = async (contractAddress: string) => {
+  if (!contractAddress) {
+    return [];
+  }
+
+  try {
+    const apiUri = `https://api.etherscan.io/api?module=contract&action=getAbi&address=${contractAddress}&apiKey=${process.env.ETHERSCAN_API_KEY}`;
+    const response = await fetch(apiUri);
+
+    if (!response.ok) {
+      return [];
+    }
+
+    const responseJSON = await response.json();
+
+    return responseJSON.result;
+  } catch (error) {
+    console.error('Failed to retrieve ABI', error);
+    return '';
+  }
+};
+
+export const extractUsefulMethods = (abi: AbiItem[]): AbiItemExtended[] => {
+  const extendedAbiItems = abi.filter(
+    ({ name, type }) => type === 'function' && !!name,
+  ) as AbiItemExtended[];
+  const getMethodSignatureAndSignatureHash = (
+    method: AbiItem,
+  ): { methodSignature: string; signatureHash: string } => {
+    const params = method.inputs?.map((x) => x.type).join(',');
+    const methodSignature = `${method.name}(${params})`;
+    const signatureHash = keccak256(methodSignature).toString();
+    return { methodSignature, signatureHash };
+  };
+  const getMethodAction = ({ stateMutability }: AbiItem): 'read' | 'write' => {
+    if (!stateMutability) {
+      return 'write';
+    }
+    return ['view', 'pure'].includes(stateMutability) ? 'read' : 'write';
+  };
+
+  return extendedAbiItems
+    .map((method) => ({
+      ...getMethodSignatureAndSignatureHash(method),
+      ...method,
+      action: getMethodAction(method),
+    }))
+    .sort(({ name: a }, { name: b }) => {
+      return a.toLowerCase() > b.toLowerCase() ? 1 : -1;
+    });
+};
+
+export const useContractABIParser = (contractAddress?: string) => {
+  const [
+    currentParsedContractAddress,
+    setCurrentParsedContractAddress,
+  ] = useState<string>('');
+  const [contractABI, setContractABI] = useState<string>('');
+  const [usefulMethods, setUsefulMethods] = useState<AbiItemExtended[]>([]);
+
+  useEffect(() => {
+    if (contractAddress && currentParsedContractAddress !== contractAddress) {
+      const contractPromise = fetchContractABI(contractAddress);
+      contractPromise.then((data) => {
+        setContractABI(data);
+      });
+
+      setCurrentParsedContractAddress(contractAddress);
+    }
+  }, [currentParsedContractAddress, contractAddress]);
+
+  useEffect(() => {
+    if (contractABI) {
+      setUsefulMethods(extractUsefulMethods(JSON.parse(contractABI)));
+    }
+  }, [contractABI]);
+
+  return {
+    contractABI,
+    usefulMethods,
+  };
+};

--- a/src/utils/getContractUsefulMethods.ts
+++ b/src/utils/getContractUsefulMethods.ts
@@ -94,7 +94,8 @@ export const getContractUsefulMethods = (
   safeChainId: number,
   handleContractABIChange: (abi: string) => void,
 ) => {
-  let parsedContractABI: AbiItem[];
+  let parsedContractABI: AbiItem[] = [];
+  let usefulMethods: AbiItemExtended[] = [];
 
   if (!contractABI && contractAddress && isAddress(contractAddress)) {
     const contractPromise = fetchContractABI(contractAddress, safeChainId);
@@ -108,9 +109,9 @@ export const getContractUsefulMethods = (
   } catch (error) {
     console.error(error);
     parsedContractABI = [];
+  } finally {
+    usefulMethods = extractUsefulMethods(parsedContractABI);
   }
-
-  const usefulMethods = extractUsefulMethods(parsedContractABI);
 
   return usefulMethods;
 };

--- a/src/utils/getContractUsefulMethods.ts
+++ b/src/utils/getContractUsefulMethods.ts
@@ -1,4 +1,4 @@
-import { AbiItem, isAddress, keccak256 } from 'web3-utils';
+import { AbiItem, keccak256 } from 'web3-utils';
 
 import {
   BINANCE_NETWORK,
@@ -15,7 +15,7 @@ export interface AbiItemExtended extends AbiItem {
   signatureHash: string;
 }
 
-const fetchContractABI = async (
+export const fetchContractABI = async (
   contractAddress: string,
   safeChainId: number,
 ) => {
@@ -51,7 +51,7 @@ const fetchContractABI = async (
 
     const responseJSON = await response.json();
 
-    return responseJSON.result || responseJSON.message;
+    return responseJSON;
   } catch (error) {
     console.error('Failed to retrieve ABI', error);
     return '';
@@ -88,21 +88,9 @@ const extractUsefulMethods = (abi: AbiItem[]): AbiItemExtended[] => {
     });
 };
 
-export const getContractUsefulMethods = (
-  contractAddress: string | undefined,
-  contractABI: string | undefined,
-  safeChainId: number,
-  handleContractABIChange: (abi: string) => void,
-) => {
+export const getContractUsefulMethods = (contractABI: string | undefined) => {
   let parsedContractABI: AbiItem[] = [];
   let usefulMethods: AbiItemExtended[] = [];
-
-  if (!contractABI && contractAddress && isAddress(contractAddress)) {
-    const contractPromise = fetchContractABI(contractAddress, safeChainId);
-    contractPromise.then((data) => {
-      handleContractABIChange(data);
-    });
-  }
 
   try {
     parsedContractABI = JSON.parse(contractABI || '[]');

--- a/src/utils/getContractUsefulMethods.ts
+++ b/src/utils/getContractUsefulMethods.ts
@@ -3,7 +3,7 @@ import { AbiItem, keccak256 } from 'web3-utils';
 import {
   BINANCE_NETWORK,
   GNOSIS_NETWORK,
-  GNOSIS_SAFE_NETWORKS,
+  SAFE_NETWORKS,
   POLYGON_NETWORK,
 } from '~constants';
 
@@ -25,7 +25,7 @@ export const fetchContractABI = async (
 
   try {
     const currentNetworkData =
-      GNOSIS_SAFE_NETWORKS.find((network) => network.chainId === safeChainId) ||
+      SAFE_NETWORKS.find((network) => network.chainId === safeChainId) ||
       GNOSIS_NETWORK;
     const getApiKey = () => {
       if (currentNetworkData.chainId === POLYGON_NETWORK.chainId) {


### PR DESCRIPTION
Added parser for the "Contract interaction" transaction type which fetches the contract ABI and parses it in order to get the functions and their params.

![FireShot Capture 694 - Actions - Colony - wonker - localhost](https://user-images.githubusercontent.com/18473896/185276394-e2e8b778-3ee6-48a7-bc23-44967a03efe2.png)
![FireShot Capture 695 - Actions - Colony - wonker - localhost](https://user-images.githubusercontent.com/18473896/185276406-092b6780-9fca-4109-bb17-be85b71a1a77.png)

- We can use the contracts here in order to test the parser: https://etherscan.io/contractsVerified
- In order to get the contract ABI, we need to use the etherscan API, which requires a API KEY. You can get 1 free following the steps here: https://docs.etherscan.io/getting-started/creating-an-account . After getting it, plug it in the `.env` file as `ETHERSCAN_API_KEY`
- Each generated field should have its own validation.

Resolves #3692 
