### PR TITLE
Fix: Input max button buggy behaviour when clicked twice

### DIFF
--- a/src/modules/core/components/Fields/Input/InputComponent.tsx
+++ b/src/modules/core/components/Fields/Input/InputComponent.tsx
@@ -150,9 +150,7 @@ const InputComponent = ({
             maxButtonParams?.customOnClickFn?.();
             const decimalValue = new Decimal(maxButtonParams.maxAmount);
             if (decimalValue.lt(0.00001) && decimalValue.gt(0)) {
-              cleave?.setRawValue(
-                decimalValue.toSD(5, Decimal.ROUND_DOWN).toNumber(),
-              );
+              cleave?.setRawValue(maxButtonParams.maxAmount);
             } else {
               cleave?.setRawValue(
                 new Decimal(maxButtonParams.maxAmount)


### PR DESCRIPTION
## Description

This PR fixes the issue described in #4011. By the time I got to the bottom of it, it became clear the bug has been present in the dapp for at least a year and its impact is likely to be minimal, since there are two conditions for it to happen:
- The max allowable amount must be less than 0.000001
- The Max button must be clicked at least twice

Anyway, the fix is just one line.

To test, add any safe and create a transaction to transfer a token of which there's less than 0.000001 in the safe (you can use the safe from the issue and select `WILL` token). You should be able to click Max as many times as you wish without the value changing to something odd.

I decided to branch this off `feature/gnosis-safe-control` (although it potentially affects all other inputs with max button) due to the bug's impact being minimal and easiest to notice inside control safe dialog. If there are any objections I'll branch it off master instead. 

**Changes** 🏗

* Removed formatting of tiny numbers in `InputComponent`

Resolves #4011 
