### PR TITLE
Fix duplicate key warning in Safe control

### DIFF
--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
@@ -208,7 +208,7 @@ const ControlSafeForm = ({
         (transaction) => transaction.value === transactionTypeValue,
       );
       return transactionType ? (
-        <FormattedMessage {...transactionType.label} />
+        <FormattedMessage {...transactionType.label} key={nanoid()} />
       ) : null;
     },
     [],


### PR DESCRIPTION
## Description

Small fix for duplicate key warning in Safe Control.

**Changes** 🏗

* Replacing `FormattedMessage` which was causing the warning for `formatMessage()`

Resolves #3860 
