### PR TITLE
Fix: Contract parser crash when no safe is selected

### DIFF
--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
@@ -151,6 +151,10 @@ const ContractInteractionSection = ({
 
   const onContractChange = useCallback(
     (contract: AnyUser) => {
+      if (!selectedSafe) {
+        return;
+      }
+
       const contractPromise = fetchContractABI(
         contract.profile.walletAddress,
         Number(selectedSafe?.chainId),


### PR DESCRIPTION
## Description

This PR fixes the bug described in #3894. The crash seems to happen in this line in `InputStatus` component:
```
const statusText =
    typeof status === 'object' ? formatMessage(status, statusValues) : status;
```
Because `typeof (null)` is `object` (🤦‍♂️), when `status` is null and not undefined it still gets passed to `formatMessage` which tries to read some properties of it, therefore crashing. 

I solved this by stopping the `onContractChange` callback execution if there is no safe selected. There might be alternative solutions, e.g.:
 * Improving UX of the entire Control Safe by hiding/disabling the target contract address field when no safe is selected,
 * Refactoring `InputStatus` to handle `null` statuses.

**Changes** 🏗

* Added condition checking if safe is selected to `ContractInteractionSection`'s `onContractChange` callback

Resolves #3894 
