### PR TITLE
Decisions: Connect Decisions list to query

### DIFF
--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -2650,7 +2650,6 @@ export type SubgraphMotionsSubscriptionVariables = Exact<{
   first?: Maybe<Scalars['Int']>;
   colonyAddress: Scalars['String'];
   extensionAddress: Scalars['String'];
-  motionAction?: Maybe<Scalars['String']>;
   motionActionNot?: Maybe<Scalars['String']>;
 }>;
 
@@ -7271,8 +7270,8 @@ export function useSubgraphEventsThatAreActionsSubscription(baseOptions?: Apollo
 export type SubgraphEventsThatAreActionsSubscriptionHookResult = ReturnType<typeof useSubgraphEventsThatAreActionsSubscription>;
 export type SubgraphEventsThatAreActionsSubscriptionResult = Apollo.SubscriptionResult<SubgraphEventsThatAreActionsSubscription>;
 export const SubgraphMotionsDocument = gql`
-    subscription SubgraphMotions($skip: Int = 0, $first: Int = 1000, $colonyAddress: String!, $extensionAddress: String!, $motionAction: String, $motionActionNot: String) {
-  motions(skip: $skip, first: $first, where: {associatedColony: $colonyAddress, extensionAddress: $extensionAddress, action: $motionAction, action_not: $motionActionNot}) {
+    subscription SubgraphMotions($skip: Int = 0, $first: Int = 1000, $colonyAddress: String!, $extensionAddress: String!, $motionActionNot: String) {
+  motions(skip: $skip, first: $first, where: {associatedColony: $colonyAddress, extensionAddress: $extensionAddress, action_not: $motionActionNot}) {
     id
     fundamentalChainId
     associatedColony {
@@ -7337,7 +7336,6 @@ export const SubgraphMotionsDocument = gql`
  *      first: // value for 'first'
  *      colonyAddress: // value for 'colonyAddress'
  *      extensionAddress: // value for 'extensionAddress'
- *      motionAction: // value for 'motionAction'
  *      motionActionNot: // value for 'motionActionNot'
  *   },
  * });

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -1380,6 +1380,7 @@ export type SubscriptionMotion = {
   type: Scalars['String'];
   args: SubscriptionMotionArguments;
   timeoutPeriods: MotionTimeoutPeriods;
+  annotationHash: Scalars['String'];
 };
 
 export type SubscriptionMotionArguments = {
@@ -2656,6 +2657,38 @@ export type SubgraphMotionsSubscriptionVariables = Exact<{
 
 export type SubgraphMotionsSubscription = { motions: Array<(
     Pick<SubscriptionMotion, 'id' | 'fundamentalChainId' | 'extensionAddress' | 'agent' | 'stakes' | 'requiredStake' | 'escalated' | 'action' | 'state' | 'type'>
+    & { associatedColony: (
+      { colonyAddress: SubgraphColony['id'], id: SubgraphColony['colonyChainId'] }
+      & { token: (
+        Pick<SubgraphToken, 'decimals' | 'symbol'>
+        & { address: SubgraphToken['id'] }
+      ) }
+    ), transaction: (
+      { hash: SubgraphTransaction['id'] }
+      & { block: Pick<SubgraphBlock, 'id' | 'timestamp'> }
+    ), domain: (
+      Pick<SubgraphDomain, 'name'>
+      & { ethDomainId: SubgraphDomain['domainChainId'] }
+    ), args: (
+      Pick<SubscriptionMotionArguments, 'amount'>
+      & { token: (
+        Pick<SubgraphToken, 'symbol' | 'decimals'>
+        & { address: SubgraphToken['id'] }
+      ) }
+    ), timeoutPeriods: Pick<MotionTimeoutPeriods, 'timeLeftToStake' | 'timeLeftToSubmit' | 'timeLeftToReveal' | 'timeLeftToEscalate'> }
+  )> };
+
+export type SubgraphDecisionsSubscriptionVariables = Exact<{
+  skip?: Maybe<Scalars['Int']>;
+  first?: Maybe<Scalars['Int']>;
+  colonyAddress: Scalars['String'];
+  extensionAddress: Scalars['String'];
+  motionAction?: Maybe<Scalars['String']>;
+}>;
+
+
+export type SubgraphDecisionsSubscription = { motions: Array<(
+    Pick<SubscriptionMotion, 'id' | 'fundamentalChainId' | 'extensionAddress' | 'agent' | 'stakes' | 'requiredStake' | 'escalated' | 'action' | 'state' | 'type' | 'annotationHash'>
     & { associatedColony: (
       { colonyAddress: SubgraphColony['id'], id: SubgraphColony['colonyChainId'] }
       & { token: (
@@ -7314,6 +7347,83 @@ export function useSubgraphMotionsSubscription(baseOptions?: Apollo.Subscription
       }
 export type SubgraphMotionsSubscriptionHookResult = ReturnType<typeof useSubgraphMotionsSubscription>;
 export type SubgraphMotionsSubscriptionResult = Apollo.SubscriptionResult<SubgraphMotionsSubscription>;
+export const SubgraphDecisionsDocument = gql`
+    subscription SubgraphDecisions($skip: Int = 0, $first: Int = 1000, $colonyAddress: String!, $extensionAddress: String!, $motionAction: String) {
+  motions(skip: $skip, first: $first, where: {associatedColony: $colonyAddress, extensionAddress: $extensionAddress, action: $motionAction}) {
+    id
+    fundamentalChainId
+    associatedColony {
+      colonyAddress: id
+      id: colonyChainId
+      token {
+        address: id
+        decimals
+        symbol
+      }
+    }
+    transaction {
+      hash: id
+      block {
+        id
+        timestamp
+      }
+    }
+    extensionAddress
+    agent
+    domain {
+      ethDomainId: domainChainId
+      name
+    }
+    stakes
+    requiredStake
+    escalated
+    action
+    state @client
+    type @client
+    args @client {
+      amount
+      token {
+        address: id
+        symbol
+        decimals
+      }
+    }
+    timeoutPeriods @client {
+      timeLeftToStake
+      timeLeftToSubmit
+      timeLeftToReveal
+      timeLeftToEscalate
+    }
+    annotationHash @client
+  }
+}
+    `;
+
+/**
+ * __useSubgraphDecisionsSubscription__
+ *
+ * To run a query within a React component, call `useSubgraphDecisionsSubscription` and pass it any options that fit your needs.
+ * When your component renders, `useSubgraphDecisionsSubscription` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the subscription, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useSubgraphDecisionsSubscription({
+ *   variables: {
+ *      skip: // value for 'skip'
+ *      first: // value for 'first'
+ *      colonyAddress: // value for 'colonyAddress'
+ *      extensionAddress: // value for 'extensionAddress'
+ *      motionAction: // value for 'motionAction'
+ *   },
+ * });
+ */
+export function useSubgraphDecisionsSubscription(baseOptions?: Apollo.SubscriptionHookOptions<SubgraphDecisionsSubscription, SubgraphDecisionsSubscriptionVariables>) {
+        return Apollo.useSubscription<SubgraphDecisionsSubscription, SubgraphDecisionsSubscriptionVariables>(SubgraphDecisionsDocument, baseOptions);
+      }
+export type SubgraphDecisionsSubscriptionHookResult = ReturnType<typeof useSubgraphDecisionsSubscription>;
+export type SubgraphDecisionsSubscriptionResult = Apollo.SubscriptionResult<SubgraphDecisionsSubscription>;
 export const CommentCountDocument = gql`
     subscription CommentCount($colonyAddress: String!) {
   transactionMessagesCount(colonyAddress: $colonyAddress) {

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -2649,6 +2649,7 @@ export type SubgraphMotionsSubscriptionVariables = Exact<{
   first?: Maybe<Scalars['Int']>;
   colonyAddress: Scalars['String'];
   extensionAddress: Scalars['String'];
+  motionAction?: Maybe<Scalars['String']>;
 }>;
 
 
@@ -7236,8 +7237,8 @@ export function useSubgraphEventsThatAreActionsSubscription(baseOptions?: Apollo
 export type SubgraphEventsThatAreActionsSubscriptionHookResult = ReturnType<typeof useSubgraphEventsThatAreActionsSubscription>;
 export type SubgraphEventsThatAreActionsSubscriptionResult = Apollo.SubscriptionResult<SubgraphEventsThatAreActionsSubscription>;
 export const SubgraphMotionsDocument = gql`
-    subscription SubgraphMotions($skip: Int = 0, $first: Int = 1000, $colonyAddress: String!, $extensionAddress: String!) {
-  motions(skip: $skip, first: $first, where: {associatedColony: $colonyAddress, extensionAddress: $extensionAddress}) {
+    subscription SubgraphMotions($skip: Int = 0, $first: Int = 1000, $colonyAddress: String!, $extensionAddress: String!, $motionAction: String) {
+  motions(skip: $skip, first: $first, where: {associatedColony: $colonyAddress, extensionAddress: $extensionAddress, action: $motionAction}) {
     id
     fundamentalChainId
     associatedColony {
@@ -7302,6 +7303,7 @@ export const SubgraphMotionsDocument = gql`
  *      first: // value for 'first'
  *      colonyAddress: // value for 'colonyAddress'
  *      extensionAddress: // value for 'extensionAddress'
+ *      motionAction: // value for 'motionAction'
  *   },
  * });
  */

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -2682,7 +2682,6 @@ export type SubgraphDecisionsSubscriptionVariables = Exact<{
   first?: Maybe<Scalars['Int']>;
   colonyAddress: Scalars['String'];
   extensionAddress: Scalars['String'];
-  motionAction?: Maybe<Scalars['String']>;
 }>;
 
 
@@ -7346,8 +7345,8 @@ export function useSubgraphMotionsSubscription(baseOptions?: Apollo.Subscription
 export type SubgraphMotionsSubscriptionHookResult = ReturnType<typeof useSubgraphMotionsSubscription>;
 export type SubgraphMotionsSubscriptionResult = Apollo.SubscriptionResult<SubgraphMotionsSubscription>;
 export const SubgraphDecisionsDocument = gql`
-    subscription SubgraphDecisions($skip: Int = 0, $first: Int = 1000, $colonyAddress: String!, $extensionAddress: String!, $motionAction: String) {
-  motions(skip: $skip, first: $first, where: {associatedColony: $colonyAddress, extensionAddress: $extensionAddress, action: $motionAction}) {
+    subscription SubgraphDecisions($skip: Int = 0, $first: Int = 1000, $colonyAddress: String!, $extensionAddress: String!) {
+  motions(skip: $skip, first: $first, where: {associatedColony: $colonyAddress, extensionAddress: $extensionAddress, action: "0x12345678"}) {
     id
     fundamentalChainId
     associatedColony {
@@ -7413,7 +7412,6 @@ export const SubgraphDecisionsDocument = gql`
  *      first: // value for 'first'
  *      colonyAddress: // value for 'colonyAddress'
  *      extensionAddress: // value for 'extensionAddress'
- *      motionAction: // value for 'motionAction'
  *   },
  * });
  */

--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -2650,6 +2650,7 @@ export type SubgraphMotionsSubscriptionVariables = Exact<{
   colonyAddress: Scalars['String'];
   extensionAddress: Scalars['String'];
   motionAction?: Maybe<Scalars['String']>;
+  motionActionNot?: Maybe<Scalars['String']>;
 }>;
 
 
@@ -7237,8 +7238,8 @@ export function useSubgraphEventsThatAreActionsSubscription(baseOptions?: Apollo
 export type SubgraphEventsThatAreActionsSubscriptionHookResult = ReturnType<typeof useSubgraphEventsThatAreActionsSubscription>;
 export type SubgraphEventsThatAreActionsSubscriptionResult = Apollo.SubscriptionResult<SubgraphEventsThatAreActionsSubscription>;
 export const SubgraphMotionsDocument = gql`
-    subscription SubgraphMotions($skip: Int = 0, $first: Int = 1000, $colonyAddress: String!, $extensionAddress: String!, $motionAction: String) {
-  motions(skip: $skip, first: $first, where: {associatedColony: $colonyAddress, extensionAddress: $extensionAddress, action: $motionAction}) {
+    subscription SubgraphMotions($skip: Int = 0, $first: Int = 1000, $colonyAddress: String!, $extensionAddress: String!, $motionAction: String, $motionActionNot: String) {
+  motions(skip: $skip, first: $first, where: {associatedColony: $colonyAddress, extensionAddress: $extensionAddress, action: $motionAction, action_not: $motionActionNot}) {
     id
     fundamentalChainId
     associatedColony {
@@ -7304,6 +7305,7 @@ export const SubgraphMotionsDocument = gql`
  *      colonyAddress: // value for 'colonyAddress'
  *      extensionAddress: // value for 'extensionAddress'
  *      motionAction: // value for 'motionAction'
+ *      motionActionNot: // value for 'motionActionNot'
  *   },
  * });
  */

--- a/src/data/graphql/subscriptions.graphql
+++ b/src/data/graphql/subscriptions.graphql
@@ -155,6 +155,7 @@ subscription SubgraphMotions(
   $colonyAddress: String!
   $extensionAddress: String!
   $motionAction: String
+  $motionActionNot: String
 ) {
   motions(
     skip: $skip
@@ -163,6 +164,7 @@ subscription SubgraphMotions(
       associatedColony: $colonyAddress
       extensionAddress: $extensionAddress
       action: $motionAction
+      action_not: $motionActionNot
     }
   ) {
     id

--- a/src/data/graphql/subscriptions.graphql
+++ b/src/data/graphql/subscriptions.graphql
@@ -213,3 +213,67 @@ subscription SubgraphMotions(
     }
   }
 }
+
+subscription SubgraphDecisions(
+  $skip: Int = 0
+  $first: Int = 1000
+  $colonyAddress: String!
+  $extensionAddress: String!
+  $motionAction: String
+) {
+  motions(
+    skip: $skip
+    first: $first
+    where: {
+      associatedColony: $colonyAddress
+      extensionAddress: $extensionAddress
+      action: $motionAction
+    }
+  ) {
+    id
+    fundamentalChainId
+    associatedColony {
+      colonyAddress: id
+      id: colonyChainId
+      token {
+        address: id
+        decimals
+        symbol
+      }
+    }
+    transaction {
+      hash: id
+      block {
+        id
+        timestamp
+      }
+    }
+    extensionAddress
+    agent
+    domain {
+      ethDomainId: domainChainId
+      name
+    }
+    stakes
+    requiredStake
+    escalated
+    action
+    state @client
+    type @client
+    args @client {
+      amount
+      token {
+        address: id
+        symbol
+        decimals
+      }
+    }
+    timeoutPeriods @client {
+      timeLeftToStake
+      timeLeftToSubmit
+      timeLeftToReveal
+      timeLeftToEscalate
+    }
+    annotationHash @client
+  }
+}

--- a/src/data/graphql/subscriptions.graphql
+++ b/src/data/graphql/subscriptions.graphql
@@ -1,15 +1,12 @@
-subscription SubgraphEvents(
-  $skip: Int = 0
-  $first: Int = 1000
-  $colonyAddress: String!
-  $sortDirection: String = asc
-) {
+subscription SubgraphEvents($skip: Int = 0, $first: Int = 1000, $colonyAddress: String!, $sortDirection: String = asc) {
   events(
-    skip: $skip
-    first: $first
-    orderBy: "timestamp"
-    orderDirection: $sortDirection
-    where: { associatedColony: $colonyAddress }
+    skip: $skip,
+    first: $first,
+    orderBy: "timestamp",
+    orderDirection: $sortDirection,
+    where: {
+      associatedColony: $colonyAddress
+    }
   ) {
     id
     address
@@ -35,17 +32,12 @@ subscription SubgraphEvents(
   }
 }
 
-subscription SubgraphOneTx(
-  $skip: Int = 0
-  $first: Int = 1000
-  $colonyAddress: String!
-  $sortDirection: String = asc
-) {
+subscription SubgraphOneTx($skip: Int = 0, $first: Int = 1000, $colonyAddress: String!, $sortDirection: String = asc) {
   oneTxPayments(
-    skip: $skip
-    first: $first
-    orderBy: "timestamp"
-    orderDirection: $sortDirection
+    skip: $skip,
+    first: $first,
+    orderBy: "timestamp",
+    orderDirection: $sortDirection,
     where: { payment_contains: $colonyAddress }
   ) {
     id
@@ -79,35 +71,29 @@ subscription SubgraphOneTx(
   }
 }
 
-subscription SubgraphEventsThatAreActions(
-  $skip: Int = 0
-  $first: Int = 1000
-  $colonyAddress: String!
-  $sortDirection: String = asc
-) {
+subscription SubgraphEventsThatAreActions($skip: Int = 0, $first: Int = 1000, $colonyAddress: String!, $sortDirection: String = asc) {
   events(
-    skip: $skip
-    first: $first
-    orderBy: "timestamp"
-    orderDirection: $sortDirection
+    skip: $skip,
+    first: $first,
+    orderBy: "timestamp",
+    orderDirection: $sortDirection,
     where: {
-      associatedColony_contains: $colonyAddress
+      associatedColony_contains: $colonyAddress,
       name_in: [
-        "TokensMinted(address,address,uint256)"
-        "DomainAdded(address,uint256)"
-        "ColonyMetadata(address,string)"
-        "ColonyFundsMovedBetweenFundingPots(address,uint256,uint256,uint256,address)"
-        "DomainMetadata(address,uint256,string)"
-        "ColonyRoleSet(address,address,uint256,uint8,bool)"
-        "ColonyUpgraded(address,uint256,uint256)"
-        "ColonyUpgraded(uint256,uint256)"
-        "RecoveryModeEntered(address)"
-        "ArbitraryReputationUpdate(address,address,uint256,int256)"
-        "TokenUnlocked(address)"
-        "TokenUnlocked()"
+        "TokensMinted(address,address,uint256)",
+        "DomainAdded(address,uint256)",
+        "ColonyMetadata(address,string)",
+        "ColonyFundsMovedBetweenFundingPots(address,uint256,uint256,uint256,address)",
+        "DomainMetadata(address,uint256,string)",
+        "ColonyRoleSet(address,address,uint256,uint8,bool)",
+        "ColonyUpgraded(address,uint256,uint256)",
+        "ColonyUpgraded(uint256,uint256)",
+        "RecoveryModeEntered(address)",
+        "ArbitraryReputationUpdate(address,address,uint256,int256)",
+        "TokenUnlocked(address)",
+        "TokenUnlocked()",
       ]
-    }
-  ) {
+    }) {
     id
     address
     associatedColony {
@@ -149,22 +135,15 @@ subscription SubgraphEventsThatAreActions(
   }
 }
 
-subscription SubgraphMotions(
-  $skip: Int = 0
-  $first: Int = 1000
-  $colonyAddress: String!
-  $extensionAddress: String!
-  $motionActionNot: String
-) {
+subscription SubgraphMotions($skip: Int = 0, $first: Int = 1000, $colonyAddress: String!, $extensionAddress: String!, $motionActionNot: String) {
   motions(
-    skip: $skip
-    first: $first
+    skip: $skip,
+    first: $first,
     where: {
-      associatedColony: $colonyAddress
-      extensionAddress: $extensionAddress
-      action_not: $motionActionNot
-    }
-  ) {
+      associatedColony: $colonyAddress,
+      extensionAddress: $extensionAddress,
+      action_not: $motionActionNot,
+  }) {
     id
     fundamentalChainId
     associatedColony {
@@ -212,22 +191,15 @@ subscription SubgraphMotions(
   }
 }
 
-subscription SubgraphDecisions(
-  $skip: Int = 0
-  $first: Int = 1000
-  $colonyAddress: String!
-  $extensionAddress: String!
-  $motionAction: String
-) {
+subscription SubgraphDecisions($skip: Int = 0, $first: Int = 1000, $colonyAddress: String!, $extensionAddress: String!) {
   motions(
-    skip: $skip
-    first: $first
+    skip: $skip,
+    first: $first,
     where: {
-      associatedColony: $colonyAddress
-      extensionAddress: $extensionAddress
-      action: $motionAction
-    }
-  ) {
+      associatedColony: $colonyAddress,
+      extensionAddress: $extensionAddress,
+      action: "0x12345678",
+  }) {
     id
     fundamentalChainId
     associatedColony {

--- a/src/data/graphql/subscriptions.graphql
+++ b/src/data/graphql/subscriptions.graphql
@@ -154,7 +154,6 @@ subscription SubgraphMotions(
   $first: Int = 1000
   $colonyAddress: String!
   $extensionAddress: String!
-  $motionAction: String
   $motionActionNot: String
 ) {
   motions(
@@ -163,7 +162,6 @@ subscription SubgraphMotions(
     where: {
       associatedColony: $colonyAddress
       extensionAddress: $extensionAddress
-      action: $motionAction
       action_not: $motionActionNot
     }
   ) {

--- a/src/data/graphql/subscriptions.graphql
+++ b/src/data/graphql/subscriptions.graphql
@@ -1,12 +1,15 @@
-subscription SubgraphEvents($skip: Int = 0, $first: Int = 1000, $colonyAddress: String!, $sortDirection: String = asc) {
+subscription SubgraphEvents(
+  $skip: Int = 0
+  $first: Int = 1000
+  $colonyAddress: String!
+  $sortDirection: String = asc
+) {
   events(
-    skip: $skip,
-    first: $first,
-    orderBy: "timestamp",
-    orderDirection: $sortDirection,
-    where: {
-      associatedColony: $colonyAddress
-    }
+    skip: $skip
+    first: $first
+    orderBy: "timestamp"
+    orderDirection: $sortDirection
+    where: { associatedColony: $colonyAddress }
   ) {
     id
     address
@@ -32,12 +35,17 @@ subscription SubgraphEvents($skip: Int = 0, $first: Int = 1000, $colonyAddress: 
   }
 }
 
-subscription SubgraphOneTx($skip: Int = 0, $first: Int = 1000, $colonyAddress: String!, $sortDirection: String = asc) {
+subscription SubgraphOneTx(
+  $skip: Int = 0
+  $first: Int = 1000
+  $colonyAddress: String!
+  $sortDirection: String = asc
+) {
   oneTxPayments(
-    skip: $skip,
-    first: $first,
-    orderBy: "timestamp",
-    orderDirection: $sortDirection,
+    skip: $skip
+    first: $first
+    orderBy: "timestamp"
+    orderDirection: $sortDirection
     where: { payment_contains: $colonyAddress }
   ) {
     id
@@ -71,29 +79,35 @@ subscription SubgraphOneTx($skip: Int = 0, $first: Int = 1000, $colonyAddress: S
   }
 }
 
-subscription SubgraphEventsThatAreActions($skip: Int = 0, $first: Int = 1000, $colonyAddress: String!, $sortDirection: String = asc) {
+subscription SubgraphEventsThatAreActions(
+  $skip: Int = 0
+  $first: Int = 1000
+  $colonyAddress: String!
+  $sortDirection: String = asc
+) {
   events(
-    skip: $skip,
-    first: $first,
-    orderBy: "timestamp",
-    orderDirection: $sortDirection,
+    skip: $skip
+    first: $first
+    orderBy: "timestamp"
+    orderDirection: $sortDirection
     where: {
-      associatedColony_contains: $colonyAddress,
+      associatedColony_contains: $colonyAddress
       name_in: [
-        "TokensMinted(address,address,uint256)",
-        "DomainAdded(address,uint256)",
-        "ColonyMetadata(address,string)",
-        "ColonyFundsMovedBetweenFundingPots(address,uint256,uint256,uint256,address)",
-        "DomainMetadata(address,uint256,string)",
-        "ColonyRoleSet(address,address,uint256,uint8,bool)",
-        "ColonyUpgraded(address,uint256,uint256)",
-        "ColonyUpgraded(uint256,uint256)",
-        "RecoveryModeEntered(address)",
-        "ArbitraryReputationUpdate(address,address,uint256,int256)",
-        "TokenUnlocked(address)",
-        "TokenUnlocked()",
+        "TokensMinted(address,address,uint256)"
+        "DomainAdded(address,uint256)"
+        "ColonyMetadata(address,string)"
+        "ColonyFundsMovedBetweenFundingPots(address,uint256,uint256,uint256,address)"
+        "DomainMetadata(address,uint256,string)"
+        "ColonyRoleSet(address,address,uint256,uint8,bool)"
+        "ColonyUpgraded(address,uint256,uint256)"
+        "ColonyUpgraded(uint256,uint256)"
+        "RecoveryModeEntered(address)"
+        "ArbitraryReputationUpdate(address,address,uint256,int256)"
+        "TokenUnlocked(address)"
+        "TokenUnlocked()"
       ]
-    }) {
+    }
+  ) {
     id
     address
     associatedColony {
@@ -135,14 +149,22 @@ subscription SubgraphEventsThatAreActions($skip: Int = 0, $first: Int = 1000, $c
   }
 }
 
-subscription SubgraphMotions($skip: Int = 0, $first: Int = 1000, $colonyAddress: String!, $extensionAddress: String!) {
+subscription SubgraphMotions(
+  $skip: Int = 0
+  $first: Int = 1000
+  $colonyAddress: String!
+  $extensionAddress: String!
+  $motionAction: String
+) {
   motions(
-    skip: $skip,
-    first: $first,
+    skip: $skip
+    first: $first
     where: {
-      associatedColony: $colonyAddress,
-      extensionAddress: $extensionAddress,
-  }) {
+      associatedColony: $colonyAddress
+      extensionAddress: $extensionAddress
+      action: $motionAction
+    }
+  ) {
     id
     fundamentalChainId
     associatedColony {

--- a/src/data/graphql/typeDefsSubscriptions.ts
+++ b/src/data/graphql/typeDefsSubscriptions.ts
@@ -34,6 +34,7 @@ export default gql`
     type: String!
     args: SubscriptionMotionArguments!
     timeoutPeriods: MotionTimeoutPeriods!
+    annotationHash: String!
   }
 
   type MotionTimeoutPeriods {

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -13,6 +13,7 @@ import { Resolvers } from '@apollo/client';
 import { Context } from '~context/index';
 import { createAddress } from '~utils/web3';
 import {
+  getAnnotationFromSubgraph,
   getMotionActionType,
   getMotionState,
   parseSubgraphEvent,
@@ -1291,6 +1292,16 @@ export const motionsResolvers = ({
           decimals,
         },
       };
+    },
+    async annotationHash({ transaction, agent }) {
+      const {
+        values: { metadata: annotationHash },
+      } = await getAnnotationFromSubgraph(
+        agent,
+        transaction.hash,
+        apolloClient,
+      );
+      return annotationHash;
     },
   },
 });

--- a/src/modules/core/components/ActionsList/ActionsListItem.tsx
+++ b/src/modules/core/components/ActionsList/ActionsListItem.tsx
@@ -105,8 +105,8 @@ const ActionsListItem = ({
     requiredStake,
     transactionTokenAddress,
     reputationChange,
-    title,
     isDecision,
+    annotationHash,
   },
   colony,
   handleOnClick,
@@ -118,6 +118,17 @@ const ActionsListItem = ({
     [metadata],
   );
 
+  const { data } = useDataFetcher(
+    ipfsDataFetcher,
+    [annotationHash as string],
+    [annotationHash],
+  );
+
+  let title = '';
+  if (data) {
+    const decision = JSON.parse(data);
+    title = decision?.title;
+  }
   const { isVotingExtensionEnabled } = useEnabledExtensions({
     colonyAddress: colony.colonyAddress,
   });

--- a/src/modules/dashboard/components/ColonyActions/ColonyActions.tsx
+++ b/src/modules/dashboard/components/ColonyActions/ColonyActions.tsx
@@ -31,6 +31,7 @@ import {
   FormattedAction,
   Address,
 } from '~types/index';
+import { ACTION_DECISION_MOTION_CODE } from '~constants';
 
 import styles from './ColonyActions.css';
 
@@ -155,6 +156,7 @@ const ColonyActions = ({
        */
       colonyAddress: colonyAddress?.toLowerCase(),
       extensionAddress: votingReputationExtension?.address?.toLowerCase() || '',
+      motionActionNot: ACTION_DECISION_MOTION_CODE,
     },
   });
 

--- a/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
+++ b/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
@@ -17,7 +17,6 @@ import {
 import { useEnabledExtensions } from '~utils/hooks/useEnabledExtensions';
 import { useTransformer } from '~utils/hooks';
 import { getActionsListData } from '~modules/dashboard/transformers';
-import { ACTION_DECISION_MOTION_CODE } from '~constants';
 
 import { SortOptions, SortSelectOptions } from './constants';
 import styles from './ColonyDecisions.css';
@@ -77,7 +76,10 @@ const ColonyDecisions = ({
     [colonyName, history],
   );
 
-  const { isVotingExtensionEnabled } = useEnabledExtensions({
+  const {
+    isVotingExtensionEnabled,
+    isLoadingExtensions,
+  } = useEnabledExtensions({
     colonyAddress,
   });
 
@@ -100,7 +102,6 @@ const ColonyDecisions = ({
        */
       colonyAddress: colonyAddress?.toLowerCase() || '',
       extensionAddress: votingReputationExtension?.address?.toLowerCase() || '',
-      motionAction: ACTION_DECISION_MOTION_CODE,
     },
   });
 
@@ -139,14 +140,6 @@ const ColonyDecisions = ({
     ITEMS_PER_PAGE * dataPage,
   );
 
-  if (!isVotingExtensionEnabled) {
-    return (
-      <div className={styles.installExtension}>
-        <FormattedMessage {...MSG.installExtension} />
-      </div>
-    );
-  }
-
   if (decisionsLoading) {
     return (
       <div className={styles.loadingSpinner}>
@@ -154,6 +147,14 @@ const ColonyDecisions = ({
           loadingText={MSG.loading}
           appearance={{ theme: 'primary', size: 'massive' }}
         />
+      </div>
+    );
+  }
+
+  if (!isVotingExtensionEnabled && !isLoadingExtensions) {
+    return (
+      <div className={styles.statusMessage}>
+        <FormattedMessage {...MSG.installExtension} />
       </div>
     );
   }

--- a/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
+++ b/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
@@ -41,7 +41,7 @@ const MSG = defineMessages({
   },
   loading: {
     id: 'dashboard.ColonyDecisions.loading',
-    defaultMessage: 'Loading decisions',
+    defaultMessage: 'Loading Decisions',
   },
   installExtension: {
     id: 'dashboard.ColonyDecisions.installExtension',
@@ -57,89 +57,6 @@ type Props = {
   ethDomainId?: number;
 };
 
-/* temp data */
-const data = [
-  {
-    id: `0xeabe562c979679dc4023dd23e8c6aa782448c2e7_motion_0xa1e73506f3ef6dc19dc27b750adf585fd0f30c63_2`,
-    initiator: '0xb77d57f4959eafa0339424b83fcfaf9c15407461',
-    recipient: '0x0000000000000000000000000000000000000000',
-    title: 'I want to add dark mode to the Dapp',
-    motionState: 'Passed',
-    isDecision: true,
-    motionId: '2',
-    createdAt: new Date(
-      'Sun Aug 17 2022 12:48:59 GMT+0300 (Eastern European Summer Time)',
-    ),
-    ending: new Date(
-      'Sun Aug 27 2022 12:48:59 GMT+0300 (Eastern European Summer Time)',
-    ),
-  },
-  {
-    title: 'Update the logo design',
-    isDecision: true,
-    actionType: undefined,
-    amount: '0',
-    blockNumber: 853,
-    commentCount: 0,
-    createdAt: new Date(
-      'Sun Aug 14 2022 12:48:59 GMT+0300 (Eastern European Summer Time)',
-    ),
-    ending: new Date(
-      'Sun Aug 24 2022 12:48:59 GMT+0300 (Eastern European Summer Time)',
-    ),
-    decimals: '18',
-    fromDomain: '1',
-    id: `0xeabe562c979679dc4023dd23e8c6aa782448c2e7_motion_0xa1e73506f3ef6dc19dc27b750adf585fd0f30c63_1`,
-    initiator: '0xb77d57f4959eafa0339424b83fcfaf9c15407461',
-    motionId: '1',
-    motionState: 'Staking',
-    recipient: '0x0000000000000000000000000000000000000000',
-    reputationChange: '0',
-    requiredStake: '1010101010101010101',
-    status: undefined,
-    symbol: '???',
-    timeoutPeriods: undefined,
-    toDomain: '1',
-    tokenAddress: '0x0000000000000000000000000000000000000000',
-    totalNayStake: '0',
-    transactionHash:
-      '0x9c742b1392fadb48c0bc0d2cebdd518e7b11c0c1ab426c084a06c68ea77f8f70',
-    transactionTokenAddress: undefined,
-  },
-  {
-    title: 'Update the actions design',
-    isDecision: true,
-    actionType: undefined,
-    amount: '0',
-    blockNumber: 853,
-    commentCount: 0,
-    createdAt: new Date(
-      'Sun Aug 18 2022 12:48:59 GMT+0300 (Eastern European Summer Time)',
-    ),
-    ending: new Date(
-      'Sun Aug 28 2022 12:48:59 GMT+0300 (Eastern European Summer Time)',
-    ),
-    decimals: '18',
-    fromDomain: '2',
-    id: `0xeabe562c979679dc4023dd23e8c6aa782448c2e7_motion_0xa1e73506f3ef6dc19dc27b750adf585fd0f30c63_3`,
-    initiator: '0xb77d57f4959eafa0339424b83fcfaf9c15407461',
-    motionId: '1',
-    motionState: 'Staked',
-    recipient: '0x0000000000000000000000000000000000000000',
-    reputationChange: '0',
-    requiredStake: '1010101010101010101',
-    status: undefined,
-    symbol: '???',
-    timeoutPeriods: undefined,
-    toDomain: '2',
-    tokenAddress: '0x0000000000000000000000000000000000000000',
-    totalNayStake: '0',
-    transactionHash:
-      '0x9c742b1392fadb48c0bc0d2cebdd518e7b11c0c1ab426c084a06c68ea77f8f70',
-    transactionTokenAddress: undefined,
-  },
-];
-
 const ITEMS_PER_PAGE = 10;
 
 const ColonyDecisions = ({
@@ -151,9 +68,6 @@ const ColonyDecisions = ({
     SortOptions.ENDING_SOONEST,
   );
   const [dataPage, setDataPage] = useState<number>(1);
-
-  // temp values, to be removed when queries are wired in
-  const isLoading = false;
 
   const history = useHistory();
 
@@ -175,7 +89,10 @@ const ColonyDecisions = ({
     ({ extensionId }) => extensionId === Extension.VotingReputation,
   );
 
-  const { data: motions } = useSubgraphDecisionsSubscription({
+  const {
+    data: motions,
+    loading: decisionsLoading,
+  } = useSubgraphDecisionsSubscription({
     variables: {
       /*
        * @NOTE We always need to fetch one more item so that we know that more
@@ -230,7 +147,7 @@ const ColonyDecisions = ({
     );
   }
 
-  if (isLoading) {
+  if (decisionsLoading) {
     return (
       <div className={styles.loadingSpinner}>
         <SpinnerLoader
@@ -271,10 +188,10 @@ const ColonyDecisions = ({
             handleItemClick={handleActionRedirect}
             colony={colony}
           />
-          {ITEMS_PER_PAGE * dataPage < data?.length && (
+          {ITEMS_PER_PAGE * dataPage < decisions?.length && (
             <LoadMoreButton
               onClick={() => setDataPage(dataPage + 1)}
-              isLoadingData={isLoading}
+              isLoadingData={decisionsLoading}
             />
           )}
         </>

--- a/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
+++ b/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
@@ -200,9 +200,12 @@ const ColonyDecisions = ({
           )}
         </>
       ) : (
-        <div className={styles.emptyState}>
-          <FormattedMessage {...MSG.noDecisionsFound} />
-        </div>
+        !decisionsLoading &&
+        isVotingExtensionEnabled && (
+          <div className={styles.statusMessage}>
+            <FormattedMessage {...MSG.noDecisionsFound} />
+          </div>
+        )
       )}
     </div>
   );

--- a/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
+++ b/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
@@ -108,6 +108,9 @@ const ColonyDecisions = ({
   const decisions = useTransformer(getActionsListData, [
     installedExtensions?.map(({ address }) => address) as string[],
     { ...motions },
+    undefined,
+    {},
+    true,
   ]);
 
   const filteredDecisions = useMemo(

--- a/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
+++ b/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
@@ -156,7 +156,7 @@ const ColonyDecisions = ({
 
   if (!isVotingExtensionEnabled && !isLoadingExtensions) {
     return (
-      <div className={styles.statusMessage}>
+      <div className={styles.installExtension}>
         <FormattedMessage {...MSG.installExtension} />
       </div>
     );
@@ -202,7 +202,7 @@ const ColonyDecisions = ({
       ) : (
         !decisionsLoading &&
         isVotingExtensionEnabled && (
-          <div className={styles.statusMessage}>
+          <div className={styles.emptyState}>
             <FormattedMessage {...MSG.noDecisionsFound} />
           </div>
         )

--- a/src/modules/dashboard/transformers/transformers.ts
+++ b/src/modules/dashboard/transformers/transformers.ts
@@ -12,10 +12,12 @@ import {
 import {
   Address,
   ColonyActions,
+  ColonyMotions,
   FormattedAction,
   FormattedEvent,
   ColonyAndExtensionsEvents,
 } from '~types/index';
+
 import { ACTIONS_EVENTS } from '~dashboard/ActionsPage/staticMaps';
 import { getValuesForActionType } from '~utils/colonyActions';
 import { TEMP_getContext, ContextModule } from '~context/index';
@@ -164,6 +166,9 @@ export const getActionsListData = (
             totalNayStake: '0',
             requiredStake: '0',
             reputationChange: '0',
+            isDecision:
+              unformattedAction.type === ColonyMotions.CreateDecisionMotion,
+            annotationHash: '',
           };
           let hash;
           let timestamp;
@@ -311,6 +316,7 @@ export const getActionsListData = (
                 timeoutPeriods,
                 stakes,
                 requiredStake,
+                annotationHash,
               } = unformattedAction;
 
               if (args?.token) {
@@ -330,6 +336,7 @@ export const getActionsListData = (
               formatedAction.fromDomain = ethDomainId;
               formatedAction.motionId = fundamentalChainId;
               formatedAction.timeoutPeriods = timeoutPeriods;
+              formatedAction.annotationHash = annotationHash;
               formatedAction.totalNayStake = bigNumberify(
                 stakes[0] || 0,
               ).toString();

--- a/src/modules/dashboard/transformers/transformers.ts
+++ b/src/modules/dashboard/transformers/transformers.ts
@@ -55,6 +55,7 @@ export const getActionsListData = (
     extensionAddresses,
     actionsThatNeedAttention,
   }: ActionsTransformerMetadata = {},
+  isDecision = false,
 ): FormattedAction[] => {
   let formattedActions = [];
   /*
@@ -131,7 +132,9 @@ export const getActionsListData = (
         const totalNayStake = bigNumberify(stakes[0] || 0);
         const totalYayStake = bigNumberify(stakes[1] || 0);
         const currentStake = totalNayStake.add(totalYayStake).toString();
-        const enoughStake = shouldDisplayMotion(currentStake, requiredStake);
+        const enoughStake = isDecision
+          ? true
+          : shouldDisplayMotion(currentStake, requiredStake);
         if (escalated || enoughStake) {
           return [...acc, motion];
         }

--- a/src/types/colonyActions.ts
+++ b/src/types/colonyActions.ts
@@ -146,7 +146,6 @@ export interface FormattedAction {
   totalNayStake?: string;
   requiredStake?: string;
   reputationChange?: string;
-  /* This is potentially temporary. Will depend on what data we get from a query */
   isDecision?: boolean;
   annotationHash?: string;
 }

--- a/src/types/colonyActions.ts
+++ b/src/types/colonyActions.ts
@@ -148,7 +148,7 @@ export interface FormattedAction {
   reputationChange?: string;
   /* This is potentially temporary. Will depend on what data we get from a query */
   isDecision?: boolean;
-  title?: string;
+  annotationHash?: string;
 }
 
 export interface FormattedEvent {

--- a/src/utils/events/getAnnotationFromSubgraph.ts
+++ b/src/utils/events/getAnnotationFromSubgraph.ts
@@ -36,8 +36,8 @@ export const getAnnotationFromSubgraph = async (
        */
       .filter(
         ({ values: { agent, address } }) =>
-          agent === userAddress || address === userAddress,
+          agent.toLowerCase() === userAddress ||
+          address.toLowerCase() === userAddress,
       ) || [];
-
   return mostRecentAnnotation;
 };

--- a/src/utils/events/getAnnotationFromSubgraph.ts
+++ b/src/utils/events/getAnnotationFromSubgraph.ts
@@ -34,10 +34,12 @@ export const getAnnotationFromSubgraph = async (
        * be filtering these out, and show the most recent annotation, no matter
        * who sent it
        */
-      .filter(
-        ({ values: { agent, address } }) =>
-          agent.toLowerCase() === userAddress ||
-          address.toLowerCase() === userAddress,
-      ) || [];
+      .filter(({ values: { agent, address } }) => {
+        const userAddressLowered = userAddress.toLowerCase();
+        return (
+          agent.toLowerCase() === userAddressLowered ||
+          address.toLowerCase() === userAddressLowered
+        );
+      }) || [];
   return mostRecentAnnotation;
 };


### PR DESCRIPTION
## Description

This PR:

- Adds extra prop to Subscription SubgraphMotion to exclude Decision motions.
- Creates Subscription SubgraphDecision that performs a query to get the annotation hash which is storing the Decision details.
- Removes Decisions from ColonyActions listItems
- Display spinner as Decisions are being loaded
- Clicking on Decision listItem navigates to transaction (Decision)

![Screenshot 2022-09-09 at 19 17 59 (2)](https://user-images.githubusercontent.com/582700/189395703-3e5b51ae-75d4-40c5-874e-8abf90e5f5f3.png)


![Screenshot 2022-09-09 at 18 50 47](https://user-images.githubusercontent.com/582700/189395065-63f037fe-9614-455a-b3c3-3a684f3597c1.png)

*I noticed a small bug where, if you create a Decision and then nav back to Decisions homepage the decisions list is not refreshed.  The subscription seems to be called but returns zero results. I'm not sure why, but i will raise an issue.

Resolves #3790