### PR TITLE
Preselect token in Transfer Funds

### DIFF
--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/AmountBalances/AmountBalances.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/AmountBalances/AmountBalances.tsx
@@ -56,10 +56,6 @@ const AmountBalances = ({
   handleChange,
   handleValidation,
 }: Props) => {
-  const [, { value: tokenAddress }] = useField(
-    `transactions.${transactionFormIndex}.tokenAddress`,
-  );
-
   const [
     ,
     { value: selectedTokenData },
@@ -96,12 +92,11 @@ const AmountBalances = ({
       networkName: getNetworkName(),
     };
   });
+
   // Set token data in form state on initialisation
   useEffect(() => {
-    const selectedToken = tokens.find((t) => t.address === tokenAddress);
-    if (selectedToken) {
-      setTokenData(selectedToken);
-    }
+    setTokenData(tokens[0]);
+
     // initialisation only
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -143,7 +138,7 @@ const AmountBalances = ({
           <TokenSymbolSelector
             label={MSG.token}
             tokens={tokens}
-            name={`transactions.${transactionFormIndex}.tokenAddress`}
+            name={`transactions.${transactionFormIndex}.tokenData.address`}
             elementOnly
             appearance={{ alignOptions: 'right', theme: 'grey' }}
             disabled={disabledInput}
@@ -153,7 +148,7 @@ const AmountBalances = ({
               );
               // can only select a token from "tokens"
               // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              setTokenData(selectedToken!);
+              setTokenData(selectedToken!, false);
               handleValidation();
             }}
           />

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/AmountBalances/AmountBalances.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/AmountBalances/AmountBalances.tsx
@@ -95,7 +95,12 @@ const AmountBalances = ({
 
   // Set token data in form state on initialisation
   useEffect(() => {
-    setTokenData(tokens[0]);
+    const isTokenInBalances = safeBalances.some(
+      (b) => b.tokenAddress === selectedTokenData?.address,
+    );
+    if (!isTokenInBalances) {
+      setTokenData(tokens[0]);
+    }
 
     // initialisation only
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/AmountBalances/AmountBalances.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/AmountBalances/AmountBalances.tsx
@@ -56,7 +56,7 @@ const AmountBalances = ({
   handleChange,
   handleValidation,
 }: Props) => {
-  const [, { value: tokenAddress }, { setValue: setTokenAddress }] = useField(
+  const [, { value: tokenAddress }] = useField(
     `transactions.${transactionFormIndex}.tokenAddress`,
   );
 
@@ -96,13 +96,15 @@ const AmountBalances = ({
       networkName: getNetworkName(),
     };
   });
-  // Set token in select component on initialisation
+  // Set token data in form state on initialisation
   useEffect(() => {
-    if (!tokenAddress && tokens[0]) {
-      setTokenAddress(tokens[0].address);
-      setTokenData(tokens[0]);
+    const selectedToken = tokens.find((t) => t.address === tokenAddress);
+    if (selectedToken) {
+      setTokenData(selectedToken);
     }
-  }, [tokenAddress, tokens, setTokenAddress, setTokenData]);
+    // initialisation only
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     if (selectedSafe) {

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeDialog.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { FormikProps } from 'formik';
 import { pipe } from 'lodash/fp';
 import { useHistory } from 'react-router';
-import { AddressZero } from 'ethers/constants';
 
 import { AnyToken, AnyUser, ColonySafe } from '~data/index';
 import Dialog, { DialogProps, ActionDialogProps } from '~core/Dialog';
@@ -34,7 +33,6 @@ export interface SafeTransaction {
   recipient: AnyUser | null;
   nft: SelectedNFT | null;
   nftData: NFT | null;
-  tokenAddress: string;
   tokenData: SafeBalanceToken | null;
   amount?: number;
   rawAmount?: number;
@@ -147,7 +145,6 @@ const ControlSafeDialog = ({
         transactions: [
           {
             transactionType: '',
-            tokenAddress: AddressZero,
             tokenData: null,
             amount: undefined,
             rawAmount: undefined,

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeDialog.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { FormikProps } from 'formik';
 import { pipe } from 'lodash/fp';
 import { useHistory } from 'react-router';
+import { AddressZero } from 'ethers/constants';
 
 import { AnyToken, AnyUser, ColonySafe } from '~data/index';
 import Dialog, { DialogProps, ActionDialogProps } from '~core/Dialog';
@@ -33,7 +34,7 @@ export interface SafeTransaction {
   recipient: AnyUser | null;
   nft: SelectedNFT | null;
   nftData: NFT | null;
-  tokenAddress?: string;
+  tokenAddress: string;
   tokenData: SafeBalanceToken | null;
   amount?: number;
   rawAmount?: number;
@@ -146,7 +147,7 @@ const ControlSafeDialog = ({
         transactions: [
           {
             transactionType: '',
-            tokenAddress: undefined,
+            tokenAddress: AddressZero,
             tokenData: null,
             amount: undefined,
             rawAmount: undefined,

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
@@ -4,7 +4,6 @@ import { FieldArray, FieldArrayRenderProps, FormikProps } from 'formik';
 import { ColonyRole, ROOT_DOMAIN_ID } from '@colony/colony-js';
 import classnames from 'classnames';
 import { nanoid } from 'nanoid';
-import { AddressZero } from 'ethers/constants';
 
 import Avatar from '~core/Avatar';
 import { DialogSection } from '~core/Dialog';
@@ -186,7 +185,7 @@ const ControlSafeForm = ({
     (arrayHelpers: FieldArrayRenderProps) => {
       arrayHelpers.push({
         transactionType: '',
-        tokenAddress: AddressZero,
+        tokenData: null,
         amount: undefined,
         recipient: null,
         data: '',

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
@@ -4,6 +4,7 @@ import { FieldArray, FieldArrayRenderProps, FormikProps } from 'formik';
 import { ColonyRole, ROOT_DOMAIN_ID } from '@colony/colony-js';
 import classnames from 'classnames';
 import { nanoid } from 'nanoid';
+import { AddressZero } from 'ethers/constants';
 
 import Avatar from '~core/Avatar';
 import { DialogSection } from '~core/Dialog';
@@ -185,7 +186,7 @@ const ControlSafeForm = ({
     (arrayHelpers: FieldArrayRenderProps) => {
       arrayHelpers.push({
         transactionType: '',
-        tokenAddress: colony.nativeTokenAddress,
+        tokenAddress: AddressZero,
         amount: undefined,
         recipient: null,
         data: '',
@@ -200,12 +201,7 @@ const ControlSafeForm = ({
       ]);
       handleValidation();
     },
-    [
-      colony.nativeTokenAddress,
-      setTransactionTabStatus,
-      transactionTabStatus,
-      handleValidation,
-    ],
+    [setTransactionTabStatus, transactionTabStatus, handleValidation],
   );
   const handleTabToggle = useCallback(
     (newIndex: number) => {

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransferFundsSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransferFundsSection.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { FormikProps, useField } from 'formik';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import moveDecimal from 'move-decimal-point';
-import { AddressZero } from 'ethers/constants';
 
 import { DEFAULT_TOKEN_DECIMALS } from '~constants';
 import { AnyUser, useMembersSubscription } from '~data/index';
@@ -105,7 +104,7 @@ const TransferFundsSection = ({
   }, [values.safe, safeAddress]);
 
   const selectedTokenAddress =
-    values.transactions[transactionFormIndex].tokenAddress;
+    values.transactions[transactionFormIndex].tokenData?.address;
 
   const selectedBalance = useMemo(
     () => getSelectedSafeBalance(safeBalances, selectedTokenAddress),
@@ -117,20 +116,9 @@ const TransferFundsSection = ({
 
   useEffect(() => {
     if (safeAddress) {
-      /*
-       * Reset state of token address. This ensures token is always preselected because native token will always be
-       * present in tokenData.
-       */
-      setFieldValue(
-        `transactions.${transactionFormIndex}.tokenAddress`,
-        AddressZero,
-      );
-      handleValidation();
       getSafeBalance();
     }
-    // including index will cause token to reset when a tab is removed.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [safeAddress, getSafeBalance, setFieldValue]);
+  }, [safeAddress, getSafeBalance]);
 
   const formattedSafeBalance = moveDecimal(
     selectedBalance?.balance || 0,

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransferFundsSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransferFundsSection.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { FormikProps, useField } from 'formik';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import moveDecimal from 'move-decimal-point';
+import { AddressZero } from 'ethers/constants';
 
 import { DEFAULT_TOKEN_DECIMALS } from '~constants';
 import { AnyUser, useMembersSubscription } from '~data/index';
@@ -116,9 +117,20 @@ const TransferFundsSection = ({
 
   useEffect(() => {
     if (safeAddress) {
+      /*
+       * Reset state of token address. This ensures token is always preselected because native token will always be
+       * present in tokenData.
+       */
+      setFieldValue(
+        `transactions.${transactionFormIndex}.tokenAddress`,
+        AddressZero,
+      );
+      handleValidation();
       getSafeBalance();
     }
-  }, [safeAddress, getSafeBalance]);
+    // including index will cause token to reset when a tab is removed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [safeAddress, getSafeBalance, setFieldValue]);
 
   const formattedSafeBalance = moveDecimal(
     selectedBalance?.balance || 0,

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/validation.ts
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/validation.ts
@@ -195,7 +195,7 @@ export const getValidationSchema = (
                       message: formatMessage(MSG.gtZeroError),
                     });
                   }
-                  const selectedToken = this.parent.tokenAddress;
+                  const selectedToken = this.parent.tokenData?.address;
                   const selectedTokenDecimals = this.parent.tokenData?.decimals;
 
                   const {
@@ -242,15 +242,6 @@ export const getValidationSchema = (
             .required(() => MSG.requiredFieldError)
             .moreThan(0, () => MSG.gtZeroError)
             .integer(() => MSG.notIntegerError),
-          otherwise: false,
-        }),
-        tokenAddress: yup.string().when('transactionType', {
-          is: (transactionType) =>
-            transactionType === TransactionTypes.TRANSFER_FUNDS,
-          then: yup
-            .string()
-            .address()
-            .required(() => MSG.requiredFieldError),
           otherwise: false,
         }),
         data: yup.string().when('transactionType', {

--- a/src/modules/dashboard/sagas/utils/safeHelpers.ts
+++ b/src/modules/dashboard/sagas/utils/safeHelpers.ts
@@ -263,7 +263,7 @@ export const getTransferFundsData = async (
     : safe.contractAddress;
   const tokenAddress = onLocalDevEnvironment
     ? LOCAL_SAFE_TOKEN_ADDRESS
-    : transaction.tokenAddress;
+    : transaction.tokenData.address;
 
   if (!safeAddress) {
     throw new Error('LOCAL_SAFE_ADDRESS not set in .env.');


### PR DESCRIPTION
## Description

This fix ensures that the Token is preselected when opening a new transfer funds tab in Safe Control.

## To test
1. Open two Transfer Funds transaction tabs
2. The second should have the token preselected. 
3. If you use this safe on rinkeby, you'll be able to select an ERC20 token in the safe:
`Safe address: 0x358E6D7C8Fa5e55fc6A0D50E23b875c6c49fF09A`
`Zodiac module address: 0xa838Bd5B1e66fE90fbCb5264D3fd88f2E4e245bB`
4. Select the ERC20. Then switch safes to a safe without that token. The token selector should still be preselected with that safe's native token. 

Basically token should be preselected no matter what you try. If you add / remove a tab, token state should be preserved.

**Changes** 🏗

* Use address in token data as token address and set default to the first token in the safeBalances array
* Remove token address from form state

Resolves #3970
