### PR TITLE
Display contract name in control safe dialog

### DIFF
--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.css
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.css
@@ -114,3 +114,8 @@
 .itemValue {
   composes: inlineEllipsis from '~styles/text.css';
 }
+
+.contractName {
+  font-size: var(--size-normal);
+  color: var(--pink);
+}

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.css.d.ts
@@ -14,3 +14,4 @@ export const rawTransactionValues: string;
 export const nftContainer: string;
 export const avatar: string;
 export const itemValue: string;
+export const contractName: string;

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.tsx
@@ -184,7 +184,9 @@ const transactionTypeFieldsMap = {
       label: MSG.contract,
       value: (contract) => (
         <div className={styles.rawTransactionValues}>
-          <MaskedAddress address={contract.profile.displayName} />
+          <span className={styles.contractName}>
+            {contract.profile.displayName}
+          </span>
         </div>
       ),
     },

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
@@ -183,13 +183,10 @@ const ContractInteractionSection = ({
           Number(selectedSafe?.chainId),
         );
 
-        setFieldValue(`transactions.${transactionFormIndex}.contract`, {
-          ...contract,
-          profile: {
-            ...contract.profile,
-            displayName: contractName || 'Unknown contract',
-          },
-        });
+        setFieldValue(
+          `transactions.${transactionFormIndex}.contract.profile.displayName`,
+          contractName || 'Unknown contract',
+        );
         setIsLoadingABI(false);
       } else {
         if (!isAddress(contract.profile.walletAddress)) {
@@ -197,13 +194,10 @@ const ContractInteractionSection = ({
         } else {
           setFetchABIError(formatMessage(MSG.noSafeSelectedError));
         }
-        setFieldValue(`transactions.${transactionFormIndex}.contract`, {
-          ...contract,
-          profile: {
-            ...contract.profile,
-            displayName: 'Unknown contract',
-          },
-        });
+        setFieldValue(
+          `transactions.${transactionFormIndex}.contract.profile.displayName`,
+          'Unknown contract',
+        );
         setIsLoadingABI(false);
       }
     },

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
@@ -190,7 +190,7 @@ const ContractInteractionSection = ({
             ...contract,
             profile: {
               ...contract.profile,
-              displayName: name,
+              displayName: name || 'Unknown contract',
             },
           });
         });

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
@@ -201,6 +201,13 @@ const ContractInteractionSection = ({
           setFetchABIError(formatMessage(MSG.noSafeSelectedError));
         }
         setIsLoadingABI(false);
+        setFieldValue(`transactions.${transactionFormIndex}.contract`, {
+          ...contract,
+          profile: {
+            ...contract.profile,
+            displayName: 'Unknown contract',
+          },
+        });
       }
     },
     [
@@ -218,9 +225,10 @@ const ContractInteractionSection = ({
   );
 
   useEffect(() => {
-    if (
+    if (!selectedSafe) {
+      setPrevSafeChainId('');
+    } else if (
       transactionValues.contract &&
-      selectedSafe &&
       // only run effect if safe chain changes
       prevSafeChainId !== selectedSafe.chainId
     ) {

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
@@ -162,45 +162,41 @@ const ContractInteractionSection = ({
   );
 
   const onContractChange = useCallback(
-    (contract: AnyUser) => {
+    async (contract: AnyUser) => {
       setIsLoadingABI(true);
       setFetchABIError('');
 
       if (selectedSafe && isAddress(contract.profile.walletAddress)) {
-        const contractABIPromise = fetchContractABI(
+        const contractABIData = await fetchContractABI(
           contract.profile.walletAddress,
           Number(selectedSafe.chainId),
         );
-        contractABIPromise.then((data) => {
-          setIsLoadingABI(false);
-          if (data) {
-            onContractABIChange(data);
-          } else {
-            setFetchABIError(formatMessage(MSG.fetchFailedError));
-          }
-        });
 
-        const contractNamePromise = fetchContractName(
+        if (contractABIData) {
+          onContractABIChange(contractABIData);
+        } else {
+          setFetchABIError(formatMessage(MSG.fetchFailedError));
+        }
+
+        const contractName = await fetchContractName(
           contract.profile.walletAddress,
           Number(selectedSafe?.chainId),
         );
 
-        contractNamePromise.then((name) => {
-          setFieldValue(`transactions.${transactionFormIndex}.contract`, {
-            ...contract,
-            profile: {
-              ...contract.profile,
-              displayName: name || 'Unknown contract',
-            },
-          });
+        setFieldValue(`transactions.${transactionFormIndex}.contract`, {
+          ...contract,
+          profile: {
+            ...contract.profile,
+            displayName: contractName || 'Unknown contract',
+          },
         });
+        setIsLoadingABI(false);
       } else {
         if (!isAddress(contract.profile.walletAddress)) {
           setFetchABIError(formatMessage(MSG.invalidAddressError));
         } else {
           setFetchABIError(formatMessage(MSG.noSafeSelectedError));
         }
-        setIsLoadingABI(false);
         setFieldValue(`transactions.${transactionFormIndex}.contract`, {
           ...contract,
           profile: {
@@ -208,6 +204,7 @@ const ContractInteractionSection = ({
             displayName: 'Unknown contract',
           },
         });
+        setIsLoadingABI(false);
       }
     },
     [

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
@@ -13,6 +13,7 @@ import {
   getContractUsefulMethods,
   AbiItemExtended,
   fetchContractABI,
+  fetchContractName,
 } from '~utils/safes';
 import { SpinnerLoader } from '~core/Preloaders';
 import { isEmpty, isEqual, isNil } from '~utils/lodash';
@@ -164,18 +165,34 @@ const ContractInteractionSection = ({
     (contract: AnyUser) => {
       setIsLoadingABI(true);
       setFetchABIError('');
+
       if (selectedSafe && isAddress(contract.profile.walletAddress)) {
-        const contractPromise = fetchContractABI(
+        const contractABIPromise = fetchContractABI(
           contract.profile.walletAddress,
           Number(selectedSafe.chainId),
         );
-        contractPromise.then((data) => {
+        contractABIPromise.then((data) => {
           setIsLoadingABI(false);
           if (data) {
             onContractABIChange(data);
           } else {
             setFetchABIError(formatMessage(MSG.fetchFailedError));
           }
+        });
+
+        const contractNamePromise = fetchContractName(
+          contract.profile.walletAddress,
+          Number(selectedSafe?.chainId),
+        );
+
+        contractNamePromise.then((name) => {
+          setFieldValue(`transactions.${transactionFormIndex}.contract`, {
+            ...contract,
+            profile: {
+              ...contract.profile,
+              displayName: name,
+            },
+          });
         });
       } else {
         if (!isAddress(contract.profile.walletAddress)) {
@@ -186,7 +203,13 @@ const ContractInteractionSection = ({
         setIsLoadingABI(false);
       }
     },
-    [selectedSafe, onContractABIChange, formatMessage],
+    [
+      selectedSafe,
+      onContractABIChange,
+      formatMessage,
+      setFieldValue,
+      transactionFormIndex,
+    ],
   );
 
   const usefulMethods: AbiItemExtended[] = useMemo(
@@ -274,6 +297,7 @@ const ContractInteractionSection = ({
             onSelected={onContractChange}
             // handled instead in effect
             validateOnChange={false}
+            showMaskedAddress
           />
         </div>
       </DialogSection>

--- a/src/utils/safes/getContractUsefulMethods.ts
+++ b/src/utils/safes/getContractUsefulMethods.ts
@@ -24,7 +24,7 @@ const getApiKey = (chainId: number) => {
 export const fetchContractName = async (
   contractAddress: string,
   safeChainId: number,
-) => {
+): Promise<string> => {
   // will be defined since fetchContractName is only called if selectedSafe is defined
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const currentNetworkData = getCurrentNetworkData(safeChainId)!;

--- a/src/utils/safes/getContractUsefulMethods.ts
+++ b/src/utils/safes/getContractUsefulMethods.ts
@@ -10,6 +10,38 @@ export interface AbiItemExtended extends AbiItem {
   signatureHash: string;
 }
 
+const getCurrentNetworkData = (chainId: number) => {
+  return SUPPORTED_SAFE_NETWORKS.find((network) => network.chainId === chainId);
+};
+
+const getApiKey = (chainId: number) => {
+  if (chainId === BINANCE_NETWORK.chainId) {
+    return process.env.BSCSCAN_API_KEY;
+  }
+  return process.env.ETHERSCAN_API_KEY;
+};
+
+export const fetchContractName = async (
+  contractAddress: string,
+  safeChainId: number,
+) => {
+  // will be defined since fetchContractName is only called if selectedSafe is defined
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const currentNetworkData = getCurrentNetworkData(safeChainId)!;
+
+  const apiKey = getApiKey(currentNetworkData.chainId);
+  const apiUri = `${currentNetworkData.apiUri}?apiKey=${apiKey}&module=contract&action=getsourcecode&address=${contractAddress}`;
+
+  try {
+    const response = await fetch(apiUri);
+    const data = await response.json();
+    return data.result[0].ContractName || '';
+  } catch (error) {
+    console.error('Failed to get contract name', error);
+    return '';
+  }
+};
+
 export const fetchContractABI = async (
   contractAddress: string,
   safeChainId: number,
@@ -19,20 +51,13 @@ export const fetchContractABI = async (
   }
 
   try {
+    // will be defined since fetchContractABI is only called if selectedSafe is defined
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const currentNetworkData = SUPPORTED_SAFE_NETWORKS.find(
-      (network) => network.chainId === safeChainId,
-    )!; // will be defined since fetchContractABI is only called if selectedSafe is defined
+    const currentNetworkData = getCurrentNetworkData(safeChainId)!;
 
-    const getApiKey = () => {
-      if (currentNetworkData.chainId === BINANCE_NETWORK.chainId) {
-        return process.env.BSCSCAN_API_KEY;
-      }
-      return process.env.ETHERSCAN_API_KEY;
-    };
     const getApiUri = () => {
       const apiUri = `${currentNetworkData.apiUri}?module=contract&action=getabi&address=${contractAddress}`;
-      return `${apiUri}&apiKey=${getApiKey()}`;
+      return `${apiUri}&apiKey=${getApiKey(currentNetworkData.chainId)}`;
     };
     const response = await fetch(getApiUri());
 

--- a/src/utils/safes/index.ts
+++ b/src/utils/safes/index.ts
@@ -4,4 +4,5 @@ export {
   AbiItemExtended,
   fetchContractABI,
   isAbiItem,
+  fetchContractName,
 } from './getContractUsefulMethods';


### PR DESCRIPTION
## Description

This PR updates the target contract address field in control safe dialog to match [the designs](https://www.figma.com/file/LlVmeMQxHVA04evfrgZyuN/Safe-Control?node-id=5416%3A24680). After selecting contract address, if we're able to fetch the name, it will be displayed in the picker:
<img width="492" alt="Screenshot 2022-10-05 at 18 52 54" src="https://user-images.githubusercontent.com/112586815/194128704-1128ba56-c3ef-42b6-aac9-b88d2db4f628.png">

The contract name is also shown in the transaction preview dialog:
<img width="519" alt="Screenshot 2022-10-13 at 16 00 09" src="https://user-images.githubusercontent.com/112586815/195633578-6dedad5b-ba3a-4232-a4e0-2983d767da5a.png">

**Changes** 🏗

* Added `fetchContractName` function and call it on contract address change
* Updated `SafeTransactionPreview` to display contract name instead of an address

## TODO

- [x] Display contract name in the target contract address field 
- [x] Display contract name in contract interaction preview screen

Resolves #3932 