### PR TITLE
Update invalidSafeError in Safe Control

### DIFF
--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
@@ -67,8 +67,12 @@ const MSG = defineMessages({
     defaultMessage: `Unable to fetch contract. Please check your connection`,
   },
   noUsefulMethodsError: {
-    id: `dashboard.ControlSafeDialog.ControlSafeForm.TransactionTypesSection.ContractInteractionSection.noUsefulMethodsError`,
+    id: `dashboard.ControlSafeDialog.TransactionTypesSection.ContractInteractionSection.noUsefulMethodsError`,
     defaultMessage: `No external methods were found in this ABI`,
+  },
+  unknownContract: {
+    id: `dashboard.ControlSafeDialog.TransactionTypesSection.ContractInteractionSection.unknownContract`,
+    defaultMessage: `Unknown contract`,
   },
 });
 
@@ -182,7 +186,7 @@ const ContractInteractionSection = ({
 
         setFieldValue(
           `transactions.${transactionFormIndex}.contract.profile.displayName`,
-          contractName || 'Unknown contract',
+          contractName || formatMessage(MSG.unknownContract),
         );
         setIsLoadingABI(false);
       } else {
@@ -192,7 +196,7 @@ const ContractInteractionSection = ({
         setFetchABIError(error);
         setFieldValue(
           `transactions.${transactionFormIndex}.contract.profile.displayName`,
-          'Unknown contract',
+          formatMessage(MSG.unknownContract),
         );
         setIsLoadingABI(false);
       }

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useMemo, useCallback } from 'react';
-import { defineMessages, useIntl } from 'react-intl';
+import { defineMessages, MessageDescriptor, useIntl } from 'react-intl';
 import { FormikProps } from 'formik';
 import { isAddress } from 'web3-utils';
 
@@ -17,8 +17,14 @@ import {
 import { isEmpty, isEqual, isNil } from '~utils/lodash';
 import { getChainNameFromSafe } from '~modules/dashboard/sagas/utils/safeHelpers';
 import { Message } from '~types/index';
+import { isMessageDescriptor } from '~utils/strings';
 
-import { FormValues, FormProps, TransactionSectionProps } from '..';
+import {
+  FormValues,
+  FormProps,
+  TransactionSectionProps,
+  invalidSafeError,
+} from '..';
 import { ErrorMessage as Error, Loading, UserAvatarXs } from './shared';
 
 import styles from './TransactionTypesSection.css';
@@ -48,10 +54,6 @@ const MSG = defineMessages({
     id: `dashboard.ControlSafeDialog.TransactionTypesSection.ContractInteractionSection.loadingContract`,
     defaultMessage: 'Loading Contract',
   },
-  noSafeSelectedError: {
-    id: `dashboard.ControlSafeDialog.TransactionTypesSection.ContractInteractionSection.noSafeSelectedError`,
-    defaultMessage: `You must select a safe before fetching the contract's ABI`,
-  },
   contractNotVerifiedError: {
     id: `dashboard.ControlSafeDialog.TransactionTypesSection.ContractInteractionSection.contractNotVerifiedError`,
     defaultMessage: `Contract could not be verified. Ensure it exists on {network}`,
@@ -63,6 +65,10 @@ const MSG = defineMessages({
   fetchFailedError: {
     id: `dashboard.ControlSafeDialog.TransactionTypesSection.ContractInteractionSection.fetchFailedError`,
     defaultMessage: `Unable to fetch contract. Please check your connection`,
+  },
+  noUsefulMethodsError: {
+    id: `dashboard.ControlSafeDialog.ControlSafeForm.TransactionTypesSection.ContractInteractionSection.noUsefulMethodsError`,
+    defaultMessage: `No external methods were found in this ABI`,
   },
 });
 
@@ -180,11 +186,10 @@ const ContractInteractionSection = ({
         );
         setIsLoadingABI(false);
       } else {
-        if (!isAddress(contract.profile.walletAddress)) {
-          setFetchABIError(MSG.invalidAddressError);
-        } else {
-          setFetchABIError(MSG.noSafeSelectedError);
-        }
+        const error = !isAddress(contract.profile.walletAddress)
+          ? MSG.invalidAddressError
+          : invalidSafeError;
+        setFetchABIError(error);
         setFieldValue(
           `transactions.${transactionFormIndex}.contract.profile.displayName`,
           'Unknown contract',
@@ -206,18 +211,29 @@ const ContractInteractionSection = ({
     [transactionValues.abi],
   );
 
+  const isSpecificError = (error: Message, comparison: MessageDescriptor) => {
+    return (
+      isMessageDescriptor(error) &&
+      error.defaultMessage === comparison.defaultMessage
+    );
+  };
+
   useEffect(() => {
-    if (!selectedSafe) {
-      setPrevSafeChainId('');
-    } else if (
+    if (
       transactionValues.contract &&
-      // only run effect if safe chain changes
-      prevSafeChainId !== selectedSafe.chainId
+      safe &&
+      // only run effect if safe chain changes or there was previously an error
+      (prevSafeChainId !== selectedSafe?.chainId || fetchABIError)
     ) {
-      setPrevSafeChainId(selectedSafe.chainId);
+      if (selectedSafe) {
+        setPrevSafeChainId(selectedSafe.chainId);
+      }
       onContractChange(transactionValues.contract);
     }
+    // Don't want to run when ABI error changes, or else cause infinite loop
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
+    safe,
     selectedSafe,
     transactionValues.contract,
     onContractChange,
@@ -226,7 +242,7 @@ const ContractInteractionSection = ({
 
   useEffect(() => {
     const updatedFormattedMethodOptions =
-      usefulMethods?.map((method) => {
+      usefulMethods.map((method) => {
         return {
           label: method.name,
           value: method.name,
@@ -236,7 +252,21 @@ const ContractInteractionSection = ({
     if (!isEqual(updatedFormattedMethodOptions, formattedMethodOptions)) {
       setFormattedMethodOptions(updatedFormattedMethodOptions);
     }
-  }, [usefulMethods, transactionFormIndex, formattedMethodOptions]);
+
+    if (
+      !fetchABIError && // so we don't override other errors
+      transactionValues.abi &&
+      !updatedFormattedMethodOptions.length
+    ) {
+      setFetchABIError(MSG.noUsefulMethodsError);
+    }
+  }, [
+    fetchABIError,
+    transactionValues.abi,
+    usefulMethods,
+    transactionFormIndex,
+    formattedMethodOptions,
+  ]);
 
   useEffect(() => {
     if (
@@ -266,7 +296,6 @@ const ContractInteractionSection = ({
     <>
       <DialogSection>
         <div className={styles.singleUserPickerContainer}>
-          {/* @TODO: Connect available contract data with picker */}
           <SingleUserPicker
             data={[]}
             label={MSG.contractLabel}
@@ -282,7 +311,8 @@ const ContractInteractionSection = ({
           />
         </div>
       </DialogSection>
-      {fetchABIError ? (
+      {fetchABIError &&
+      !isSpecificError(fetchABIError, MSG.noUsefulMethodsError) ? (
         <Error error={fetchABIError} />
       ) : (
         <>
@@ -296,29 +326,38 @@ const ContractInteractionSection = ({
           </DialogSection>
           <DialogSection appearance={{ theme: 'sidePadding' }}>
             <div className={styles.contractFunctionSelectorContainer}>
-              {/*
-               * This is the component we don't want to let Formik validate immediately on change.
-               * Validation happens before the form state updates, which causes the form to be valid when
-               * it shouldn't be.
-               */}
-              <Select
-                label={MSG.functionLabel}
-                name={`transactions.${transactionFormIndex}.contractFunction`}
-                appearance={{ theme: 'grey', width: 'fluid' }}
-                placeholder={MSG.functionPlaceholder}
-                disabled={disabledInput}
-                options={formattedMethodOptions}
-                onChange={(value) => {
-                  const updatedSelectedContractMethods = {
-                    ...selectedContractMethods,
-                    [transactionFormIndex]: usefulMethods.find(
-                      (method) => method.name === value,
-                    ),
-                  };
-                  handleSelectedContractMethods(updatedSelectedContractMethods);
-                  handleValidation();
-                }}
-              />
+              {fetchABIError &&
+              isSpecificError(fetchABIError, MSG.noUsefulMethodsError) ? (
+                <div className={styles.noUsefulMethods}>
+                  <Error error={fetchABIError} />
+                </div>
+              ) : (
+                /*
+                 * This is the component we don't want to let Formik validate immediately on change.
+                 * Validation happens before the form state updates, which causes the form to be valid when
+                 * it shouldn't be.
+                 */
+                <Select
+                  label={MSG.functionLabel}
+                  name={`transactions.${transactionFormIndex}.contractFunction`}
+                  appearance={{ theme: 'grey', width: 'fluid' }}
+                  placeholder={MSG.functionPlaceholder}
+                  disabled={disabledInput}
+                  options={formattedMethodOptions}
+                  onChange={(value) => {
+                    const updatedSelectedContractMethods = {
+                      ...selectedContractMethods,
+                      [transactionFormIndex]: usefulMethods.find(
+                        (method) => method.name === value,
+                      ),
+                    };
+                    handleSelectedContractMethods(
+                      updatedSelectedContractMethods,
+                    );
+                    handleValidation();
+                  }}
+                />
+              )}
             </div>
           </DialogSection>
           {selectedContractMethods[transactionFormIndex]?.inputs?.map(

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css
@@ -50,3 +50,9 @@
   text-align: center;
   color: var(--pink);
 }
+
+/* Ensures noUsefulMethods error sits in between
+ * text area and  AddNewItem button */
+.noUsefulMethods > section {
+  padding: 1px 20px 20px;
+}

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css.d.ts
@@ -4,3 +4,4 @@ export const labelDescription: string;
 export const inputParamContainer: string;
 export const spinner: string;
 export const error: string;
+export const noUsefulMethods: string;

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransferFundsSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransferFundsSection.tsx
@@ -43,10 +43,6 @@ export const MSG = defineMessages({
     defaultMessage:
       'Unable to fetch Safe balances. Please check your connection',
   },
-  noSafeSelectedError: {
-    id: `dashboard.ControlSafeDialog.TransactionTypesSection.TransferFundsSection.noSafeSelectedError`,
-    defaultMessage: 'You must first select a safe',
-  },
 });
 
 const displayName = `dashboard.ControlSafeDialog.TransactionTypesSection.TransferFundsSection`;
@@ -58,8 +54,7 @@ export interface TransferFundsProps extends TransactionSectionProps {
 const TransferFundsSection = ({
   colony: { colonyAddress, safes },
   disabledInput,
-  values: { safe },
-  values,
+  values: { safe, transactions },
   transactionFormIndex,
   setFieldValue,
   handleInputChange,
@@ -113,7 +108,7 @@ const TransferFundsSection = ({
   }, [safe, safeAddress, setSavedTokens]);
 
   const selectedTokenAddress =
-    values.transactions[transactionFormIndex].tokenData?.address;
+    transactions[transactionFormIndex].tokenData?.address;
 
   const selectedBalance = useMemo(
     () => getSelectedSafeBalance(safeBalances, selectedTokenAddress),
@@ -134,14 +129,6 @@ const TransferFundsSection = ({
     // setSafeBalances causes infinite loop
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [safeAddress, getSafeBalance, savedTokens]);
-
-  useEffect(() => {
-    if (!safeAddress) {
-      setBalanceError(MSG.noSafeSelectedError);
-    }
-    // initialisation only
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const formattedSafeBalance = moveDecimal(
     selectedBalance?.balance || 0,

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransferNFTSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransferNFTSection.tsx
@@ -20,7 +20,6 @@ import { Address, Message } from '~types/index';
 import { log } from '~utils/debug';
 
 import { FormValues, TransactionSectionProps, SafeTransaction } from '..';
-import { MSG as FundsMSG } from './TransferFundsSection';
 import { UserAvatarXs, ErrorMessage as Error, Loading } from './shared';
 
 import styles from './TransferNFTSection.css';
@@ -169,10 +168,6 @@ const TransferNFTSection = ({
       handleValidation();
     }
   }, [safe, savedNFTs, setSavedNFTs, handleValidation]);
-
-  if (!safe && !availableNFTs && !nftError) {
-    return <Error error={FundsMSG.noSafeSelectedError} />;
-  }
 
   if (isLoadingNFTData || isFirstFetch) {
     return <Loading message={MSG.nftLoading} />;

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/index.ts
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/index.ts
@@ -2,3 +2,4 @@ export { default as TransferFundsSection } from './TransferFundsSection';
 export { default as RawTransactionSection } from './RawTransactionSection';
 export { default as ContractInteractionSection } from './ContractInteractionSection';
 export { default as TransferNFTSection } from './TransferNFTSection';
+export * from './shared';

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/index.ts
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/index.ts
@@ -5,4 +5,8 @@ export {
   SafeTransaction,
   SafeBalance,
 } from './ControlSafeDialog';
-export { FormProps, TransactionSectionProps } from './ControlSafeForm';
+export {
+  FormProps,
+  TransactionSectionProps,
+  invalidSafeError,
+} from './ControlSafeForm';

--- a/src/utils/strings/index.ts
+++ b/src/utils/strings/index.ts
@@ -1,9 +1,10 @@
 import { addressNormalizer, addressValidator } from '@purser/core';
 import { customAlphabet, urlAlphabet } from 'nanoid';
+import { MessageDescriptor } from 'react-intl';
 
 import { isTransactionFormat } from '~utils/web3';
 
-import { Address } from '~types/index';
+import { Address, Message } from '~types/index';
 
 const HTTP_PROTOCOL = 'http://';
 const HTTPS_PROTOCOL = 'https://';
@@ -151,4 +152,14 @@ export const ensureHexPrefix = (value: string): string => {
     return value;
   }
   return `${HEX_HEADER}${value}`;
+};
+
+export const isMessageDescriptor = (
+  message: Message,
+): message is MessageDescriptor => {
+  if (typeof message !== 'string') {
+    return true;
+  }
+
+  return false;
 };


### PR DESCRIPTION
## Description

This PR adds a couple of extra error messages to Safe Control and fixes a bug in the Contract Interaction section. 

**Changes** 🏗

1. Replace "noSafeSelected" error with "invalidSafeError", which covers the previous case in addition to the case of a user entering a safe address directly into the safe picker. 
2. Fixes a bug in the Contract Interaction section where it wasn't refetching if there was an error displayed
3. Adds a specific message if there are no useful methods on the abi in the contract interaction section

## To test

Open a form section with either no safe selected or something manually entered into the safe picker (valid address or not). Should receive the corresponding error. Make sure it then duly disappears when selecting a safe correctly.

If you fetch a contract such as `0x05b990D01A2f86852feD1E7d609dd3E52aA9EA27` (rinkeby), which has no useful methods, you should see the corresponding message instead of a function selector with no options.

## Screenshots

Invalid Address:

![invalid](https://user-images.githubusercontent.com/64402732/196920930-78194660-a205-410b-b417-e7db3b8c321c.png)

No external methods:

![noexternals](https://user-images.githubusercontent.com/64402732/196217097-58f13474-d746-4d76-944e-223aa302bcf9.png)

Resolves #4002
