### PR TITLE
Connect safe picker on Control Safe dialog with colony's safes

### DIFF
--- a/src/modules/core/components/SingleUserPicker/SingleSafePicker.tsx
+++ b/src/modules/core/components/SingleUserPicker/SingleSafePicker.tsx
@@ -1,12 +1,13 @@
 import React, { ComponentProps, useMemo } from 'react';
 
-import { GnosisSafe } from '~dashboard/Dialogs/GnosisControlSafeDialog';
+import { GNOSIS_SAFE_NETWORKS } from '~constants';
+import { ColonySafe } from '~data/index';
 
 import SingleUserPicker from './SingleUserPicker';
 
 /* SingleSafePicker is a wrapper around SingleUserPicker component */
 interface Props extends ComponentProps<typeof SingleUserPicker> {
-  data: GnosisSafe[];
+  data: ColonySafe[];
 }
 
 const displayName = 'SingleUserPicker.SingleSafePicker';
@@ -14,13 +15,18 @@ const displayName = 'SingleUserPicker.SingleSafePicker';
 const SingleSafePicker = ({ data, ...props }: Props) => {
   const formattedData = useMemo(
     () =>
-      data.map((item) => ({
-        id: item.address,
-        profile: {
-          displayName: `${item.name} (${item.chain})`,
-          walletAddress: item.address,
-        },
-      })),
+      data.map((item) => {
+        const safeNetwork = GNOSIS_SAFE_NETWORKS.find(
+          (network) => network.chainId === Number(item.chainId),
+        );
+        return {
+          id: item.contractAddress,
+          profile: {
+            displayName: `${item.safeName} (${safeNetwork?.name})`,
+            walletAddress: item.contractAddress,
+          },
+        };
+      }),
     [data],
   );
 

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeDialog.tsx
@@ -26,20 +26,6 @@ const MSG = defineMessages({
   },
 });
 
-/* to remove when data is wired in */
-const safes = [
-  {
-    name: 'All Saints',
-    address: '0x3a157280ca91bB49dAe3D1619C55Da7F9D4438c2',
-    chain: 'Gnosis Chain',
-  },
-  {
-    name: '',
-    address: '0x3a157280ca91bB49dAe3D1619C55Da7F9D4438c3',
-    chain: 'Mainnet',
-  },
-];
-
 export interface FormValues {
   transactions: {
     transactionType: string;
@@ -164,6 +150,7 @@ const GnosisControlSafeDialog = ({
   isVotingExtensionEnabled,
 }: Props) => {
   const [showPreview, setShowPreview] = useState(false);
+  const { safes } = colony;
 
   return (
     <ActionForm

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
@@ -20,7 +20,7 @@ import { userHasRole } from '~modules/users/checks';
 import { useTransformer } from '~utils/hooks';
 import { useDialogActionPermissions } from '~utils/hooks/useDialogActionPermissions';
 import { GNOSIS_SAFE_INTEGRATION_LEARN_MORE } from '~externalUrls';
-import { Colony, useLoggedInUser } from '~data/index';
+import { Colony, ColonySafe, useLoggedInUser } from '~data/index';
 import { Address, PrimitiveType } from '~types/index';
 
 import SafeTransactionPreview from './SafeTransactionPreview';
@@ -93,12 +93,6 @@ const MSG = defineMessages({
 
 const displayName = 'dashboard.GnosisControlSafeDialog.GnosisControlSafeForm';
 
-export interface GnosisSafe {
-  name: string;
-  address: Address;
-  chain: string;
-}
-
 // @TODO - figure out the mapping of the nftCatalogue to the safe
 export interface NFT {
   name: string;
@@ -128,7 +122,7 @@ const testNFTData: NFT[] = [
 
 interface Props {
   colony: Colony;
-  safes: GnosisSafe[];
+  safes: ColonySafe[];
   isVotingExtensionEnabled: boolean;
   back?: () => void;
   showPreview: boolean;

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/index.ts
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/index.ts
@@ -1,2 +1,2 @@
 export { default } from './GnosisControlSafeDialog';
-export { GnosisSafe, NFT } from './GnosisControlSafeForm';
+export { NFT } from './GnosisControlSafeForm';


### PR DESCRIPTION
As the title suggests, this PR connects the SingleSafePicker with safes linked to the colony.

![FireShot Capture 709 - Actions - Colony - wonker - localhost](https://user-images.githubusercontent.com/18473896/187589824-88ed1ae2-75a9-401e-83fc-08744eb7df7f.png)
