### PR TITLE
Disable `Reveal` button in voting widget when the user didn't vote

### DIFF
--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -568,9 +568,10 @@ export const motionsResolvers = ({
           fetchPolicy: 'network-only',
         });
 
-        const hasCurrentUserVoted = !!data?.motionVoteSubmittedEvents.filter(
-          (event) => event.args.includes(userAddress),
-        );
+        const hasCurrentUserVoted =
+          data?.motionVoteSubmittedEvents.filter((event) =>
+            event.args.includes(userAddress.toLowerCase()),
+          ).length !== 0;
 
         return hasCurrentUserVoted;
       } catch (error) {


### PR DESCRIPTION
## Description

This PR fixes the condition in motion resolver whether the user voted or not.

resolves #3930 
