### PR TITLE
Refactor contract abi errors

### DIFF
--- a/src/modules/constants.ts
+++ b/src/modules/constants.ts
@@ -339,6 +339,12 @@ export const GNOSIS_AMB_BRIDGES: { [x: number]: AmbBridge } = {
   },
 };
 
+export const SUPPORTED_SAFE_NETWORKS = SAFE_NETWORKS.filter((network) =>
+  Object.keys(GNOSIS_AMB_BRIDGES).some(
+    (chainId) => chainId === network.chainId.toString(),
+  ),
+);
+
 export const ALLDOMAINS_DOMAIN_SELECTION = {
   id: String(COLONY_TOTAL_BALANCE_DOMAIN_ID),
   color: Color.Yellow,

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
@@ -139,8 +139,6 @@ const ControlSafeForm = ({
   values,
   isVotingExtensionEnabled,
   setFieldValue,
-  setStatus,
-  status,
   showPreview,
   handleShowPreview,
   validateForm,
@@ -153,6 +151,7 @@ const ControlSafeForm = ({
   const [customAmountError, setCustomAmountError] = useState<
     MessageDescriptor | string | undefined
   >(undefined);
+  const [prevSafeAddress, setPrevSafeAddress] = useState<string>('');
 
   const { walletAddress } = useLoggedInUser();
   const fromDomainRoles = useTransformer(getUserRolesForDomain, [
@@ -265,7 +264,6 @@ const ControlSafeForm = ({
    * When the selected safe changes, reset the state of
    * the "Transfer NFT" fields.
    */
-  const [prevSafeAddress, setPrevSafeAddress] = useState<string>('');
   const handleSafeChange = (selectedSafe: SelectedSafe) => {
     const safeAddress = selectedSafe.profile.walletAddress;
     if (safeAddress !== prevSafeAddress) {
@@ -278,21 +276,24 @@ const ControlSafeForm = ({
     }
   };
 
-  const removeSelectedContractMethods = (transactionFormIndex: number) => {
-    const updatedSelectedContractMethods = omit(
-      selectedContractMethods,
-      transactionFormIndex,
-    );
-
-    if (!isEqual(updatedSelectedContractMethods, selectedContractMethods)) {
-      handleSelectedContractMethods(updatedSelectedContractMethods);
-      setFieldValue(
-        `transactions.${transactionFormIndex}.contractFunction`,
-        '',
-        true,
+  const removeSelectedContractMethod = useCallback(
+    (transactionFormIndex: number) => {
+      const updatedSelectedContractMethods = omit(
+        selectedContractMethods,
+        transactionFormIndex,
       );
-    }
-  };
+
+      if (!isEqual(updatedSelectedContractMethods, selectedContractMethods)) {
+        handleSelectedContractMethods(updatedSelectedContractMethods);
+        setFieldValue(
+          `transactions.${transactionFormIndex}.contractFunction`,
+          '',
+          true,
+        );
+      }
+    },
+    [selectedContractMethods, handleSelectedContractMethods, setFieldValue],
+  );
 
   const savedNFTState = useState({});
   return (
@@ -404,9 +405,7 @@ const ControlSafeForm = ({
                             options={transactionOptions}
                             label={MSG.transactionLabel}
                             name={`transactions.${index}.transactionType`}
-                            onChange={() =>
-                              removeSelectedContractMethods(index)
-                            }
+                            onChange={() => removeSelectedContractMethod(index)}
                             appearance={{ theme: 'grey', width: 'fluid' }}
                             placeholder={MSG.transactionPlaceholder}
                             disabled={!userHasPermission || isSubmitting}
@@ -444,16 +443,14 @@ const ControlSafeForm = ({
                           values={values}
                           safes={safes}
                           setFieldValue={setFieldValue}
-                          setStatus={setStatus}
-                          status={status}
                           selectedContractMethods={selectedContractMethods}
                           handleSelectedContractMethods={
                             handleSelectedContractMethods
                           }
                           handleValidation={handleValidation}
                           handleInputChange={handleInputChange}
-                          removeSelectedContractMethods={
-                            removeSelectedContractMethods
+                          removeSelectedContractMethod={
+                            removeSelectedContractMethod
                           }
                         />
                       )}

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css
@@ -41,3 +41,10 @@
   display: flex;
   justify-content: center;
 }
+
+.error {
+  display: flex;
+  justify-content: center;
+  text-align: center;
+  color: var(--pink);
+}

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css.d.ts
@@ -4,3 +4,4 @@ export const labelDescription: string;
 export const inputParamContainer: string;
 export const spinner: string;
 export const balanceError: string;
+export const error: string;

--- a/src/utils/safes/getContractUsefulMethods.ts
+++ b/src/utils/safes/getContractUsefulMethods.ts
@@ -3,8 +3,8 @@ import { AbiItem, keccak256 } from 'web3-utils';
 import {
   BINANCE_NETWORK,
   GNOSIS_NETWORK,
-  SAFE_NETWORKS,
   POLYGON_NETWORK,
+  SUPPORTED_SAFE_NETWORKS,
 } from '~constants';
 
 export interface AbiItemExtended extends AbiItem {
@@ -24,9 +24,11 @@ export const fetchContractABI = async (
   }
 
   try {
-    const currentNetworkData =
-      SAFE_NETWORKS.find((network) => network.chainId === safeChainId) ||
-      GNOSIS_NETWORK;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const currentNetworkData = SUPPORTED_SAFE_NETWORKS.find(
+      (network) => network.chainId === safeChainId,
+    )!; // will be defined since fetchContractABI is only called if selectedSafe is defined
+
     const getApiKey = () => {
       if (currentNetworkData.chainId === POLYGON_NETWORK.chainId) {
         return process.env.POLYGONSCAN_API_KEY;


### PR DESCRIPTION
## Description

This PR proposes a change to the way we display errors when fetching the contract abi in the Contract Interaction section, which would bring the error ui in line with the Transfer NFT section.

To test, try and generate every conceivable error state and ensure there's some feedback in the ui that's consistent with the images below. And ensure nothing weird happens when selecting a different safe, switching the transaction type, or add another transaction.

**Changes** 🏗

* Displaying errors in the contract abi section by replacing the `textarea`, instead of placing them as statuses below it.

Incorporating #3910  -- no safe
![selectsafe](https://user-images.githubusercontent.com/64402732/194371643-7707ff0e-fa15-4f83-b6ae-feacb3866539.png)

Fetch error (user is offline)
![network](https://user-images.githubusercontent.com/64402732/194371646-a99a8e9e-ed33-4b98-8c90-a12732f8b4ed.png)

Couldn't verify contract (wrong chain)
![notverified](https://user-images.githubusercontent.com/64402732/194371648-99e426fa-0dbf-4fd3-b608-6d6a35796db5.png)

Invalid address
![notvalid](https://user-images.githubusercontent.com/64402732/194371651-c9383c00-2c73-480f-bf1d-edc9d90441cd.png)

Leaving this one as it makes sense to keep the text area
![setval](https://user-images.githubusercontent.com/64402732/194379859-182ba175-6593-4975-a687-fef9804c8110.png)

Resolves #3923
