### PR TITLE
Set AddItemButton disabled cursor

### DIFF
--- a/src/modules/core/components/Button/AddItemButton.css
+++ b/src/modules/core/components/Button/AddItemButton.css
@@ -17,6 +17,7 @@
 .main[disabled] {
   background-color: color-mod(var(--text-disabled) alpha(12%));
   color: var(--text-disabled);
+  cursor: default;
 }
 
 .main i {


### PR DESCRIPTION
## Description

Small tweak to the cursor when the `AddItemButton` is disabled.

**Changes** 🏗

* Setting the cursor on `AddItemButton` when disabled to default

## Before 

![safe-control-cursor](https://user-images.githubusercontent.com/64402732/187931657-72bf0f9a-218b-4617-877a-26f9849952cc.gif)

## After

![aatcursor](https://user-images.githubusercontent.com/64402732/188860328-6c01afda-71e0-4c71-93f8-d561fb3e0744.gif)

Resolves #3800
