### PR TITLE
Fix mobile menu not opening in production

### DIFF
--- a/src/modules/pages/components/RouteLayouts/UserNavigation.tsx
+++ b/src/modules/pages/components/RouteLayouts/UserNavigation.tsx
@@ -291,7 +291,6 @@ const UserNavigation = () => {
           }}
         />
         <HamburgerDropdown
-          onlyLogout={!isNetworkAllowed}
           colony={colonyData?.processedColony as Colony}
           colonyName={colonyName}
         />

--- a/src/modules/users/components/HamburgerDropdown/HamburgerDropdown.tsx
+++ b/src/modules/users/components/HamburgerDropdown/HamburgerDropdown.tsx
@@ -9,14 +9,13 @@ import HamburgerDropdownPopover from './HamburgerDropdownPopover';
 import styles from './HamburgerDropdown.css';
 
 interface Props {
-  onlyLogout?: boolean;
   colony: Colony;
   colonyName: string;
 }
 
 const displayName = 'users.HamburgerDropdown';
 
-const HamburgerDropdown = ({ onlyLogout, colony, colonyName }: Props) => {
+const HamburgerDropdown = ({ colony, colonyName }: Props) => {
   const { username, walletAddress, ethereal } = useLoggedInUser();
   return (
     <Popover
@@ -27,7 +26,6 @@ const HamburgerDropdown = ({ onlyLogout, colony, colonyName }: Props) => {
           {...{
             colony,
             colonyName,
-            onlyLogout,
             username,
           }}
         />

--- a/src/modules/users/components/HamburgerDropdown/HamburgerDropdownPopover.tsx
+++ b/src/modules/users/components/HamburgerDropdown/HamburgerDropdownPopover.tsx
@@ -42,7 +42,6 @@ const MSG = defineMessages({
 const displayName = 'users.HamburgerDropdown.HamburgerDropdownPopover';
 
 interface Props {
-  onlyLogout?: boolean;
   closePopover: () => void;
   colony: Colony;
   colonyName: string;
@@ -52,7 +51,6 @@ interface Props {
 
 const HamburgerDropdownPopover = ({
   closePopover,
-  onlyLogout,
   colony,
   colonyName,
   username,
@@ -63,35 +61,28 @@ const HamburgerDropdownPopover = ({
   return (
     <div className={styles.menu}>
       <DropdownMenu onClick={closePopover}>
-        {!onlyLogout && (
-          <>
-            {username && colonyName && (
-              <DropdownMenuSection>
-                <DropdownMenuItem>
-                  <NavLink to={colonyHomePath} text={MSG.actions} exact />
-                </DropdownMenuItem>
-                <DropdownMenuItem>
-                  <NavLink to={`${colonyHomePath}/funds`} text={MSG.funds} />
-                </DropdownMenuItem>
-                <DropdownMenuItem>
-                  <NavLink
-                    to={`${colonyHomePath}/members`}
-                    text={MSG.members}
-                  />
-                </DropdownMenuItem>
-                <DropdownMenuItem>
-                  <NavLink
-                    to={`${colonyHomePath}/extensions`}
-                    text={MSG.extensions}
-                  />
-                </DropdownMenuItem>
-              </DropdownMenuSection>
-            )}
-            <UserSection colony={colony} username={username} />
-            <ColonySection />
-            <HelperSection />
-          </>
+        {username && colonyName && (
+          <DropdownMenuSection>
+            <DropdownMenuItem>
+              <NavLink to={colonyHomePath} text={MSG.actions} exact />
+            </DropdownMenuItem>
+            <DropdownMenuItem>
+              <NavLink to={`${colonyHomePath}/funds`} text={MSG.funds} />
+            </DropdownMenuItem>
+            <DropdownMenuItem>
+              <NavLink to={`${colonyHomePath}/members`} text={MSG.members} />
+            </DropdownMenuItem>
+            <DropdownMenuItem>
+              <NavLink
+                to={`${colonyHomePath}/extensions`}
+                text={MSG.extensions}
+              />
+            </DropdownMenuItem>
+          </DropdownMenuSection>
         )}
+        <UserSection colony={colony} username={username} />
+        <ColonySection />
+        <HelperSection />
         {isWalletConnected && <MetaSection />}
       </DropdownMenu>
     </div>


### PR DESCRIPTION
## Description

This PR fixes a bug in the mobile responsive menu where the popover wasn't displaying anything if the user was on the wrong network or logged out.

**Changes** 🏗

* Move "basic menu" out of logged-in control flow so it's always visible, no matter what

User will now see this: 


![fixedmenu](https://user-images.githubusercontent.com/64402732/196958952-f88726f8-7c3e-4e95-ba9b-15057c9a2720.png)


Instead of this:

![brokenmenu](https://user-images.githubusercontent.com/64402732/196959264-34ba233d-f762-45a1-8955-c37180493dd6.png)
