### PR TITLE
Fix: Many colonies overlap Add New button

### DIFF
--- a/src/modules/dashboard/components/SubscribedColoniesList/SubscribedColoniesList.css
+++ b/src/modules/dashboard/components/SubscribedColoniesList/SubscribedColoniesList.css
@@ -50,11 +50,6 @@
   fill: var(--temp-grey-blue-7);
 }
 
-.newColonyItem {
-  position: sticky;
-  bottom: 0;
-}
-
 .loadingColonies {
   padding: 8px 0 2px;
 }
@@ -62,15 +57,6 @@
 @media screen and query700 {
   .main {
     align-items: center;
-  }
-
-  .newColonyItem {
-    transform: scale(0.76) translateX(-8px);
-  }
-
-  .newColonyItem a {
-    height: auto;
-    width: auto;
   }
 
   .scrollableContainer {

--- a/src/modules/dashboard/components/SubscribedColoniesList/SubscribedColoniesList.css.d.ts
+++ b/src/modules/dashboard/components/SubscribedColoniesList/SubscribedColoniesList.css.d.ts
@@ -9,6 +9,5 @@ export const itemLink: string;
 export const activeColony: string;
 export const itemImage: string;
 export const newColonyIcon: string;
-export const newColonyItem: string;
 export const loadingColonies: string;
 export const dropdownItem: string;

--- a/src/modules/dashboard/components/SubscribedColoniesList/SubscribedColoniesList.tsx
+++ b/src/modules/dashboard/components/SubscribedColoniesList/SubscribedColoniesList.tsx
@@ -51,7 +51,7 @@ const SubscribedColoniesList = ({ loggedInUser, path }: Props) => {
   })[0];
 
   const AddColony = () => (
-    <div className={`${styles.item} ${styles.newColonyItem}`}>
+    <div className={styles.item}>
       <NavLink
         className={styles.itemLink}
         to={CREATE_COLONY_ROUTE}


### PR DESCRIPTION
## Description

I was unable to reproduce the bug myself (it might as well be a Chrome/Windows specific issue) but looking at the code I found some CSS that I believe could possibly be the offender here. 

In Chrome 106 on Mac OS, the Add New button wasn't overlapped before or after:
<img width="797" alt="Screenshot 2022-10-19 at 23 05 17" src="https://user-images.githubusercontent.com/112586815/196815636-ebc7a22f-ac24-4d9e-b531-02da474fd06b.png">

@willm30 Please let me know if this fix works for you. I'll request review from the rest of the team once you confirm that.

**Deletions** ⚰️

* Deleted CSS setting the Add New button position to sticky

Resolves #4007 