### PR TITLE
Add NFT preview

### DIFF
--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeDialog.tsx
@@ -288,7 +288,6 @@ const ControlSafeDialog = ({
               displayName: yup.string().required(() => MSG.requiredFieldError),
               walletAddress: yup
                 .string()
-                .address()
                 .required(() => MSG.requiredFieldError),
             }),
           }),

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
@@ -104,7 +104,7 @@ export interface NFT {
 }
 
 // Test data for dev - should be obtained from the safe
-const testNFTData: NFT[] = [
+export const testNFTData: NFT[] = [
   {
     name: 'BoredApeYachtClub',
     avatar: 'bla',

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.css
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.css
@@ -98,3 +98,10 @@
   text-align: right;
   overflow-wrap: anywhere;
 }
+
+.nftContainer {
+  display: flex;
+  align-items: center;
+  color: var(--pink);
+  column-gap: 11px;
+}

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.css.d.ts
@@ -11,3 +11,4 @@ export const transactionTitle: string;
 export const tokenAmount: string;
 export const transactionDetailsSection: string;
 export const rawTransactionValues: string;
+export const nftContainer: string;

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.tsx
@@ -10,7 +10,7 @@ import Numeral from '~core/Numeral';
 import TokenIcon from '~dashboard/HookedTokenIcon';
 import Button from '~core/Button';
 import Icon from '~core/Icon';
-
+import Avatar from '~core/Avatar';
 import { Colony, AnyUser } from '~data/index';
 
 import AddressDetailsView from './TransactionPreview/AddressDetailsView';
@@ -23,6 +23,8 @@ import {
 import DetailsItem from './DetailsItem';
 
 import styles from './SafeTransactionPreview.css';
+import { testNFTData } from './ControlSafeForm';
+import { getFilteredNFTData } from './utils';
 
 const MSG = defineMessages({
   previewTitle: {
@@ -65,6 +67,22 @@ const MSG = defineMessages({
     id: 'dashboard.ControlSafeDialog.SafeTransactionPreview.nft',
     defaultMessage: 'NFT',
   },
+  transactionType: {
+    id: `dashboard.ControlSafeDialog.SafeTransactionPreview.transactionType`,
+    defaultMessage: 'Transaction type',
+  },
+  nftHeldByTheSafe: {
+    id: `dashboard.ControlSafeDialog.SafeTransactionPreview.nftHeldByTheSafe`,
+    defaultMessage: 'NFT held by the safe',
+  },
+  targetContract: {
+    id: `dashboard.ControlSafeDialog.SafeTransactionPreview.targetContract`,
+    defaultMessage: 'Target contract',
+  },
+  nftId: {
+    id: 'dashboard.ControlSafeDialog.SafeTransactionPreview.nftId',
+    defaultMessage: 'Id',
+  },
   data: {
     id: 'dashboard.ControlSafeDialog.SafeTransactionPreview.data',
     defaultMessage: 'Data',
@@ -102,11 +120,56 @@ const transactionTypeFieldsMap = {
     },
   ],
   [TransactionTypes.TRANSFER_NFT]: [
-    // To be finished once NFT part of the form is merged
     {
-      key: 'function',
-      label: MSG.function,
+      key: 'transactionType',
+      label: MSG.transactionType,
       value: () => <FormattedMessage {...ConstantsMSG.transferNft} />,
+    },
+    {
+      key: 'nft',
+      label: MSG.nftHeldByTheSafe,
+      value: (nft) => (
+        <div className={styles.nftContainer}>
+          <Avatar
+            avatarURL={undefined}
+            placeholderIcon="circle-close"
+            seed={nft.id.toLocaleLowerCase()}
+            title=""
+            size="xs"
+          />
+          <div>{nft.profile.displayName}</div>
+        </div>
+      ),
+    },
+    {
+      key: 'nft',
+      label: MSG.targetContract,
+      value: (nft) => (
+        <div className={styles.nftContainer}>
+          <Avatar
+            avatarURL={undefined}
+            placeholderIcon="circle-close"
+            seed={nft.id.toLocaleLowerCase()}
+            title=""
+            size="xs"
+          />
+          <div>{getFilteredNFTData(testNFTData, nft.id)?.name}</div>
+        </div>
+      ),
+    },
+    {
+      key: 'nft',
+      label: MSG.nftId,
+      value: (nft) => (
+        <div>{getFilteredNFTData(testNFTData, nft.id)?.tokenID}</div>
+      ),
+    },
+    {
+      key: 'recipient',
+      label: MSG.to,
+      value: (recipient) => (
+        <AddressDetailsView item={recipient} isSafeItem={false} />
+      ),
     },
   ],
   [TransactionTypes.CONTRACT_INTERACTION]: [
@@ -170,6 +233,10 @@ const SafeTransactionPreview = ({ colony, values }: Props) => {
     () => [...new Array(values.transactions.length)].map(nanoid),
     [values.transactions.length],
   );
+
+  const isNFT = (index) =>
+    values.transactions[index].transactionType ===
+    TransactionTypes.TRANSFER_NFT;
 
   return (
     <>
@@ -242,36 +309,39 @@ const SafeTransactionPreview = ({ colony, values }: Props) => {
                       />
                     </div>
                   )}
-                <DetailsItem
-                  label={MSG.safe}
-                  value={
-                    <AddressDetailsView
-                      item={(values.safe as never) as AnyUser}
-                      isSafeItem
-                    />
-                  }
-                />
-                {values.transactions[index].transactionType !==
-                  TransactionTypes.CONTRACT_INTERACTION && (
+                {!isNFT(index) && (
                   <DetailsItem
-                    label={MSG.to}
+                    label={MSG.safe}
                     value={
                       <AddressDetailsView
-                        item={
-                          (values.transactions[index]
-                            .recipient as never) as AnyUser
-                        }
-                        isSafeItem={false}
+                        item={(values.safe as never) as AnyUser}
+                        isSafeItem
                       />
                     }
                   />
                 )}
+                {values.transactions[index].transactionType !==
+                  TransactionTypes.CONTRACT_INTERACTION &&
+                  !isNFT(index) && (
+                    <DetailsItem
+                      label={MSG.to}
+                      value={
+                        <AddressDetailsView
+                          item={
+                            (values.transactions[index]
+                              .recipient as never) as AnyUser
+                          }
+                          isSafeItem={false}
+                        />
+                      }
+                    />
+                  )}
                 {values.transactions[index].transactionType !== '' &&
                   transactionTypeFieldsMap[
                     values.transactions[index].transactionType
                   ].map(({ key, label, value }) => (
                     <DetailsItem
-                      key={key}
+                      key={nanoid()}
                       label={label}
                       value={value(
                         values.transactions[index][key],

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransferNFTSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransferNFTSection.tsx
@@ -12,6 +12,7 @@ import { useMembersSubscription } from '~data/index';
 
 import { Address } from '~types/index';
 import { NFT } from '~dashboard/Dialogs/ControlSafeDialog';
+import { getFilteredNFTData } from '../utils';
 
 import styles from './TransferNFTSection.css';
 
@@ -79,11 +80,11 @@ const TransferNFTSection = ({
 
   const filteredNFTData = useMemo(
     () =>
-      nftCatalogue.find(
-        (item) =>
-          item?.address === values?.transactions[transactionFormIndex]?.nft?.id,
+      getFilteredNFTData(
+        nftCatalogue,
+        values?.transactions[transactionFormIndex]?.nft?.id,
       ),
-    [nftCatalogue, transactionFormIndex, values],
+    [nftCatalogue, values, transactionFormIndex],
   );
 
   return (

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/utils/index.ts
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/utils/index.ts
@@ -1,0 +1,5 @@
+import { Address } from '~types/index';
+import { NFT } from '../ControlSafeForm';
+
+export const getFilteredNFTData = (nftCatalogue: NFT[], address: Address) =>
+  nftCatalogue.find((item) => item?.address === address);


### PR DESCRIPTION
## Description

This PR adds the NFT preview screen to Gnosis Control Safe form. 

[Design](https://www.figma.com/file/LlVmeMQxHVA04evfrgZyuN/Safe-Control?node-id=115%3A7477)

To test:

* Go to Gnosis Safe Control
* Click Transfer NFT and create transaction
* Preview should look like the design. 
* Test with multiple transactions.

**Changes** 🏗

* Adding NFT Transfer preview

## Screenshots

![gs-nft-prev](https://user-images.githubusercontent.com/64402732/186645903-560881cf-e18c-4b08-9576-f9f004d1b53a.png)

![gs-nft-prev-multiple](https://user-images.githubusercontent.com/64402732/186645898-64ca51d8-b13d-4bf0-a998-8a3a656d4228.png)

Resolves #3729

## Note

I have a created a separate issue for the "Approve NFT" transaction type & preview.  https://github.com/JoinColony/colonyDapp/issues/3844
