### PR TITLE
Set scroll position to bottom when going back from preview

### DIFF
--- a/src/modules/core/components/Dialog/DialogSection.tsx
+++ b/src/modules/core/components/Dialog/DialogSection.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, RefObject, forwardRef } from 'react';
 
 import { getMainClasses } from '~utils/css';
 
@@ -18,8 +18,12 @@ interface Props {
   children?: ReactNode;
 }
 
-const DialogSection = ({ appearance, children }: Props) => (
-  <section className={getMainClasses(appearance, styles)}>{children}</section>
+const DialogSection = forwardRef(
+  ({ appearance, children }: Props, ref: RefObject<any>) => (
+    <section ref={ref} className={getMainClasses(appearance, styles)}>
+      {children}
+    </section>
+  ),
 );
 
 export default DialogSection;

--- a/src/modules/core/components/Dialog/DialogSection.tsx
+++ b/src/modules/core/components/Dialog/DialogSection.tsx
@@ -18,12 +18,13 @@ interface Props {
   children?: ReactNode;
 }
 
-const DialogSection = forwardRef(
-  ({ appearance, children }: Props, ref: RefObject<any>) => (
-    <section ref={ref} className={getMainClasses(appearance, styles)}>
-      {children}
-    </section>
-  ),
+const DialogSection = (
+  { appearance, children }: Props,
+  ref: RefObject<any>,
+) => (
+  <section ref={ref} className={getMainClasses(appearance, styles)}>
+    {children}
+  </section>
 );
 
-export default DialogSection;
+export default forwardRef(DialogSection);

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
@@ -157,7 +157,7 @@ const ControlSafeForm = ({
   setFieldTouched,
   handleSelectedContractMethods,
 }: FormProps & FormikProps<FormValues>) => {
-  const ref = useRef<HTMLSpanElement>(null);
+  const ref = useRef<HTMLElement>(null);
   const [transactionTabStatus, setTransactionTabStatus] = useState([true]);
   const [prevSafeAddress, setPrevSafeAddress] = useState<string>('');
   const [
@@ -550,29 +550,27 @@ const ControlSafeForm = ({
           handleValidation={handleValidation}
         />
       )}
-      <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
-        <span ref={ref}>
-          <Button
-            appearance={{ theme: 'secondary', size: 'large' }}
-            onClick={showPreview ? () => handleShowPreview(showPreview) : back}
-            text={{ id: 'button.back' }}
-          />
-          <Button
-            appearance={{ theme: 'primary', size: 'large' }}
-            onClick={() =>
-              showPreview ? handleSubmit() : handleShowPreview(showPreview)
-            }
-            text={submitButtonText}
-            loading={isSubmitting}
-            disabled={
-              !isValid ||
-              isSubmitting ||
-              !dirty ||
-              (showPreview && onlyForceAction)
-            }
-            style={{ width: styles.wideButton }}
-          />
-        </span>
+      <DialogSection ref={ref} appearance={{ align: 'right', theme: 'footer' }}>
+        <Button
+          appearance={{ theme: 'secondary', size: 'large' }}
+          onClick={showPreview ? () => handleShowPreview(showPreview) : back}
+          text={{ id: 'button.back' }}
+        />
+        <Button
+          appearance={{ theme: 'primary', size: 'large' }}
+          onClick={() =>
+            showPreview ? handleSubmit() : handleShowPreview(showPreview)
+          }
+          text={submitButtonText}
+          loading={isSubmitting}
+          disabled={
+            !isValid ||
+            isSubmitting ||
+            !dirty ||
+            (showPreview && onlyForceAction)
+          }
+          style={{ width: styles.wideButton }}
+        />
       </DialogSection>
     </>
   );

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useRef,
+} from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { FieldArray, FieldArrayRenderProps, FormikProps } from 'formik';
 import { ColonyRole } from '@colony/colony-js';
@@ -151,6 +157,7 @@ const ControlSafeForm = ({
   setFieldTouched,
   handleSelectedContractMethods,
 }: FormProps & FormikProps<FormValues>) => {
+  const ref = useRef<HTMLSpanElement>(null);
   const [transactionTabStatus, setTransactionTabStatus] = useState([true]);
   const [prevSafeAddress, setPrevSafeAddress] = useState<string>('');
   const [
@@ -259,6 +266,13 @@ const ControlSafeForm = ({
       validateForm();
     }
   }, [showPreview, validateForm]);
+
+  useEffect(() => {
+    if (!ref.current) {
+      return;
+    }
+    ref.current.scrollIntoView();
+  }, [showPreview]);
 
   /*
    * When the selected safe changes, reset the state of
@@ -537,26 +551,28 @@ const ControlSafeForm = ({
         />
       )}
       <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
-        <Button
-          appearance={{ theme: 'secondary', size: 'large' }}
-          onClick={showPreview ? () => handleShowPreview(showPreview) : back}
-          text={{ id: 'button.back' }}
-        />
-        <Button
-          appearance={{ theme: 'primary', size: 'large' }}
-          onClick={() =>
-            showPreview ? handleSubmit() : handleShowPreview(showPreview)
-          }
-          text={submitButtonText}
-          loading={isSubmitting}
-          disabled={
-            !isValid ||
-            isSubmitting ||
-            !dirty ||
-            (showPreview && onlyForceAction)
-          }
-          style={{ width: styles.wideButton }}
-        />
+        <span ref={ref}>
+          <Button
+            appearance={{ theme: 'secondary', size: 'large' }}
+            onClick={showPreview ? () => handleShowPreview(showPreview) : back}
+            text={{ id: 'button.back' }}
+          />
+          <Button
+            appearance={{ theme: 'primary', size: 'large' }}
+            onClick={() =>
+              showPreview ? handleSubmit() : handleShowPreview(showPreview)
+            }
+            text={submitButtonText}
+            loading={isSubmitting}
+            disabled={
+              !isValid ||
+              isSubmitting ||
+              !dirty ||
+              (showPreview && onlyForceAction)
+            }
+            style={{ width: styles.wideButton }}
+          />
+        </span>
       </DialogSection>
     </>
   );


### PR DESCRIPTION
## Description

This PR adds a small fix so when you click the "back" button from the transaction preview screen and return to the ControlSafe form the scroll position is set to the bottom instead of the top.

![scrollbottom](https://user-images.githubusercontent.com/71563622/195705902-a0fb6cff-854f-4814-9763-7442c3b9e545.gif)

**To Test:**

* Create a few transactions 
* Press Create transaction 
* Once you are in the preview hit  the "back" button 
* Your view should be fixed at the bottom of the screen

Resolves #3942