### PR TITLE
Fix copy address label tooltip positioning

### DIFF
--- a/src/modules/core/components/Popover/Tooltip.tsx
+++ b/src/modules/core/components/Popover/Tooltip.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useEffect } from 'react';
 import {
   usePopperTooltip,
   TriggerType,
@@ -46,6 +46,7 @@ const Tooltip = ({
     setTooltipRef,
     setTriggerRef,
     visible,
+    update,
   } = usePopperTooltip(
     {
       delayShow: 200,
@@ -55,6 +56,10 @@ const Tooltip = ({
     },
     popperOptions,
   );
+
+  useEffect(() => {
+    update?.();
+  }, [content, update]);
 
   return (
     <>
@@ -69,6 +74,7 @@ const Tooltip = ({
               className: showArrow ? styles.tooltipArrow : '',
             })}
           />
+
           {content}
         </div>
       )}

--- a/src/modules/core/components/Popover/Tooltip.tsx
+++ b/src/modules/core/components/Popover/Tooltip.tsx
@@ -74,7 +74,6 @@ const Tooltip = ({
               className: showArrow ? styles.tooltipArrow : '',
             })}
           />
-
           {content}
         </div>
       )}


### PR DESCRIPTION
## Description

This PR fixes the bug described in #3898

Before:

https://user-images.githubusercontent.com/112586815/192309425-c2c07679-a6ef-409f-8d50-250f8ef361aa.mov

After:

https://user-images.githubusercontent.com/112586815/192309574-02aa490f-131a-4f0a-ba2c-fc128012c34b.mov

**Changes** 🏗

* The Tooltip component wasn't triggering the popover repositioning when content changed. I added `useEffect` to trigger the repositioning.

Resolves #3898 
