### PR TITLE
Prevent jumping of UI when displaying the transaction fee

### DIFF
--- a/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.css
+++ b/src/modules/dashboard/components/Dialogs/CreatePaymentDialog/CreatePaymentDialogForm.css
@@ -26,6 +26,7 @@
 }
 
 .domainPotBalance, .networkFee {
+  height: 0px;
   position: relative;
   bottom: 14px;
   font-size: var(--size-tiny);


### PR DESCRIPTION
## Description

Simple PR that prevents jumping when displaying the transaction fee.

Can be tested by:

1. Go to create a payment dialog
2. Add payment amount
3. There shouldn't be any jumping.

Resolves #3774
