### PR TITLE
Fix: Tidy up Install Governance Extension message

### DIFF
--- a/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.css
+++ b/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.css
@@ -36,3 +36,7 @@
   font-weight: var(--weight-bold);
   color: var(--dark);
 }
+
+.installExtension {
+  margin-top: 20px;
+}

--- a/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.css.d.ts
+++ b/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.css.d.ts
@@ -3,3 +3,4 @@ export const filter: string;
 export const loadingSpinner: string;
 export const bar: string;
 export const title: string;
+export const installExtension: string;

--- a/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
+++ b/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
@@ -38,8 +38,8 @@ const MSG = defineMessages({
     defaultMessage: 'Loading decisions',
   },
   installExtension: {
-    id: 'dashboard.ColonyDecisions.loading',
-    defaultMessage: `You need to install Governance extension to use Decisions feature`,
+    id: 'dashboard.ColonyDecisions.installExtension',
+    defaultMessage: `You need to install the Governance extension to use the Decisions feature.`,
   },
 });
 
@@ -193,7 +193,7 @@ const ColonyDecisions = ({
 
   if (!isVotingExtensionEnabled) {
     return (
-      <div>
+      <div className={styles.installExtension}>
         <FormattedMessage {...MSG.installExtension} />
       </div>
     );


### PR DESCRIPTION
## Description

This PR tidies up the Install Governance Extension message in Decisions page:
<img width="804" alt="image" src="https://user-images.githubusercontent.com/112586815/190629501-a89a789e-13b5-4f5a-9771-2d94da0a1869.png">

I added a 20px top margin which matches the spacing in Actions page:
<img width="818" alt="image" src="https://user-images.githubusercontent.com/112586815/190629582-6f8a7c3a-9ab7-4823-96ab-d5e7fb688e9c.png">

**Changes** 🏗

* Update the message, message id and styles of `ColonyDecisions` component
Resolves #3841 
