### PR TITLE
Fix error in contract parser ABI text area

### DIFF
--- a/src/utils/safes/getContractUsefulMethods.ts
+++ b/src/utils/safes/getContractUsefulMethods.ts
@@ -88,11 +88,11 @@ const extractUsefulMethods = (abi: AbiItem[]): AbiItemExtended[] => {
     });
 };
 
-const isAbiItem = (value: unknown): value is AbiItem[] => {
-  return (
+export const isAbiItem = (value: unknown): value is AbiItem[] => {
+  const test =
     Array.isArray(value) &&
-    value.every((element) => typeof element === 'object')
-  );
+    value.every((element) => typeof element === 'object');
+  return test;
 };
 
 export const getContractUsefulMethods = (contractABI: string | undefined) => {

--- a/src/utils/safes/getContractUsefulMethods.ts
+++ b/src/utils/safes/getContractUsefulMethods.ts
@@ -89,10 +89,10 @@ const extractUsefulMethods = (abi: AbiItem[]): AbiItemExtended[] => {
 };
 
 export const isAbiItem = (value: unknown): value is AbiItem[] => {
-  const test =
+  return (
     Array.isArray(value) &&
-    value.every((element) => typeof element === 'object');
-  return test;
+    value.every((element) => typeof element === 'object')
+  );
 };
 
 export const getContractUsefulMethods = (contractABI: string | undefined) => {

--- a/src/utils/safes/getContractUsefulMethods.ts
+++ b/src/utils/safes/getContractUsefulMethods.ts
@@ -88,12 +88,22 @@ const extractUsefulMethods = (abi: AbiItem[]): AbiItemExtended[] => {
     });
 };
 
+const isAbiItem = (value: unknown): value is AbiItem[] => {
+  return (
+    Array.isArray(value) &&
+    value.every((element) => typeof element === 'object')
+  );
+};
+
 export const getContractUsefulMethods = (contractABI: string | undefined) => {
   let parsedContractABI: AbiItem[] = [];
   let usefulMethods: AbiItemExtended[] = [];
 
   try {
     parsedContractABI = JSON.parse(contractABI || '[]');
+    if (!isAbiItem(parsedContractABI)) {
+      throw new Error('Contract ABI is not valid');
+    }
   } catch (error) {
     console.error(error);
     parsedContractABI = [];

--- a/src/utils/safes/index.ts
+++ b/src/utils/safes/index.ts
@@ -3,4 +3,5 @@ export {
   getContractUsefulMethods,
   AbiItemExtended,
   fetchContractABI,
+  isAbiItem,
 } from './getContractUsefulMethods';


### PR DESCRIPTION
## Description

This PR fixes a bug described in PR #3901. The DApp crashes when entering any number in the Contract Parser ABI text area.

**Changes** 🏗

* Added validation to check if the parsed JSON is an ABI item.

----
Resolves #3901