### PR TITLE
Create decisions objection modal

### DIFF
--- a/src/modules/core/components/Comment/Comment.tsx
+++ b/src/modules/core/components/Comment/Comment.tsx
@@ -137,7 +137,7 @@ const Comment = ({
             )}
         </div>
         <div className={styles.text} data-test="comment">
-          <Decorate>{comment ? parse(comment) : comment}</Decorate>
+          {comment && <Decorate> {parse(comment)}</Decorate>}
         </div>
       </div>
       <div className={styles.actions}>

--- a/src/modules/core/components/Comment/Comment.tsx
+++ b/src/modules/core/components/Comment/Comment.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { ColonyRole, ROOT_DOMAIN_ID } from '@colony/colony-js';
+import parse from 'html-react-parser';
 
 import { getMainClasses } from '~utils/css';
 import { useTransformer } from '~utils/hooks';
@@ -136,7 +137,7 @@ const Comment = ({
             )}
         </div>
         <div className={styles.text} data-test="comment">
-          <Decorate>{comment}</Decorate>
+          <Decorate>{comment ? parse(comment) : comment}</Decorate>
         </div>
       </div>
       <div className={styles.actions}>

--- a/src/modules/core/components/RichTextEditor/RichTextEditor.css
+++ b/src/modules/core/components/RichTextEditor/RichTextEditor.css
@@ -1,5 +1,4 @@
 .main {
-  min-height: 325px;
   position: relative;
 }
 
