### PR TITLE
Scroll to the currently checked option in Select component

### DIFF
--- a/src/modules/core/components/Fields/SelectOption/SelectOption.tsx
+++ b/src/modules/core/components/Fields/SelectOption/SelectOption.tsx
@@ -1,4 +1,10 @@
-import React, { KeyboardEvent, SyntheticEvent, useCallback } from 'react';
+import React, {
+  KeyboardEvent,
+  SyntheticEvent,
+  useCallback,
+  useEffect,
+  useRef,
+} from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 
 import { getMainClasses } from '~utils/css';
@@ -39,6 +45,23 @@ const SelectOption = ({
   selected,
   dataTest,
 }: Props) => {
+  const ref = useRef<HTMLLIElement>(null);
+
+  /** Scroll to the currently checked item */
+  useEffect(() => {
+    if (!ref.current?.parentElement || !checked) {
+      return;
+    }
+    ref.current.parentElement.scrollTop = ref.current.offsetTop;
+  }, [checked]);
+
+  useEffect(() => {
+    if (!ref.current || !selected) {
+      return;
+    }
+    ref.current.focus();
+  }, [selected]);
+
   const { formatMessage } = useIntl();
 
   const handleItemClick = useCallback(
@@ -76,7 +99,7 @@ const SelectOption = ({
       aria-selected={selected}
       id={id}
       role="option"
-      ref={(e) => selected && e && e.focus()}
+      ref={ref}
       onClick={handleItemClick}
       onKeyPress={handleItemKeyPress}
       onMouseEnter={handleItemSelect}


### PR DESCRIPTION
## Description

This PR solves the problem @willm30 described in #3943 by adding scrolling to the currently checked option. Unless there are some reasons against, I think it makes sense for every `Select` to have this behaviour so I applied the changes to all `Select` instances rather than just function select in contract interaction. Let me know if you disagree and I can change it.


https://user-images.githubusercontent.com/112586815/194142586-7f741004-c631-4a43-86eb-8c813f5a7a84.mov


**Changes** 🏗

* Moved existing ref "callback" to useEffect in `SelectOption`
* Added useEffect that scrolls to the checked option

Resolves #3943
