### PR TITLE
Refactor raw transaction section to enable transferring funds

### DIFF
--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
@@ -434,6 +434,7 @@ const ControlSafeForm = ({
                           disabledInput={!userHasPermission || isSubmitting}
                           transactionFormIndex={index}
                           handleInputChange={handleInputChange}
+                          handleValidation={handleValidation}
                         />
                       )}
                       {values.transactions[index]?.transactionType ===
@@ -474,7 +475,7 @@ const ControlSafeForm = ({
                   <div className={styles.addTransaction}>
                     <AddItemButton
                       text={MSG.buttonTransaction}
-                      disabled={isSubmitting || !isValid}
+                      disabled={isSubmitting || !isValid || !!customAmountError}
                       handleClick={() => handleNewTab(arrayHelpers)}
                     />
                   </div>

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionPreview/AddressDetailsView/AddressDetailsView.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionPreview/AddressDetailsView/AddressDetailsView.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { isAddress } from 'web3-utils';
 
 import MaskedAddress from '~core/MaskedAddress';
 import Avatar from '~core/Avatar';
@@ -12,20 +13,26 @@ interface Props {
 }
 
 const AddressDetailsView = ({ item, isSafeItem }: Props) => {
-  const userDisplayName = item?.profile?.displayName;
-  const username = item?.profile?.username;
+  const userDisplayName = isAddress(item.profile.displayName || '')
+    ? /*
+       * If address entered manually, e.g. in raw transaction
+       * or if you wish to transfer funds to someone outside the colony
+       */
+      'Address'
+    : item.profile.displayName;
+  const { username } = item.profile;
 
   return (
     <div className={styles.main}>
       <Avatar
-        seed={item?.id?.toLowerCase()}
+        seed={item.profile.walletAddress.toLowerCase()}
         size="xs"
-        avatarURL={item?.profile?.avatarHash || ''}
+        avatarURL={item.profile?.avatarHash || ''}
         title="avatar"
         placeholderIcon={isSafeItem ? 'safe-logo' : 'circle-person'}
       />
       <span className={styles.name}>{userDisplayName || `@${username}`}</span>
-      <MaskedAddress address={item?.id} />
+      <MaskedAddress address={item.profile.walletAddress} />
     </div>
   );
 };

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/RawTransactionSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/RawTransactionSection.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { defineMessages } from 'react-intl';
+import { useField } from 'formik';
 
 import { AnyUser, useMembersSubscription } from '~data/index';
 import { Address } from '~types/index';
@@ -41,10 +42,22 @@ const RawTransactionSection = ({
   disabledInput,
   transactionFormIndex,
   handleInputChange,
-}: TransactionSectionProps) => {
+  handleValidation,
+}: TransactionSectionProps & { handleValidation: () => void }) => {
   const { data: colonyMembers } = useMembersSubscription({
     variables: { colonyAddress },
   });
+
+  const [{ value: recipient }] = useField(
+    `transactions.${transactionFormIndex}.recipient`,
+  );
+
+  // Effect needed to ensure form can't be submitted when recipient empty.
+  useEffect(() => {
+    if (recipient === null) {
+      handleValidation();
+    }
+  }, [recipient, handleValidation]);
 
   return (
     <>

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransferNFTSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransferNFTSection.tsx
@@ -287,7 +287,6 @@ const TransferNFTSection = ({
       <DialogSection>
         <div className={styles.recipientPicker}>
           <SingleUserPicker
-            appearance={{ width: 'wide' }}
             data={colonyMembers?.subscribedUsers || []}
             label={MSG.selectRecipient}
             name={`transactions.${transactionFormIndex}.recipient`}
@@ -295,7 +294,6 @@ const TransferNFTSection = ({
             renderAvatar={renderAvatar}
             placeholder={MSG.userPickerPlaceholder}
             disabled={disabledInput}
-            showMaskedAddress
             dataTest="NFTRecipientSelector"
             itemDataTest="NFTRecipientSelectorItem"
             valueDataTest="NFTRecipientName"


### PR DESCRIPTION
## Description

This PR makes some small refactors to the raw transaction section in Control Safe form, so that you can enter data that will enable you to transfer funds (and by extension, perform any kind of transaction). 

**Changes** 🏗

* Update validation to enable manually entered contract addresses
* Update safe transaction preview to accomodate manually entered contract addresses
* Enable value to be 0

![rawtx](https://user-images.githubusercontent.com/64402732/195332574-af2ec713-3254-4c56-8f1b-b1de6e07bc16.png)


Resolves #3968
