### PR TITLE
Fix not being able to remove safes with equal addresses

### DIFF
--- a/src/modules/core/components/Fields/Checkbox/Checkbox.tsx
+++ b/src/modules/core/components/Fields/Checkbox/Checkbox.tsx
@@ -8,6 +8,7 @@ import React, {
 } from 'react';
 import { MessageDescriptor } from 'react-intl';
 import { nanoid } from 'nanoid';
+import findIndex from 'lodash/findIndex';
 
 import { PopperOptions } from 'react-popper-tooltip';
 
@@ -93,9 +94,9 @@ const Checkbox = ({
 
   const handleOnChange = useCallback(
     (e: SyntheticEvent<HTMLInputElement>) => {
-      const idx = values[name].indexOf(value);
+      const idx = findIndex(values[name], value);
       if (idx >= 0) {
-        remove(idx);
+        remove(idx.toString());
       } else {
         push(value);
       }
@@ -106,7 +107,7 @@ const Checkbox = ({
     [name, onChange, push, remove, value, values],
   );
 
-  const isChecked = values[name].indexOf(value) >= 0;
+  const isChecked = findIndex(values[name], value) >= 0;
   const mainClasses = getMainClasses(appearance, styles, {
     isChecked,
     disabled,

--- a/src/modules/dashboard/components/ColonyHome/ColonySafes/ColonySafes.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonySafes/ColonySafes.tsx
@@ -32,7 +32,10 @@ const ColonySafes = ({ colony: { safes } }: Props) => {
       </Heading>
       <ul>
         {safes.map((safe) => (
-          <li key={safe.contractAddress} className={styles.safeItem}>
+          <li
+            key={`${safe.chainId}-${safe.contractAddress}`}
+            className={styles.safeItem}
+          >
             {safe.safeName}
           </li>
         ))}

--- a/src/modules/dashboard/components/Dialogs/AddExistingSafeDialog/AddExistingSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/AddExistingSafeDialog/AddExistingSafeDialog.tsx
@@ -61,7 +61,7 @@ const AddExistingSafeDialog = ({
           return {
             colonyName,
             colonyAddress,
-            safeAddresses: [
+            safeList: [
               {
                 chainId,
                 safeName,

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialog.tsx
@@ -4,18 +4,18 @@ import { useHistory } from 'react-router';
 
 import Dialog, { DialogProps, ActionDialogProps } from '~core/Dialog';
 import { ActionForm } from '~core/Fields';
-import { Address } from '~types/index';
 
 import { ActionTypes } from '~redux/index';
 import { WizardDialogType } from '~utils/hooks';
 import { pipe, withMeta, mapPayload } from '~utils/actions';
+import { ColonySafe } from '~data/generated';
 
 import DialogForm from './RemoveSafeDialogForm';
 
 const displayName = 'dashboard.RemoveSafeDialog';
 
 export interface FormValues {
-  safeList: Address[];
+  safeList: ColonySafe[];
 }
 
 type Props = DialogProps &
@@ -38,7 +38,7 @@ const RemoveSafeDialog = ({
         return {
           colonyName: colony.colonyName,
           colonyAddress: colony.colonyAddress,
-          safeAddresses: safeList,
+          safeList,
           annotationMessage,
           isRemovingSafes: true,
         };
@@ -52,7 +52,7 @@ const RemoveSafeDialog = ({
     <ActionForm
       initialValues={{
         // if there's only 1 safe then that safe is already checked.
-        safeList: safes.length === 1 ? [safes[0].contractAddress] : [],
+        safeList: safes.length === 1 ? [safes[0]] : [],
       }}
       submit={ActionTypes.ACTION_MANAGE_EXISTING_SAFES}
       error={ActionTypes.ACTION_MANAGE_EXISTING_SAFES_ERROR}

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialogForm.tsx
@@ -24,7 +24,7 @@ const MSG = defineMessages({
   },
   desc: {
     id: 'dashboard.RemoveSafeDialog.RemoveSafeDialogForm.desc',
-    defaultMessage: 'Select Safe you wish to remove',
+    defaultMessage: 'Select the Safe(s) you wish to remove',
   },
   emptySafeMsg: {
     id: 'dashboard.RemoveSafeDialog.RemoveSafeDialogForm.emptySafeMsg',
@@ -76,9 +76,15 @@ const RemoveSafeDialogForm = ({
             <div className={styles.content}>
               {safeList.map((item) => (
                 <SafeListItem
-                  key={item.contractAddress}
+                  key={`${item.chainId}-${item.contractAddress}`}
                   safe={item}
-                  isChecked={values?.safeList?.includes(item.contractAddress)}
+                  isChecked={
+                    !!values?.safeList?.find(
+                      (safe) =>
+                        item.contractAddress === safe.contractAddress &&
+                        item.chainId === safe.chainId,
+                    )
+                  }
                 />
               ))}
             </div>

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/SafeListItem.tsx
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/SafeListItem.tsx
@@ -39,7 +39,7 @@ const SafeListItem = ({ safe, isChecked }: Props) => {
       <Checkbox
         name="safeList"
         appearance={{ theme: 'pink' }}
-        value={safe.contractAddress}
+        value={safe}
         className={styles.checkbox}
       />
       <Avatar

--- a/src/modules/dashboard/sagas/actions/manageExistingSafes.ts
+++ b/src/modules/dashboard/sagas/actions/manageExistingSafes.ts
@@ -32,7 +32,7 @@ function* manageExistingSafesAction({
   payload: {
     colonyName,
     colonyAddress,
-    safeAddresses,
+    safeList,
     annotationMessage,
     isRemovingSafes,
   },
@@ -44,7 +44,7 @@ function* manageExistingSafesAction({
     const apolloClient = TEMP_getContext(ContextModule.ApolloClient);
     const ipfsWithFallback = TEMP_getContext(ContextModule.IPFSWithFallback);
 
-    if (isEmpty(safeAddresses)) {
+    if (isEmpty(safeList)) {
       throw new Error('A list with safe addresses is required to manage safes');
     }
 
@@ -134,14 +134,16 @@ function* manageExistingSafesAction({
       updatedColonyMetadata = {
         ...colonyMetadata,
         colonySafes: colonyMetadata.colonySafes
-          ? [...colonyMetadata.colonySafes, ...safeAddresses]
-          : safeAddresses,
+          ? [...colonyMetadata.colonySafes, ...safeList]
+          : safeList,
       };
     } else {
       const updatedColonySafes = colonyMetadata.colonySafes.filter(
         (safe: ColonySafe) =>
-          !safeAddresses.some(
-            (safeAddress) => safeAddress === safe.contractAddress,
+          !safeList.some(
+            (removedSafe) =>
+              removedSafe.contractAddress === safe.contractAddress &&
+              removedSafe.chainId === safe.chainId,
           ),
       );
       updatedColonyMetadata = {

--- a/src/redux/types/actions/colonyActions.ts
+++ b/src/redux/types/actions/colonyActions.ts
@@ -255,7 +255,7 @@ export type ColonyActionsActionTypes =
       {
         colonyName: string;
         colonyAddress: Address;
-        safeAddresses: ColonySafe[] | Address[];
+        safeList: ColonySafe[];
         annotationMessage?: string;
         isRemovingSafes?: boolean;
       },


### PR DESCRIPTION
Fixed remove safes dialog treating safes with the same address but of a different chain as 1 option (Visually and logically).

![FireShot Capture 698 - Actions - Colony - wonker - localhost](https://user-images.githubusercontent.com/18473896/186333640-ae53729e-e0e7-4690-81cd-890120301c81.png)

Resolves #3752 
