### PR TITLE
Replace `ITEMS_PER_SECTION` value & members clean up

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonyMembers/MembersSubsection.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMembers/MembersSubsection.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
-import Maybe from 'graphql/tsutils/Maybe';
 
 import NavLink from '~core/NavLink';
 import Heading from '~core/Heading';
@@ -13,8 +12,6 @@ import useAvatarDisplayCounter from '~utils/hooks/useAvatarDisplayCounter';
 import {
   Colony,
   useLoggedInUser,
-  BannedUser,
-  UserProfile,
   ColonyContributor,
   ColonyWatcher,
 } from '~data/index';
@@ -62,14 +59,6 @@ const MSG = defineMessages({
     defaultMessage: 'View more',
   },
 });
-
-type BannedMember = Maybe<
-  Pick<BannedUser, 'id' | 'eventId' | 'banned'> & {
-    profile?:
-      | Maybe<Pick<UserProfile, 'displayName' | 'username' | 'walletAddress'>>
-      | undefined;
-  }
->;
 
 interface Props {
   colony: Colony;

--- a/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
+++ b/src/modules/dashboard/components/ColonyMembers/ColonyMembers.tsx
@@ -45,7 +45,7 @@ const MSG = defineMessages({
   },
   totalReputationTitle: {
     id: 'dashboard.ColonyMembers.totalReputationTitle',
-    defaultMessage: 'Total reputation in team',
+    defaultMessage: 'Total reputation in the team',
   },
 });
 

--- a/src/modules/dashboard/components/Members/MembersSection.tsx
+++ b/src/modules/dashboard/components/Members/MembersSection.tsx
@@ -38,9 +38,9 @@ interface Props<U> {
   members: ColonyWatcher[] | ColonyContributor[];
   canAdministerComments: boolean;
   extraItemContent: (user: U) => ReactNode;
+  itemsPerSection?: number;
 }
 
-const ITEMS_PER_SECTION = 10;
 const MembersSection = <U extends ColonyWatcher | ColonyContributor>({
   colony,
   currentDomainId,
@@ -48,10 +48,11 @@ const MembersSection = <U extends ColonyWatcher | ColonyContributor>({
   canAdministerComments,
   extraItemContent,
   isContributorsSection,
+  itemsPerSection = 10,
 }: Props<U>) => {
   const [dataPage, setDataPage] = useState<number>(1);
 
-  const paginatedMembers = members.slice(0, ITEMS_PER_SECTION * dataPage);
+  const paginatedMembers = members.slice(0, itemsPerSection * dataPage);
   const handleDataPagination = useCallback(() => {
     setDataPage(dataPage + 1);
   }, [dataPage]);
@@ -104,7 +105,7 @@ const MembersSection = <U extends ColonyWatcher | ColonyContributor>({
           <FormattedMessage {...MSG.noMemebersFound} />
         </div>
       )}
-      {ITEMS_PER_SECTION * dataPage < members.length && (
+      {itemsPerSection * dataPage < members.length && (
         <LoadMoreButton onClick={handleDataPagination} isLoadingData={false} />
       )}
     </>


### PR DESCRIPTION
## Description

This PR tracks the work involved with the clean up of the members section by:

1. Replacing the `ITEMS_PER_SECTION` value in MemberSection and keeping the default value of 10, but making it a prop.

2. Changing the default message for totalReputationTitle in ColonyMembers from Total reputation in team to Total reputation in the team.

3. Remove BannedMember from MembersSubsection file as it's not used anywhere.

<img width="229" alt="Screen Shot 2022-08-22 at 9 13 56 PM" src="https://user-images.githubusercontent.com/71563622/186000561-e50a0edd-180d-41ba-8f18-4282c4556455.png">
<img width="825" alt="Screen Shot 2022-08-22 at 9 14 08 PM" src="https://user-images.githubusercontent.com/71563622/186000565-73826dc1-eccc-4a4d-93e2-320261f00c86.png">


(Resolves | Contributes to) #3644