### PR TITLE
Fix selectedContractMethods when deleting a tab

### DIFF
--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
@@ -163,14 +163,42 @@ const ControlSafeForm = ({
   }, [validateForm]);
 
   const handleTabRemoval = useCallback(
-    (arrayHelpers: FieldArrayRenderProps, index: number) => {
+    (
+      arrayHelpers: FieldArrayRenderProps,
+      index: number,
+      contractMethods?: UpdatedMethods,
+    ) => {
       arrayHelpers.remove(index);
+
+      const shiftedContractMethods = contractMethods
+        ? Object.keys(contractMethods).reduce((acc, contractMethodIndex) => {
+            if (index < Number(contractMethodIndex)) {
+              return {
+                ...acc,
+                [Number(contractMethodIndex) - 1]: contractMethods[
+                  contractMethodIndex
+                ],
+              };
+            }
+            return {
+              ...acc,
+              [contractMethodIndex]: contractMethods[contractMethodIndex],
+            };
+          }, {})
+        : {};
+      handleSelectedContractMethods(shiftedContractMethods);
+
       const newTransactionTabStatus = [...transactionTabStatus];
       newTransactionTabStatus.splice(index, 1);
       setTransactionTabStatus(newTransactionTabStatus);
       handleValidation();
     },
-    [transactionTabStatus, setTransactionTabStatus, handleValidation],
+    [
+      transactionTabStatus,
+      setTransactionTabStatus,
+      handleValidation,
+      handleSelectedContractMethods,
+    ],
   );
   const handleNewTab = useCallback(
     (arrayHelpers: FieldArrayRenderProps) => {
@@ -341,7 +369,13 @@ const ControlSafeForm = ({
                         />
                         <Button
                           className={styles.tabButton}
-                          onClick={() => handleTabRemoval(arrayHelpers, index)}
+                          onClick={() =>
+                            handleTabRemoval(
+                              arrayHelpers,
+                              index,
+                              selectedContractMethods,
+                            )
+                          }
                         >
                           <IconTooltip
                             icon="trash"


### PR DESCRIPTION
## Description

Currently, when you remove a tab, the keys are not being updated in the selectedContractMethods as these are dependent on the transactionFormIndex which changes when a tab is deleted.

The expected behavior is that when you delete a tab, the contract methods for a contract interaction transaction should not disappear.

**New stuff** ✨

* Updated `handleTabRemoval` to shift the keys of the selectedContractMethods when a tab is removed.

![contractmethods](https://user-images.githubusercontent.com/71563622/197108270-5893ce45-1219-4d87-bfad-f89d20a12689.gif)


(Resolves #3944)