### PR TITLE
Fix the display of decisions list after creating decision motion

### DIFF
--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -58,6 +58,7 @@ import {
   UserReputationQueryVariables,
   UserReputationDocument,
 } from '~data/index';
+import { log } from '~utils/debug';
 
 import {
   ActionsPageFeedType,
@@ -1294,13 +1295,21 @@ export const motionsResolvers = ({
       };
     },
     async annotationHash({ transaction, agent }) {
-      const {
-        values: { metadata: annotationHash },
-      } = await getAnnotationFromSubgraph(
-        agent,
-        transaction.hash,
-        apolloClient,
-      );
+      let annotationHash;
+      try {
+        const {
+          values: { metadata },
+        } = await getAnnotationFromSubgraph(
+          agent,
+          transaction.hash,
+          apolloClient,
+        );
+
+        annotationHash = metadata;
+      } catch (error) {
+        log.verbose('Could not fetch IPFS metadata for decision');
+      }
+
       return annotationHash;
     },
   },


### PR DESCRIPTION
## Description

The ipfs hash was not available right after decision creation (without refresh), so the whole decisions list was undefined. I added the try catch block to guard from the error. Now we just have a placeholder for the decision title until we refresh (nothing we can do about that part).

resolves #3870 
