### PR TITLE
Refactor: Replace motions resolver action name strings with an enum

### DIFF
--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -24,7 +24,10 @@ import {
   getMotionRequiredStake,
   getEarlierEventTimestamp,
 } from '~utils/colonyMotions';
-import { ColonyAndExtensionsEvents } from '~types/index';
+import {
+  ColonyAndExtensionsEvents,
+  ColonyMotionActionName,
+} from '~types/index';
 import {
   SubgraphMotionEventsQuery,
   SubgraphMotionEventsQueryVariables,
@@ -1209,7 +1212,7 @@ export const motionsResolvers = ({
         };
       }
 
-      if (actionValues.name === 'addDomain') {
+      if (actionValues.name === ColonyMotionActionName.AddDomain) {
         return {
           ...defaultValues,
           metadata: actionValues.args[3],
@@ -1225,14 +1228,14 @@ export const motionsResolvers = ({
         };
       }
 
-      if (actionValues.name === 'editColony') {
+      if (actionValues.name === ColonyMotionActionName.EditColony) {
         return {
           ...defaultValues,
           metadata: actionValues.args[0],
         };
       }
 
-      if (actionValues.name === 'createDecision') {
+      if (actionValues.name === ColonyMotionActionName.CreateDecision) {
         return actionValues.args[0];
       }
 

--- a/src/types/colonyMotions.ts
+++ b/src/types/colonyMotions.ts
@@ -31,3 +31,9 @@ export const motionNameMapping = {
   emitDomainReputationReward: ColonyMotions.EmitDomainReputationRewardMotion,
   createDecision: ColonyMotions.CreateDecisionMotion,
 };
+
+export enum ColonyMotionActionName {
+  AddDomain = 'addDomain',
+  EditColony = 'editColony',
+  CreateDecision = 'createDecision',
+}


### PR DESCRIPTION
## Description

This issue originated from review of [#3769](https://github.com/JoinColony/colonyDapp/pull/3769#discussion_r963688044). This PR replaces hardcoded string values with an enum.

**Changes** 🏗

* Add `ColonyMotionActionName` enum
* Replace hardcoded strings in `motions` resolver with enum

Resolves #3829 
