### PR TITLE
Add contract interaction to preview dialog

### DIFF
--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
@@ -428,7 +428,11 @@ const ControlSafeForm = ({
           />
         </>
       ) : (
-        <SafeTransactionPreview values={values} colony={colony} />
+        <SafeTransactionPreview
+          values={values}
+          colony={colony}
+          selectedContractMethods={selectedContractMethods}
+        />
       )}
       <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
         <Button

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/DetailsItem/DetailsItem.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/DetailsItem/DetailsItem.tsx
@@ -1,20 +1,33 @@
-import React from 'react';
-import { FormattedMessage, MessageDescriptor } from 'react-intl';
+import React, { useMemo } from 'react';
+import { MessageDescriptor, useIntl } from 'react-intl';
 
+import { SimpleMessageValues } from '~types/index';
 import styles from './DetailsItem.css';
 
 const DetailsItem = ({
   label,
+  textValues,
   value,
 }: {
   label: MessageDescriptor;
+  textValues?: SimpleMessageValues;
   value: JSX.Element;
 }) => {
+  const { formatMessage } = useIntl();
+
+  const textValue = useMemo(() => {
+    if (!label) {
+      return '';
+    }
+    if (typeof label === 'string') {
+      return label;
+    }
+    return formatMessage(label, textValues);
+  }, [formatMessage, label, textValues]);
+
   return (
     <div className={styles.detailsItem}>
-      <div className={styles.detailsItemLabel}>
-        <FormattedMessage {...label} />
-      </div>
+      <div className={styles.detailsItemLabel}>{textValue}</div>
       <div className={styles.detailsItemValue}>{value}</div>
     </div>
   );

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.tsx
@@ -14,6 +14,7 @@ import Avatar from '~core/Avatar';
 import MaskedAddress from '~core/MaskedAddress';
 import { Colony, AnyUser } from '~data/index';
 import { AbiItemExtended } from '~utils/getContractUsefulMethods';
+import { getArrayFromString } from '~utils/safes';
 
 import AddressDetailsView from './TransactionPreview/AddressDetailsView';
 import { FormValues } from './ControlSafeDialog';
@@ -264,6 +265,28 @@ const SafeTransactionPreview = ({
     values.transactions[index].transactionType ===
     TransactionTypes.TRANSFER_NFT;
 
+  const getDetailsItemValue = (input, transaction) => {
+    switch (input.type) {
+      case 'address': {
+        return <MaskedAddress address={transaction[input.name]} />;
+      }
+      case 'address[]': {
+        const formattedArray = `[${getArrayFromString(
+          transaction[input.name],
+        ).join(', ')}]`;
+        return (
+          <div className={styles.rawTransactionValues}>{formattedArray}</div>
+        );
+      }
+      default:
+        return (
+          <div className={styles.rawTransactionValues}>
+            {transaction[input.name]}
+          </div>
+        );
+    }
+  };
+
   return (
     <>
       <DialogSection>
@@ -383,17 +406,10 @@ const SafeTransactionPreview = ({
                       key={nanoid()}
                       label={MSG.contractMethodInputLabel}
                       textValues={{ name: input.name, type: input.type }}
-                      value={
-                        input.type === 'address' ? (
-                          <MaskedAddress
-                            address={values.transactions[index][input.name]}
-                          />
-                        ) : (
-                          <div className={styles.rawTransactionValues}>
-                            {values.transactions[index][input.name]}
-                          </div>
-                        )
-                      }
+                      value={getDetailsItemValue(
+                        input,
+                        values.transactions[index],
+                      )}
                     />
                   ))}
               </div>

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.tsx
@@ -13,8 +13,7 @@ import Icon from '~core/Icon';
 import Avatar from '~core/Avatar';
 import MaskedAddress from '~core/MaskedAddress';
 import { Colony, AnyUser } from '~data/index';
-import { AbiItemExtended } from '~utils/getContractUsefulMethods';
-import { getArrayFromString } from '~utils/safes';
+import { AbiItemExtended, getArrayFromString } from '~utils/safes';
 
 import AddressDetailsView from './TransactionPreview/AddressDetailsView';
 import { FormValues } from './ControlSafeDialog';

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.tsx
@@ -272,11 +272,11 @@ const SafeTransactionPreview = ({
       case input.type === 'address[]': {
         const formattedArray = getArrayFromString(transaction[input.name]);
 
-        const maskedArray = formattedArray.map((address) => {
+        const maskedArray = formattedArray.map((address, index, arr) => {
           return (
             <div>
               <MaskedAddress address={address} />
-              <span>, </span>
+              {index < arr.length - 1 && <span>, </span>}
             </div>
           );
         });

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.tsx
@@ -11,6 +11,7 @@ import TokenIcon from '~dashboard/HookedTokenIcon';
 import Button from '~core/Button';
 import Icon from '~core/Icon';
 import Avatar from '~core/Avatar';
+import MaskedAddress from '~core/MaskedAddress';
 import { Colony, AnyUser } from '~data/index';
 
 import AddressDetailsView from './TransactionPreview/AddressDetailsView';
@@ -179,7 +180,7 @@ const transactionTypeFieldsMap = {
       label: MSG.contract,
       value: (contract) => (
         <div className={styles.rawTransactionValues}>
-          {contract.profile.displayName}
+          <MaskedAddress address={contract.profile.displayName} />
         </div>
       ),
     },
@@ -382,7 +383,15 @@ const SafeTransactionPreview = ({
                       key={nanoid()}
                       label={MSG.contractMethodInputLabel}
                       textValues={{ name: input.name, type: input.type }}
-                      value={<div>placeholder</div>}
+                      value={
+                        input.type === 'address' ? (
+                          <MaskedAddress
+                            address={values.transactions[index][input.name]}
+                          />
+                        ) : (
+                          <div>{values.transactions[index][input.name]}</div>
+                        )
+                      }
                     />
                   ))}
               </div>

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.tsx
@@ -13,6 +13,7 @@ import Icon from '~core/Icon';
 import Avatar from '~core/Avatar';
 import MaskedAddress from '~core/MaskedAddress';
 import { Colony, AnyUser } from '~data/index';
+import { AbiItemExtended } from '~utils/getContractUsefulMethods';
 
 import AddressDetailsView from './TransactionPreview/AddressDetailsView';
 import { FormValues } from './ControlSafeDialog';
@@ -22,7 +23,6 @@ import {
   MSG as ConstantsMSG,
 } from './constants';
 import DetailsItem from './DetailsItem';
-import { AbiItemExtended } from '~utils/getContractUsefulMethods';
 
 import styles from './SafeTransactionPreview.css';
 

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.tsx
@@ -265,11 +265,25 @@ const SafeTransactionPreview = ({
     TransactionTypes.TRANSFER_NFT;
 
   const getDetailsItemValue = (input, transaction) => {
-    switch (input.type) {
-      case 'address': {
+    switch (true) {
+      case input.type === 'address': {
         return <MaskedAddress address={transaction[input.name]} />;
       }
-      case 'address[]': {
+      case input.type === 'address[]': {
+        const formattedArray = getArrayFromString(transaction[input.name]);
+
+        const maskedArray = formattedArray.map((address) => {
+          return (
+            <div>
+              <MaskedAddress address={address} />
+              <span>, </span>
+            </div>
+          );
+        });
+        return <div className={styles.rawTransactionValues}>{maskedArray}</div>;
+      }
+      case input.type.substr(input.type.length - 2, input.type.length) ===
+        '[]': {
         const formattedArray = `[${getArrayFromString(
           transaction[input.name],
         ).join(', ')}]`;

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.tsx
@@ -275,7 +275,7 @@ const SafeTransactionPreview = ({
         const maskedArray = formattedArray.map((address, index, arr) => {
           return (
             <div>
-              <MaskedAddress address={address} />
+              <MaskedAddress address={address.trim()} />
               {index < arr.length - 1 && <span>, </span>}
             </div>
           );
@@ -284,9 +284,9 @@ const SafeTransactionPreview = ({
       }
       case input.type.substr(input.type.length - 2, input.type.length) ===
         '[]': {
-        const formattedArray = `[${getArrayFromString(
-          transaction[input.name],
-        ).join(', ')}]`;
+        const formattedArray = `[${getArrayFromString(transaction[input.name])
+          .map((item) => item.trim())
+          .join(', ')}]`;
         return (
           <div className={styles.rawTransactionValues}>{formattedArray}</div>
         );

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.tsx
@@ -21,6 +21,7 @@ import {
   MSG as ConstantsMSG,
 } from './constants';
 import DetailsItem from './DetailsItem';
+import { AbiItemExtended } from '~utils/getContractUsefulMethods';
 
 import styles from './SafeTransactionPreview.css';
 
@@ -102,6 +103,10 @@ const MSG = defineMessages({
     defaultMessage:
       '{tabToggleStatus, select, true {Expand} false {Close}} transaction',
   },
+  contractMethodInputLabel: {
+    id: `dashboard.ControlSafeDialog.SafeTransactionPreview.contractMethodInputLabel`,
+    defaultMessage: `{name} ({type})`,
+  },
 });
 
 const transactionTypeFieldsMap = {
@@ -169,7 +174,22 @@ const transactionTypeFieldsMap = {
     },
   ],
   [TransactionTypes.CONTRACT_INTERACTION]: [
-    // To be finished once NFT part of the form is merged
+    {
+      key: 'contract',
+      label: MSG.contract,
+      value: (contract) => (
+        <div className={styles.rawTransactionValues}>
+          {contract.profile.displayName}
+        </div>
+      ),
+    },
+    {
+      key: 'contractFunction',
+      label: MSG.contractFunction,
+      value: (contractFunction) => (
+        <div className={styles.rawTransactionValues}>{contractFunction}</div>
+      ),
+    },
   ],
   [TransactionTypes.RAW_TRANSACTION]: [
     {
@@ -194,9 +214,18 @@ const displayName = 'dashboard.ControlSafeDialog.SafeTransactionPreview';
 interface Props {
   colony: Colony;
   values: FormValues;
+  selectedContractMethods?:
+    | {
+        [key: number]: AbiItemExtended | undefined;
+      }
+    | undefined;
 }
 
-const SafeTransactionPreview = ({ colony, values }: Props) => {
+const SafeTransactionPreview = ({
+  colony,
+  values,
+  selectedContractMethods,
+}: Props) => {
   const [transactionTabStatus, setTransactionTabStatus] = useState(
     Array(values.transactions.length).fill(false),
   );
@@ -343,6 +372,17 @@ const SafeTransactionPreview = ({ colony, values }: Props) => {
                         values.transactions[index][key],
                         tokens[index],
                       )}
+                    />
+                  ))}
+                {values.transactions[index].transactionType ===
+                  TransactionTypes.CONTRACT_INTERACTION &&
+                  selectedContractMethods &&
+                  selectedContractMethods[index]?.inputs?.map((input) => (
+                    <DetailsItem
+                      key={nanoid()}
+                      label={MSG.contractMethodInputLabel}
+                      textValues={{ name: input.name, type: input.type }}
+                      value={<div>placeholder</div>}
                     />
                   ))}
               </div>

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.tsx
@@ -389,7 +389,9 @@ const SafeTransactionPreview = ({
                             address={values.transactions[index][input.name]}
                           />
                         ) : (
-                          <div>{values.transactions[index][input.name]}</div>
+                          <div className={styles.rawTransactionValues}>
+                            {values.transactions[index][input.name]}
+                          </div>
                         )
                       }
                     />

--- a/src/utils/safes/contractParserValidation.ts
+++ b/src/utils/safes/contractParserValidation.ts
@@ -58,7 +58,7 @@ const isIntSafe = (value: string, inputType: string) => {
   return isSafe;
 };
 
-const getArrayFromString = (array: string) => {
+export const getArrayFromString = (array: string) => {
   if (array === '[]') {
     return [];
   }

--- a/src/utils/safes/index.ts
+++ b/src/utils/safes/index.ts
@@ -1,4 +1,4 @@
-export { validateType } from './contractParserValidation';
+export { validateType, getArrayFromString } from './contractParserValidation';
 export {
   getContractUsefulMethods,
   AbiItemExtended,


### PR DESCRIPTION
## Description

This PR adds the Contract Interaction preview to the Safe form.

[Figma Design](https://www.figma.com/file/LlVmeMQxHVA04evfrgZyuN/Safe-Control?node-id=115%3A7477)

**To test:**

* Add a safe
* Click Contract Interaction
* Add a verified contract address (find a verified contracts here: https://blockscout.com/xdai/mainnet/api-docs#contract or https://etherscan.io/contractsVerified)
* Select a function to interact with - you can play around with different functions and make sure all their data is showing up in the preview correctly
* Test with one or multiple transactions - Make sure they are all in the preview

Changes 🏗

* Adding Contract Interaction preview

<img width="489" alt="Screen Shot 2022-09-21 at 10 47 11 PM" src="https://user-images.githubusercontent.com/71563622/191607227-b29eac20-af1f-4724-843c-5c7c1bd82b68.png">

<img width="491" alt="Screen Shot 2022-09-21 at 11 30 21 PM" src="https://user-images.githubusercontent.com/71563622/191614106-e70b28cc-33c5-49db-ba5b-0a28ebd38273.png">


---
Resolves #3731