### PR TITLE
Decisions: Handle Decisions heading formatting in preview & staking pages

### DIFF
--- a/src/modules/dashboard/components/ActionsPage/ActionPageDecisionWithIPFS/ActionPageDecisionWithIPFS.css
+++ b/src/modules/dashboard/components/ActionsPage/ActionPageDecisionWithIPFS/ActionPageDecisionWithIPFS.css
@@ -90,6 +90,10 @@
   width: 340px;
 }
 
+.descriptionContainer > h3 {
+  font-size: var(--size-medium);
+}
+
 .titleDecoration {
   font-weight: var(--weight-bold);
   color: var(--pink);

--- a/src/modules/dashboard/components/ActionsPage/ActionPageDecisionWithIPFS/ActionPageDecisionWithIPFS.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/ActionPageDecisionWithIPFS/ActionPageDecisionWithIPFS.css.d.ts
@@ -14,5 +14,6 @@ export const time: string;
 export const tag: string;
 export const title: string;
 export const details: string;
+export const descriptionContainer: string;
 export const titleDecoration: string;
 export const loadingWrapper: string;

--- a/src/modules/dashboard/components/ActionsPage/ActionPageDecisionWithIPFS/ActionPageDecisionWithIPFS.tsx
+++ b/src/modules/dashboard/components/ActionsPage/ActionPageDecisionWithIPFS/ActionPageDecisionWithIPFS.tsx
@@ -183,7 +183,9 @@ const ActionPageDecisionWithIPFS = ({
               />
             </div>
           )}
-          {parse(decisionDetails?.description)}
+          <div className={styles.descriptionContainer}>
+            {parse(decisionDetails?.description)}
+          </div>
         </div>
       </div>
       {isObjection && <hr className={styles.divider} />}

--- a/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultAction.css.d.ts
+++ b/src/modules/dashboard/components/ActionsPage/ActionsComponents/DefaultAction.css.d.ts
@@ -15,3 +15,4 @@ export const addressInTitle: string;
 export const titleDecoration: string;
 export const tagWrapper: string;
 export const commentBox: string;
+export const setMarginWidth: string;

--- a/src/modules/dashboard/components/DecisionPreview/DecisionPreview.css
+++ b/src/modules/dashboard/components/DecisionPreview/DecisionPreview.css
@@ -60,10 +60,6 @@
   text-align: center;
 }
 
-.noContent > button {
-  margin-left: 5px;
-}
-
 .rightContent {
   margin-top: 17px;
 }

--- a/src/modules/dashboard/components/DecisionPreview/DecisionPreview.css
+++ b/src/modules/dashboard/components/DecisionPreview/DecisionPreview.css
@@ -92,6 +92,10 @@
   width: 340px;
 }
 
+.descriptionContainer > h3 {
+  font-size: var(--size-medium);
+}
+
 .buttonContainer {
   display: flex;
   justify-content: flex-end;

--- a/src/modules/dashboard/components/DecisionPreview/DecisionPreview.css.d.ts
+++ b/src/modules/dashboard/components/DecisionPreview/DecisionPreview.css.d.ts
@@ -12,6 +12,7 @@ export const userinfo: string;
 export const userName: string;
 export const title: string;
 export const details: string;
+export const descriptionContainer: string;
 export const buttonContainer: string;
 export const titleDecoration: string;
 export const loadingWrapper: string;

--- a/src/modules/dashboard/components/DecisionPreview/DecisionPreview.tsx
+++ b/src/modules/dashboard/components/DecisionPreview/DecisionPreview.tsx
@@ -43,7 +43,7 @@ const MSG = defineMessages({
   },
   noDecisionText: {
     id: 'dashboard.DecisionPreview.noDecisionText',
-    defaultMessage: 'No draft Decision found.',
+    defaultMessage: 'No draft Decision found. ',
   },
   createDecision: {
     id: 'dashboard.DecisionPreview.createDecision',

--- a/src/modules/dashboard/components/DecisionPreview/DecisionPreview.tsx
+++ b/src/modules/dashboard/components/DecisionPreview/DecisionPreview.tsx
@@ -173,7 +173,9 @@ const DecisionPreview = () => {
                   text={decisionData.title}
                 />
               </div>
-              {parse(decisionData.description)}
+              <div className={styles.descriptionContainer}>
+                {parse(decisionData.description)}
+              </div>
             </>
           ) : (
             <>


### PR DESCRIPTION
## Description

This PR fixes a bug when formatting of the Decision details is not consistently applied.

The heading formatting sets the text as \<H3> and is displaying in the Decisions dialog as font size 16, but the same \<H3> is displayed as font size 14 in preview & staking pages. The updates forces the \<H3> to be font size 16 when displaying the Decision description.

I also added another small bug fix where a space is added before the button/link (and margin removed)

<img width="518" alt="Screenshot 2022-10-13 at 21 52 06" src="https://user-images.githubusercontent.com/582700/195631128-1c8c79a6-6e59-4cd0-9508-e35027671051.png">

Resolves #3980
