### PR TITLE
Add Raw Transaction validation

### DIFF
--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/TransactionTypesSection/RawTransactionSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/TransactionTypesSection/RawTransactionSection.tsx
@@ -7,7 +7,6 @@ import { Input } from '~core/Fields';
 import UserAvatar from '~core/UserAvatar';
 import SingleUserPicker, { filterUserSelection } from '~core/SingleUserPicker';
 import { DialogSection } from '~core/Dialog';
-import { getTokenDecimalsWithFallback } from '~utils/tokens';
 
 import styles from './TransactionTypesSection.css';
 
@@ -43,16 +42,13 @@ const renderAvatar = (address: Address, item: AnyUser) => (
 );
 
 const RawTransactionSection = ({
-  colony: { colonyAddress, nativeTokenAddress, tokens },
+  colony: { colonyAddress },
   disabledInput,
   transactionFormIndex,
 }: Props) => {
   const { data: colonyMembers } = useMembersSubscription({
     variables: { colonyAddress },
   });
-  const nativeToken = tokens.find(
-    ({ address }) => address === nativeTokenAddress,
-  );
 
   return (
     <>
@@ -83,9 +79,7 @@ const RawTransactionSection = ({
           formattingOptions={{
             numeral: true,
             numeralPositiveOnly: true,
-            numeralDecimalScale: getTokenDecimalsWithFallback(
-              nativeToken?.decimals,
-            ),
+            numeralDecimalScale: 0,
           }}
         />
       </DialogSection>


### PR DESCRIPTION
## Description

When connecting up the raw transaction form to the saga, I noticed a number of problems with validation that meant that the interaction with the Gnosis Safe SDK would fail. 

These were:

-- That you could enter an invalid address for the recipient
-- That you could enter a decimal for the value
-- That you could enter a non-hex string for the byte data

This PR addresses these. 

**New stuff** ✨

* Add form validation as detailed above

Resolves #3777 