### PR TITLE
Fix types in colony metadata checks & fix verified addresses check

### DIFF
--- a/src/modules/dashboard/components/ActionsPageFeed/ActionsPageEvent/ActionsPageEvent.tsx
+++ b/src/modules/dashboard/components/ActionsPageFeed/ActionsPageEvent/ActionsPageEvent.tsx
@@ -20,7 +20,7 @@ import {
 } from '~data/index';
 import { ColonyAndExtensionsEvents, ColonyActions } from '~types/index';
 import {
-  getSpecificActionValuesCheck,
+  getDomainValuesCheck,
   sortMetadataHistory,
   parseDomainMetadata,
   getColonyMetadataMessageDescriptorsIds,
@@ -204,7 +204,7 @@ const ActionsPageEvent = ({
           if (metadataJSON) {
             const previousParsedMetadata = parseDomainMetadata(metadataJSON);
             setPreviousDomainMetadata(previousParsedMetadata);
-            return getSpecificActionValuesCheck(
+            return getDomainValuesCheck(
               eventName as ColonyAndExtensionsEvents,
               actionData,
               previousParsedMetadata,

--- a/src/modules/dashboard/hooks/useColonyMetadataChecks.ts
+++ b/src/modules/dashboard/hooks/useColonyMetadataChecks.ts
@@ -98,14 +98,6 @@ const useColonyMetadataChecks = (
               actionData,
               prevColonyMetadata,
             );
-            // console.log(
-            //   '🚀 ~ file: useColonyMetadataChecks.ts ~ line 101 ~ useEffect ~ newMetadataChecks',
-            //   newMetadataChecks,
-            // );
-            // console.log(
-            //   '🚀 ~ file: useColonyMetadataChecks.ts ~ line 104 ~ useEffect ~ metadataChecks',
-            //   metadataChecks,
-            // );
 
             if (!isEqual(newMetadataChecks, metadataChecks)) {
               setMetadataChecks(newMetadataChecks);

--- a/src/modules/dashboard/hooks/useColonyMetadataChecks.ts
+++ b/src/modules/dashboard/hooks/useColonyMetadataChecks.ts
@@ -10,7 +10,7 @@ import {
 import { ipfsDataFetcher } from '~modules/core/fetchers';
 import { ColonyAndExtensionsEvents, ColonyActions } from '~types/colonyActions';
 import {
-  getSpecificActionValuesCheck,
+  getColonyValuesCheck,
   sortMetadataHistory,
   parseColonyMetadata,
   ColonyMetadata,
@@ -93,11 +93,19 @@ const useColonyMetadataChecks = (
              *
              * This should be the default case for a colony with metadata history
              */
-            const newMetadataChecks = getSpecificActionValuesCheck(
+            const newMetadataChecks = getColonyValuesCheck(
               ColonyAndExtensionsEvents.ColonyMetadata,
               actionData,
               prevColonyMetadata,
             );
+            // console.log(
+            //   '🚀 ~ file: useColonyMetadataChecks.ts ~ line 101 ~ useEffect ~ newMetadataChecks',
+            //   newMetadataChecks,
+            // );
+            // console.log(
+            //   '🚀 ~ file: useColonyMetadataChecks.ts ~ line 104 ~ useEffect ~ metadataChecks',
+            //   metadataChecks,
+            // );
 
             if (!isEqual(newMetadataChecks, metadataChecks)) {
               setMetadataChecks(newMetadataChecks);


### PR DESCRIPTION
## Description

This PR fixes the type errors in metadata checks by splitting `getSpecificActionValuesCheck` into 2 functions. It also fixes the verified recipients check when one of the values is null or undefined.

resolves #3782 
