### PR TITLE
Decisions: Editor Dialog not disabled

### DIFF
--- a/src/modules/core/components/RichTextEditor/RichTextEditor.tsx
+++ b/src/modules/core/components/RichTextEditor/RichTextEditor.tsx
@@ -39,11 +39,12 @@ const RichTextEditor = ({
       setContentValue(editorContent.getHTML());
 
     editor.on('update', handleUpdate);
+    editor.setEditable(!disabled);
 
     return () => {
       editor.off('update', handleUpdate);
     };
-  }, [editor, setContentValue]);
+  }, [disabled, editor, setContentValue]);
 
   return (
     <div
@@ -59,7 +60,7 @@ const RichTextEditor = ({
         })}
         name={name}
         onBlur={() => {
-          setContentTouched(true);
+          if (!disabled) setContentTouched(true);
         }}
       />
       <span className={styles.characterCount}>


### PR DESCRIPTION
## Description

This PR, fixes the bug where the editor input in the Decision dialog is not disabled. This can be required if the user lacks appropriate reputation.

Can be easily tested by trying to create a Decision without reputation and trying to interact with the description field.

More details can be found in the issue....
Resolves #3938 
