### PR TITLE
Update draft decision localStorage logic

### DIFF
--- a/src/modules/dashboard/components/ColonyNewDecision/ColonyNewDecision.tsx
+++ b/src/modules/dashboard/components/ColonyNewDecision/ColonyNewDecision.tsx
@@ -44,7 +44,7 @@ const ColonyNewDecision = ({
   draftDecision,
   removeDraftDecision,
 }: Props) => {
-  const { networkId, username, ethereal } = useLoggedInUser();
+  const { networkId, username, ethereal, walletAddress } = useLoggedInUser();
   const { version: networkVersion } = useNetworkContracts();
 
   const [isLoadingUser, setIsLoadingUser] = useState<boolean>(!ethereal);
@@ -86,9 +86,10 @@ const ColonyNewDecision = ({
           appearance={{ theme: 'primary', size: 'large' }}
           text={MSG.newDecision}
           onClick={() =>
-            draftDecision === undefined
-              ? openNewDecisionDialog()
-              : openDeleteDraftDialog({ colony, openNewDecisionDialog })
+            draftDecision !== undefined &&
+            draftDecision.userAddress === walletAddress
+              ? openDeleteDraftDialog({ colony, openNewDecisionDialog })
+              : openNewDecisionDialog()
           }
           disabled={
             mustUpgrade ||

--- a/src/modules/dashboard/components/Dialogs/DecisionDialog/DecisionDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/DecisionDialog/DecisionDialog.tsx
@@ -52,6 +52,9 @@ const DecisionDialog = ({
       : JSON.parse(localStorage.getItem(LOCAL_STORAGE_DECISION_KEY) || ''),
   );
 
+  const isTheSameUser =
+    decisionData !== undefined && decisionData.userAddress === walletAddress;
+
   const editor = useEditor({
     extensions: [
       StarterKit,
@@ -64,7 +67,7 @@ const DecisionDialog = ({
         placeholder: 'Enter the description...',
       }),
     ],
-    content: decisionData?.description,
+    content: isTheSameUser ? decisionData?.description : undefined,
   });
 
   const domainId =
@@ -100,9 +103,9 @@ const DecisionDialog = ({
   return (
     <Form
       initialValues={{
-        motionDomainId: domainId || decisionData?.motionDomainId,
-        title: decisionData?.title,
-        description: decisionData?.description,
+        motionDomainId: isTheSameUser ? decisionData?.motionDomainId : domainId,
+        title: isTheSameUser ? decisionData?.title : undefined,
+        description: isTheSameUser ? decisionData?.description : undefined,
       }}
       onSubmit={handleSubmit}
       validationSchema={validationSchema}


### PR DESCRIPTION
## Description

This PR fixes a bug when one user had a draft decision and you switch users, this new user still could see the draft info of the previous user.

Resolves #3978 
