### PR TITLE
Fix "Address format is wrong" displayed next to the SafePicker

### DIFF
--- a/src/modules/core/components/SingleUserPicker/SingleUserPicker.tsx
+++ b/src/modules/core/components/SingleUserPicker/SingleUserPicker.tsx
@@ -4,6 +4,7 @@ import compose from 'recompose/compose';
 import classnames from 'classnames';
 
 import { useField } from 'formik';
+import { isAddress } from '@colony/colony-js/lib/utils';
 import { AnyUser } from '~data/index';
 import { Address, SimpleMessageValues } from '~types/index';
 import { getMainClasses } from '~utils/css';
@@ -233,7 +234,8 @@ const SingleUserPicker = ({
                   {value.profile.displayName ||
                     value.profile.username ||
                     value.profile.walletAddress}
-                  {showMaskedAddress && (
+                  {/* eslint-disable-next-line max-len */}
+                  {showMaskedAddress && isAddress(value.profile.walletAddress) && (
                     <span className={styles.maskedAddress}>
                       <MaskedAddress address={value.profile.walletAddress} />
                     </span>

--- a/src/modules/core/components/SingleUserPicker/SingleUserPicker.tsx
+++ b/src/modules/core/components/SingleUserPicker/SingleUserPicker.tsx
@@ -194,9 +194,7 @@ const SingleUserPicker = ({
       ? placeholder
       : formatMessage(placeholder);
 
-  const isValidWalletAddress = value
-    ? isAddress(value?.profile.walletAddress)
-    : false;
+  const isValidWalletAddress = isAddress(value?.profile.walletAddress || '');
 
   return (
     <div className={styles.omniContainer}>

--- a/src/modules/core/components/SingleUserPicker/SingleUserPicker.tsx
+++ b/src/modules/core/components/SingleUserPicker/SingleUserPicker.tsx
@@ -194,6 +194,10 @@ const SingleUserPicker = ({
       ? placeholder
       : formatMessage(placeholder);
 
+  const isValidWalletAddress = value
+    ? isAddress(value?.profile.walletAddress)
+    : false;
+
   return (
     <div className={styles.omniContainer}>
       <OmniPickerWrapper className={getMainClasses(appearance, styles)}>
@@ -234,8 +238,7 @@ const SingleUserPicker = ({
                   {value.profile.displayName ||
                     value.profile.username ||
                     value.profile.walletAddress}
-                  {/* eslint-disable-next-line max-len */}
-                  {showMaskedAddress && isAddress(value.profile.walletAddress) && (
+                  {showMaskedAddress && isValidWalletAddress && (
                     <span className={styles.maskedAddress}>
                       <MaskedAddress address={value.profile.walletAddress} />
                     </span>


### PR DESCRIPTION
## Description

This PR fixes the bug described in #3899:
<img width="489" alt="image" src="https://user-images.githubusercontent.com/112586815/192230366-2aaadd26-52c4-4a27-a737-a13e9b81bc9d.png">

Upon investigation, I realised this happens not only in the safe picker mentioned above, but in any instance where the `SingleUserPicker` is being passed `showMaskedAddress` prop, so also in the Recipient field of the Transfer NFT section: 
<img width="487" alt="image" src="https://user-images.githubusercontent.com/112586815/192230231-41d5dc57-e661-4398-85ad-5448e463cf3a.png">

I added an optional prop to the `MaskedAddress` component that hides the "Address format is wrong" message and set it in `SingleUserPicker` whenever the `showMaskedAddress` option is enabled to achieve consistent behaviour. @willm30 mentioned in the original issue we could potentially change the colour of the safe picker to red when it's invalid, I noticed however that the `SingleUserPicker` text is always red, not only when the field is invalid. I believe no changes are needed for error messages beneath the field since there's support for Formik/yup validation already.

The end result is that the "Address format is wrong" message doesn't get appended to both field's value anymore:
<img width="484" alt="image" src="https://user-images.githubusercontent.com/112586815/192231104-e19f602e-b703-4f0b-8e79-4d3ada88445a.png">
<img width="486" alt="image" src="https://user-images.githubusercontent.com/112586815/192231189-2aab0f0a-8c91-4448-977d-22a762e694e0.png">


Resolves #3899 
