### PR TITLE
Fix: GasStationPopover causing horizontal overflow

### DIFF
--- a/src/modules/users/components/GasStation/GasStationPopover.css
+++ b/src/modules/users/components/GasStation/GasStationPopover.css
@@ -1,3 +1,1 @@
-@value refWidth: 106px;
-@value horizontalOffset: 20px;
 @value verticalOffset: 24px;

--- a/src/modules/users/components/GasStation/GasStationPopover.css.d.ts
+++ b/src/modules/users/components/GasStation/GasStationPopover.css.d.ts
@@ -1,3 +1,1 @@
-export const refWidth: string;
-export const horizontalOffset: string;
 export const verticalOffset: string;

--- a/src/modules/users/components/GasStation/GasStationPopover.tsx
+++ b/src/modules/users/components/GasStation/GasStationPopover.tsx
@@ -14,11 +14,7 @@ import {
 import GasStationContent from './GasStationContent';
 
 import { query700 as query } from '~styles/queries.css';
-import {
-  refWidth,
-  horizontalOffset,
-  verticalOffset,
-} from './GasStationPopover.css';
+import { verticalOffset } from './GasStationPopover.css';
 
 interface Props {
   transactionAndMessageGroups: TransactionOrMessageGroups;
@@ -58,9 +54,7 @@ const GasStationPopover = ({
    * reference element.
    */
   const popoverOffset = useMemo(() => {
-    const skid =
-      removeValueUnits(refWidth) / 2 + removeValueUnits(horizontalOffset);
-    return isMobile ? [-86, 25] : [-1 * skid, removeValueUnits(verticalOffset)];
+    return isMobile ? [0, 25] : [0, removeValueUnits(verticalOffset)];
   }, [isMobile]);
 
   return (
@@ -74,7 +68,7 @@ const GasStationPopover = ({
           close={close}
         />
       )}
-      placement="bottom"
+      placement="bottom-end"
       showArrow={false}
       isOpen={isOpen}
       onClose={() => {


### PR DESCRIPTION
## Description

This PR fixes the issue described in #3781. Unfortunately after spending good few hours on it I was unable to pinpoint what the issue is exactly (my bet is either Popper positioning not working properly or a Chrome-specific issue, since it doesn't occur in other browsers). After a call with @chinins I decided to amend the placement of the gas station popover so that it "faces away" from the right edge of the window and doesn't cause overflow:
<img width="496" alt="image" src="https://user-images.githubusercontent.com/112586815/195206049-7f17b3a2-7d5b-4478-b16f-6e8614909fd3.png">

The issue was quite tricky to reproduce in first place so here are the steps I followed:
 - Connect a wallet
 - Go to the Profile page
 - Click on the address button
You should see a horizontal overflow equal to roughly the width of the popover

Resolves #3781 
