### PR TITLE
Add empty string as ipfs hash fallback where missing

### DIFF
--- a/src/modules/dashboard/sagas/actions/createDomain.ts
+++ b/src/modules/dashboard/sagas/actions/createDomain.ts
@@ -16,7 +16,6 @@ import {
   createTransactionChannels,
   getTxChannel,
 } from '../../../core/sagas';
-import { ipfsUpload } from '../../../core/sagas/ipfs';
 import {
   transactionReady,
   transactionPending,
@@ -99,14 +98,11 @@ function* createDomainAction({
      * Upload domain metadata to IPFS
      */
     let domainMetadataIpfsHash = null;
-    domainMetadataIpfsHash = yield call(
-      ipfsUpload,
-      JSON.stringify({
-        domainName,
-        domainColor,
-        domainPurpose,
-      }),
-    );
+    domainMetadataIpfsHash = yield call(uploadIfsWithFallback, {
+      domainName,
+      domainColor,
+      domainPurpose,
+    });
 
     yield put(
       transactionAddParams(createDomain.id, [

--- a/src/modules/dashboard/sagas/actions/createDomain.ts
+++ b/src/modules/dashboard/sagas/actions/createDomain.ts
@@ -126,10 +126,9 @@ function* createDomainAction({
       /*
        * Upload annotaiton to IPFS
        */
-      const annotationMessageIpfsHash = yield call(
-        uploadIfsWithFallback,
+      const annotationMessageIpfsHash = yield call(uploadIfsWithFallback, {
         annotationMessage,
-      );
+      });
 
       yield put(
         transactionAddParams(annotateCreateDomain.id, [

--- a/src/modules/dashboard/sagas/actions/createDomain.ts
+++ b/src/modules/dashboard/sagas/actions/createDomain.ts
@@ -129,7 +129,7 @@ function* createDomainAction({
       yield put(transactionPending(annotateCreateDomain.id));
 
       /*
-       * Upload domain metadata to IPFS
+       * Upload annotaiton to IPFS
        */
       const annotationMessageIpfsHash = yield call(
         uploadIfpsAnnotation,

--- a/src/modules/dashboard/sagas/actions/createDomain.ts
+++ b/src/modules/dashboard/sagas/actions/createDomain.ts
@@ -10,7 +10,7 @@ import {
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
 
-import { uploadIfpsAnnotation } from '../utils';
+import { uploadIfsWithFallback } from '../utils';
 import {
   createTransaction,
   createTransactionChannels,
@@ -132,7 +132,7 @@ function* createDomainAction({
        * Upload annotaiton to IPFS
        */
       const annotationMessageIpfsHash = yield call(
-        uploadIfpsAnnotation,
+        uploadIfsWithFallback,
         annotationMessage,
       );
 

--- a/src/modules/dashboard/sagas/actions/createDomain.ts
+++ b/src/modules/dashboard/sagas/actions/createDomain.ts
@@ -97,8 +97,7 @@ function* createDomainAction({
     /*
      * Upload domain metadata to IPFS
      */
-    let domainMetadataIpfsHash = null;
-    domainMetadataIpfsHash = yield call(uploadIfsWithFallback, {
+    const domainMetadataIpfsHash = yield call(uploadIfsWithFallback, {
       domainName,
       domainColor,
       domainPurpose,

--- a/src/modules/dashboard/sagas/actions/editColony.ts
+++ b/src/modules/dashboard/sagas/actions/editColony.ts
@@ -149,10 +149,9 @@ function* editColonyAction({
       /*
        * Upload annotation metadata to IPFS
        */
-      const annotationMessageIpfsHash = yield call(
-        uploadIfsWithFallback,
+      const annotationMessageIpfsHash = yield call(uploadIfsWithFallback, {
         annotationMessage,
-      );
+      });
 
       yield put(
         transactionAddParams(annotateEditColony.id, [

--- a/src/modules/dashboard/sagas/actions/editColony.ts
+++ b/src/modules/dashboard/sagas/actions/editColony.ts
@@ -21,7 +21,7 @@ import {
   transactionPending,
   transactionAddParams,
 } from '../../../core/actionCreators';
-import { updateColonyDisplayCache, uploadIfpsAnnotation } from '../utils';
+import { updateColonyDisplayCache, uploadIfsWithFallback } from '../utils';
 
 function* editColonyAction({
   payload: {
@@ -158,7 +158,7 @@ function* editColonyAction({
        * Upload annotation metadata to IPFS
        */
       const annotationMessageIpfsHash = yield call(
-        uploadIfpsAnnotation,
+        uploadIfsWithFallback,
         annotationMessage,
       );
 

--- a/src/modules/dashboard/sagas/actions/editColony.ts
+++ b/src/modules/dashboard/sagas/actions/editColony.ts
@@ -15,7 +15,6 @@ import {
   createTransactionChannels,
   getTxChannel,
 } from '../../../core/sagas';
-import { ipfsUpload } from '../../../core/sagas/ipfs';
 import {
   transactionReady,
   transactionPending,
@@ -110,30 +109,23 @@ function* editColonyAction({
      */
     let colonyAvatarIpfsHash = null;
     if (colonyAvatarImage && hasAvatarChanged) {
-      colonyAvatarIpfsHash = yield call(
-        ipfsUpload,
-        JSON.stringify({
-          image: colonyAvatarImage,
-        }),
-      );
+      colonyAvatarIpfsHash = yield call(uploadIfsWithFallback, {
+        image: colonyAvatarImage,
+      });
     }
 
     /*
      * Upload colony metadata to IPFS
      */
-    let colonyMetadataIpfsHash = null;
-    colonyMetadataIpfsHash = yield call(
-      ipfsUpload,
-      JSON.stringify({
-        colonyDisplayName,
-        colonyAvatarHash: hasAvatarChanged
-          ? colonyAvatarIpfsHash
-          : colonyAvatarHash,
-        colonyTokens,
-        verifiedAddresses,
-        isWhitelistActivated,
-      }),
-    );
+    const colonyMetadataIpfsHash = yield call(uploadIfsWithFallback, {
+      colonyDisplayName,
+      colonyAvatarHash: hasAvatarChanged
+        ? colonyAvatarIpfsHash
+        : colonyAvatarHash,
+      colonyTokens,
+      verifiedAddresses,
+      isWhitelistActivated,
+    });
 
     yield put(
       transactionAddParams(editColony.id, [

--- a/src/modules/dashboard/sagas/actions/editDomain.ts
+++ b/src/modules/dashboard/sagas/actions/editDomain.ts
@@ -10,7 +10,7 @@ import {
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
 
-import { uploadIfpsAnnotation } from '../utils';
+import { uploadIfsWithFallback } from '../utils';
 import {
   createTransaction,
   createTransactionChannels,
@@ -130,7 +130,7 @@ function* editDomainAction({
        * Upload annotationMessage to IPFS
        */
       const annotationMessageIpfsHash = yield call(
-        uploadIfpsAnnotation,
+        uploadIfsWithFallback,
         annotationMessage,
       );
 

--- a/src/modules/dashboard/sagas/actions/editDomain.ts
+++ b/src/modules/dashboard/sagas/actions/editDomain.ts
@@ -16,7 +16,6 @@ import {
   createTransactionChannels,
   getTxChannel,
 } from '../../../core/sagas';
-import { ipfsUpload } from '../../../core/sagas/ipfs';
 import {
   transactionReady,
   transactionPending,
@@ -96,15 +95,11 @@ function* editDomainAction({
     /*
      * Upload domain metadata to IPFS
      */
-    let domainMetadataIpfsHash = null;
-    domainMetadataIpfsHash = yield call(
-      ipfsUpload,
-      JSON.stringify({
-        domainName,
-        domainColor,
-        domainPurpose,
-      }),
-    );
+    const domainMetadataIpfsHash = yield call(uploadIfsWithFallback, {
+      domainName,
+      domainColor,
+      domainPurpose,
+    });
 
     yield put(
       transactionAddParams(editDomain.id, [

--- a/src/modules/dashboard/sagas/actions/editDomain.ts
+++ b/src/modules/dashboard/sagas/actions/editDomain.ts
@@ -124,10 +124,9 @@ function* editDomainAction({
       /*
        * Upload annotationMessage to IPFS
        */
-      const annotationMessageIpfsHash = yield call(
-        uploadIfsWithFallback,
+      const annotationMessageIpfsHash = yield call(uploadIfsWithFallback, {
         annotationMessage,
-      );
+      });
 
       yield put(
         transactionAddParams(annotateEditDomain.id, [

--- a/src/modules/dashboard/sagas/actions/enterRecovery.ts
+++ b/src/modules/dashboard/sagas/actions/enterRecovery.ts
@@ -106,7 +106,7 @@ function* enterRecoveryAction({
     if (annotationMessage) {
       yield put(transactionPending(annotateRecoveryAction.id));
 
-      const ipfsHash = yield call(uploadIfsWithFallback, annotationMessage);
+      const ipfsHash = yield call(uploadIfsWithFallback, { annotationMessage });
 
       yield put(
         transactionAddParams(annotateRecoveryAction.id, [txHash, ipfsHash]),

--- a/src/modules/dashboard/sagas/actions/enterRecovery.ts
+++ b/src/modules/dashboard/sagas/actions/enterRecovery.ts
@@ -25,7 +25,7 @@ import {
 } from '~data/index';
 import { ContextModule, TEMP_getContext } from '~context/index';
 
-import { uploadIfpsAnnotation } from '../utils';
+import { uploadIfsWithFallback } from '../utils';
 import {
   transactionReady,
   transactionPending,
@@ -106,7 +106,7 @@ function* enterRecoveryAction({
     if (annotationMessage) {
       yield put(transactionPending(annotateRecoveryAction.id));
 
-      const ipfsHash = yield call(uploadIfpsAnnotation, annotationMessage);
+      const ipfsHash = yield call(uploadIfsWithFallback, annotationMessage);
 
       yield put(
         transactionAddParams(annotateRecoveryAction.id, [txHash, ipfsHash]),

--- a/src/modules/dashboard/sagas/actions/managePermissions.ts
+++ b/src/modules/dashboard/sagas/actions/managePermissions.ts
@@ -125,10 +125,9 @@ function* managePermissionsAction({
     if (annotationMessage) {
       yield put(transactionPending(annotateSetUserRoles.id));
 
-      const annotationMessageIpfsHash = yield call(
-        uploadIfsWithFallback,
+      const annotationMessageIpfsHash = yield call(uploadIfsWithFallback, {
         annotationMessage,
-      );
+      });
 
       yield put(
         transactionAddParams(annotateSetUserRoles.id, [

--- a/src/modules/dashboard/sagas/actions/managePermissions.ts
+++ b/src/modules/dashboard/sagas/actions/managePermissions.ts
@@ -11,7 +11,7 @@ import {
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
 
-import { uploadIfpsAnnotation } from '../utils';
+import { uploadIfsWithFallback } from '../utils';
 import {
   createTransaction,
   createTransactionChannels,
@@ -126,7 +126,7 @@ function* managePermissionsAction({
       yield put(transactionPending(annotateSetUserRoles.id));
 
       const annotationMessageIpfsHash = yield call(
-        uploadIfpsAnnotation,
+        uploadIfsWithFallback,
         annotationMessage,
       );
 

--- a/src/modules/dashboard/sagas/actions/manageReputation.ts
+++ b/src/modules/dashboard/sagas/actions/manageReputation.ts
@@ -14,7 +14,7 @@ import {
   transactionPending,
   transactionAddParams,
 } from '../../../core/actionCreators';
-import { updateDomainReputation, uploadIfpsAnnotation } from '../utils';
+import { updateDomainReputation, uploadIfsWithFallback } from '../utils';
 
 function* manageReputationAction({
   payload: {
@@ -113,7 +113,7 @@ function* manageReputationAction({
        * Upload annotaiton to IPFS
        */
       const annotationMessageIpfsHash = yield call(
-        uploadIfpsAnnotation,
+        uploadIfsWithFallback,
         annotationMessage,
       );
 

--- a/src/modules/dashboard/sagas/actions/manageReputation.ts
+++ b/src/modules/dashboard/sagas/actions/manageReputation.ts
@@ -112,10 +112,9 @@ function* manageReputationAction({
       /*
        * Upload annotaiton to IPFS
        */
-      const annotationMessageIpfsHash = yield call(
-        uploadIfsWithFallback,
+      const annotationMessageIpfsHash = yield call(uploadIfsWithFallback, {
         annotationMessage,
-      );
+      });
 
       yield put(
         transactionAddParams(annotateManageReputation.id, [

--- a/src/modules/dashboard/sagas/actions/manageReputation.ts
+++ b/src/modules/dashboard/sagas/actions/manageReputation.ts
@@ -9,13 +9,12 @@ import {
   createTransactionChannels,
   getTxChannel,
 } from '../../../core/sagas';
-import { ipfsUpload } from '../../../core/sagas/ipfs';
 import {
   transactionReady,
   transactionPending,
   transactionAddParams,
 } from '../../../core/actionCreators';
-import { updateDomainReputation } from '../utils';
+import { updateDomainReputation, uploadIfpsAnnotation } from '../utils';
 
 function* manageReputationAction({
   payload: {
@@ -110,12 +109,12 @@ function* manageReputationAction({
     if (annotationMessage) {
       yield put(transactionPending(annotateManageReputation.id));
 
-      let annotationMessageIpfsHash = null;
-      annotationMessageIpfsHash = yield call(
-        ipfsUpload,
-        JSON.stringify({
-          annotationMessage,
-        }),
+      /*
+       * Upload annotaiton to IPFS
+       */
+      const annotationMessageIpfsHash = yield call(
+        uploadIfpsAnnotation,
+        annotationMessage,
       );
 
       yield put(

--- a/src/modules/dashboard/sagas/actions/mintTokens.ts
+++ b/src/modules/dashboard/sagas/actions/mintTokens.ts
@@ -10,7 +10,7 @@ import {
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
 
-import { uploadIfpsAnnotation } from '../utils';
+import { uploadIfsWithFallback } from '../utils';
 import {
   createTransaction,
   createTransactionChannels,
@@ -121,7 +121,7 @@ function* createMintTokensAction({
     if (annotationMessage) {
       yield put(transactionPending(annotateMintTokens.id));
 
-      const ipfsHash = yield call(uploadIfpsAnnotation, annotationMessage);
+      const ipfsHash = yield call(uploadIfsWithFallback, annotationMessage);
 
       yield put(
         transactionAddParams(annotateMintTokens.id, [txHash, ipfsHash]),

--- a/src/modules/dashboard/sagas/actions/mintTokens.ts
+++ b/src/modules/dashboard/sagas/actions/mintTokens.ts
@@ -121,7 +121,7 @@ function* createMintTokensAction({
     if (annotationMessage) {
       yield put(transactionPending(annotateMintTokens.id));
 
-      const ipfsHash = yield call(uploadIfsWithFallback, annotationMessage);
+      const ipfsHash = yield call(uploadIfsWithFallback, { annotationMessage });
 
       yield put(
         transactionAddParams(annotateMintTokens.id, [txHash, ipfsHash]),

--- a/src/modules/dashboard/sagas/actions/moveFunds.ts
+++ b/src/modules/dashboard/sagas/actions/moveFunds.ts
@@ -10,7 +10,7 @@ import {
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
 
-import { uploadIfpsAnnotation } from '../utils';
+import { uploadIfsWithFallback } from '../utils';
 import {
   createTransaction,
   createTransactionChannels,
@@ -150,7 +150,7 @@ function* createMoveFundsAction({
     if (annotationMessage) {
       yield put(transactionPending(annotateMoveFunds.id));
 
-      const ipfsHash = yield call(uploadIfpsAnnotation, annotationMessage);
+      const ipfsHash = yield call(uploadIfsWithFallback, annotationMessage);
 
       yield put(transactionAddParams(annotateMoveFunds.id, [txHash, ipfsHash]));
 

--- a/src/modules/dashboard/sagas/actions/moveFunds.ts
+++ b/src/modules/dashboard/sagas/actions/moveFunds.ts
@@ -150,7 +150,7 @@ function* createMoveFundsAction({
     if (annotationMessage) {
       yield put(transactionPending(annotateMoveFunds.id));
 
-      const ipfsHash = yield call(uploadIfsWithFallback, annotationMessage);
+      const ipfsHash = yield call(uploadIfsWithFallback, { annotationMessage });
 
       yield put(transactionAddParams(annotateMoveFunds.id, [txHash, ipfsHash]));
 

--- a/src/modules/dashboard/sagas/actions/payment.ts
+++ b/src/modules/dashboard/sagas/actions/payment.ts
@@ -17,7 +17,7 @@ import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
 import { COLONY_TOTAL_BALANCE_DOMAIN_ID } from '~constants';
 
-import { uploadIfpsAnnotation } from '../utils';
+import { uploadIfsWithFallback } from '../utils';
 import {
   createTransaction,
   createTransactionChannels,
@@ -161,7 +161,7 @@ function* createPaymentAction({
     if (annotationMessage) {
       yield put(transactionPending(annotatePaymentAction.id));
 
-      const ipfsHash = yield call(uploadIfpsAnnotation, annotationMessage);
+      const ipfsHash = yield call(uploadIfsWithFallback, annotationMessage);
 
       yield put(
         transactionAddParams(annotatePaymentAction.id, [txHash, ipfsHash]),

--- a/src/modules/dashboard/sagas/actions/payment.ts
+++ b/src/modules/dashboard/sagas/actions/payment.ts
@@ -161,7 +161,7 @@ function* createPaymentAction({
     if (annotationMessage) {
       yield put(transactionPending(annotatePaymentAction.id));
 
-      const ipfsHash = yield call(uploadIfsWithFallback, annotationMessage);
+      const ipfsHash = yield call(uploadIfsWithFallback, { annotationMessage });
 
       yield put(
         transactionAddParams(annotatePaymentAction.id, [txHash, ipfsHash]),

--- a/src/modules/dashboard/sagas/actions/unlockToken.ts
+++ b/src/modules/dashboard/sagas/actions/unlockToken.ts
@@ -114,10 +114,9 @@ function* tokenUnlockAction({
       /*
        * Upload annotation metadata to IPFS
        */
-      const annotationMessageIpfsHash = yield call(
-        uploadIfsWithFallback,
+      const annotationMessageIpfsHash = yield call(uploadIfsWithFallback, {
         annotationMessage,
-      );
+      });
 
       yield put(
         transactionAddParams(annotateTokenUnlock.id, [

--- a/src/modules/dashboard/sagas/actions/unlockToken.ts
+++ b/src/modules/dashboard/sagas/actions/unlockToken.ts
@@ -19,7 +19,7 @@ import {
   transactionPending,
   transactionAddParams,
 } from '../../../core/actionCreators';
-import { uploadIfpsAnnotation } from '../utils';
+import { uploadIfsWithFallback } from '../utils';
 
 function* tokenUnlockAction({
   meta,
@@ -115,7 +115,7 @@ function* tokenUnlockAction({
        * Upload annotation metadata to IPFS
        */
       const annotationMessageIpfsHash = yield call(
-        uploadIfpsAnnotation,
+        uploadIfsWithFallback,
         annotationMessage,
       );
 

--- a/src/modules/dashboard/sagas/actions/unlockToken.ts
+++ b/src/modules/dashboard/sagas/actions/unlockToken.ts
@@ -14,12 +14,12 @@ import {
   createTransactionChannels,
   getTxChannel,
 } from '../../../core/sagas';
-import { ipfsUpload } from '../../../core/sagas/ipfs';
 import {
   transactionReady,
   transactionPending,
   transactionAddParams,
 } from '../../../core/actionCreators';
+import { uploadIfpsAnnotation } from '../utils';
 
 function* tokenUnlockAction({
   meta,
@@ -114,12 +114,9 @@ function* tokenUnlockAction({
       /*
        * Upload annotation metadata to IPFS
        */
-      let annotationMessageIpfsHash = null;
-      annotationMessageIpfsHash = yield call(
-        ipfsUpload,
-        JSON.stringify({
-          annotationMessage,
-        }),
+      const annotationMessageIpfsHash = yield call(
+        uploadIfpsAnnotation,
+        annotationMessage,
       );
 
       yield put(

--- a/src/modules/dashboard/sagas/actions/versionUpgrade.ts
+++ b/src/modules/dashboard/sagas/actions/versionUpgrade.ts
@@ -11,7 +11,7 @@ import {
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
 
-import { uploadIfpsAnnotation } from '../utils';
+import { uploadIfsWithFallback } from '../utils';
 import {
   createTransaction,
   createTransactionChannels,
@@ -98,7 +98,7 @@ function* createVersionUpgradeAction({
     if (annotationMessage && supportAnnotation) {
       yield put(transactionPending(annotateUpgrade.id));
 
-      const ipfsHash = yield call(uploadIfpsAnnotation, annotationMessage);
+      const ipfsHash = yield call(uploadIfsWithFallback, annotationMessage);
 
       yield put(transactionAddParams(annotateUpgrade.id, [txHash, ipfsHash]));
 

--- a/src/modules/dashboard/sagas/actions/versionUpgrade.ts
+++ b/src/modules/dashboard/sagas/actions/versionUpgrade.ts
@@ -98,7 +98,7 @@ function* createVersionUpgradeAction({
     if (annotationMessage && supportAnnotation) {
       yield put(transactionPending(annotateUpgrade.id));
 
-      const ipfsHash = yield call(uploadIfsWithFallback, annotationMessage);
+      const ipfsHash = yield call(uploadIfsWithFallback, { annotationMessage });
 
       yield put(transactionAddParams(annotateUpgrade.id, [txHash, ipfsHash]));
 

--- a/src/modules/dashboard/sagas/colonyCreate.ts
+++ b/src/modules/dashboard/sagas/colonyCreate.ts
@@ -40,9 +40,9 @@ import {
   transactionPending,
 } from '../../core/actionCreators';
 import { createTransaction, createTransactionChannels } from '../../core/sagas';
-import { ipfsUpload } from '../../core/sagas/ipfs';
 import { createUserWithSecondAttempt } from '../../users/sagas/utils';
-import { log } from '~utils/debug';
+
+import { uploadIfsWithFallback } from '../sagas/utils';
 
 interface ChannelDefinition {
   channel: Channel<any>;
@@ -289,37 +289,12 @@ function* colonyCreate({
      */
     let colonyAddress;
     if (createColony) {
-      /*
-       * First IPFS upload try
-       */
-      let colonyMetadataIpfsHash;
-      try {
-        colonyMetadataIpfsHash = yield call(
-          ipfsUpload,
-          JSON.stringify({
-            colonyName,
-            colonyDisplayName: displayName,
-            colonyAvatarHash: null,
-            colonyTokens: [],
-          }),
-        );
-      } catch (error) {
-        log.verbose('Could not upload the colony metadata IPFS. Retrying...');
-        log.verbose(error);
-        /*
-         * If the first try fails, then attempt to upload again
-         * We assume the first error was due to a connection issue
-         */
-        colonyMetadataIpfsHash = yield call(
-          ipfsUpload,
-          JSON.stringify({
-            colonyName,
-            colonyDisplayName: displayName,
-            colonyAvatarHash: null,
-            colonyTokens: [],
-          }),
-        );
-      }
+      const colonyMetadataIpfsHash = yield call(uploadIfsWithFallback, {
+        colonyName,
+        colonyDisplayName: displayName,
+        colonyAvatarHash: null,
+        colonyTokens: [],
+      });
 
       const { version: latestVersion } = yield getNetworkContracts();
 

--- a/src/modules/dashboard/sagas/motions/createEditDomainMotion.ts
+++ b/src/modules/dashboard/sagas/motions/createEditDomainMotion.ts
@@ -18,7 +18,6 @@ import {
   createTransactionChannels,
   getTxChannel,
 } from '../../../core/sagas';
-import { ipfsUpload } from '../../../core/sagas/ipfs';
 import {
   transactionReady,
   transactionPending,
@@ -108,15 +107,11 @@ function* createEditDomainMotion({
     /*
      * Upload domain metadata to IPFS
      */
-    let domainMetadataIpfsHash = null;
-    domainMetadataIpfsHash = yield call(
-      ipfsUpload,
-      JSON.stringify({
-        domainName,
-        domainColor,
-        domainPurpose,
-      }),
-    );
+    const domainMetadataIpfsHash = yield call(uploadIfsWithFallback, {
+      domainName,
+      domainColor,
+      domainPurpose,
+    });
 
     const encodedAction = colonyClient.interface.functions[
       isCreateDomain

--- a/src/modules/dashboard/sagas/motions/createEditDomainMotion.ts
+++ b/src/modules/dashboard/sagas/motions/createEditDomainMotion.ts
@@ -178,7 +178,7 @@ function* createEditDomainMotion({
     yield takeFrom(createMotion.channel, ActionTypes.TRANSACTION_SUCCEEDED);
 
     if (annotationMessage) {
-      const ipfsHash = yield call(uploadIfsWithFallback, annotationMessage);
+      const ipfsHash = yield call(uploadIfsWithFallback, { annotationMessage });
       yield put(transactionPending(annotateMotion.id));
 
       yield put(transactionAddParams(annotateMotion.id, [txHash, ipfsHash]));

--- a/src/modules/dashboard/sagas/motions/createEditDomainMotion.ts
+++ b/src/modules/dashboard/sagas/motions/createEditDomainMotion.ts
@@ -12,7 +12,7 @@ import { ContextModule, TEMP_getContext } from '~context/index';
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
 
-import { uploadIfpsAnnotation } from '../utils';
+import { uploadIfsWithFallback } from '../utils';
 import {
   createTransaction,
   createTransactionChannels,
@@ -183,7 +183,7 @@ function* createEditDomainMotion({
     yield takeFrom(createMotion.channel, ActionTypes.TRANSACTION_SUCCEEDED);
 
     if (annotationMessage) {
-      const ipfsHash = yield call(uploadIfpsAnnotation, annotationMessage);
+      const ipfsHash = yield call(uploadIfsWithFallback, annotationMessage);
       yield put(transactionPending(annotateMotion.id));
 
       yield put(transactionAddParams(annotateMotion.id, [txHash, ipfsHash]));

--- a/src/modules/dashboard/sagas/motions/editColonyMotion.ts
+++ b/src/modules/dashboard/sagas/motions/editColonyMotion.ts
@@ -12,7 +12,6 @@ import {
   createTransactionChannels,
   getTxChannel,
 } from '../../../core/sagas';
-import { ipfsUpload } from '../../../core/sagas/ipfs';
 import {
   transactionReady,
   transactionPending,
@@ -89,28 +88,21 @@ function* editColonyMotion({
      */
     let colonyAvatarIpfsHash = null;
     if (colonyAvatarImage && hasAvatarChanged) {
-      colonyAvatarIpfsHash = yield call(
-        ipfsUpload,
-        JSON.stringify({
-          image: colonyAvatarImage,
-        }),
-      );
+      colonyAvatarIpfsHash = yield call(uploadIfsWithFallback, {
+        image: colonyAvatarImage,
+      });
     }
 
     /*
      * Upload colony metadata to IPFS
      */
-    let colonyMetadataIpfsHash = null;
-    colonyMetadataIpfsHash = yield call(
-      ipfsUpload,
-      JSON.stringify({
-        colonyDisplayName,
-        colonyAvatarHash: hasAvatarChanged
-          ? colonyAvatarIpfsHash
-          : colonyAvatarHash,
-        colonyTokens,
-      }),
-    );
+    const colonyMetadataIpfsHash = yield call(uploadIfsWithFallback, {
+      colonyDisplayName,
+      colonyAvatarHash: hasAvatarChanged
+        ? colonyAvatarIpfsHash
+        : colonyAvatarHash,
+      colonyTokens,
+    });
 
     const encodedAction = colonyClient.interface.functions.editColony.encode([
       colonyMetadataIpfsHash,

--- a/src/modules/dashboard/sagas/motions/editColonyMotion.ts
+++ b/src/modules/dashboard/sagas/motions/editColonyMotion.ts
@@ -6,7 +6,7 @@ import { ContextModule, TEMP_getContext } from '~context/index';
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
 
-import { uploadIfpsAnnotation } from '../utils';
+import { uploadIfsWithFallback } from '../utils';
 import {
   createTransaction,
   createTransactionChannels,
@@ -173,7 +173,7 @@ function* editColonyMotion({
     yield takeFrom(createMotion.channel, ActionTypes.TRANSACTION_SUCCEEDED);
 
     if (annotationMessage) {
-      const ipfsHash = yield call(uploadIfpsAnnotation, annotationMessage);
+      const ipfsHash = yield call(uploadIfsWithFallback, annotationMessage);
       yield put(transactionPending(annotateEditColonyMotion.id));
 
       yield put(

--- a/src/modules/dashboard/sagas/motions/editColonyMotion.ts
+++ b/src/modules/dashboard/sagas/motions/editColonyMotion.ts
@@ -165,7 +165,7 @@ function* editColonyMotion({
     yield takeFrom(createMotion.channel, ActionTypes.TRANSACTION_SUCCEEDED);
 
     if (annotationMessage) {
-      const ipfsHash = yield call(uploadIfsWithFallback, annotationMessage);
+      const ipfsHash = yield call(uploadIfsWithFallback, { annotationMessage });
       yield put(transactionPending(annotateEditColonyMotion.id));
 
       yield put(

--- a/src/modules/dashboard/sagas/motions/managePermissionsMotion.ts
+++ b/src/modules/dashboard/sagas/motions/managePermissionsMotion.ts
@@ -181,7 +181,7 @@ function* managePermissionsMotion({
     yield takeFrom(createMotion.channel, ActionTypes.TRANSACTION_SUCCEEDED);
 
     if (annotationMessage) {
-      const ipfsHash = yield call(uploadIfsWithFallback, annotationMessage);
+      const ipfsHash = yield call(uploadIfsWithFallback, { annotationMessage });
       yield put(transactionPending(annotateSetUserRolesMotion.id));
 
       yield put(

--- a/src/modules/dashboard/sagas/motions/managePermissionsMotion.ts
+++ b/src/modules/dashboard/sagas/motions/managePermissionsMotion.ts
@@ -13,7 +13,7 @@ import { ContextModule, TEMP_getContext } from '~context/index';
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
 
-import { uploadIfpsAnnotation } from '../utils';
+import { uploadIfsWithFallback } from '../utils';
 import {
   createTransaction,
   createTransactionChannels,
@@ -181,7 +181,7 @@ function* managePermissionsMotion({
     yield takeFrom(createMotion.channel, ActionTypes.TRANSACTION_SUCCEEDED);
 
     if (annotationMessage) {
-      const ipfsHash = yield call(uploadIfpsAnnotation, annotationMessage);
+      const ipfsHash = yield call(uploadIfsWithFallback, annotationMessage);
       yield put(transactionPending(annotateSetUserRolesMotion.id));
 
       yield put(

--- a/src/modules/dashboard/sagas/motions/manageReputationMotion.ts
+++ b/src/modules/dashboard/sagas/motions/manageReputationMotion.ts
@@ -21,7 +21,7 @@ import {
   transactionPending,
   transactionAddParams,
 } from '../../../core/actionCreators';
-import { updateDomainReputation, uploadIfpsAnnotation } from '../utils';
+import { updateDomainReputation, uploadIfsWithFallback } from '../utils';
 
 function* manageReputationMotion({
   payload: {
@@ -181,7 +181,7 @@ function* manageReputationMotion({
       /*
        * Upload annotaiton to IPFS
        */
-      const ipfsHash = yield call(uploadIfpsAnnotation, annotationMessage);
+      const ipfsHash = yield call(uploadIfsWithFallback, annotationMessage);
 
       yield put(transactionPending(annotateManageReputationMotion.id));
 

--- a/src/modules/dashboard/sagas/motions/manageReputationMotion.ts
+++ b/src/modules/dashboard/sagas/motions/manageReputationMotion.ts
@@ -16,13 +16,12 @@ import {
   createTransactionChannels,
   getTxChannel,
 } from '../../../core/sagas';
-import { ipfsUpload } from '../../../core/sagas/ipfs';
 import {
   transactionReady,
   transactionPending,
   transactionAddParams,
 } from '../../../core/actionCreators';
-import { updateDomainReputation } from '../utils';
+import { updateDomainReputation, uploadIfpsAnnotation } from '../utils';
 
 function* manageReputationMotion({
   payload: {
@@ -162,20 +161,6 @@ function* manageReputationMotion({
     }
 
     yield takeFrom(createMotion.channel, ActionTypes.TRANSACTION_CREATED);
-    if (annotationMessage) {
-      yield takeFrom(
-        annotateManageReputationMotion.channel,
-        ActionTypes.TRANSACTION_CREATED,
-      );
-    }
-
-    let ipfsHash = null;
-    ipfsHash = yield call(
-      ipfsUpload,
-      JSON.stringify({
-        annotationMessage,
-      }),
-    );
 
     yield put(transactionReady(createMotion.id));
 
@@ -188,6 +173,16 @@ function* manageReputationMotion({
     yield takeFrom(createMotion.channel, ActionTypes.TRANSACTION_SUCCEEDED);
 
     if (annotationMessage) {
+      yield takeFrom(
+        annotateManageReputationMotion.channel,
+        ActionTypes.TRANSACTION_CREATED,
+      );
+
+      /*
+       * Upload annotaiton to IPFS
+       */
+      const ipfsHash = yield call(uploadIfpsAnnotation, annotationMessage);
+
       yield put(transactionPending(annotateManageReputationMotion.id));
 
       yield put(

--- a/src/modules/dashboard/sagas/motions/manageReputationMotion.ts
+++ b/src/modules/dashboard/sagas/motions/manageReputationMotion.ts
@@ -181,7 +181,7 @@ function* manageReputationMotion({
       /*
        * Upload annotaiton to IPFS
        */
-      const ipfsHash = yield call(uploadIfsWithFallback, annotationMessage);
+      const ipfsHash = yield call(uploadIfsWithFallback, { annotationMessage });
 
       yield put(transactionPending(annotateManageReputationMotion.id));
 

--- a/src/modules/dashboard/sagas/motions/moveFundsMotion.ts
+++ b/src/modules/dashboard/sagas/motions/moveFundsMotion.ts
@@ -196,7 +196,7 @@ function* moveFundsMotion({
     yield takeFrom(createMotion.channel, ActionTypes.TRANSACTION_SUCCEEDED);
 
     if (annotationMessage) {
-      const ipfsHash = yield call(uploadIfsWithFallback, annotationMessage);
+      const ipfsHash = yield call(uploadIfsWithFallback, { annotationMessage });
       yield put(transactionPending(annotateMoveFundsMotion.id));
 
       yield put(

--- a/src/modules/dashboard/sagas/motions/moveFundsMotion.ts
+++ b/src/modules/dashboard/sagas/motions/moveFundsMotion.ts
@@ -12,7 +12,7 @@ import { ContextModule, TEMP_getContext } from '~context/index';
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
 
-import { uploadIfpsAnnotation } from '../utils';
+import { uploadIfsWithFallback } from '../utils';
 import {
   createTransaction,
   createTransactionChannels,
@@ -196,7 +196,7 @@ function* moveFundsMotion({
     yield takeFrom(createMotion.channel, ActionTypes.TRANSACTION_SUCCEEDED);
 
     if (annotationMessage) {
-      const ipfsHash = yield call(uploadIfpsAnnotation, annotationMessage);
+      const ipfsHash = yield call(uploadIfsWithFallback, annotationMessage);
       yield put(transactionPending(annotateMoveFundsMotion.id));
 
       yield put(

--- a/src/modules/dashboard/sagas/motions/paymentMotion.ts
+++ b/src/modules/dashboard/sagas/motions/paymentMotion.ts
@@ -206,7 +206,7 @@ function* createPaymentMotion({
     if (annotationMessage) {
       yield put(transactionPending(annotatePaymentMotion.id));
 
-      const ipfsHash = yield call(uploadIfsWithFallback, annotationMessage);
+      const ipfsHash = yield call(uploadIfsWithFallback, { annotationMessage });
 
       yield put(
         transactionAddParams(annotatePaymentMotion.id, [txHash, ipfsHash]),

--- a/src/modules/dashboard/sagas/motions/paymentMotion.ts
+++ b/src/modules/dashboard/sagas/motions/paymentMotion.ts
@@ -12,7 +12,7 @@ import { ContextModule, TEMP_getContext } from '~context/index';
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
 
-import { uploadIfpsAnnotation } from '../utils';
+import { uploadIfsWithFallback } from '../utils';
 import {
   createTransaction,
   createTransactionChannels,
@@ -206,7 +206,7 @@ function* createPaymentMotion({
     if (annotationMessage) {
       yield put(transactionPending(annotatePaymentMotion.id));
 
-      const ipfsHash = yield call(uploadIfpsAnnotation, annotationMessage);
+      const ipfsHash = yield call(uploadIfsWithFallback, annotationMessage);
 
       yield put(
         transactionAddParams(annotatePaymentMotion.id, [txHash, ipfsHash]),

--- a/src/modules/dashboard/sagas/motions/rootMotion.ts
+++ b/src/modules/dashboard/sagas/motions/rootMotion.ts
@@ -135,7 +135,7 @@ function* createRootMotionSaga({
     if (annotationMessage) {
       yield put(transactionPending(annotateRootMotion.id));
 
-      const ipfsHash = yield call(uploadIfsWithFallback, annotationMessage);
+      const ipfsHash = yield call(uploadIfsWithFallback, { annotationMessage });
 
       yield put(
         transactionAddParams(annotateRootMotion.id, [txHash, ipfsHash]),

--- a/src/modules/dashboard/sagas/motions/rootMotion.ts
+++ b/src/modules/dashboard/sagas/motions/rootMotion.ts
@@ -6,7 +6,7 @@ import { ContextModule, TEMP_getContext } from '~context/index';
 import { Action, ActionTypes, AllActions } from '~redux/index';
 import { putError, takeFrom, routeRedirect } from '~utils/saga/effects';
 
-import { uploadIfpsAnnotation } from '../utils';
+import { uploadIfsWithFallback } from '../utils';
 import {
   createTransaction,
   createTransactionChannels,
@@ -135,7 +135,7 @@ function* createRootMotionSaga({
     if (annotationMessage) {
       yield put(transactionPending(annotateRootMotion.id));
 
-      const ipfsHash = yield call(uploadIfpsAnnotation, annotationMessage);
+      const ipfsHash = yield call(uploadIfsWithFallback, annotationMessage);
 
       yield put(
         transactionAddParams(annotateRootMotion.id, [txHash, ipfsHash]),

--- a/src/modules/dashboard/sagas/motions/stakeMotion.ts
+++ b/src/modules/dashboard/sagas/motions/stakeMotion.ts
@@ -15,9 +15,8 @@ import {
   transactionPending,
   transactionAddParams,
 } from '../../../core/actionCreators';
-import { ipfsUpload } from '../../../core/sagas/ipfs';
 
-import { updateMotionValues } from '../utils';
+import { updateMotionValues, uploadIfsWithFallback } from '../utils';
 
 function* stakeMotion({
   meta,
@@ -143,13 +142,9 @@ function* stakeMotion({
       /*
        * Upload annotation metadata to IPFS
        */
-      let annotationMessageIpfsHash = null;
-      annotationMessageIpfsHash = yield call(
-        ipfsUpload,
-        JSON.stringify({
-          annotationMessage,
-        }),
-      );
+      const annotationMessageIpfsHash = yield call(uploadIfsWithFallback, {
+        annotationMessage,
+      });
 
       yield put(
         transactionAddParams(annotateStaking.id, [

--- a/src/modules/dashboard/sagas/utils/index.ts
+++ b/src/modules/dashboard/sagas/utils/index.ts
@@ -1,7 +1,7 @@
 export * from './updateColonyDisplayCache';
 export { updateMotionValues } from './updateMotionValues';
 export { refreshExtension } from './refreshExtension';
-export { uploadIfpsAnnotation } from './uploadIfpsAnnotation';
+export { uploadIfsWithFallback } from './uploadIfsWithFallback';
 export {
   modifyParams,
   removeOldExtensionClients,

--- a/src/modules/dashboard/sagas/utils/uploadIfsWithFallback.ts
+++ b/src/modules/dashboard/sagas/utils/uploadIfsWithFallback.ts
@@ -1,14 +1,22 @@
 import { call } from 'redux-saga/effects';
+
+import { log } from '~utils/debug';
+
 import { ipfsUpload } from '../../../core/sagas/ipfs';
 
-export function* uploadIfsWithFallback(annotationMessage: string) {
+export function* uploadIfsWithFallback(annotationMessage: string | object) {
   let ipfsHash: string | null = null;
-  ipfsHash = yield call(
-    ipfsUpload,
-    JSON.stringify({
-      annotationMessage,
-    }),
-  );
+  try {
+    ipfsHash = yield call(
+      ipfsUpload,
+      JSON.stringify({
+        annotationMessage,
+      }),
+    );
+  } catch (error) {
+    log.verbose('Could not upload the colony metadata IPFS. Retrying...');
+    log.verbose(error);
+  }
 
   /* If the ipfs upload failed we try again, then if it fails again we just assign
       an empty string so that the `transactionAddParams` won't fail */

--- a/src/modules/dashboard/sagas/utils/uploadIfsWithFallback.ts
+++ b/src/modules/dashboard/sagas/utils/uploadIfsWithFallback.ts
@@ -4,15 +4,10 @@ import { log } from '~utils/debug';
 
 import { ipfsUpload } from '../../../core/sagas/ipfs';
 
-export function* uploadIfsWithFallback(annotationMessage: string | object) {
+export function* uploadIfsWithFallback(uploadObject: object) {
   let ipfsHash: string | null = null;
   try {
-    ipfsHash = yield call(
-      ipfsUpload,
-      JSON.stringify({
-        annotationMessage,
-      }),
-    );
+    ipfsHash = yield call(ipfsUpload, JSON.stringify(uploadObject));
   } catch (error) {
     log.verbose('Could not upload the colony metadata IPFS. Retrying...');
     log.verbose(error);
@@ -21,12 +16,7 @@ export function* uploadIfsWithFallback(annotationMessage: string | object) {
   /* If the ipfs upload failed we try again, then if it fails again we just assign
       an empty string so that the `transactionAddParams` won't fail */
   if (!ipfsHash) {
-    ipfsHash = yield call(
-      ipfsUpload,
-      JSON.stringify({
-        annotationMessage,
-      }),
-    );
+    ipfsHash = yield call(ipfsUpload, JSON.stringify(uploadObject));
     if (!ipfsHash) {
       ipfsHash = '';
     }

--- a/src/modules/dashboard/sagas/utils/uploadIfsWithFallback.ts
+++ b/src/modules/dashboard/sagas/utils/uploadIfsWithFallback.ts
@@ -1,7 +1,7 @@
 import { call } from 'redux-saga/effects';
 import { ipfsUpload } from '../../../core/sagas/ipfs';
 
-export function* uploadIfpsAnnotation(annotationMessage: string) {
+export function* uploadIfsWithFallback(annotationMessage: string) {
   let ipfsHash: string | null = null;
   ipfsHash = yield call(
     ipfsUpload,

--- a/src/modules/dashboard/sagas/whitelist/manageVerifiedRecipients.ts
+++ b/src/modules/dashboard/sagas/whitelist/manageVerifiedRecipients.ts
@@ -133,10 +133,9 @@ function* manageVerifiedRecipients({
       /*
        * Upload annotation metadata to IPFS
        */
-      const annotationMessageIpfsHash = yield call(
-        uploadIfsWithFallback,
+      const annotationMessageIpfsHash = yield call(uploadIfsWithFallback, {
         annotationMessage,
-      );
+      });
 
       yield put(
         transactionAddParams(annotateEditColony.id, [

--- a/src/modules/dashboard/sagas/whitelist/manageVerifiedRecipients.ts
+++ b/src/modules/dashboard/sagas/whitelist/manageVerifiedRecipients.ts
@@ -22,7 +22,7 @@ import {
   transactionAddParams,
 } from '../../../core/actionCreators';
 
-import { updateColonyDisplayCache, uploadIfpsAnnotation } from '../utils';
+import { updateColonyDisplayCache, uploadIfsWithFallback } from '../utils';
 
 function* manageVerifiedRecipients({
   payload: {
@@ -140,7 +140,7 @@ function* manageVerifiedRecipients({
        * Upload annotation metadata to IPFS
        */
       const annotationMessageIpfsHash = yield call(
-        uploadIfpsAnnotation,
+        uploadIfsWithFallback,
         annotationMessage,
       );
 

--- a/src/modules/dashboard/sagas/whitelist/manageVerifiedRecipients.ts
+++ b/src/modules/dashboard/sagas/whitelist/manageVerifiedRecipients.ts
@@ -15,7 +15,6 @@ import {
   createTransactionChannels,
   getTxChannel,
 } from '../../../core/sagas';
-import { ipfsUpload } from '../../../core/sagas/ipfs';
 import {
   transactionReady,
   transactionPending,
@@ -104,18 +103,13 @@ function* manageVerifiedRecipients({
     /*
      * Upload colony metadata to IPFS
      */
-    let colonyMetadataIpfsHash = null;
-
-    colonyMetadataIpfsHash = yield call(
-      ipfsUpload,
-      JSON.stringify({
-        colonyDisplayName,
-        colonyAvatarHash,
-        verifiedAddresses,
-        colonyTokens,
-        isWhitelistActivated,
-      }),
-    );
+    const colonyMetadataIpfsHash = yield call(uploadIfsWithFallback, {
+      colonyDisplayName,
+      colonyAvatarHash,
+      verifiedAddresses,
+      colonyTokens,
+      isWhitelistActivated,
+    });
 
     yield put(
       transactionAddParams(editColony.id, [

--- a/src/modules/users/sagas/user.ts
+++ b/src/modules/users/sagas/user.ts
@@ -29,7 +29,7 @@ import { putError, takeFrom } from '~utils/saga/effects';
 import { clearLastWallet } from '~utils/autoLogin';
 import { IPFSAvatarImage } from '~types/index';
 
-import { uploadIfpsAnnotation } from '../../dashboard/sagas/utils';
+import { uploadIfsWithFallback } from '../../dashboard/sagas/utils';
 import { clearToken } from '../../../api/auth';
 import {
   transactionLoadRelated,
@@ -74,7 +74,7 @@ function* userAvatarUpload({
     if (payload.data) {
       try {
         ipfsHash = yield call(
-          uploadIfpsAnnotation,
+          uploadIfsWithFallback,
           JSON.stringify({ image: payload.data } as IPFSAvatarImage),
         );
       } catch (error) {

--- a/src/modules/users/sagas/user.ts
+++ b/src/modules/users/sagas/user.ts
@@ -27,7 +27,6 @@ import {
 } from '~data/index';
 import { putError, takeFrom } from '~utils/saga/effects';
 import { clearLastWallet } from '~utils/autoLogin';
-import { IPFSAvatarImage } from '~types/index';
 
 import { uploadIfsWithFallback } from '../../dashboard/sagas/utils';
 import { clearToken } from '../../../api/auth';
@@ -73,10 +72,7 @@ function* userAvatarUpload({
     let ipfsHash = null;
     if (payload.data) {
       try {
-        ipfsHash = yield call(
-          uploadIfsWithFallback,
-          JSON.stringify({ image: payload.data } as IPFSAvatarImage),
-        );
+        ipfsHash = yield call(uploadIfsWithFallback, { image: payload.data });
       } catch (error) {
         // silent error
       }

--- a/src/modules/users/sagas/user.ts
+++ b/src/modules/users/sagas/user.ts
@@ -29,8 +29,8 @@ import { putError, takeFrom } from '~utils/saga/effects';
 import { clearLastWallet } from '~utils/autoLogin';
 import { IPFSAvatarImage } from '~types/index';
 
+import { uploadIfpsAnnotation } from '../../dashboard/sagas/utils';
 import { clearToken } from '../../../api/auth';
-import { ipfsUpload } from '../../core/sagas/ipfs';
 import {
   transactionLoadRelated,
   transactionReady,
@@ -74,7 +74,7 @@ function* userAvatarUpload({
     if (payload.data) {
       try {
         ipfsHash = yield call(
-          ipfsUpload,
+          uploadIfpsAnnotation,
           JSON.stringify({ image: payload.data } as IPFSAvatarImage),
         );
       } catch (error) {


### PR DESCRIPTION
## Description

This PR adds string as ipfs upload fallback to avoid app crashing (like we had in production recently).

I've renamed the util function to show that it's not only annotation that we will upload. I've also added try-catch block and logs there.

resolves #3787 
