### PR TITLE
Fix: Avatar uploader gets stuck

### DIFF
--- a/src/modules/core/components/AvatarUploader/AvatarUploadItem.tsx
+++ b/src/modules/core/components/AvatarUploader/AvatarUploadItem.tsx
@@ -64,11 +64,14 @@ const AvatarUploadItem = ({
     if (file && !error && !uploaded) {
       uploadFile();
     }
-    if (error && handleError) {
-      handleError({ ...value, file });
+    if (error) {
+      handleError?.({ ...value, file });
+
+      // reset the form to allow for another upload attempt
+      reset();
     }
     // Only on first render
-  }, [handleError, file, error, uploadFile, uploaded, value]);
+  }, [handleError, file, error, uploadFile, uploaded, value, reset]);
 
   return (
     <div className={styles.main}>

--- a/src/modules/users/components/UserProfileEdit/UserAvatarUploader.css
+++ b/src/modules/users/components/UserProfileEdit/UserAvatarUploader.css
@@ -1,0 +1,3 @@
+.inputStatus {
+  margin-top: 10px;
+}

--- a/src/modules/users/components/UserProfileEdit/UserAvatarUploader.css.d.ts
+++ b/src/modules/users/components/UserProfileEdit/UserAvatarUploader.css.d.ts
@@ -1,0 +1,1 @@
+export const inputStatus: string;

--- a/src/modules/users/components/UserProfileEdit/UserAvatarUploader.tsx
+++ b/src/modules/users/components/UserProfileEdit/UserAvatarUploader.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { defineMessages } from 'react-intl';
 
 import { FileReaderFile } from '~core/FileUpload';
@@ -7,11 +7,18 @@ import { useAsyncFunction } from '~utils/hooks';
 import AvatarUploader from '~core/AvatarUploader';
 import HookedUserAvatar from '~users/HookedUserAvatar';
 import { ActionTypes } from '~redux/index';
+import { InputStatus } from '~core/Fields';
+
+import styles from './UserAvatarUploader.css';
 
 const MSG = defineMessages({
   uploaderLabel: {
-    id: 'users.UserProfileEdit.UserAvatarUploader',
+    id: 'users.UserProfileEdit.UserAvatarUploader.uploaderLabel',
     defaultMessage: 'At least 250x250px, up to 1MB, .png or .svg',
+  },
+  avatarFileError: {
+    id: 'users.UserProfileEdit.UserAvatarUploader.avatarFileError',
+    defaultMessage: 'This filetype is not allowed or file is too big',
   },
 });
 
@@ -42,22 +49,41 @@ const UserAvatarUploader = ({ user }: Props) => {
   ) => Promise<string>;
   const remove = useAsyncFunction(removeActions);
 
+  const [avatarFileError, setAvatarFileError] = useState(false);
+
+  const handleUpload = async (fileData: FileReaderFile) => {
+    setAvatarFileError(false);
+    return upload(fileData);
+  };
+
+  const handleError = async () => {
+    setAvatarFileError(true);
+  };
+
   return (
-    <AvatarUploader
-      label={MSG.uploaderLabel}
-      hasButtons
-      placeholder={
-        <UserAvatar
-          address={user.profile.walletAddress}
-          user={user}
-          size="xl"
-          notSet={false}
-        />
-      }
-      upload={upload}
-      remove={remove}
-      isSet={user && user.profile && !!user.profile.avatarHash}
-    />
+    <>
+      <AvatarUploader
+        label={MSG.uploaderLabel}
+        hasButtons
+        placeholder={
+          <UserAvatar
+            address={user.profile.walletAddress}
+            user={user}
+            size="xl"
+            notSet={false}
+          />
+        }
+        upload={handleUpload}
+        remove={remove}
+        isSet={user && user.profile && !!user.profile.avatarHash}
+        handleError={handleError}
+      />
+      {avatarFileError && (
+        <div className={styles.inputStatus}>
+          <InputStatus error={MSG.avatarFileError} />
+        </div>
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
## Description

This PR fixes the bug described in #3786. 

The investigation took way longer than expected and I'm still not 100% sure of the solution. The issue affects both avatar uploaders that use `AvatarUploader` which is `UserAvatarUploader` and the colony avatar uploader.
It looks like there is some error handling logic in `FileUpload` which is used internally by `AvatarUploader` but it'd be quite hard to get right considering other components depend on it. Instead, I opted for a fix that's specific to `AvatarUploader` and followed the error handling convention set out in the colony avatar uploader (handling error in its own local state).

Before:
- Clicking on Choose does nothing:
<img width="314" alt="image" src="https://user-images.githubusercontent.com/112586815/193125823-564b9b29-77e4-44d7-a475-0e8c4ada3b72.png">

- The browse button disappears:
<img width="488" alt="image" src="https://user-images.githubusercontent.com/112586815/193125759-fb791d9f-6e1b-4ac5-8ef7-1cb1d2320b92.png">

After:
![Screenshot 2022-09-29 at 19 40 04](https://user-images.githubusercontent.com/112586815/193125976-1d5ebdc0-adbd-4000-a6f5-77b5b0d85fae.png)

<img width="494" alt="Screenshot 2022-09-29 at 20 35 03" src="https://user-images.githubusercontent.com/112586815/193126000-26596055-f570-454a-8707-aaee36cdf0ea.png">



**Changes** 🏗

* Reset file uploader form upon error so that another upload attempt can be made
* Display appropriate error message if invalid file is uploaded

Resolves #3786 
