### PR TITLE
Decisions: QA sessions - multiple bug fixes

### DIFF
--- a/src/i18n/en-motions.ts
+++ b/src/i18n/en-motions.ts
@@ -34,7 +34,7 @@ const motionsMessageDescriptors = {
       ${ColonyMotions.EmitDomainReputationPenaltyMotion} {Smite}
       ${ColonyMotions.EmitDomainReputationRewardMotion} {Award}
       ${ColonyMotions.UnlockTokenMotion} {Unlock Token}
-      ${ColonyMotions.CreateDecisionMotion} {Discussion}
+      ${ColonyMotions.CreateDecisionMotion} {Decision}
       other {Generic}
     }`,
 };

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultMotion.tsx
@@ -362,15 +362,11 @@ const DefaultMotion = ({
   );
 
   const isDecision = actionType === ColonyMotions.CreateDecisionMotion;
-  const hasBanner = useMemo(
-    () =>
-      isDecision ? false : !shouldDisplayMotion(currentStake, requiredStake),
-    [currentStake, isDecision, requiredStake],
-  );
+  const hasBanner = !shouldDisplayMotion(currentStake, requiredStake);
 
   return (
     <div className={styles.main}>
-      <StakeRequiredBanner stakeRequired={hasBanner} />
+      <StakeRequiredBanner stakeRequired={hasBanner} isDecision={isDecision} />
       <div
         className={`${styles.upperContainer} ${
           hasBanner && styles.bannerPadding

--- a/src/modules/dashboard/components/ActionsPage/StakeRequiredBanner/StakeRequiredBanner.tsx
+++ b/src/modules/dashboard/components/ActionsPage/StakeRequiredBanner/StakeRequiredBanner.tsx
@@ -11,7 +11,14 @@ import styles from './StakeRequiredBanner.css';
 const MSG = defineMessages({
   stakeRequired: {
     id: `dashboard.ActionsPage.StakeRequiredBanner.stakeRequired`,
-    defaultMessage: `Motion requires at least 10% stake to appear in the actions list.`,
+    defaultMessage: `{isDecision, select,
+      true {Decision}
+      false {Motion}
+      } requires at least 10% stake to appear in the
+      {isDecision, select,
+        true {Decisions}
+        false {actions}
+        } list.`,
   },
   shareUrl: {
     id: `dashboard.ActionsPage.StakeRequiredBanner.shareUrl`,
@@ -25,11 +32,12 @@ const MSG = defineMessages({
 
 type Props = {
   stakeRequired: boolean;
+  isDecision?: boolean;
 };
 
 const displayName = 'dashboard.ActionsPage.StakeRequiredBanner';
 
-const StakeRequiredBanner = ({ stakeRequired }: Props) => {
+const StakeRequiredBanner = ({ stakeRequired, isDecision = false }: Props) => {
   return stakeRequired ? (
     <div
       className={styles.stakeRequiredBannerContainer}
@@ -43,7 +51,7 @@ const StakeRequiredBanner = ({ stakeRequired }: Props) => {
         }}
       >
         <div className={styles.stakeRequiredBanner}>
-          <FormattedMessage {...MSG.stakeRequired} />
+          <FormattedMessage {...MSG.stakeRequired} values={{ isDecision }} />
           <span className={styles.share}>
             <Tooltip
               placement="left"

--- a/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/VoteWidget/VoteWidget.tsx
@@ -54,7 +54,7 @@ const MSG = defineMessages({
       ${ColonyMotions.VersionUpgradeMotion} {Version Upgrade}
       ${ColonyMotions.EmitDomainReputationPenaltyMotion} {Smite}
       ${ColonyMotions.EmitDomainReputationRewardMotion} {Award}
-      ${ColonyMotions.CreateDecisionMotion} {Discussion}
+      ${ColonyMotions.CreateDecisionMotion} {Decision}
       other {Generic Action}
     }" be approved?`,
   },

--- a/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
+++ b/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
@@ -115,7 +115,6 @@ const ColonyDecisions = ({
     { ...motions },
     undefined,
     {},
-    true,
   ]);
 
   const filteredDecisions = useMemo(

--- a/src/modules/dashboard/components/DecisionPreview/DecisionPreview.tsx
+++ b/src/modules/dashboard/components/DecisionPreview/DecisionPreview.tsx
@@ -120,7 +120,7 @@ const DecisionPreview = () => {
 
   const actionAndEventValues = {
     actionType: ColonyMotions.CreateDecisionMotion,
-    fromDomain: colonyData.processedColony.domains.find(
+    motionDomain: colonyData.processedColony.domains.find(
       ({ ethDomainId }) => ethDomainId === decisionData?.motionDomainId,
     ) as OneDomain,
   };

--- a/src/modules/dashboard/transformers/transformers.ts
+++ b/src/modules/dashboard/transformers/transformers.ts
@@ -55,7 +55,6 @@ export const getActionsListData = (
     extensionAddresses,
     actionsThatNeedAttention,
   }: ActionsTransformerMetadata = {},
-  isDecision = false,
 ): FormattedAction[] => {
   let formattedActions = [];
   /*
@@ -132,9 +131,7 @@ export const getActionsListData = (
         const totalNayStake = bigNumberify(stakes[0] || 0);
         const totalYayStake = bigNumberify(stakes[1] || 0);
         const currentStake = totalNayStake.add(totalYayStake).toString();
-        const enoughStake = isDecision
-          ? true
-          : shouldDisplayMotion(currentStake, requiredStake);
+        const enoughStake = shouldDisplayMotion(currentStake, requiredStake);
         if (escalated || enoughStake) {
           return [...acc, motion];
         }


### PR DESCRIPTION
## Description

This PR fixes several minor bugs:

1. The Decision preview page is was displaying Type as discussion, this was changed to "Decision".
2. "Motion was created in" was not being shown on Decision preview page. This is now being display.
<img width="523" alt="Screenshot 2022-10-10 at 17 11 14" src="https://user-images.githubusercontent.com/582700/194908667-e1d5629c-f99d-43a4-bb85-34153b7fee68.png">

3. As with motions, the Decisions list now only displays Decisions that have been staked >10%. 
As the 10% rule is now implemented, the 10% staking banner is also displayed on the staking screen, as already implemented with Motions.

<img width="790" alt="Screenshot 2022-10-10 at 17 13 37" src="https://user-images.githubusercontent.com/582700/194909814-5645ace8-54e4-4f2f-a772-72e3b2735bb7.png">

<img width="1386" alt="Screenshot 2022-10-10 at 17 12 00" src="https://user-images.githubusercontent.com/582700/194909623-3a175b8b-87b7-4157-8f83-332ab290f120.png">






Resolves #3957 #3958 #3956 
