### PR TITLE
Fix: Colonies list height

### DIFF
--- a/src/modules/pages/components/RouteLayouts/Default/Default.css
+++ b/src/modules/pages/components/RouteLayouts/Default/Default.css
@@ -9,6 +9,7 @@
 
 .coloniesList {
   flex: 0 0 auto;
+  height: 100%;
   width: 60px;
   position: fixed;
   border-right: 1px solid var(--temp-grey-13);


### PR DESCRIPTION
## Description

The colonies list wasn't taking up 100% of height as expected. This PR fixes the issue.

**Changes** 🏗

* Added `height: 100%` to the colonies list wrapper

Resolves #3820 
