### PR TITLE
Handle long strings in SingleUserPicker

### DIFF
--- a/src/modules/core/components/SingleUserPicker/SingleUserPicker.css
+++ b/src/modules/core/components/SingleUserPicker/SingleUserPicker.css
@@ -1,7 +1,7 @@
 @value query700 from '~styles/queries.css';
 
 .main {
-  composes: field from "~styles/fields.css";
+  composes: field from '~styles/fields.css';
   width: 100%;
 }
 
@@ -77,7 +77,7 @@
   color: var(--colony-black);
   outline: none;
 
-  &[aria-invalid="true"] {
+  &[aria-invalid='true'] {
     border-color: var(--danger);
   }
 
@@ -111,9 +111,11 @@
 
 .recipientName {
   composes: baseInput;
+  padding-right: 15px;
   overflow: hidden;
   font-weight: var(--weight-bold);
   text-overflow: ellipsis;
+  white-space: nowrap;
   color: var(--danger);
 
   &:hover {


### PR DESCRIPTION
This PR fixes ellipsis text-overflow in SingleUserPicker:
<img width="485" alt="image" src="https://user-images.githubusercontent.com/112586815/196061964-84455c7e-f1fc-48c2-95c3-a2d764024ecb.png">

<img width="488" alt="image" src="https://user-images.githubusercontent.com/112586815/196062006-4de74000-acf9-4429-ad7a-bea7c79dbcca.png">
