### PR TITLE
Standardize input widths in Safe Control

### DIFF
--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.css
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.css
@@ -1,5 +1,4 @@
 @value wideButton: 197px;
-@value max-width: 424px;
 
 .heading {
   margin-bottom: 0px;
@@ -13,33 +12,38 @@
   margin: 20px 0;
 }
 
+.safePicker div[class*="inputContainer"] {
+  column-gap: 10px;
+}
+
 .safePicker > div {
   padding-left: 0px;
 }
 
-.safePicker input {
-  max-width: max-width;
+.safePicker input,
+.safePicker button {
+  margin-left: 0px;
+  max-width: none;
 }
 
-.safePicker button {
-  max-width: max-width;
+.safePicker button,
+.safePicker label,
+.transactionTypeSelectContainer label {
   color: var(--dark);
 }
 
 .safePicker div + i {
-  left: 412px;
+  right: 3px;
+  left: initial;
 }
 
 .safePicker label + i svg {
   stroke: unset;
 }
 
-.safePicker label {
-  color: var(--dark);
-}
-
-.transactionTypeSelectContainer label {
-  color: var(--dark);
+/* Avatar container */
+.safePicker label + div {
+  display: flex;
 }
 
 .addTransaction {

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.css.d.ts
@@ -1,5 +1,4 @@
 export const wideButton: string;
-export const maxWidth: string;
 export const heading: string;
 export const footer: string;
 export const safePicker: string;

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css
@@ -1,13 +1,12 @@
 .singleUserPickerContainer div + i {
-  /* @NOTE: Negative value here to compensate for the
-  empty space inside the icon's SVG */
-  right: -7px;
+  right: 3px;
   left: inherit;
 }
 
 .singleUserPickerContainer input,
 .singleUserPickerContainer button {
-  max-width: 424px;
+  margin-left: 0px;
+  max-width: none;
 }
 
 .singleUserPickerContainer > div {
@@ -17,6 +16,10 @@
 .singleUserPickerContainer label,
 .contractFunctionSelectorContainer label {
   color: var(--dark);
+}
+
+.singleUserPickerContainer div[class*="inputContainer"] {
+  column-gap: 10px;
 }
 
 .labelDescription {

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransferNFTSection.css
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransferNFTSection.css
@@ -12,8 +12,14 @@
 .nftPicker button,
 .recipientPicker input,
 .recipientPicker button {
+  margin-left: 0px;
   width: 100%;
-  max-width: 419px;
+  max-width: none;
+}
+
+.nftPicker div[class*="inputContainer"],
+.recipientPicker div[class*="inputContainer"] {
+  column-gap: 10px;
 }
 
 .nftPicker label,
@@ -23,7 +29,8 @@
 
 .nftPicker i,
 .recipientPicker i {
-  left: 412px;
+  right: 3px;
+  left: initial;
 }
 
 .nftDetailsContainer {
@@ -34,9 +41,11 @@
 
 .nftDetails {
   display: flex;
+  flex-grow: 1;
   flex-direction: column;
   justify-content: flex-start;
   margin-top: 20px;
+  width: 100px;
 }
 
 .nftLineItem {
@@ -46,7 +55,6 @@
   padding-top: 8px;
   padding-bottom: 8px;
   min-height: 43px;
-  width: 315px;
   border-bottom: 1px solid color-mod(var(--temp-grey-blue-7) alpha(15%));
   font-size: var(--size-smallish);
   gap: 70px;


### PR DESCRIPTION
## Description

This PR ensures that all input widths are even throughout the Safe Control form. Before, the pickers were extending into the form's padding border and weren't aligned with other inputs. 

To test, ensure all pickers are aligned in all sections and remain so when items are selected (with the exception of the [known issue](https://github.com/JoinColony/colonyDapp/pull/3999) of manually entering input that overflows the picker, e.g. manually entering a safe address). 

**Changes** 🏗

* Aligning picker widths

Resolves #4000

## Screenshot

See issue for before. All inputs are aligned and no element extends into form's padding.

![pickerWeven](https://user-images.githubusercontent.com/64402732/196213834-c8c98e15-c636-47cb-b52c-1ac030daa1d6.png)

![pickers2](https://user-images.githubusercontent.com/64402732/196438312-1a2501ee-4fba-4c44-9b4e-a5bc6dc9ed3c.png)