@@ -31,8 +30,8 @@
 
 .characterCount {
   position: absolute;
+  top: 285px;
   right: 20px;
-  bottom: 23px;
   font-size: var(--size-tiny);
   line-height: 18px;
   color: color-mod(var(--temp-grey-blue-7) alpha(65%));

--- a/src/modules/core/components/RichTextEditor/RichTextEditor.tsx
+++ b/src/modules/core/components/RichTextEditor/RichTextEditor.tsx
@@ -15,6 +15,7 @@ interface Props {
   isSubmitting: boolean;
   limit: number;
   name: string;
+  className?: string;
   disabled?: boolean;
 }
 
@@ -23,6 +24,7 @@ const RichTextEditor = ({
   isSubmitting,
   limit,
   name,
+  className,
   disabled = false,
 }: Props) => {
   const [
@@ -45,7 +47,7 @@ const RichTextEditor = ({
 
   return (
     <div
-      className={classnames(styles.main, {
+      className={classnames(styles.main, className, {
         [styles.disabled]: isSubmitting || disabled,
       })}
     >

--- a/src/modules/core/components/RichTextEditor/RichTextEditor.tsx
+++ b/src/modules/core/components/RichTextEditor/RichTextEditor.tsx
@@ -15,9 +15,16 @@ interface Props {
   isSubmitting: boolean;
   limit: number;
   name: string;
+  disabled?: boolean;
 }
 
-const RichTextEditor = ({ editor, isSubmitting, limit, name }: Props) => {
+const RichTextEditor = ({
+  editor,
+  isSubmitting,
+  limit,
+  name,
+  disabled = false,
+}: Props) => {
   const [
     ,
     { error: contentError, touched: contentTouched },
@@ -39,7 +46,7 @@ const RichTextEditor = ({ editor, isSubmitting, limit, name }: Props) => {
   return (
     <div
       className={classnames(styles.main, {
-        [styles.disabled]: isSubmitting,
+        [styles.disabled]: isSubmitting || disabled,
       })}
     >
       <Toolbar editor={editor} />

--- a/src/modules/core/components/RichTextEditor/index.ts
+++ b/src/modules/core/components/RichTextEditor/index.ts
@@ -1,0 +1,1 @@
+export { default } from './RichTextEditor';

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
@@ -620,6 +620,7 @@ const DefaultMotion = ({
               motionId={motionId}
               colony={colony}
               scrollToRef={bottomElementRef}
+              isDecision={isDecision}
             />
           )}
           {motionState === MotionState.Voting && (

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
@@ -7,6 +7,7 @@ import Heading from '~core/Heading';
 import Slider, { Appearance } from '~core/Slider';
 import Numeral from '~core/Numeral';
 import StakingValidationError from '~dashboard/ActionsPage/StakingValidationError';
+import QuestionMarkTooltip from '~core/QuestionMarkTooltip';
 
 import { Colony, useLoggedInUser } from '~data/index';
 import { getFormattedTokenValue } from '~utils/tokens';
@@ -58,6 +59,10 @@ const MSG = defineMessages({
   minimumAmount: {
     id: 'dashboard.ActionsPage.StakingSlider.minimumAmount',
     defaultMessage: 'at least {minStake}',
+  },
+  stakingToolTip: {
+    id: 'dashboard.ActionsPage.StakingSlider.stakingToolTip',
+    defaultMessage: `Staking involves committing an amount of tokens as collateral to support your decision.`,
   },
 });
 
@@ -152,6 +157,15 @@ const StakingSlider = ({
           text={isObjection ? MSG.titleObject : MSG.titleStake}
           className={styles.title}
           appearance={{ size: 'normal', theme: 'dark', margin: 'none' }}
+        />
+        <QuestionMarkTooltip
+          tooltipText={MSG.stakingToolTip}
+          className={styles.questionMarkIcon}
+          tooltipClassName={styles.tooltip}
+          showArrow={false}
+          tooltipPopperOptions={{
+            placement: 'top-end',
+          }}
         />
       </div>
       <p className={styles.description}>

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
@@ -33,35 +33,35 @@ interface Props extends StakingAmounts {
   isObjection: boolean;
 }
 
-const displayName = 'StakingSlider';
+const displayName = 'dashboard.ActionsPage.StakingWidget.StakingSlider';
 
 const MSG = defineMessages({
   titleStake: {
-    id: 'dashboard.ActionsPage.StakingSlider.title',
+    id: 'dashboard.ActionsPage.StakingWidget.StakingSlider.title',
     defaultMessage: `Select the amount to back the motion`,
   },
   titleObject: {
-    id: 'dashboard.ActionsPage.StakingSlider.title',
+    id: 'dashboard.ActionsPage.StakingWidget.StakingSlider.title',
     defaultMessage: `Select the amount to stake the objection`,
   },
   descriptionStake: {
-    id: 'dashboard.ActionsPage.StakingSlider.description',
+    id: 'dashboard.ActionsPage.StakingWidget.StakingSlider.description',
     defaultMessage: `Stake is returned if the motion passes. If there is a dispute, and the motion loses, part or all of your stake will be lost.`,
   },
   descriptionObject: {
-    id: 'dashboard.ActionsPage.StakingSlider.description',
+    id: 'dashboard.ActionsPage.StakingWidget.StakingSlider.description',
     defaultMessage: `Stake will be returned if the objection succeeds. If the objection fails, part or all of your stake will be lost.`,
   },
   loading: {
-    id: 'dashboard.ActionsPage.StakingSlider.loading',
+    id: 'dashboard.ActionsPage.StakingWidget.StakingSlider.loading',
     defaultMessage: 'Loading staking values ...',
   },
   minimumAmount: {
-    id: 'dashboard.ActionsPage.StakingSlider.minimumAmount',
+    id: 'dashboard.ActionsPage.StakingWidget.StakingSlider.minimumAmount',
     defaultMessage: 'at least {minStake}',
   },
   stakingToolTip: {
-    id: 'dashboard.ActionsPage.StakingSlider.stakingToolTip',
+    id: 'dashboard.ActionsPage.StakingWidget.StakingSlider.stakingToolTip',
     defaultMessage: `Staking involves committing an amount of tokens as collateral to support your decision.`,
   },
 });

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
@@ -162,7 +162,6 @@ const StakingSlider = ({
           tooltipText={MSG.stakingToolTip}
           className={styles.questionMarkIcon}
           tooltipClassName={styles.tooltip}
-          showArrow={false}
           tooltipPopperOptions={{
             placement: 'top-end',
           }}

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.css
@@ -94,5 +94,4 @@
   align-self: flex-end;
   margin-top: 16px;
   margin-left: 7px;
-  cursor: pointer;
 }

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.css
@@ -89,3 +89,10 @@
   margin-left: 14px;
   width: fit-content;
 }
+
+.questionMarkIcon {
+  align-self: flex-end;
+  margin-top: 16px;
+  margin-left: 7px;
+  cursor: pointer;
+}

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.css.d.ts
@@ -13,3 +13,4 @@ export const help: string;
 export const tooltip: string;
 export const loading: string;
 export const backButtonWrapper: string;
+export const questionMarkIcon: string;

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
@@ -115,7 +115,7 @@ const StakingWidget = ({
       CharacterCount.configure({ limit: LIMIT }),
       Placeholder.configure({
         emptyEditorClass: 'is-editor-empty',
-        placeholder: 'Enter the description...',
+        placeholder: 'What would you like to say?',
       }),
     ],
   });

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
@@ -104,6 +104,8 @@ const StakingWidget = ({
         colony,
         canUserStake: userHasPermission,
         scrollToRef,
+        /* temporary; to replace with a check if a motion is a decision */
+        isDecision: false,
         ...stakingAmounts,
       }),
     [colony, openRaiseObjectionDialog, scrollToRef, motionId],

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
@@ -28,6 +28,7 @@ Decimal.set({ toExpPos: 78 });
 export interface Props extends StakingFlowProps {
   isObjection: boolean;
   handleWidgetState: (isObjection: boolean) => void;
+  isDecision: boolean;
 }
 
 const displayName = 'StakingWidget';
@@ -66,6 +67,7 @@ const StakingWidget = ({
   scrollToRef,
   isObjection,
   handleWidgetState,
+  isDecision,
 }: Props) => {
   const { walletAddress, username, ethereal } = useLoggedInUser();
   const { setIsOpen: openTokenActivationPopover } = useContext(
@@ -104,11 +106,10 @@ const StakingWidget = ({
         colony,
         canUserStake: userHasPermission,
         scrollToRef,
-        /* temporary; to replace with a check if a motion is a decision */
-        isDecision: false,
+        isDecision,
         ...stakingAmounts,
       }),
-    [colony, openRaiseObjectionDialog, scrollToRef, motionId],
+    [colony, openRaiseObjectionDialog, scrollToRef, motionId, isDecision],
   );
 
   const getDecimalStake = useCallback(

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
@@ -3,13 +3,6 @@ import { defineMessages } from 'react-intl';
 import { bigNumberify } from 'ethers/utils';
 import * as yup from 'yup';
 import { Decimal } from 'decimal.js';
-import { useEditor } from '@tiptap/react';
-import CharacterCount from '@tiptap/extension-character-count';
-import Color from '@tiptap/extension-color';
-import Placeholder from '@tiptap/extension-placeholder';
-import TextStyle from '@tiptap/extension-text-style';
-import Underline from '@tiptap/extension-underline';
-import StarterKit from '@tiptap/starter-kit';
 
 import { ActionForm } from '~core/Fields';
 import Button from '~core/Button';
@@ -66,8 +59,6 @@ const validationSchema = yup.object({
   amount: yup.number(),
 });
 
-const LIMIT = 4000;
-
 const StakingWidget = ({
   colony,
   colony: { colonyAddress, nativeTokenAddress },
@@ -106,20 +97,6 @@ const StakingWidget = ({
 
   const openRaiseObjectionDialog = useDialog(RaiseObjectionDialog);
 
-  const editor = useEditor({
-    extensions: [
-      StarterKit,
-      Underline,
-      TextStyle,
-      Color,
-      CharacterCount.configure({ limit: LIMIT }),
-      Placeholder.configure({
-        emptyEditorClass: 'is-editor-empty',
-        placeholder: 'What would you like to say?',
-      }),
-    ],
-  });
-
   const handleRaiseObjection = useCallback(
     (userHasPermission: boolean, stakingAmounts: StakingAmounts) =>
       openRaiseObjectionDialog({
@@ -128,10 +105,8 @@ const StakingWidget = ({
         canUserStake: userHasPermission,
         scrollToRef,
         ...stakingAmounts,
-        editor,
-        limit: LIMIT,
       }),
-    [colony, openRaiseObjectionDialog, scrollToRef, motionId, editor],
+    [colony, openRaiseObjectionDialog, scrollToRef, motionId],
   );
 
   const getDecimalStake = useCallback(

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
@@ -66,7 +66,7 @@ const validationSchema = yup.object({
   amount: yup.number(),
 });
 
-const limit = 4000;
+const LIMIT = 4000;
 
 const StakingWidget = ({
   colony,
@@ -112,7 +112,7 @@ const StakingWidget = ({
       Underline,
       TextStyle,
       Color,
-      CharacterCount.configure({ limit }),
+      CharacterCount.configure({ limit: LIMIT }),
       Placeholder.configure({
         emptyEditorClass: 'is-editor-empty',
         placeholder: 'Enter the description...',
@@ -129,7 +129,7 @@ const StakingWidget = ({
         scrollToRef,
         ...stakingAmounts,
         editor,
-        limit,
+        limit: LIMIT,
       }),
     [colony, openRaiseObjectionDialog, scrollToRef, motionId, editor],
   );

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
@@ -3,6 +3,13 @@ import { defineMessages } from 'react-intl';
 import { bigNumberify } from 'ethers/utils';
 import * as yup from 'yup';
 import { Decimal } from 'decimal.js';
+import { useEditor } from '@tiptap/react';
+import CharacterCount from '@tiptap/extension-character-count';
+import Color from '@tiptap/extension-color';
+import Placeholder from '@tiptap/extension-placeholder';
+import TextStyle from '@tiptap/extension-text-style';
+import Underline from '@tiptap/extension-underline';
+import StarterKit from '@tiptap/starter-kit';
 
 import { ActionForm } from '~core/Fields';
 import Button from '~core/Button';
@@ -59,6 +66,8 @@ const validationSchema = yup.object({
   amount: yup.number(),
 });
 
+const limit = 4000;
+
 const StakingWidget = ({
   colony,
   colony: { colonyAddress, nativeTokenAddress },
@@ -97,6 +106,20 @@ const StakingWidget = ({
 
   const openRaiseObjectionDialog = useDialog(RaiseObjectionDialog);
 
+  const editor = useEditor({
+    extensions: [
+      StarterKit,
+      Underline,
+      TextStyle,
+      Color,
+      CharacterCount.configure({ limit }),
+      Placeholder.configure({
+        emptyEditorClass: 'is-editor-empty',
+        placeholder: 'Enter the description...',
+      }),
+    ],
+  });
+
   const handleRaiseObjection = useCallback(
     (userHasPermission: boolean, stakingAmounts: StakingAmounts) =>
       openRaiseObjectionDialog({
@@ -105,8 +128,10 @@ const StakingWidget = ({
         canUserStake: userHasPermission,
         scrollToRef,
         ...stakingAmounts,
+        editor,
+        limit,
       }),
-    [colony, openRaiseObjectionDialog, scrollToRef, motionId],
+    [colony, openRaiseObjectionDialog, scrollToRef, motionId, editor],
   );
 
   const getDecimalStake = useCallback(

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidgetFlow.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidgetFlow.tsx
@@ -24,6 +24,7 @@ const displayName = 'StakingWidgetFlow';
 export interface Props {
   colony: Colony;
   motionId: number;
+  isDecision: boolean;
   scrollToRef?: RefObject<HTMLInputElement>;
 }
 
@@ -34,7 +35,12 @@ const MSG = defineMessages({
   },
 });
 
-const StakingWidgetFlow = ({ colony, motionId, scrollToRef }: Props) => {
+const StakingWidgetFlow = ({
+  colony,
+  motionId,
+  isDecision,
+  scrollToRef,
+}: Props) => {
   const [isSummary, setIsSummary] = useState(false);
   const [isObjection, setIsObjection] = useState(false);
 
@@ -135,6 +141,7 @@ const StakingWidgetFlow = ({ colony, motionId, scrollToRef }: Props) => {
           motionId={motionId}
           colony={colony}
           handleWidgetState={setIsSummary}
+          isDecision={isDecision}
         />
       )}
     </div>

--- a/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialog.tsx
@@ -1,4 +1,11 @@
 import React, { useCallback, RefObject } from 'react';
+import { useEditor } from '@tiptap/react';
+import CharacterCount from '@tiptap/extension-character-count';
+import Color from '@tiptap/extension-color';
+import Placeholder from '@tiptap/extension-placeholder';
+import TextStyle from '@tiptap/extension-text-style';
+import Underline from '@tiptap/extension-underline';
+import StarterKit from '@tiptap/starter-kit';
 import { FormikProps } from 'formik';
 import * as yup from 'yup';
 import { bigNumberify } from 'ethers/utils';
@@ -27,6 +34,8 @@ interface Props extends FormProps {
 
 const displayName = 'dashboard.RaiseObjectionDialog';
 
+const characterLimit = 4000;
+
 const RaiseObjectionDialog = ({
   cancel,
   close,
@@ -37,6 +46,20 @@ const RaiseObjectionDialog = ({
   scrollToRef,
   ...props
 }: Props) => {
+  const editor = useEditor({
+    extensions: [
+      StarterKit,
+      Underline,
+      TextStyle,
+      Color,
+      CharacterCount.configure({ limit: characterLimit }),
+      Placeholder.configure({
+        emptyEditorClass: 'is-editor-empty',
+        placeholder: 'Enter the description...',
+      }),
+    ],
+  });
+
   const { walletAddress } = useLoggedInUser();
 
   const validationSchema = yup.object().shape({
@@ -101,6 +124,7 @@ const RaiseObjectionDialog = ({
             minUserStake={minUserStake}
             cancel={cancel}
             {...props}
+            editor={editor}
           />
         </Dialog>
       )}

--- a/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialog.tsx
@@ -1,11 +1,4 @@
 import React, { useCallback, RefObject } from 'react';
-import { useEditor } from '@tiptap/react';
-import CharacterCount from '@tiptap/extension-character-count';
-import Color from '@tiptap/extension-color';
-import Placeholder from '@tiptap/extension-placeholder';
-import TextStyle from '@tiptap/extension-text-style';
-import Underline from '@tiptap/extension-underline';
-import StarterKit from '@tiptap/starter-kit';
 import { FormikProps } from 'formik';
 import * as yup from 'yup';
 import { bigNumberify } from 'ethers/utils';
@@ -34,8 +27,6 @@ interface Props extends FormProps {
 
 const displayName = 'dashboard.RaiseObjectionDialog';
 
-const characterLimit = 4000;
-
 const RaiseObjectionDialog = ({
   cancel,
   close,
@@ -46,20 +37,6 @@ const RaiseObjectionDialog = ({
   scrollToRef,
   ...props
 }: Props) => {
-  const editor = useEditor({
-    extensions: [
-      StarterKit,
-      Underline,
-      TextStyle,
-      Color,
-      CharacterCount.configure({ limit: characterLimit }),
-      Placeholder.configure({
-        emptyEditorClass: 'is-editor-empty',
-        placeholder: 'Enter the description...',
-      }),
-    ],
-  });
-
   const { walletAddress } = useLoggedInUser();
 
   const validationSchema = yup.object().shape({
@@ -124,7 +101,6 @@ const RaiseObjectionDialog = ({
             minUserStake={minUserStake}
             cancel={cancel}
             {...props}
-            editor={editor}
           />
         </Dialog>
       )}

--- a/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialog.tsx
@@ -3,22 +3,33 @@ import { FormikProps } from 'formik';
 import * as yup from 'yup';
 import { bigNumberify } from 'ethers/utils';
 import { Decimal } from 'decimal.js';
+import { useEditor } from '@tiptap/react';
+import CharacterCount from '@tiptap/extension-character-count';
+import Color from '@tiptap/extension-color';
+import Placeholder from '@tiptap/extension-placeholder';
+import TextStyle from '@tiptap/extension-text-style';
+import Underline from '@tiptap/extension-underline';
+import StarterKit from '@tiptap/starter-kit';
 
 import Dialog from '~core/Dialog';
 import { ActionForm } from '~core/Fields';
+import { StakingAmounts } from '~dashboard/ActionsPage/StakingWidget';
 
-import { useLoggedInUser } from '~data/index';
+import { useLoggedInUser, Colony } from '~data/index';
 import { ActionTypes } from '~redux/index';
 import { pipe, mapPayload } from '~utils/actions';
 
-import DialogForm, { Props as FormProps } from './RaiseObjectionDialogForm';
+import DialogForm from './RaiseObjectionDialogForm';
 
 export interface FormValues {
   amount: number;
   annotation: string;
 }
 
-interface Props extends FormProps {
+interface Props extends StakingAmounts {
+  colony: Colony;
+  canUserStake: boolean;
+  userActivatedTokens: Decimal;
   cancel: () => void;
   close: () => void;
   motionId: number;
@@ -26,6 +37,8 @@ interface Props extends FormProps {
 }
 
 const displayName = 'dashboard.RaiseObjectionDialog';
+
+const LIMIT = 4000;
 
 const RaiseObjectionDialog = ({
   cancel,
@@ -38,6 +51,20 @@ const RaiseObjectionDialog = ({
   ...props
 }: Props) => {
   const { walletAddress } = useLoggedInUser();
+
+  const editor = useEditor({
+    extensions: [
+      StarterKit,
+      Underline,
+      TextStyle,
+      Color,
+      CharacterCount.configure({ limit: LIMIT }),
+      Placeholder.configure({
+        emptyEditorClass: 'is-editor-empty',
+        placeholder: 'What would you like to say?',
+      }),
+    ],
+  });
 
   const validationSchema = yup.object().shape({
     amount: yup.number().required(),
@@ -99,6 +126,8 @@ const RaiseObjectionDialog = ({
             colony={colony}
             minUserStake={minUserStake}
             cancel={cancel}
+            editor={editor}
+            limit={LIMIT}
             {...props}
           />
         </Dialog>

--- a/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialog.tsx
@@ -41,7 +41,6 @@ const RaiseObjectionDialog = ({
 
   const validationSchema = yup.object().shape({
     amount: yup.number().required(),
-    annotation: yup.string().max(4000),
   });
 
   const transform = useCallback(

--- a/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialog.tsx
@@ -34,6 +34,7 @@ interface Props extends StakingAmounts {
   close: () => void;
   motionId: number;
   scrollToRef?: RefObject<HTMLInputElement>;
+  isDecision?: boolean;
 }
 
 const displayName = 'dashboard.RaiseObjectionDialog';

--- a/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialogForm.css
+++ b/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialogForm.css
@@ -9,9 +9,26 @@
   width: 160px;
 }
 
+.divider {
+  width: 100%;
+  border-top: 1px solid var(--grey-blue-0);
+}
+
 .slider {
   display: flex;
   flex-direction: column;
-  margin: 10px auto 50px;
+  margin: 0px auto 27px;
   width: 341px;
+}
+
+.richTextEditor span[class*='characterCount'] {
+  top: 152px;
+}
+
+.richTextEditor div[class*='ProseMirror'] {
+  height: 100px;
+}
+
+.descriptionText {
+  padding-bottom: 20px;
 }

--- a/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialogForm.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialogForm.css.d.ts
@@ -1,3 +1,6 @@
 export const title: string;
 export const submitButton: string;
+export const divider: string;
 export const slider: string;
+export const richTextEditor: string;
+export const descriptionText: string;

--- a/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialogForm.tsx
@@ -7,7 +7,7 @@ import Decimal from 'decimal.js';
 import Button from '~core/Button';
 import DialogSection from '~core/Dialog/DialogSection';
 import ExternalLink from '~core/ExternalLink';
-import { InputLabel } from '~core/Fields';
+import { InputLabel, Annotations } from '~core/Fields';
 import RichTextEditor from '~core/RichTextEditor/RichTextEditor';
 import Heading from '~core/Heading';
 import {
@@ -35,7 +35,7 @@ const MSG = defineMessages({
   },
   annotation: {
     id: 'dashboard.RaiseObjectionDialog.RaiseObjectionDialogForm.annotation',
-    defaultMessage: 'Explain why you’re making this objection (optional)',
+    defaultMessage: `Explain why you’re making this objection (optional)`,
   },
   stakeButton: {
     id: 'dashboard.RaiseObjectionDialog.RaiseObjectionDialogForm.stakeButton',
@@ -50,6 +50,7 @@ export interface Props extends StakingAmounts {
   editor: Editor | null;
   limit: number;
   cancel: () => void;
+  isDecision?: boolean;
 }
 
 const RaiseObjectionDialogForm = ({
@@ -64,6 +65,7 @@ const RaiseObjectionDialogForm = ({
   userActivatedTokens,
   remainingToFullyNayStaked,
   minUserStake,
+  isDecision = false,
   ...props
 }: Props & FormikProps<FormValues>) => {
   const decimalAmount = new Decimal(values.amount)
@@ -106,16 +108,25 @@ const RaiseObjectionDialogForm = ({
       </DialogSection>
       <DialogSection appearance={{ border: 'top' }}>
         <DialogSection>
-          <InputLabel
-            label={MSG.annotation}
-            appearance={{ colorSchema: 'grey' }}
-          />
-          {editor && (
-            <RichTextEditor
-              editor={editor}
+          {isDecision && editor ? (
+            <>
+              <InputLabel
+                label={MSG.annotation}
+                appearance={{ colorSchema: 'grey' }}
+              />
+              <RichTextEditor
+                editor={editor}
+                name="annotation"
+                isSubmitting={isSubmitting}
+                limit={limit}
+                disabled={!canUserStake || isSubmitting}
+              />
+            </>
+          ) : (
+            <Annotations
+              label={MSG.annotation}
               name="annotation"
-              isSubmitting={isSubmitting}
-              limit={limit}
+              maxLength={4000}
               disabled={!canUserStake || isSubmitting}
             />
           )}

--- a/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialogForm.tsx
@@ -113,6 +113,7 @@ const RaiseObjectionDialogForm = ({
           {editor && (
             <RichTextEditor
               editor={editor}
+              name="annotation"
               isSubmitting={isSubmitting}
               limit={limit}
               disabled={!canUserStake || isSubmitting}

--- a/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialogForm.tsx
@@ -82,16 +82,18 @@ const RaiseObjectionDialogForm = ({
         />
       </DialogSection>
       <DialogSection appearance={{ theme: 'sidePadding' }}>
-        <FormattedMessage
-          {...MSG.objectionDescription}
-          values={{
-            a: (chunks) => (
-              <ExternalLink href={MD_OBJECTIONS_HELP}>{chunks}</ExternalLink>
-            ),
-          }}
-        />
+        <div className={styles.descriptionText}>
+          <FormattedMessage
+            {...MSG.objectionDescription}
+            values={{
+              a: (chunks) => (
+                <ExternalLink href={MD_OBJECTIONS_HELP}>{chunks}</ExternalLink>
+              ),
+            }}
+          />
+        </div>
       </DialogSection>
-      <DialogSection appearance={{ theme: 'sidePadding' }}>
+      <DialogSection appearance={{ theme: 'sidePadding', border: 'top' }}>
         <div className={styles.slider}>
           <StakingSlider
             colony={colony}
@@ -107,30 +109,29 @@ const RaiseObjectionDialogForm = ({
         </div>
       </DialogSection>
       <DialogSection appearance={{ border: 'top' }}>
-        <DialogSection>
-          {isDecision && editor ? (
-            <>
-              <InputLabel
-                label={MSG.annotation}
-                appearance={{ colorSchema: 'grey' }}
-              />
-              <RichTextEditor
-                editor={editor}
-                name="annotation"
-                isSubmitting={isSubmitting}
-                limit={limit}
-                disabled={!canUserStake || isSubmitting}
-              />
-            </>
-          ) : (
-            <Annotations
+        {isDecision && editor ? (
+          <>
+            <InputLabel
               label={MSG.annotation}
-              name="annotation"
-              maxLength={4000}
-              disabled={!canUserStake || isSubmitting}
+              appearance={{ colorSchema: 'grey' }}
             />
-          )}
-        </DialogSection>
+            <RichTextEditor
+              editor={editor}
+              name="annotation"
+              isSubmitting={isSubmitting}
+              limit={limit}
+              disabled={!canUserStake || isSubmitting}
+              className={styles.richTextEditor}
+            />
+          </>
+        ) : (
+          <Annotations
+            label={MSG.annotation}
+            name="annotation"
+            maxLength={4000}
+            disabled={!canUserStake || isSubmitting}
+          />
+        )}
       </DialogSection>
       <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
         <Button

--- a/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialogForm.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { FormattedMessage, defineMessages } from 'react-intl';
+import { Editor } from '@tiptap/react';
 import { FormikProps } from 'formik';
 import Decimal from 'decimal.js';
 
 import Button from '~core/Button';
 import DialogSection from '~core/Dialog/DialogSection';
 import ExternalLink from '~core/ExternalLink';
-import { Annotations } from '~core/Fields';
+import { InputLabel } from '~core/Fields';
+import RichTextEditor from '~core/RichTextEditor/RichTextEditor';
 import Heading from '~core/Heading';
 import {
   StakingSlider,
@@ -45,6 +47,8 @@ export interface Props extends StakingAmounts {
   colony: Colony;
   canUserStake: boolean;
   userActivatedTokens: Decimal;
+  editor: Editor | null;
+  limit: number;
   cancel: () => void;
 }
 
@@ -54,6 +58,8 @@ const RaiseObjectionDialogForm = ({
   isSubmitting,
   canUserStake,
   values,
+  editor,
+  limit,
   cancel,
   userActivatedTokens,
   remainingToFullyNayStaked,
@@ -99,12 +105,19 @@ const RaiseObjectionDialogForm = ({
         </div>
       </DialogSection>
       <DialogSection appearance={{ border: 'top' }}>
-        <Annotations
-          label={MSG.annotation}
-          name="annotation"
-          maxLength={4000}
-          disabled={!canUserStake || isSubmitting}
-        />
+        <DialogSection>
+          <InputLabel
+            label={MSG.annotation}
+            appearance={{ colorSchema: 'grey' }}
+          />
+          {editor && (
+            <RichTextEditor
+              editor={editor}
+              isSubmitting={isSubmitting}
+              limit={limit}
+            />
+          )}
+        </DialogSection>
       </DialogSection>
       <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
         <Button

--- a/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/RaiseObjectionDialog/RaiseObjectionDialogForm.tsx
@@ -115,6 +115,7 @@ const RaiseObjectionDialogForm = ({
               editor={editor}
               isSubmitting={isSubmitting}
               limit={limit}
+              disabled={!canUserStake || isSubmitting}
             />
           )}
         </DialogSection>


### PR DESCRIPTION
## Description

This PR tracks the work done for the creation of the decisions objection modal. 

In a conversation with Arren, it was decided we were going to add the `RichTextEditor` to the `RaiseObjectionDialogForm` component we have already in the dapp and keep the current design we have, in addition to the `QuestionMarkTooltip`.

**Before** 
<img width="488" alt="Screen Shot 2022-08-22 at 9 37 35 PM" src="https://user-images.githubusercontent.com/71563622/186280901-0c34653a-0c14-4090-88ee-0b272e0e70bd.png">

**After** 
<img width="490" alt="Screen Shot 2022-09-07 at 11 41 31 PM" src="https://user-images.githubusercontent.com/71563622/188987893-133c8c69-4cca-438f-b482-9d13080b6076.png">
**New stuff** ✨

- `RichTextEditor`
- `QuestionMarkTooltip`

**Changes** 🏗

* Added html parser to `comment`
* Passed name prop into `RichTextEditor`

<img width="1175" alt="Screen Shot 2022-09-07 at 11 42 25 PM" src="https://user-images.githubusercontent.com/71563622/188988028-c59d024c-e7c3-4e2b-83e6-88fd21fc76bf.png">

(Resolves | Contributes to) #3741