### PR TITLE
Disable finalize button during escalation

### DIFF
--- a/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/FinalizeMotionAndClaimWidget/FinalizeMotionAndClaimWidget.tsx
@@ -340,7 +340,10 @@ const FinalizeMotionAndClaimWidget = ({
                     appearance={{ theme: 'primary', size: 'medium' }}
                     text={MSG.finalizeButton}
                     disabled={
-                      !hasRegisteredProfile || !isFinalizable || isSubmitting
+                      !hasRegisteredProfile ||
+                      !isFinalizable ||
+                      isSubmitting ||
+                      motionState === MotionState.Escalation
                     }
                     onClick={() => handleSubmit()}
                     loading={isSubmitting}


### PR DESCRIPTION
## Description

This PR, changes the behaviour of the dapp so that the finalise button is disabled when a motion is in the escalation phase.

Resolves #3934
