### PR TITLE
Fix webpack build error

### DIFF
--- a/src/modules/dashboard/sagas/utils/safeHelpers.ts
+++ b/src/modules/dashboard/sagas/utils/safeHelpers.ts
@@ -74,9 +74,19 @@ export const getHomeBridge = (safe: Omit<ColonySafe, 'safeName'>) => {
 };
 
 /* Currently only used to get the ForeignBridgeMock contract from Colony Network, for testing locally. */
-const getBuildFromColonyNetwork = (contractName: string) =>
-  // eslint-disable-next-line @typescript-eslint/no-var-requires, max-len, global-require, import/no-dynamic-require
-  require(`~lib/colonyNetwork/build/contracts/${contractName}.json`);
+const getBuildFromColonyNetwork = (contractName: string) => {
+  /*
+   * "isProduction" is injected by webpack in the relevant config.
+   * This is to avoid a github actions build error. https://github.com/JoinColony/colonyDapp/actions/runs/3175487585/jobs/5176947845
+   */
+  // @ts-ignore
+  // eslint-disable-next-line no-undef
+  if (!isProduction) {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require, import/no-dynamic-require
+    return require(`~lib/colonyNetwork/build/contracts/${contractName}.json`);
+  }
+  return undefined;
+};
 
 /* Only used locally in order to confirm foreign bridge received message from home bridge. */
 export const getForeignBridgeMock = () => {

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -54,5 +54,8 @@ module.exports = () => ({
       analyzerMode: 'static',
       openAnalyzer: false,
     }),
+    new webpack.DefinePlugin({
+      "isProduction": JSON.stringify(false),
+    }),
   ],
 });

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -65,5 +65,8 @@ module.exports = () => ({
       resourceRegExp: /^(.*)\.json$/,
       contextRegExp: /colonyNetwork\/build\/contracts$/
     }),
+    new webpack.DefinePlugin({
+      "isProduction": JSON.stringify(true),
+    }),
   ],
 });


### PR DESCRIPTION
## Description

This PR fixes an error in github actions when building the safe control branch that was being caused by the `require(~lib/colonyNetwork/build/contracts...)`  in the `safeHelpers` file not being properly guarded for development only.

The only way I got this to work was by using a custom webpack plugin. Not sure why, but the approach of calling it only if `process.env.NODE_ENV === 'development'` didn't work. 

**New stuff** ✨

* custom webpack variable `isProduction`
