### PR TITLE
Fix Invite button misalignment

### DIFF
--- a/src/modules/core/components/ClickableHeading/ClickableHeading.tsx
+++ b/src/modules/core/components/ClickableHeading/ClickableHeading.tsx
@@ -1,6 +1,6 @@
 import React, { ReactChild } from 'react';
 
-import Heading from '~core/Heading';
+import Heading, { Appearance } from '~core/Heading';
 import NavLink from '~core/NavLink';
 import Icon from '~core/Icon';
 
@@ -9,12 +9,13 @@ import styles from './ClickableHeading.css';
 interface Props {
   linkTo: string;
   children?: ReactChild;
+  appearance?: Pick<Appearance, 'margin'>;
 }
 
-const ClickableHeading = ({ linkTo, children }: Props) => {
+const ClickableHeading = ({ linkTo, children, appearance }: Props) => {
   return (
     <div className={styles.heading}>
-      <Heading appearance={{ size: 'smallish', weight: 'bold' }}>
+      <Heading appearance={{ size: 'smallish', weight: 'bold', ...appearance }}>
         <NavLink to={linkTo}>
           <span className={styles.contents}>
             {children}

--- a/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.css
@@ -77,6 +77,7 @@
 .heading {
   display: flex;
   align-items: center;
+  margin-bottom: 20px;
   gap: 8px;
 }
 
@@ -87,8 +88,4 @@
 
 .heading > span:first-child {
   margin-left: 0;
-}
-
-.inviteButton {
-  margin-bottom: 20px;
 }

--- a/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.css
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.css
@@ -76,7 +76,7 @@
 
 .heading {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   margin-bottom: 20px;
   gap: 8px;
 }

--- a/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.css.d.ts
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMembers/ColonyMembers.css.d.ts
@@ -6,4 +6,3 @@ export const loadingText: string;
 export const userBanned: string;
 export const tooltip: string;
 export const heading: string;
-export const inviteButton: string;

--- a/src/modules/dashboard/components/ColonyHome/ColonyMembers/MembersSubsection.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyMembers/MembersSubsection.tsx
@@ -120,7 +120,10 @@ const MembersSubsection = ({
             </div>
           }
         >
-          <ClickableHeading linkTo={membersPageRoute}>
+          <ClickableHeading
+            linkTo={membersPageRoute}
+            appearance={{ margin: 'none' }}
+          >
             <FormattedMessage
               {...MSG.title}
               values={{
@@ -132,12 +135,10 @@ const MembersSubsection = ({
           </ClickableHeading>
         </Tooltip>
         {!isContributorsSubsection && (
-          <div className={styles.inviteButton}>
-            <InviteLinkButton
-              colonyName={colonyName}
-              buttonAppearance={{ theme: 'blueWithBackground' }}
-            />
-          </div>
+          <InviteLinkButton
+            colonyName={colonyName}
+            buttonAppearance={{ theme: 'blueWithBackground' }}
+          />
         )}
       </div>
     ),


### PR DESCRIPTION
## Description

Arren spotted an issue with the alignment between Watchers heading and Invite button:
![image](https://user-images.githubusercontent.com/112586815/190645231-f86c2761-70c9-4d51-a10e-48a9ff646db7.png)

Fixed:
<img width="668" alt="image" src="https://user-images.githubusercontent.com/112586815/190645906-63c86a3f-5a47-4510-afe4-6bbb79f29f5f.png">

**Changes** 🏗

* `ClickableHeading` got a new prop to control the margin

**Deletions** ⚰️

* Deleted styles adding margin to the Invite button directly

resolves #3862 
