### PR TITLE
Fix SingleSafePicker width

### DIFF
--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css
@@ -1,5 +1,5 @@
 @value wideButton: 197px;
-@value width: 419px;
+@value max-width: 424px;
 
 .heading {
   margin-bottom: 0px;
@@ -18,12 +18,11 @@
 }
 
 .safePicker input {
-  width: width;
-  max-width: width;
+  max-width: max-width;
 }
 
 .safePicker button {
-  max-width: width;
+  max-width: max-width;
   color: var(--dark);
 }
 

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.css.d.ts
@@ -1,5 +1,5 @@
 export const wideButton: string;
-export const width: string;
+export const maxWidth: string;
 export const heading: string;
 export const footer: string;
 export const safePicker: string;

--- a/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/GnosisControlSafeDialog/GnosisControlSafeForm.tsx
@@ -278,7 +278,6 @@ const GnosisControlSafeForm = ({
           <DialogSection>
             <div className={styles.safePicker}>
               <SingleSafePicker
-                appearance={{ width: 'wide' }}
                 label={MSG.selectSafe}
                 name="safe"
                 filter={filterUserSelection}


### PR DESCRIPTION
## Description

This PR implements a small fix to the `SingleSafePicker` that stops it from breaking onto a new line when the scroll bar is present. See issue for screenshot of problem.

**Changes** 🏗

* Changing input and button width / max-width to the same as in the `TransactionTypesSection.css`

## Screenshot

**Doesn't break onto a new line**
![safepicker](https://user-images.githubusercontent.com/64402732/187922752-f4a8bf92-049d-4303-b253-a1db12bed574.png)

Resolves #3796 