### PR TITLE
Improve validation for same param names

### DIFF
--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeDialog.tsx
@@ -71,9 +71,12 @@ const ControlSafeDialog = ({
 
       Object.values(selectedContractMethods).forEach((method) => {
         method?.inputs?.forEach((input) => {
-          updatedExpandedValidationSchema[
-            `${input.name}(${input.type})`
-          ] = getMethodInputValidation(input.type, method.name);
+          const inputName = `${input.name}(${input.type})-${method.name}`;
+          if (!updatedExpandedValidationSchema[inputName]) {
+            updatedExpandedValidationSchema[
+              inputName
+            ] = getMethodInputValidation(input.type, method.name);
+          }
         });
       });
 

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeDialog.tsx
@@ -72,7 +72,7 @@ const ControlSafeDialog = ({
       Object.values(selectedContractMethods).forEach((method) => {
         method?.inputs?.forEach((input) => {
           updatedExpandedValidationSchema[
-            input.name
+            `${input.name}(${input.type})`
           ] = getMethodInputValidation(input.type, method.name);
         });
       });

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
@@ -309,7 +309,7 @@ const ContractInteractionSection = ({
                   <Input
                     label={`${input.name} (${input.type})`}
                     // eslint-disable-next-line max-len
-                    name={`transactions.${transactionFormIndex}.${input.name}(${input.type})`}
+                    name={`transactions.${transactionFormIndex}.${input.name}(${input.type})-${selectedContractMethods[transactionFormIndex]?.name}`}
                     appearance={{ colorSchema: 'grey', theme: 'fat' }}
                     disabled={disabledInput}
                     placeholder={`${input.name} (${input.type})`}

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
@@ -308,7 +308,8 @@ const ContractInteractionSection = ({
                 <div className={styles.inputParamContainer}>
                   <Input
                     label={`${input.name} (${input.type})`}
-                    name={`transactions.${transactionFormIndex}.${input.name}`}
+                    // eslint-disable-next-line max-len
+                    name={`transactions.${transactionFormIndex}.${input.name}(${input.type})`}
                     appearance={{ colorSchema: 'grey', theme: 'fat' }}
                     disabled={disabledInput}
                     placeholder={`${input.name} (${input.type})`}


### PR DESCRIPTION
Fixed validation of contract interaction transactions overriding validation when there is more than 1 param with the same name but different types. For an example, take a look at the issue's description.

Resolves #3896 
