### PR TITLE
Add V2 IPFS metadata support for decisions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@apollo/client": "^3.0.2",
-        "@colony/colony-event-metadata-parser": "^1.0.5",
+        "@colony/colony-event-metadata-parser": "^1.1.0",
         "@colony/colony-js": "^4.2.1-beta.1",
         "@colony/redux-promise-listener": "^1.2.0",
         "@colony/unicode-confusables-noascii": "^0.1.2",
@@ -4062,9 +4062,9 @@
       }
     },
     "node_modules/@colony/colony-event-metadata-parser": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@colony/colony-event-metadata-parser/-/colony-event-metadata-parser-1.0.5.tgz",
-      "integrity": "sha512-DHvgur5VgULMM0bAjMriRWob7+3nja15MNEV7F5l1AgKodYqiebapeoT/wJI3UMlCbR75V5GPu32QYpTCbDQiw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@colony/colony-event-metadata-parser/-/colony-event-metadata-parser-1.1.0.tgz",
+      "integrity": "sha512-esGVL4oqJe1M6Q8Eo5tg9J3YlJPnm9j1u4cHVAfY6JZkYlJIvtJL/aDFQ5rEJHjaddVIZIwANM1wzQtyOBs7HQ==",
       "dependencies": {
         "lint-staged": "^13.0.3",
         "react-intl": "^6.0.4",
@@ -58675,9 +58675,9 @@
       }
     },
     "@colony/colony-event-metadata-parser": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@colony/colony-event-metadata-parser/-/colony-event-metadata-parser-1.0.5.tgz",
-      "integrity": "sha512-DHvgur5VgULMM0bAjMriRWob7+3nja15MNEV7F5l1AgKodYqiebapeoT/wJI3UMlCbR75V5GPu32QYpTCbDQiw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@colony/colony-event-metadata-parser/-/colony-event-metadata-parser-1.1.0.tgz",
+      "integrity": "sha512-esGVL4oqJe1M6Q8Eo5tg9J3YlJPnm9j1u4cHVAfY6JZkYlJIvtJL/aDFQ5rEJHjaddVIZIwANM1wzQtyOBs7HQ==",
       "requires": {
         "lint-staged": "^13.0.3",
         "react-intl": "^6.0.4",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.0.2",
-    "@colony/colony-event-metadata-parser": "^1.0.5",
+    "@colony/colony-event-metadata-parser": "^1.1.0",
     "@colony/colony-js": "^4.2.1-beta.1",
     "@colony/redux-promise-listener": "^1.2.0",
     "@colony/unicode-confusables-noascii": "^0.1.2",

--- a/src/data/resolvers/colony.ts
+++ b/src/data/resolvers/colony.ts
@@ -13,7 +13,6 @@ import {
   formatColonyRoles,
   ColonyRole,
 } from '@colony/colony-js';
-
 import {
   getColonyAvatarImage,
   getColonyMetadataFromResponse,

--- a/src/modules/core/components/ActionsList/ActionsListItem.tsx
+++ b/src/modules/core/components/ActionsList/ActionsListItem.tsx
@@ -9,6 +9,7 @@ import {
 import { ColonyRoles } from '@colony/colony-js';
 import Decimal from 'decimal.js';
 import { AddressZero } from 'ethers/constants';
+import { getDecisionDetailsFromResponse } from '@colony/colony-event-metadata-parser';
 
 import HookedUserAvatar from '~users/HookedUserAvatar';
 import Numeral, { AbbreviatedNumeral } from '~core/Numeral';
@@ -137,7 +138,7 @@ const ActionsListItem = ({
 
   let title = '';
   if (data) {
-    const decision = JSON.parse(data);
+    const decision = getDecisionDetailsFromResponse(data) as DecisionDetails;
     title = decision?.title;
   }
 

--- a/src/modules/dashboard/components/ActionsPage/ActionPageDecisionWithIPFS/ActionPageDecisionWithIPFS.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionPageDecisionWithIPFS/ActionPageDecisionWithIPFS.tsx
@@ -2,7 +2,10 @@ import React, { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import { defineMessages } from 'react-intl';
 import parse from 'html-react-parser';
-import { getDecisionDetailsFromResponse } from '@colony/colony-event-metadata-parser';
+import {
+  getDecisionDetailsFromResponse,
+  getAnnotationMsgFromResponse,
+} from '@colony/colony-event-metadata-parser';
 
 import Heading from '~core/Heading';
 import CalloutCard from '~core/CalloutCard';
@@ -67,9 +70,9 @@ const ActionPageDecisionWithIPFS = ({
     }
     // @NOTE: Decision objection message is stored in the `annotationMessage` field
     if (isObjection) {
-      const objectionMessage = JSON.parse(ipfsDataJSON);
+      const objectionMessage = getAnnotationMsgFromResponse(ipfsDataJSON);
       return {
-        description: objectionMessage?.annotationMessage,
+        description: objectionMessage,
       } as DecisionDetails;
     }
 

--- a/src/modules/dashboard/components/ActionsPage/ActionPageDecisionWithIPFS/ActionPageDecisionWithIPFS.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionPageDecisionWithIPFS/ActionPageDecisionWithIPFS.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import { defineMessages } from 'react-intl';
 import parse from 'html-react-parser';
+import { getDecisionDetailsFromResponse } from '@colony/colony-event-metadata-parser';
 
 import Heading from '~core/Heading';
 import CalloutCard from '~core/CalloutCard';
@@ -72,8 +73,9 @@ const ActionPageDecisionWithIPFS = ({
       } as DecisionDetails;
     }
 
-    // @TODO - add V2 IPFS support inc validation
-    const details: DecisionDetails = JSON.parse(ipfsDataJSON);
+    const details: DecisionDetails = getDecisionDetailsFromResponse(
+      ipfsDataJSON,
+    ) as DecisionDetails;
     return details;
   }, [ipfsDataJSON, isObjection]);
 

--- a/src/modules/dashboard/sagas/motions/createDecisionMotion.ts
+++ b/src/modules/dashboard/sagas/motions/createDecisionMotion.ts
@@ -1,6 +1,7 @@
 import { call, fork, put, takeEvery } from 'redux-saga/effects';
 import { ClientType, ROOT_DOMAIN_ID, getChildIndex } from '@colony/colony-js';
 import { AddressZero } from 'ethers/constants';
+import { getStringForMetadataDecision } from '@colony/colony-event-metadata-parser';
 
 import { ContextModule, TEMP_getContext } from '~context/index';
 import { Action, ActionTypes, AllActions } from '~redux/index';
@@ -16,12 +17,12 @@ import {
   createTransactionChannels,
   getTxChannel,
 } from '../../../core/sagas';
-import { ipfsUpload } from '../../../core/sagas/ipfs';
 import {
   transactionReady,
   transactionPending,
   transactionAddParams,
 } from '../../../core/actionCreators';
+import { ipfsUploadWithFallback } from '../utils';
 
 function* createDecisionMotion({
   payload: {
@@ -148,7 +149,10 @@ function* createDecisionMotion({
     /*
      * Upload Decision details to IPFS
      */
-    const decisionIpfsHash = yield call(ipfsUpload, JSON.stringify(details));
+    const decisionIpfsHash = yield call(
+      ipfsUploadWithFallback,
+      getStringForMetadataDecision(details),
+    );
     yield put(
       transactionAddParams(annotateMotion.id, [txHash, decisionIpfsHash]),
     );


### PR DESCRIPTION
## Description

This PR adds V2 IPFS metadata support fro decisions. You need to run npm i to have an updated version of the package.

resolves #3887 
