### PR TITLE
Integrate motion components with Control Safe dialog

### DIFF
--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeDialog.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { FormikProps } from 'formik';
 import { pipe } from 'lodash/fp';
 import { useHistory } from 'react-router';
+import { ROOT_DOMAIN_ID } from '@colony/colony-js';
 
 import { AnyToken, AnyUser, ColonySafe } from '~data/index';
 import Dialog, { DialogProps, ActionDialogProps } from '~core/Dialog';
@@ -157,6 +158,8 @@ const ControlSafeDialog = ({
             nftData: null,
           },
         ],
+        forceAction: false,
+        motionDomainId: ROOT_DOMAIN_ID,
       }}
       validationSchema={validationSchema}
       submit={ActionTypes.ACTION_INITIATE_SAFE_TRANSACTION}

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
@@ -70,6 +70,10 @@ const MSG = defineMessages({
     id: `dashboard.ControlSafeDialog.ControlSafeForm.buttonCreateTransaction`,
     defaultMessage: 'Create transaction',
   },
+  buttonCreateMotion: {
+    id: `dashboard.ControlSafeDialog.ControlSafeForm.buttonCreateMotion`,
+    defaultMessage: 'Create motion',
+  },
   buttonConfirm: {
     id: `dashboard.ControlSafeDialog.ControlSafeForm.buttonConfirm`,
     defaultMessage: 'Confirm',
@@ -285,6 +289,17 @@ const ControlSafeForm = ({
   );
 
   const savedNFTState = useState({});
+
+  const submitButtonText = (() => {
+    if (!showPreview) {
+      if (isVotingExtensionEnabled && !values.forceAction) {
+        return MSG.buttonCreateMotion;
+      }
+      return MSG.buttonCreateTransaction;
+    }
+    return MSG.buttonConfirm;
+  })();
+
   return (
     <>
       {!showPreview ? (
@@ -492,7 +507,7 @@ const ControlSafeForm = ({
           onClick={() =>
             showPreview ? handleSubmit() : handleShowPreview(!showPreview)
           }
-          text={showPreview ? MSG.buttonConfirm : MSG.buttonCreateTransaction}
+          text={submitButtonText}
           loading={isSubmitting}
           disabled={
             !isValid ||

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
@@ -74,10 +74,6 @@ const MSG = defineMessages({
     id: `dashboard.ControlSafeDialog.ControlSafeForm.buttonCreateMotion`,
     defaultMessage: 'Create motion',
   },
-  buttonConfirm: {
-    id: `dashboard.ControlSafeDialog.ControlSafeForm.buttonConfirm`,
-    defaultMessage: 'Confirm',
-  },
   transactionTitle: {
     id: `dashboard.ControlSafeDialog.ControlSafeForm.transactionTitle`,
     defaultMessage: `Transaction #{transactionNumber} {transactionType, select, undefined {} other {({transactionType})}}`,
@@ -292,12 +288,9 @@ const ControlSafeForm = ({
 
   const submitButtonText = (() => {
     if (!showPreview) {
-      if (isVotingExtensionEnabled && !values.forceAction) {
-        return MSG.buttonCreateMotion;
-      }
       return MSG.buttonCreateTransaction;
     }
-    return MSG.buttonConfirm;
+    return { id: 'button.confirm' };
   })();
 
   return (

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
@@ -495,7 +495,11 @@ const ControlSafeForm = ({
           text={showPreview ? MSG.buttonConfirm : MSG.buttonCreateTransaction}
           loading={isSubmitting}
           disabled={
-            !isValid || isSubmitting || !hasTitle || !dirty || !onlyForceAction
+            !isValid ||
+            isSubmitting ||
+            !hasTitle ||
+            !dirty ||
+            (showPreview && onlyForceAction)
           }
           style={{ width: styles.wideButton }}
         />

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
@@ -159,7 +159,7 @@ const ControlSafeForm = ({
   );
   const userHasRootPermission = userHasRole(fromDomainRoles, ColonyRole.Root);
   const hasRoles = userHasFundingPermission && userHasRootPermission;
-  const [userHasPermission] = useDialogActionPermissions(
+  const [userHasPermission, onlyForceAction] = useDialogActionPermissions(
     colony.colonyAddress,
     hasRoles,
     isVotingExtensionEnabled,
@@ -472,8 +472,13 @@ const ControlSafeForm = ({
         </>
       ) : (
         <SafeTransactionPreview
+          colony={colony}
+          isSubmitting={isSubmitting}
           values={values}
           selectedContractMethods={selectedContractMethods}
+          isVotingExtensionEnabled={isVotingExtensionEnabled}
+          userHasPermission={userHasPermission}
+          onlyForceAction={onlyForceAction}
         />
       )}
       <DialogSection appearance={{ align: 'right', theme: 'footer' }}>
@@ -489,7 +494,9 @@ const ControlSafeForm = ({
           }
           text={showPreview ? MSG.buttonConfirm : MSG.buttonCreateTransaction}
           loading={isSubmitting}
-          disabled={!isValid || isSubmitting || !hasTitle || !dirty}
+          disabled={
+            !isValid || isSubmitting || !hasTitle || !dirty || !onlyForceAction
+          }
           style={{ width: styles.wideButton }}
         />
       </DialogSection>

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
@@ -70,10 +70,6 @@ const MSG = defineMessages({
     id: `dashboard.ControlSafeDialog.ControlSafeForm.buttonCreateTransaction`,
     defaultMessage: 'Create transaction',
   },
-  buttonCreateMotion: {
-    id: `dashboard.ControlSafeDialog.ControlSafeForm.buttonCreateMotion`,
-    defaultMessage: 'Create motion',
-  },
   transactionTitle: {
     id: `dashboard.ControlSafeDialog.ControlSafeForm.transactionTitle`,
     defaultMessage: `Transaction #{transactionNumber} {transactionType, select, undefined {} other {({transactionType})}}`,

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.css
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.css
@@ -119,3 +119,9 @@
   font-size: var(--size-normal);
   color: var(--pink);
 }
+
+.motionHeading {
+  display: flex;
+  justify-content: space-between;
+  padding-top: 18px;
+}

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.css.d.ts
@@ -15,3 +15,4 @@ export const nftContainer: string;
 export const avatar: string;
 export const itemValue: string;
 export const contractName: string;
+export const motionHeading: string;

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.tsx
@@ -4,15 +4,17 @@ import classnames from 'classnames';
 import { nanoid } from 'nanoid';
 
 import { DialogSection } from '~core/Dialog';
-import { Annotations, Input } from '~core/Fields';
+import { Annotations, Input, Toggle } from '~core/Fields';
 import Heading from '~core/Heading';
 import Numeral from '~core/Numeral';
 import TokenIcon from '~dashboard/HookedTokenIcon';
+import MotionDomainSelect from '~dashboard/MotionDomainSelect';
+import NotEnoughReputation from '~dashboard/NotEnoughReputation';
 import Button from '~core/Button';
 import Icon from '~core/Icon';
 import Avatar from '~core/Avatar';
 import MaskedAddress from '~core/MaskedAddress';
-import { AnyUser } from '~data/index';
+import { AnyUser, Colony } from '~data/index';
 import { AbiItemExtended, getArrayFromString } from '~utils/safes';
 
 import AddressDetailsView from './TransactionPreview/AddressDetailsView';
@@ -219,7 +221,12 @@ const transactionTypeFieldsMap = {
 const displayName = 'dashboard.ControlSafeDialog.SafeTransactionPreview';
 
 interface Props {
+  colony: Colony;
   values: FormValues;
+  isVotingExtensionEnabled: boolean;
+  userHasPermission: boolean;
+  isSubmitting: boolean;
+  onlyForceAction: boolean;
   selectedContractMethods?:
     | {
         [key: number]: AbiItemExtended | undefined;
@@ -227,7 +234,15 @@ interface Props {
     | undefined;
 }
 
-const SafeTransactionPreview = ({ values, selectedContractMethods }: Props) => {
+const SafeTransactionPreview = ({
+  colony,
+  values,
+  selectedContractMethods,
+  isVotingExtensionEnabled,
+  userHasPermission,
+  isSubmitting,
+  onlyForceAction,
+}: Props) => {
   const [transactionTabStatus, setTransactionTabStatus] = useState(
     Array(values.transactions.length).fill(false),
   );
@@ -299,6 +314,26 @@ const SafeTransactionPreview = ({ values, selectedContractMethods }: Props) => {
 
   return (
     <>
+      <DialogSection appearance={{ theme: 'sidePadding' }}>
+        <div className={styles.motionHeading}>
+          {isVotingExtensionEnabled && (
+            <MotionDomainSelect
+              colony={colony}
+              /*
+               * @NOTE Always disabled since you can only create this motion in root
+               */
+              disabled
+            />
+          )}
+          {userHasPermission && isVotingExtensionEnabled && (
+            <Toggle
+              label={{ id: 'label.force' }}
+              name="forceAction"
+              disabled={isSubmitting}
+            />
+          )}
+        </div>
+      </DialogSection>
       <DialogSection>
         <div className={styles.heading}>
           <Heading
@@ -433,11 +468,19 @@ const SafeTransactionPreview = ({ values, selectedContractMethods }: Props) => {
             appearance={{ colorSchema: 'grey', theme: 'fat' }}
             label={MSG.transactionsTitle}
             name="transactionsTitle"
+            disabled={onlyForceAction}
           />
         </DialogSection>
         <DialogSection>
-          <Annotations label={MSG.description} name="annotation" />
+          <Annotations
+            label={MSG.description}
+            name="annotation"
+            disabled={onlyForceAction}
+          />
         </DialogSection>
+        {onlyForceAction && (
+          <NotEnoughReputation appearance={{ marginTop: 'negative' }} />
+        )}
       </div>
     </>
   );

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/validation.ts
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/validation.ts
@@ -350,4 +350,6 @@ export const getValidationSchema = (
         ...expandedValidationSchema,
       }),
     ),
+    forceAction: yup.boolean(),
+    motionDomainId: yup.number(),
   });


### PR DESCRIPTION
Added force action toggle and motion domain selector.

The motion domain selector is disabled because you are not supposed to create the motion in any other domain that is not the main one.

![FireShot Capture 732 - Actions - Colony - wonker - localhost](https://user-images.githubusercontent.com/18473896/196564225-53291eba-9e2a-4ef2-a21e-d86bdec63f06.png)
![FireShot Capture 733 - Actions - Colony - wonker - localhost](https://user-images.githubusercontent.com/18473896/196564240-69f2082b-1879-4809-bfdf-14ba55a052fc.png)

Resolves #4005 
