### PR TITLE
Set merge policy for safes

### DIFF
--- a/src/data/cache.ts
+++ b/src/data/cache.ts
@@ -28,6 +28,9 @@ export default new InMemoryCache({
         installedExtensions: {
           merge: false,
         },
+        safes: {
+          merge: false,
+        },
       },
     },
     User: {


### PR DESCRIPTION
## Description

A small fix to remove the error from apollo when removing safes. 

**Changes** 🏗

* Adding a merge policy for `safes` 

Resolves #3798
