### PR TITLE
Add failed motion

### DIFF
--- a/src/modules/dashboard/components/ExpenditurePage/Stages/LinkedMotions/LinkedMotions.css
+++ b/src/modules/dashboard/components/ExpenditurePage/Stages/LinkedMotions/LinkedMotions.css
@@ -50,17 +50,6 @@
   color: var(--pink);
 }
 
-.link {
-  padding: 0px 10px;
-  height: 20px;
-  border-radius: var(--radius-large);
-  background-color: var(--primary);
-  font-size: var(--size-tiny);
-  font-weight: var(--weight-bold);
-  color: var(--colony-white);
-}
-
 .link:hover {
-  background-color: color-mod(var(--primary) shade(15%));
-  color: var(--colony-white);
+  color: var(--action-secondary);
 }

--- a/src/modules/dashboard/components/ExpenditurePage/Stages/LinkedMotions/LinkedMotions.tsx
+++ b/src/modules/dashboard/components/ExpenditurePage/Stages/LinkedMotions/LinkedMotions.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
-import Link from '~core/Link';
 
+import Link from '~core/Link';
 import Tag from '~core/Tag';
+
 import { MotionStatus } from '../constants';
+
 import styles from './LinkedMotions.css';
 
 const MSG = defineMessages({
@@ -41,6 +43,30 @@ interface Props {
 const LinkedMotions = ({ status, motionLink, motion, id }: Props) => {
   const { formatMessage } = useIntl();
 
+  const tagText = useMemo(() => {
+    switch (status) {
+      case MotionStatus.Pending:
+        return MSG.motion;
+      case MotionStatus.Passed:
+        return MSG.passed;
+      case MotionStatus.Failed:
+        return MSG.failed;
+      default:
+        return '';
+    }
+  }, [status]);
+
+  const tagColor = useMemo(() => {
+    switch (status) {
+      case MotionStatus.Passed:
+        return styles.passedColor;
+      case MotionStatus.Failed:
+        return styles.failedColor;
+      default:
+        return undefined;
+    }
+  }, [status]);
+
   return (
     <div className={styles.wrapper}>
       <div className={styles.titleWrapper}>
@@ -52,24 +78,22 @@ const LinkedMotions = ({ status, motionLink, motion, id }: Props) => {
         </div>
       </div>
       <div className={styles.statusWrapper}>
-        {formatMessage(MSG.foundExp, { motion, id })}
-        {status === MotionStatus.Pending && motionLink ? (
+        {motionLink ? (
           <Link to={motionLink} className={styles.link}>
-            <FormattedMessage {...MSG.motion} />
+            {formatMessage(MSG.foundExp, { motion, id })}
           </Link>
         ) : (
-          <Tag
-            text={status === MotionStatus.Passed ? MSG.passed : MSG.failed}
-            data-test="deprecatedStatusTag"
-            style={{
-              color:
-                status === MotionStatus.Passed
-                  ? styles.passedColor
-                  : styles.failedColor,
-            }}
-            appearance={{ theme: 'light' }}
-          />
+          formatMessage(MSG.foundExp, { motion, id })
         )}
+        <Tag
+          text={tagText}
+          style={{
+            color: tagColor,
+          }}
+          appearance={{
+            theme: status === MotionStatus.Pending ? 'primary' : 'light',
+          }}
+        />
       </div>
     </div>
   );

--- a/src/modules/dashboard/components/ExpenditurePage/Stages/LinkedMotions/LinkedMotions.tsx
+++ b/src/modules/dashboard/components/ExpenditurePage/Stages/LinkedMotions/LinkedMotions.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { defineMessages, FormattedMessage, useIntl } from 'react-intl';
+import { defineMessages, FormattedMessage } from 'react-intl';
 
 import Link from '~core/Link';
 import Tag from '~core/Tag';
@@ -41,29 +41,16 @@ interface Props {
 }
 
 const LinkedMotions = ({ status, motionLink, motion, id }: Props) => {
-  const { formatMessage } = useIntl();
-
-  const tagText = useMemo(() => {
+  const tagOptions = useMemo(() => {
     switch (status) {
       case MotionStatus.Pending:
-        return MSG.motion;
+        return { text: MSG.motion, color: undefined };
       case MotionStatus.Passed:
-        return MSG.passed;
+        return { text: MSG.passed, color: styles.passedColor };
       case MotionStatus.Failed:
-        return MSG.failed;
+        return { text: MSG.failed, color: styles.failedColor };
       default:
-        return '';
-    }
-  }, [status]);
-
-  const tagColor = useMemo(() => {
-    switch (status) {
-      case MotionStatus.Passed:
-        return styles.passedColor;
-      case MotionStatus.Failed:
-        return styles.failedColor;
-      default:
-        return undefined;
+        return { text: '', color: undefined };
     }
   }, [status]);
 
@@ -80,15 +67,15 @@ const LinkedMotions = ({ status, motionLink, motion, id }: Props) => {
       <div className={styles.statusWrapper}>
         {motionLink ? (
           <Link to={motionLink} className={styles.link}>
-            {formatMessage(MSG.foundExp, { motion, id })}
+            <FormattedMessage {...MSG.foundExp} values={{ motion, id }} />
           </Link>
         ) : (
-          formatMessage(MSG.foundExp, { motion, id })
+          <FormattedMessage {...MSG.foundExp} values={{ motion, id }} />
         )}
         <Tag
-          text={tagText}
+          text={tagOptions.text}
           style={{
-            color: tagColor,
+            color: tagOptions.color,
           }}
           appearance={{
             theme: status === MotionStatus.Pending ? 'primary' : 'light',

--- a/src/modules/dashboard/components/ExpenditurePage/Stages/LockedStages.tsx
+++ b/src/modules/dashboard/components/ExpenditurePage/Stages/LockedStages.tsx
@@ -96,7 +96,11 @@ const LockedStages = ({
         </Tag>
       )}
       {isStreamingPaymentType ? (
-        <StreamingStagesLocked motion={motion} />
+        <StreamingStagesLocked
+          motion={motion}
+          status={status}
+          handleButtonClick={() => {}}
+        />
       ) : (
         <Stages
           recipients={formValues?.recipients}

--- a/src/modules/dashboard/components/ExpenditurePage/Stages/LockedStages.tsx
+++ b/src/modules/dashboard/components/ExpenditurePage/Stages/LockedStages.tsx
@@ -117,10 +117,11 @@ const LockedStages = ({
         />
       )}
       {motion && (
-        // motion link needs to be changed and redirects to actual motions page
         <LinkedMotions
           status={motion.status}
           motion={motion.type}
+          // The id and the link are hardcoded, they should be replaced with actual values.
+          // Link should redirect to the motion page
           motionLink={LANDING_PAGE_ROUTE}
           id="25"
         />

--- a/src/modules/dashboard/components/ExpenditurePage/Stages/StreamingStages/StreamingStagesLocked/StreamingStagesLocked.tsx
+++ b/src/modules/dashboard/components/ExpenditurePage/Stages/StreamingStages/StreamingStagesLocked/StreamingStagesLocked.tsx
@@ -39,7 +39,7 @@ const MSG = defineMessages({
     defaultMessage: 'Claim funds',
   },
   startStream: {
-    id: `dashboard.ExpenditurePage.Stages.StreamingStage.StreamingStagesLocked.startStream`,
+    id: `dashboard.ExpenditurePage.Stages.StreamingStages.StreamingStagesLocked.startStream`,
     defaultMessage: 'Start Stream',
   },
 });

--- a/src/modules/dashboard/components/ExpenditurePage/Stages/StreamingStages/StreamingStagesLocked/StreamingStagesLocked.tsx
+++ b/src/modules/dashboard/components/ExpenditurePage/Stages/StreamingStages/StreamingStagesLocked/StreamingStagesLocked.tsx
@@ -9,7 +9,7 @@ import Tag from '~core/Tag';
 import Icon from '~core/Icon';
 import { Tooltip } from '~core/Popover';
 
-import { Motion, MotionStatus } from '../../constants';
+import { Motion, MotionStatus, Status } from '../../constants';
 
 import styles from './StreamingStagesLocked.css';
 
@@ -38,6 +38,10 @@ const MSG = defineMessages({
     id: `dashboard.ExpenditurePage.Stages.StreamingStages.StreamingStagesLocked.claimFunds`,
     defaultMessage: 'Claim funds',
   },
+  startStream: {
+    id: `dashboard.ExpenditurePage.Stages.StreamingStage.StreamingStagesLocked.startStream`,
+    defaultMessage: 'Start Stream',
+  },
 });
 
 const displayName =
@@ -51,9 +55,15 @@ export const buttonStyles = {
 
 export interface Props {
   motion?: Motion;
+  status?: Status;
+  handleButtonClick?: () => void;
 }
 
-const StreamingStagesLocked = ({ motion }: Props) => {
+const StreamingStagesLocked = ({
+  motion,
+  status,
+  handleButtonClick,
+}: Props) => {
   const [valueIsCopied, setValueIsCopied] = useState(false);
   const userFeedbackTimer = useRef<any>(null);
   const { formatMessage } = useIntl();
@@ -159,6 +169,15 @@ const StreamingStagesLocked = ({ motion }: Props) => {
                 </Tooltip>
               )}
             </Button>
+            {motion?.status !== MotionStatus.Pending &&
+              status !== Status.StartedStream &&
+              status !== Status.Cancelled && (
+                <Button
+                  text={MSG.startStream}
+                  onClick={handleButtonClick}
+                  style={buttonStyles}
+                />
+              )}
           </div>
         </div>
       </FormSection>

--- a/src/modules/pages/components/ExpenditurePage/ExpenditurePage.tsx
+++ b/src/modules/pages/components/ExpenditurePage/ExpenditurePage.tsx
@@ -214,6 +214,14 @@ const ExpenditurePage = ({ match }: Props) => {
         });
         setFormValues(values);
 
+        // it's temporary timeout
+        setTimeout(() => {
+          setMotion({
+            type: MotionType.StartStream,
+            status: MotionStatus.Failed,
+          });
+        }, 5000);
+
         return;
       }
 


### PR DESCRIPTION
## Description

This PR adds failed motion on Streaming payment type. UI only.  
After displaying active motion state,  a message appears that the motion has failed.
Other states (active, cancelled, ...) will be added in next PRs.

<img width="421" alt="Screenshot 2022-09-22 at 09 33 01" src="https://user-images.githubusercontent.com/91876137/191685983-2d993f67-358a-42a2-adca-4a7c0e8ab5ed.png">


[Figma link](https://www.figma.com/file/dCtvv76S8mk5HNApjwmBto/Expenditures?node-id=5755%3A331095)



Resolves #3847