### PR TITLE
Refactor loading spinner in Transfer Funds

### DIFF
--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransferFundsSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransferFundsSection.tsx
@@ -166,7 +166,10 @@ const TransferFundsSection = ({
     return (
       <DialogSection>
         <div className={styles.balanceLoading}>
-          <SpinnerLoader loadingText={MSG.balancesLoading} />
+          <SpinnerLoader
+            appearance={{ size: 'medium' }}
+            loadingText={MSG.balancesLoading}
+          />
         </div>
       </DialogSection>
     );


### PR DESCRIPTION
## Description

Small PR that changes the appearance of the Transfer Funds `SpinnerLoader` to match the one found in Transfer NFTs and Contract Interaction. 

Check PR #3902 to see the NFTs and Contract interaction loaders.

Changes 🏗

- Included the appearance attribute in the `SpinnerLoader` to access the same size in Transfer Funds.

--
Resolves #3920