### PR TITLE
Add a 10% stake visibility threshold on Motions page

### DIFF
--- a/src/modules/core/components/ProgressBar/ProgressBar.css
+++ b/src/modules/core/components/ProgressBar/ProgressBar.css
@@ -74,7 +74,7 @@
   flex-direction: column;
   align-items: center;
   position: absolute;
-  top: -21px;
+  top: -19px;
 }
 
 .thresholdPercentage {
@@ -96,7 +96,8 @@
 }
 
 .sizeNormal .thresholdSeparator {
-  height: 22px;
+  height: 18px;
+  border-radius: 3px;
 }
 
 .borderRadiusSmall .main::-webkit-progress-bar {

--- a/src/modules/core/components/ProgressBar/ProgressBar.css
+++ b/src/modules/core/components/ProgressBar/ProgressBar.css
@@ -55,8 +55,10 @@
 
 .barThemePrimary .main::-webkit-progress-value {
   background-color: var(--primary);
+}
 
-  /* background-color: var(--golden); */
+.barColorBelowThreshold .main::-webkit-progress-value {
+  background-color: var(--golden);
 }
 
 .barThemeDanger .main::-webkit-progress-value {

--- a/src/modules/core/components/ProgressBar/ProgressBar.css
+++ b/src/modules/core/components/ProgressBar/ProgressBar.css
@@ -86,7 +86,7 @@
 
 .thresholdSeparator {
   height: 14px;
-  width: 2px;
+  width: 3px;
   border-radius: 1px;
   background-color: var(--pink);
 }

--- a/src/modules/core/components/ProgressBar/ProgressBar.css
+++ b/src/modules/core/components/ProgressBar/ProgressBar.css
@@ -55,6 +55,8 @@
 
 .barThemePrimary .main::-webkit-progress-value {
   background-color: var(--primary);
+
+  /* background-color: var(--golden); */
 }
 
 .barThemeDanger .main::-webkit-progress-value {
@@ -85,6 +87,10 @@
   width: 2px;
   border-radius: 1px;
   background-color: var(--pink);
+}
+
+.thresholdVisibility {
+  visibility: hidden;
 }
 
 .sizeNormal .thresholdSeparator {

--- a/src/modules/core/components/ProgressBar/ProgressBar.css.d.ts
+++ b/src/modules/core/components/ProgressBar/ProgressBar.css.d.ts
@@ -6,6 +6,7 @@ export const backgroundThemeTransparent: string;
 export const backgroundThemeDefault: string;
 export const backgroundThemeDark: string;
 export const barThemePrimary: string;
+export const barColorBelowThreshold: string;
 export const barThemeDanger: string;
 export const threshold: string;
 export const thresholdPercentage: string;

--- a/src/modules/core/components/ProgressBar/ProgressBar.css.d.ts
+++ b/src/modules/core/components/ProgressBar/ProgressBar.css.d.ts
@@ -10,4 +10,5 @@ export const barThemeDanger: string;
 export const threshold: string;
 export const thresholdPercentage: string;
 export const thresholdSeparator: string;
+export const thresholdVisibility: string;
 export const borderRadiusSmall: string;

--- a/src/modules/core/components/ProgressBar/ProgressBar.tsx
+++ b/src/modules/core/components/ProgressBar/ProgressBar.tsx
@@ -69,7 +69,6 @@ const ProgressBar = ({
           >
             {threshold}%
           </span>
-
           <div className={styles.thresholdSeparator} />
         </div>
       )}

--- a/src/modules/core/components/ProgressBar/ProgressBar.tsx
+++ b/src/modules/core/components/ProgressBar/ProgressBar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { defineMessages, useIntl } from 'react-intl';
+import classnames from 'classnames';
 
 import { getMainClasses } from '~utils/css';
 
@@ -24,6 +25,7 @@ interface Props {
   value?: number;
   max?: number;
   threshold?: number;
+  hidePercentage?: boolean;
 }
 
 const displayName = 'ProgressBar';
@@ -39,9 +41,11 @@ const ProgressBar = ({
   value = 0,
   max = 100,
   threshold,
+  hidePercentage = false,
 }: Props) => {
   const { formatMessage } = useIntl();
   const titleText = formatMessage(MSG.titleProgress, { value, max });
+  const visible = styles.thresholdVisibility;
 
   return (
     <div className={`${styles.wrapper} ${getMainClasses(appearance, styles)}`}>
@@ -52,7 +56,14 @@ const ProgressBar = ({
           }}
           className={styles.threshold}
         >
-          <span className={styles.thresholdPercentage}>{threshold}%</span>
+          <span
+            className={classnames(styles.thresholdPercentage, {
+              [visible]: hidePercentage,
+            })}
+          >
+            {threshold}%
+          </span>
+
           <div className={styles.thresholdSeparator} />
         </div>
       )}

--- a/src/modules/core/components/ProgressBar/ProgressBar.tsx
+++ b/src/modules/core/components/ProgressBar/ProgressBar.tsx
@@ -46,9 +46,15 @@ const ProgressBar = ({
   const { formatMessage } = useIntl();
   const titleText = formatMessage(MSG.titleProgress, { value, max });
   const visible = styles.thresholdVisibility;
+  const belowThreshold = styles.barColorBelowThreshold;
 
   return (
-    <div className={`${styles.wrapper} ${getMainClasses(appearance, styles)}`}>
+    <div
+      className={`${styles.wrapper} ${getMainClasses(
+        appearance,
+        styles,
+      )} ${classnames({ [belowThreshold]: threshold && value < threshold })}`}
+    >
       {!!threshold && (
         <div
           style={{

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
@@ -33,6 +33,7 @@ interface Props extends StakingAmounts {
   };
   canUserStake: boolean;
   isObjection: boolean;
+  totalPercentage: number;
 }
 
 const displayName = 'StakingSlider';
@@ -83,6 +84,7 @@ const StakingSlider = ({
   appearance,
   userActivatedTokens,
   isObjection,
+  totalPercentage,
 }: Props) => {
   const [limitExceeded, setLimitExceeded] = useState(false);
   const { ethereal } = useLoggedInUser();
@@ -117,6 +119,9 @@ const StakingSlider = ({
     stakeWithMin.round().toString(),
     nativeToken?.decimals,
   );
+
+  const isThresholdAchieved = totalPercentage >= 10;
+
   const userStakePercentage = stakeWithMin
     .round()
     .div(remainingToStake)
@@ -223,9 +228,9 @@ const StakingSlider = ({
               <span
                 className={classnames(styles.requiredStakeText, {
                   [styles.requiredStakeUnderThreshold]:
-                    userStakePercentage < 10,
+                    !isThresholdAchieved && userStakePercentage < 10,
                   [styles.requiredStakeAboveThreshold]:
-                    userStakePercentage >= 10,
+                    isThresholdAchieved || userStakePercentage >= 10,
                 })}
               >
                 <FormattedMessage

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
@@ -33,7 +33,7 @@ interface Props extends StakingAmounts {
   };
   canUserStake: boolean;
   isObjection: boolean;
-  totalPercentage: number;
+  totalPercentage?: number;
 }
 
 const displayName = 'StakingSlider';
@@ -84,7 +84,7 @@ const StakingSlider = ({
   appearance,
   userActivatedTokens,
   isObjection,
-  totalPercentage,
+  totalPercentage = 0,
 }: Props) => {
   const [limitExceeded, setLimitExceeded] = useState(false);
   const { ethereal } = useLoggedInUser();

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
@@ -229,9 +229,11 @@ const StakingSlider = ({
                 <span
                   className={classnames(styles.requiredStakeText, {
                     [styles.requiredStakeUnderThreshold]:
-                      !isThresholdAchieved && userStakePercentage < 10,
+                      !isThresholdAchieved &&
+                      userStakePercentage < 10 - totalPercentage,
                     [styles.requiredStakeAboveThreshold]:
-                      isThresholdAchieved || userStakePercentage >= 10,
+                      isThresholdAchieved ||
+                      userStakePercentage >= 10 - totalPercentage,
                   })}
                 >
                   <FormattedMessage

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
@@ -164,7 +164,7 @@ const StakingSlider = ({
           {...(isObjection ? MSG.descriptionObject : MSG.descriptionStake)}
         />
       </p>
-      <span>
+      <span className={styles.minStakeAmountContainer}>
         <Tooltip
           trigger="hover"
           content={
@@ -178,7 +178,7 @@ const StakingSlider = ({
               {
                 name: 'offset',
                 options: {
-                  offset: [0, 5],
+                  offset: [0, 0],
                 },
               },
             ],

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
@@ -2,6 +2,8 @@ import React, { useState, useMemo } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { Decimal } from 'decimal.js';
 import { bigNumberify } from 'ethers/utils';
+import formatNumber from 'format-number';
+import classnames from 'classnames';
 
 import Heading from '~core/Heading';
 import Slider, { Appearance } from '~core/Slider';
@@ -64,6 +66,10 @@ const MSG = defineMessages({
     id: 'dashboard.ActionsPage.StakingSlider.tooltip',
     defaultMessage: `Stake above the minimum 10% threshold to make it visible to others within the Actions list.`,
   },
+  requiredStake: {
+    id: 'dashboard.ActionsPage.StakingSlider.requiredStake',
+    defaultMessage: ` ({stakePercentage}% of required)`,
+  },
 });
 
 const StakingSlider = ({
@@ -111,6 +117,11 @@ const StakingSlider = ({
     stakeWithMin.round().toString(),
     nativeToken?.decimals,
   );
+  const userStakePercentage = stakeWithMin
+    .round()
+    .div(remainingToStake)
+    .times(100)
+    .toNumber();
 
   const errorStakeType = useMemo(() => {
     if (!ethereal) {
@@ -203,11 +214,30 @@ const StakingSlider = ({
               />
             </span>
           ) : (
-            <Numeral
-              className={styles.amount}
-              value={displayStake}
-              suffix={nativeToken?.symbol}
-            />
+            <>
+              <Numeral
+                className={styles.amount}
+                value={displayStake}
+                suffix={nativeToken?.symbol}
+              />
+              <span
+                className={classnames(styles.requiredStakeText, {
+                  [styles.requiredStakeUnderThreshold]:
+                    userStakePercentage < 10,
+                  [styles.requiredStakeAboveThreshold]:
+                    userStakePercentage >= 10,
+                })}
+              >
+                <FormattedMessage
+                  {...MSG.requiredStake}
+                  values={{
+                    stakePercentage: formatNumber({
+                      truncate: 2,
+                    })(userStakePercentage),
+                  }}
+                />
+              </span>
+            </>
           )}
         </Tooltip>
       </span>

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
@@ -180,72 +180,74 @@ const StakingSlider = ({
           {...(isObjection ? MSG.descriptionObject : MSG.descriptionStake)}
         />
       </p>
-      <span className={styles.minStakeAmountContainer}>
-        <Tooltip
-          trigger="hover"
-          content={
-            <div className={styles.tooltip}>
-              <FormattedMessage {...MSG.tooltip} />
-            </div>
-          }
-          placement="top"
-          popperOptions={{
-            modifiers: [
-              {
-                name: 'offset',
-                options: {
-                  offset: [0, 0],
+      {!remainingToStake.isZero() && (
+        <span className={styles.minStakeAmountContainer}>
+          <Tooltip
+            trigger="hover"
+            content={
+              <div className={styles.tooltip}>
+                <FormattedMessage {...MSG.tooltip} />
+              </div>
+            }
+            placement="top"
+            popperOptions={{
+              modifiers: [
+                {
+                  name: 'offset',
+                  options: {
+                    offset: [0, 0],
+                  },
                 },
-              },
-            ],
-          }}
-        >
-          {errorStakeType === 'tokens' ? (
-            <span className={styles.minStakeAmount}>
-              <FormattedMessage
-                {...MSG.minimumAmount}
-                values={{
-                  minStake: (
-                    <Numeral
-                      className={styles.minStakeAmount}
-                      value={getFormattedTokenValue(
-                        minUserStake,
-                        nativeToken?.decimals,
-                      )}
-                      suffix={nativeToken?.symbol}
-                    />
-                  ),
-                }}
-              />
-            </span>
-          ) : (
-            <>
-              <Numeral
-                className={styles.amount}
-                value={displayStake}
-                suffix={nativeToken?.symbol}
-              />
-              <span
-                className={classnames(styles.requiredStakeText, {
-                  [styles.requiredStakeUnderThreshold]:
-                    !isThresholdAchieved && userStakePercentage < 10,
-                  [styles.requiredStakeAboveThreshold]:
-                    isThresholdAchieved || userStakePercentage >= 10,
-                })}
-              >
+              ],
+            }}
+          >
+            {errorStakeType === 'tokens' ? (
+              <span className={styles.minStakeAmount}>
                 <FormattedMessage
-                  {...MSG.requiredStake}
+                  {...MSG.minimumAmount}
                   values={{
-                    stakePercentage: formatNumber({
-                      truncate: 2,
-                    })(userStakePercentage),
+                    minStake: (
+                      <Numeral
+                        className={styles.minStakeAmount}
+                        value={getFormattedTokenValue(
+                          minUserStake,
+                          nativeToken?.decimals,
+                        )}
+                        suffix={nativeToken?.symbol}
+                      />
+                    ),
                   }}
                 />
               </span>
-            </>
-          )}
-        </Tooltip>
-      </span>
+            ) : (
+              <>
+                <Numeral
+                  className={styles.amount}
+                  value={displayStake}
+                  suffix={nativeToken?.symbol}
+                />
+                <span
+                  className={classnames(styles.requiredStakeText, {
+                    [styles.requiredStakeUnderThreshold]:
+                      !isThresholdAchieved && userStakePercentage < 10,
+                    [styles.requiredStakeAboveThreshold]:
+                      isThresholdAchieved || userStakePercentage >= 10,
+                  })}
+                >
+                  <FormattedMessage
+                    {...MSG.requiredStake}
+                    values={{
+                      stakePercentage: formatNumber({
+                        truncate: 2,
+                      })(userStakePercentage),
+                    }}
+                  />
+                </span>
+              </>
+            )}
+          </Tooltip>
+        </span>
+      )}
       <div className={styles.sliderContainer}>
         <Slider
           name="amount"

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingSlider.tsx
@@ -5,6 +5,7 @@ import { bigNumberify } from 'ethers/utils';
 
 import Heading from '~core/Heading';
 import Slider, { Appearance } from '~core/Slider';
+import { Tooltip } from '~core/Popover';
 import Numeral from '~core/Numeral';
 import StakingValidationError from '~dashboard/ActionsPage/StakingValidationError';
 
@@ -58,6 +59,10 @@ const MSG = defineMessages({
   minimumAmount: {
     id: 'dashboard.ActionsPage.StakingSlider.minimumAmount',
     defaultMessage: 'at least {minStake}',
+  },
+  tooltip: {
+    id: 'dashboard.ActionsPage.StakingSlider.tooltip',
+    defaultMessage: `Stake above the minimum 10% threshold to make it visible to others within the Actions list.`,
   },
 });
 
@@ -159,31 +164,53 @@ const StakingSlider = ({
           {...(isObjection ? MSG.descriptionObject : MSG.descriptionStake)}
         />
       </p>
-      {errorStakeType === 'tokens' ? (
-        <span className={styles.minStakeAmount}>
-          <FormattedMessage
-            {...MSG.minimumAmount}
-            values={{
-              minStake: (
-                <Numeral
-                  className={styles.minStakeAmount}
-                  value={getFormattedTokenValue(
-                    minUserStake,
-                    nativeToken?.decimals,
-                  )}
-                  suffix={nativeToken?.symbol}
-                />
-              ),
-            }}
-          />
-        </span>
-      ) : (
-        <Numeral
-          className={styles.amount}
-          value={displayStake}
-          suffix={nativeToken?.symbol}
-        />
-      )}
+      <span>
+        <Tooltip
+          trigger="hover"
+          content={
+            <div className={styles.tooltip}>
+              <FormattedMessage {...MSG.tooltip} />
+            </div>
+          }
+          placement="top"
+          popperOptions={{
+            modifiers: [
+              {
+                name: 'offset',
+                options: {
+                  offset: [0, 5],
+                },
+              },
+            ],
+          }}
+        >
+          {errorStakeType === 'tokens' ? (
+            <span className={styles.minStakeAmount}>
+              <FormattedMessage
+                {...MSG.minimumAmount}
+                values={{
+                  minStake: (
+                    <Numeral
+                      className={styles.minStakeAmount}
+                      value={getFormattedTokenValue(
+                        minUserStake,
+                        nativeToken?.decimals,
+                      )}
+                      suffix={nativeToken?.symbol}
+                    />
+                  ),
+                }}
+              />
+            </span>
+          ) : (
+            <Numeral
+              className={styles.amount}
+              value={displayStake}
+              suffix={nativeToken?.symbol}
+            />
+          )}
+        </Tooltip>
+      </span>
       <div className={styles.sliderContainer}>
         <Slider
           name="amount"

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.css
@@ -89,3 +89,16 @@
   display: flex;
   align-self: flex-end;
 }
+
+.requiredStakeText {
+  font-size: var(--size-tiny);
+  font-weight: var(--weight-bold);
+}
+
+.requiredStakeUnderThreshold {
+  color: var(--golden);
+}
+
+.requiredStakeAboveThreshold {
+  color: var(--primary);
+}

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.css
@@ -84,3 +84,8 @@
 .loading {
   padding-top: 35px;
 }
+
+.minStakeAmountContainer {
+  display: flex;
+  align-self: flex-end;
+}

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.css.d.ts
@@ -13,3 +13,6 @@ export const help: string;
 export const tooltip: string;
 export const loading: string;
 export const minStakeAmountContainer: string;
+export const requiredStakeText: string;
+export const requiredStakeUnderThreshold: string;
+export const requiredStakeAboveThreshold: string;

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.css.d.ts
@@ -12,3 +12,4 @@ export const sliderContainer: string;
 export const help: string;
 export const tooltip: string;
 export const loading: string;
+export const minStakeAmountContainer: string;

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidget.tsx
@@ -29,6 +29,7 @@ Decimal.set({ toExpPos: 78 });
 export interface Props extends StakingFlowProps {
   isObjection: boolean;
   handleWidgetState: (isObjection: boolean) => void;
+  totalPercentage: number;
 }
 
 const displayName = 'StakingWidget';
@@ -67,6 +68,7 @@ const StakingWidget = ({
   scrollToRef,
   isObjection,
   handleWidgetState,
+  totalPercentage,
 }: Props) => {
   const { walletAddress, username, ethereal } = useLoggedInUser();
   const [sliderAmount, setSliderAmount] = useState(0);
@@ -295,6 +297,7 @@ const StakingWidget = ({
                 maxUserStake={maxUserStake}
                 minUserStake={minUserStake}
                 userActivatedTokens={userActivatedTokens}
+                totalPercentage={totalPercentage}
               />
               <div
                 className={`${styles.buttonGroup} ${

--- a/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidgetFlow.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakingWidget/StakingWidgetFlow.tsx
@@ -135,6 +135,7 @@ const StakingWidgetFlow = ({ colony, motionId, scrollToRef }: Props) => {
           motionId={motionId}
           colony={colony}
           handleWidgetState={setIsSummary}
+          totalPercentage={!isObjection ? yayPercentage : nayPercentage}
         />
       )}
     </div>

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/SingleTotalStake.tsx
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/SingleTotalStake.tsx
@@ -6,6 +6,7 @@ import { bigNumberify } from 'ethers/utils';
 import Heading from '~core/Heading';
 import ProgressBar from '~core/ProgressBar';
 import Numeral from '~core/Numeral';
+import QuestionMarkTooltip from '~core/QuestionMarkTooltip';
 import { getFormattedTokenValue } from '~utils/tokens';
 
 import styles from './TotalStakeWidget.css';
@@ -38,6 +39,10 @@ const MSG = defineMessages({
     id: 'dashboard.ActionsPage.TotalStakeWidget.SingleTotalStake.userStake',
     defaultMessage: `You staked {userPercentage}% of this motion ({userStake}).`,
   },
+  stakeToolTip: {
+    id: 'dashboard.ActionsPage.TotalStakeWidget.SingleTotalStake.stakeToolTip',
+    defaultMessage: `Percentage this Motion has been staked. For it to show up in the Actions list a min 10% is required.`,
+  },
 });
 
 const SingleTotalStake = ({
@@ -69,16 +74,35 @@ const SingleTotalStake = ({
   return (
     <>
       <div className={styles.widgetHeading}>
-        <Heading
-          appearance={{
-            theme: 'dark',
-            size: 'small',
-            weight: 'bold',
-            margin: 'none',
-          }}
-          text={isObjection ? MSG.objectionTitle : MSG.motionTitle}
-          className={styles.title}
-        />
+        <span className={styles.subHeading}>
+          <Heading
+            appearance={{
+              theme: 'dark',
+              size: 'small',
+              weight: 'bold',
+              margin: 'none',
+            }}
+            text={isObjection ? MSG.objectionTitle : MSG.motionTitle}
+            className={styles.title}
+          />
+          <QuestionMarkTooltip
+            tooltipText={MSG.stakeToolTip}
+            className={styles.helpTooltip}
+            tooltipClassName={styles.tooltip}
+            showArrow={false}
+            tooltipPopperOptions={{
+              placement: 'top-end',
+              modifiers: [
+                {
+                  name: 'offset',
+                  options: {
+                    offset: [0, 10],
+                  },
+                },
+              ],
+            }}
+          />
+        </span>
         <span className={styles.stakeProgress}>
           <FormattedMessage
             {...MSG.stakeProgress}
@@ -93,11 +117,14 @@ const SingleTotalStake = ({
       </div>
       <ProgressBar
         value={totalPercentage}
+        threshold={10}
         max={100}
         appearance={{
           barTheme: isObjection ? 'danger' : 'primary',
           backgroundTheme: 'default',
+          size: 'normal',
         }}
+        hidePercentage
       />
       {userStake && userStake !== '0' && (
         <p className={styles.userStake}>

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/SingleTotalStake.tsx
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/SingleTotalStake.tsx
@@ -5,6 +5,7 @@ import { bigNumberify } from 'ethers/utils';
 
 import Heading from '~core/Heading';
 import ProgressBar from '~core/ProgressBar';
+import { Tooltip } from '~core/Popover';
 import Numeral from '~core/Numeral';
 import QuestionMarkTooltip from '~core/QuestionMarkTooltip';
 import { getFormattedTokenValue } from '~utils/tokens';
@@ -42,6 +43,10 @@ const MSG = defineMessages({
   stakeToolTip: {
     id: 'dashboard.ActionsPage.TotalStakeWidget.SingleTotalStake.stakeToolTip',
     defaultMessage: `Percentage this Motion has been staked. For it to show up in the Actions list a min 10% is required.`,
+  },
+  progressTooltip: {
+    id: 'dashboard.ActionsPage.TotalStakeWidget.SingleTotalStake.tooltip',
+    defaultMessage: `Stake above the minimum 10% threshold to make it visible to others within the Actions list.`,
   },
 });
 
@@ -115,17 +120,42 @@ const SingleTotalStake = ({
           />
         </span>
       </div>
-      <ProgressBar
-        value={totalPercentage}
-        threshold={10}
-        max={100}
-        appearance={{
-          barTheme: isObjection ? 'danger' : 'primary',
-          backgroundTheme: 'default',
-          size: 'normal',
-        }}
-        hidePercentage
-      />
+      {totalPercentage < 10 && (
+        <Tooltip
+          placement="left"
+          trigger="hover"
+          content={
+            <div className={styles.tooltip}>
+              <FormattedMessage {...MSG.progressTooltip} />
+            </div>
+          }
+        >
+          <ProgressBar
+            value={totalPercentage}
+            threshold={10}
+            max={100}
+            appearance={{
+              barTheme: isObjection ? 'danger' : 'primary',
+              backgroundTheme: 'default',
+              size: 'normal',
+            }}
+            hidePercentage
+          />
+        </Tooltip>
+      )}
+      {totalPercentage >= 10 && (
+        <ProgressBar
+          value={totalPercentage}
+          threshold={10}
+          max={100}
+          appearance={{
+            barTheme: isObjection ? 'danger' : 'primary',
+            backgroundTheme: 'default',
+            size: 'normal',
+          }}
+          hidePercentage
+        />
+      )}
       {userStake && userStake !== '0' && (
         <p className={styles.userStake}>
           <FormattedMessage

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css
@@ -61,3 +61,20 @@
   font-size: var(--size-small);
   font-weight: var(--weight-bold);
 }
+
+.thresholdSeparator {
+  height: 22px;
+  width: 3px;
+}
+
+.helpTooltip {
+  align-self: flex-end;
+  margin-left: 7px;
+  margin-top: 1px;
+  cursor: pointer;
+}
+
+.subHeading {
+  display: flex;
+  flex-direction: row;
+}

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css
@@ -62,11 +62,6 @@
   font-weight: var(--weight-bold);
 }
 
-.thresholdSeparator {
-  height: 22px;
-  width: 3px;
-}
-
 .helpTooltip {
   align-self: flex-end;
   margin-left: 7px;

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css.d.ts
@@ -7,6 +7,5 @@ export const totalStakeRadio: string;
 export const help: string;
 export const tooltip: string;
 export const submitButtonContainer: string;
-export const thresholdSeparator: string;
 export const helpTooltip: string;
 export const subHeading: string;

--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/TotalStakeWidget.css.d.ts
@@ -7,3 +7,6 @@ export const totalStakeRadio: string;
 export const help: string;
 export const tooltip: string;
 export const submitButtonContainer: string;
+export const thresholdSeparator: string;
+export const helpTooltip: string;
+export const subHeading: string;


### PR DESCRIPTION
## Description

Add an indicator line to the Staked Progress Bar to show the 10% threshold for making a Motion visible within the Actions list. This also includes adding a changing color state for the progress bar as an additional indicator. As well as Tooltips to provide more information.

Add a percentage of the required stake value to the Staking Slider value to show how much of the total required stake will be staked. This will help not only indicate the 10% threshold is being met during the staking process, but also help improve the clarity of the impact their stake will have. There is also a tooltip on this percentage value with additional information.

##Design
[Figma Link - Updates to Staking Progress](https://www.figma.com/file/CCgGsBzhX3BUENS1IvgP7N/Motions-%26-Disputes?node-id=6692%3A184845)
[Figma Link - Updates to Staking Slider](https://www.figma.com/file/CCgGsBzhX3BUENS1IvgP7N/Motions-%26-Disputes?node-id=6692%3A184845)

**New stuff** ✨
<img width="581" alt="Screen Shot 2022-09-15 at 12 22 09 PM" src="https://user-images.githubusercontent.com/71563622/190380753-9aa2f76b-f5a9-42f5-9a1d-83321c88ba6f.png">

<img width="636" alt="Screen Shot 2022-09-15 at 12 07 32 AM" src="https://user-images.githubusercontent.com/71563622/190380769-62428b8d-b88b-4260-8ede-90d3a7d66f4f.png">

<img width="389" alt="Screen Shot 2022-09-15 at 12 22 51 PM" src="https://user-images.githubusercontent.com/71563622/190380790-8a12de4a-6bde-492d-8063-e39a79af0d1d.png">

<img width="377" alt="Screen Shot 2022-09-15 at 12 23 27 PM" src="https://user-images.githubusercontent.com/71563622/190380803-68b97d44-80f9-4266-b32a-2802a1a001b7.png">

<img width="405" alt="Screen Shot 2022-09-15 at 12 26 01 PM" src="https://user-images.githubusercontent.com/71563622/190380942-a9565775-3769-42a7-8508-7e522ccdfb5b.png">


**Changes** 🏗

## TODO

- [x] Add an indicator line to the Staked Progress Bar positioned to 10% of the total size of the progress bar using css
- [x] Add a QuestionMarkIcon to the right side of the stake text 
- [x] Add a tooltip before the 10% threshold in the progress bar
- [x] Show yellow bar color below 10% threshold
- [x] Show green bar color over the 10% threshold
- [x] Show yellow percentage of amount required below 10% threshold
- [x] Show green percentage of amount required above 10% threshold


## Not Covered in this PR 

To be updated with the future UI/UX overhaul: 
* Progress bar re design 
* Staking slider re design  

Declutter section - tooltip:
* A question mark tooltip was already added for the "Select the amount to back the motion" in another PR in the Decisions branch. See [here](https://github.com/JoinColony/colonyDapp/issues/3741) if you are curious. Not sure if we needed to repeat some of the work here?

---

Resolves #3767
