### PR TITLE
Add loading spinner to contract interaction's ABI fetching and parsing

### DIFF
--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
@@ -239,8 +239,6 @@ const ContractInteractionSection = ({
     transactionFormIndex,
   ]);
 
-  // console.log('loadingABI', loadingABI);
-
   return (
     <>
       <DialogSection>

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
@@ -50,7 +50,7 @@ const MSG = defineMessages({
   },
 });
 
-const displayName = `dashboard.ControlSafeDialog.ControlSafeForm.ContractInteractionSection`;
+const displayName = `dashboard.ControlSafeDialog.TransactionTypesSection.ContractInteractionSection`;
 
 interface Props {
   disabledInput: boolean;

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
@@ -25,24 +25,28 @@ import styles from './TransactionTypesSection.css';
 
 const MSG = defineMessages({
   abiLabel: {
-    id: `dashboard.ControlSafeDialog.ControlSafeForm.ContractInteractionSection.abiLabel`,
+    id: `dashboard.ControlSafeDialog.TransactionTypesSection.ContractInteractionSection.abiLabel`,
     defaultMessage: 'ABI/JSON',
   },
   functionLabel: {
-    id: `dashboard.ControlSafeDialog.ControlSafeForm.ContractInteractionSection.functionLabel`,
+    id: `dashboard.ControlSafeDialog.TransactionTypesSection.ContractInteractionSection.functionLabel`,
     defaultMessage: 'Select function to interact with',
   },
   functionPlaceholder: {
-    id: `dashboard.ControlSafeDialog.ControlSafeForm.ContractInteractionSection.functionPlaceholder`,
+    id: `dashboard.ControlSafeDialog.TransactionTypesSection.ContractInteractionSection.functionPlaceholder`,
     defaultMessage: 'Select function',
   },
   contractLabel: {
-    id: `dashboard.ControlSafeDialog.ControlSafeForm.ContractInteractionSection.contractLabel`,
+    id: `dashboard.ControlSafeDialog.TransactionTypesSection.ContractInteractionSection.contractLabel`,
     defaultMessage: 'Target contract address',
   },
   userPickerPlaceholder: {
-    id: `dashboard.ControlSafeDialog.ControlSafeForm.ContractInteractionSection.userPickerPlaceholder`,
+    id: `dashboard.ControlSafeDialog.TransactionTypesSection.ContractInteractionSection.userPickerPlaceholder`,
     defaultMessage: 'Select or paste a contract address',
+  },
+  loadingContract: {
+    id: `dashboard.ControlSafeDialog.TransactionTypesSection.ContractInteractionSection.loadingContract`,
+    defaultMessage: 'Loading Contract',
   },
 });
 
@@ -258,7 +262,10 @@ const ContractInteractionSection = ({
       </DialogSection>
       {isLoadingABI ? (
         <div className={styles.spinner}>
-          <SpinnerLoader appearance={{ size: 'medium' }} />
+          <SpinnerLoader
+            appearance={{ size: 'medium' }}
+            loadingText={MSG.loadingContract}
+          />
         </div>
       ) : (
         <>

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
@@ -17,6 +17,7 @@ import {
   fetchContractABI,
 } from '~utils/safes';
 import { GNOSIS_NETWORK } from '~constants';
+import { SpinnerLoader } from '~core/Preloaders';
 
 import { FormValues } from '../ControlSafeDialog';
 
@@ -89,6 +90,7 @@ const ContractInteractionSection = ({
     SelectOption[]
   >([]);
   const [currentSafeChainId, setCurrentSafeChainId] = useState<number>();
+  const [loadingABI, setLoadingABI] = useState<boolean>(false);
 
   const transactionValues = values.transactions[transactionFormIndex];
 
@@ -151,11 +153,14 @@ const ContractInteractionSection = ({
 
   const onContractChange = useCallback(
     (contract: AnyUser) => {
+      setLoadingABI(true);
       const contractPromise = fetchContractABI(
         contract.profile.walletAddress,
         Number(selectedSafe?.chainId),
       );
       contractPromise.then((data) => {
+        setLoadingABI(false);
+
         onContractABIChange(data);
 
         if (Number(selectedSafe?.chainId) !== currentSafeChainId) {
@@ -234,6 +239,8 @@ const ContractInteractionSection = ({
     transactionFormIndex,
   ]);
 
+  // console.log('loadingABI', loadingABI);
+
   return (
     <>
       <DialogSection>
@@ -252,6 +259,11 @@ const ContractInteractionSection = ({
         </div>
       </DialogSection>
       <DialogSection>
+        {loadingABI && (
+          <div>
+            <SpinnerLoader appearance={{ size: 'medium' }} />
+          </div>
+        )}
         <Textarea
           label={MSG.abiLabel}
           name={`transactions.${transactionFormIndex}.abi`}

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
@@ -90,7 +90,7 @@ const ContractInteractionSection = ({
     SelectOption[]
   >([]);
   const [currentSafeChainId, setCurrentSafeChainId] = useState<number>();
-  const [loadingABI, setLoadingABI] = useState<boolean>(false);
+  const [isLoadingABI, setIsLoadingABI] = useState<boolean>(false);
 
   const transactionValues = values.transactions[transactionFormIndex];
 
@@ -153,13 +153,13 @@ const ContractInteractionSection = ({
 
   const onContractChange = useCallback(
     (contract: AnyUser) => {
-      setLoadingABI(true);
+      setIsLoadingABI(true);
       const contractPromise = fetchContractABI(
         contract.profile.walletAddress,
         Number(selectedSafe?.chainId),
       );
       contractPromise.then((data) => {
-        setLoadingABI(false);
+        setIsLoadingABI(false);
 
         onContractABIChange(data);
 
@@ -258,68 +258,73 @@ const ContractInteractionSection = ({
           />
         </div>
       </DialogSection>
-      <DialogSection>
-        {loadingABI && (
-          <div>
-            <SpinnerLoader appearance={{ size: 'medium' }} />
-          </div>
-        )}
-        <Textarea
-          label={MSG.abiLabel}
-          name={`transactions.${transactionFormIndex}.abi`}
-          appearance={{ colorSchema: 'grey', resizable: 'vertical' }}
-          disabled={disabledInput}
-          status={status}
-        />
-      </DialogSection>
-      <DialogSection appearance={{ theme: 'sidePadding' }}>
-        <div className={styles.contractFunctionSelectorContainer}>
-          <Select
-            label={MSG.functionLabel}
-            name={`transactions.${transactionFormIndex}.contractFunction`}
-            appearance={{ theme: 'grey', width: 'fluid' }}
-            placeholder={MSG.functionPlaceholder}
-            disabled={disabledInput}
-            options={formattedMethodOptions}
-            onChange={(value) => {
-              const updatedSelectedContractMethods = {
-                ...selectedContractMethods,
-                [transactionFormIndex]: usefulMethods.find(
-                  (method) => method.name === value,
-                ),
-              };
-              handleSelectedContractMethods(updatedSelectedContractMethods);
-            }}
-          />
+      {isLoadingABI ? (
+        <div className={styles.spinner}>
+          <SpinnerLoader appearance={{ size: 'medium' }} />
         </div>
-      </DialogSection>
-      {selectedContractMethods[transactionFormIndex]?.inputs?.map((input) => (
-        <DialogSection
-          key={`${input.name}-${input.type}`}
-          appearance={{ theme: 'sidePadding' }}
-        >
-          <div className={styles.inputParamContainer}>
-            <Input
-              label={`${input.name} (${input.type})`}
-              name={`transactions.${transactionFormIndex}.${input.name}`}
-              appearance={{ colorSchema: 'grey', theme: 'fat' }}
+      ) : (
+        <>
+          <DialogSection>
+            <Textarea
+              label={MSG.abiLabel}
+              name={`transactions.${transactionFormIndex}.abi`}
+              appearance={{ colorSchema: 'grey', resizable: 'vertical' }}
               disabled={disabledInput}
-              placeholder={`${input.name} (${input.type})`}
-              formattingOptions={
-                input.type.includes('int') &&
-                input.type.substring(input.type.length - 2) !== '[]'
-                  ? {
-                      numeral: true,
-                      numeralPositiveOnly:
-                        input.type.substring(0, 4) === 'uint',
-                      numeralDecimalScale: 0,
-                    }
-                  : undefined
-              }
+              status={status}
             />
-          </div>
-        </DialogSection>
-      ))}
+          </DialogSection>
+          <DialogSection appearance={{ theme: 'sidePadding' }}>
+            <div className={styles.contractFunctionSelectorContainer}>
+              <Select
+                label={MSG.functionLabel}
+                name={`transactions.${transactionFormIndex}.contractFunction`}
+                appearance={{ theme: 'grey', width: 'fluid' }}
+                placeholder={MSG.functionPlaceholder}
+                disabled={disabledInput}
+                options={formattedMethodOptions}
+                onChange={(value) => {
+                  const updatedSelectedContractMethods = {
+                    ...selectedContractMethods,
+                    [transactionFormIndex]: usefulMethods.find(
+                      (method) => method.name === value,
+                    ),
+                  };
+                  handleSelectedContractMethods(updatedSelectedContractMethods);
+                }}
+              />
+            </div>
+          </DialogSection>
+          {selectedContractMethods[transactionFormIndex]?.inputs?.map(
+            (input) => (
+              <DialogSection
+                key={`${input.name}-${input.type}`}
+                appearance={{ theme: 'sidePadding' }}
+              >
+                <div className={styles.inputParamContainer}>
+                  <Input
+                    label={`${input.name} (${input.type})`}
+                    name={`transactions.${transactionFormIndex}.${input.name}`}
+                    appearance={{ colorSchema: 'grey', theme: 'fat' }}
+                    disabled={disabledInput}
+                    placeholder={`${input.name} (${input.type})`}
+                    formattingOptions={
+                      input.type.includes('int') &&
+                      input.type.substring(input.type.length - 2) !== '[]'
+                        ? {
+                            numeral: true,
+                            numeralPositiveOnly:
+                              input.type.substring(0, 4) === 'uint',
+                            numeralDecimalScale: 0,
+                          }
+                        : undefined
+                    }
+                  />
+                </div>
+              </DialogSection>
+            ),
+          )}
+        </>
+      )}
     </>
   );
 };

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css
@@ -35,3 +35,7 @@
 .inputParamContainer p {
   margin-bottom: 10px;
 }
+
+.spinner {
+  text-align: center;
+}

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css.d.ts
@@ -2,3 +2,4 @@ export const singleUserPickerContainer: string;
 export const contractFunctionSelectorContainer: string;
 export const labelDescription: string;
 export const inputParamContainer: string;
+export const spinner: string;

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransferNFTSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransferNFTSection.tsx
@@ -55,11 +55,11 @@ const MSG = defineMessages({
   },
   noNftsFound: {
     id: `dashboard.ControlSafeDialog.TransferNFTSection.noNftsFound`,
-    defaultMessage: 'No NFTs found.',
+    defaultMessage: 'No NFTs found',
   },
   nftLoading: {
     id: `dashboard.ControlSafeDialog.TransferNFTSection.nftLoading`,
-    defaultMessage: 'Loading NFTs.',
+    defaultMessage: 'Loading NFTs',
   },
   nftError: {
     id: `dashboard.ControlSafeDialog.TransferNFTSection.nftError`,
@@ -198,7 +198,10 @@ const TransferNFTSection = ({
     return (
       <DialogSection>
         <div className={styles.loading}>
-          <SpinnerLoader loadingText={MSG.nftLoading} />
+          <SpinnerLoader
+            appearance={{ size: 'medium' }}
+            loadingText={MSG.nftLoading}
+          />
         </div>
       </DialogSection>
     );


### PR DESCRIPTION
## Description

This PR adds a loading spinner to the contract interaction ABI. The spinner should appear as long as the ABI is being fetched and parsed. It should appear for at least 1-5 seconds. 

**For testing:**
- It would be easier to slow down your network speed as the spinner only shows up 1-2 secs.

![network](https://user-images.githubusercontent.com/71563622/192315828-7ace4281-3db9-43df-9e3c-aab0591f5a28.gif)

**Changes** 🏗
- Added `SpinnerLoader`

![isloadingabi](https://user-images.githubusercontent.com/71563622/192315516-8031fd02-6e05-4a49-829d-807b2dff4d17.gif)

---
Resolves #3804