### PR TITLE
Connect Safe Transactions to Actions List 

### DIFF
--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -839,7 +839,7 @@ export type LoggedInUser = {
   networkId?: Maybe<Scalars['Int']>;
 };
 
-export type SugraphEventProcessedValues = {
+export type SubgraphEventProcessedValues = {
   agent: Scalars['String'];
   who: Scalars['String'];
   fromPot: Scalars['String'];
@@ -857,6 +857,7 @@ export type SugraphEventProcessedValues = {
   newVersion: Scalars['String'];
   storageSlot: Scalars['String'];
   storageSlotValue: Scalars['String'];
+  txHash: Scalars['String'];
 };
 
 export type SubgraphEvent = {
@@ -867,7 +868,7 @@ export type SubgraphEvent = {
   args: Scalars['String'];
   timestamp: Scalars['String'];
   associatedColony: SubgraphColony;
-  processedValues: SugraphEventProcessedValues;
+  processedValues: SubgraphEventProcessedValues;
 };
 
 export type SubgraphMotion = {
@@ -2750,7 +2751,7 @@ export type SubgraphEventsThatAreActionsSubscription = { events: Array<(
     ), transaction: (
       { hash: SubgraphTransaction['id'] }
       & { block: Pick<SubgraphBlock, 'id' | 'timestamp'> }
-    ), processedValues: Pick<SugraphEventProcessedValues, 'agent' | 'who' | 'fromPot' | 'fromDomain' | 'toPot' | 'toDomain' | 'domainId' | 'amount' | 'token' | 'metadata' | 'user' | 'oldVersion' | 'newVersion' | 'storageSlot' | 'storageSlotValue'> }
+    ), processedValues: Pick<SubgraphEventProcessedValues, 'agent' | 'who' | 'fromPot' | 'fromDomain' | 'toPot' | 'toDomain' | 'domainId' | 'amount' | 'token' | 'metadata' | 'user' | 'oldVersion' | 'newVersion' | 'storageSlot' | 'storageSlotValue' | 'txHash'> }
   )> };
 
 export type SubgraphMotionsSubscriptionVariables = Exact<{
@@ -7298,7 +7299,7 @@ export type SubgraphOneTxSubscriptionHookResult = ReturnType<typeof useSubgraphO
 export type SubgraphOneTxSubscriptionResult = Apollo.SubscriptionResult<SubgraphOneTxSubscription>;
 export const SubgraphEventsThatAreActionsDocument = gql`
     subscription SubgraphEventsThatAreActions($skip: Int = 0, $first: Int = 1000, $colonyAddress: String!, $sortDirection: String = asc) {
-  events(skip: $skip, first: $first, orderBy: "timestamp", orderDirection: $sortDirection, where: {associatedColony_contains: $colonyAddress, name_in: ["TokensMinted(address,address,uint256)", "DomainAdded(address,uint256)", "ColonyMetadata(address,string)", "ColonyFundsMovedBetweenFundingPots(address,uint256,uint256,uint256,address)", "DomainMetadata(address,uint256,string)", "ColonyRoleSet(address,address,uint256,uint8,bool)", "ColonyUpgraded(address,uint256,uint256)", "ColonyUpgraded(uint256,uint256)", "RecoveryModeEntered(address)", "ArbitraryReputationUpdate(address,address,uint256,int256)", "TokenUnlocked(address)", "TokenUnlocked()"]}) {
+  events(skip: $skip, first: $first, orderBy: "timestamp", orderDirection: $sortDirection, where: {associatedColony_contains: $colonyAddress, name_in: ["TokensMinted(address,address,uint256)", "DomainAdded(address,uint256)", "ColonyMetadata(address,string)", "ColonyFundsMovedBetweenFundingPots(address,uint256,uint256,uint256,address)", "DomainMetadata(address,uint256,string)", "ColonyRoleSet(address,address,uint256,uint8,bool)", "ColonyUpgraded(address,uint256,uint256)", "ColonyUpgraded(uint256,uint256)", "RecoveryModeEntered(address)", "ArbitraryReputationUpdate(address,address,uint256,int256)", "TokenUnlocked(address)", "TokenUnlocked()", "Annotation(address,bytes32,string)"]}) {
     id
     address
     associatedColony {
@@ -7336,6 +7337,7 @@ export const SubgraphEventsThatAreActionsDocument = gql`
       newVersion
       storageSlot
       storageSlotValue
+      txHash
     }
   }
 }

--- a/src/data/graphql/subscriptions.graphql
+++ b/src/data/graphql/subscriptions.graphql
@@ -92,6 +92,7 @@ subscription SubgraphEventsThatAreActions($skip: Int = 0, $first: Int = 1000, $c
         "ArbitraryReputationUpdate(address,address,uint256,int256)",
         "TokenUnlocked(address)",
         "TokenUnlocked()",
+        "Annotation(address,bytes32,string)",
       ]
     }) {
     id
@@ -131,6 +132,7 @@ subscription SubgraphEventsThatAreActions($skip: Int = 0, $first: Int = 1000, $c
       newVersion
       storageSlot
       storageSlotValue
+      txHash
     }
   }
 }

--- a/src/data/graphql/typeDefs.ts
+++ b/src/data/graphql/typeDefs.ts
@@ -35,7 +35,7 @@ export default gql`
     networkId: Int
   }
 
-  type SugraphEventProcessedValues {
+  type SubgraphEventProcessedValues {
     agent: String!
     who: String!
     fromPot: String!
@@ -53,6 +53,7 @@ export default gql`
     newVersion: String!
     storageSlot: String!
     storageSlotValue: String!
+    txHash: String!
   }
 
   type SubgraphEvent {
@@ -63,7 +64,7 @@ export default gql`
     args: String!
     timestamp: String!
     associatedColony: SubgraphColony!
-    processedValues: SugraphEventProcessedValues!
+    processedValues: SubgraphEventProcessedValues!
   }
 
   type SubgraphMotion {

--- a/src/i18n/en-actions.ts
+++ b/src/i18n/en-actions.ts
@@ -37,6 +37,11 @@ const actionsMessageDescriptors = {
       ${ColonyExtendedActions.SafeTransactionInitiated} {{safeTransactionTitle}}
       other {Generic action we don't have information about}
     }`,
+  [`action.title.${ColonyExtendedActions.SafeTransactionInitiated}.multipleTransactions`]: `Initiate Multiple Transactions from Safe Control`,
+  [`action.title.${ColonyExtendedActions.SafeTransactionInitiated}.transferFunds`]: `Transfer Funds from Safe Control`,
+  [`action.title.${ColonyExtendedActions.SafeTransactionInitiated}.transferNFT`]: `Transfer NFT from Safe Control`,
+  [`action.title.${ColonyExtendedActions.SafeTransactionInitiated}.contractInteraction`]: `Initiate Contract Interaction from Safe Control`,
+  [`action.title.${ColonyExtendedActions.SafeTransactionInitiated}.rawTransaction`]: `Initiate Raw Transaction from Safe Control`,
   [`action.${ColonyActions.SetUserRoles}.assign`]: `Assign the {roles} in {fromDomain} to {recipient}`,
   [`action.${ColonyMotions.SetUserRolesMotion}.assign`]: `Assign the {roles} in {fromDomain} to {recipient}`,
   [`action.${ColonyActions.SetUserRoles}.remove`]: `Remove the {roles} in {fromDomain} from {recipient}`,

--- a/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.tsx
+++ b/src/modules/dashboard/components/ActionsPage/DetailsWidget/DetailsWidget.tsx
@@ -10,7 +10,7 @@ import TokenIcon from '~dashboard/HookedTokenIcon';
 import { AnyUser, Colony, ColonySafe, SafeTransaction } from '~data/index';
 import { AddedActions, ColonyActions, ColonyMotions } from '~types/index';
 import { splitTransactionHash } from '~utils/strings';
-import { getSafeTransactionActionTypeMessageId } from '~utils/safes';
+import { getSafeTransactionActionMessageId } from '~utils/safes';
 import { ExtendedActions, getDetailsForAction } from '~utils/colonyActions';
 import { EventValues } from '../../ActionsPageFeed/ActionsPageFeed';
 import { ACTION_TYPES_ICONS_MAP } from '../../ActionsPage/staticMaps';
@@ -125,7 +125,11 @@ const getMessageId = (
     actionType === AddedActions.SafeTransactionInitiated &&
     safeTransactions
   ) {
-    return getSafeTransactionActionTypeMessageId(actionType, safeTransactions);
+    return getSafeTransactionActionMessageId(
+      actionType,
+      safeTransactions,
+      'type',
+    );
   }
   return 'action.type';
 };

--- a/src/modules/dashboard/components/ColonyActions/ColonyActions.tsx
+++ b/src/modules/dashboard/components/ColonyActions/ColonyActions.tsx
@@ -43,7 +43,6 @@ const MSG = defineMessages({
     id: 'dashboard.ColonyActions.transactionsLogLink',
     defaultMessage: 'Transactions log',
   },
-
   labelFilter: {
     id: 'dashboard.ColonyActions.labelFilter',
     defaultMessage: 'Filter',

--- a/src/modules/dashboard/hooks/useExtendedColonyActionType.ts
+++ b/src/modules/dashboard/hooks/useExtendedColonyActionType.ts
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 
-import { Colony } from '~data/index';
-import { ColonyActionQuery } from '~data/generated';
+import { Colony, ColonyActionQuery } from '~data/index';
 import { ColonyActions, ColonyExtendedActions } from '~types/index';
 import { ColonyMetadata } from '~utils/colonyActions';
 

--- a/src/modules/dashboard/hooks/useFetchSafeTransactionData.ts
+++ b/src/modules/dashboard/hooks/useFetchSafeTransactionData.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+import { SafeTransaction } from '~data/index';
+import { getColonyMetadataIPFS } from '~utils/events';
+
+export const useFetchSafeTransactionData = (metadata?: string) => {
+  const [safeTransactions, setSafeTransactions] = useState<SafeTransaction[]>();
+
+  useEffect(() => {
+    const fetchSafeTxData = async () => {
+      if (metadata) {
+        const safeTransactionData = await getColonyMetadataIPFS(metadata);
+        if (safeTransactionData) {
+          const { annotationMessage } = JSON.parse(safeTransactionData);
+          setSafeTransactions(annotationMessage?.transactions);
+        }
+      }
+    };
+
+    fetchSafeTxData();
+  }, [metadata]);
+
+  return safeTransactions;
+};

--- a/src/modules/dashboard/transformers/transformers.ts
+++ b/src/modules/dashboard/transformers/transformers.ts
@@ -78,47 +78,63 @@ export const getActionsListData = (
         return [...acc, action];
       }, []) || [],
     events:
-      unformattedActions?.events?.reduce((acc, event) => {
-        if (
-          formatEventName(event.name) ===
-          ColonyAndExtensionsEvents.DomainMetadata
-        ) {
-          const linkedDomainAddedEvent = (
-            unformattedActions?.events || []
-          ).find(
-            (e) =>
-              formatEventName(e.name) ===
-                ColonyAndExtensionsEvents.DomainAdded &&
-              e.transaction?.hash === event.transaction?.hash,
+      unformattedActions?.events
+        /* Remove all annotations that are not the result of initiating a Safe Transaction via Safe Control */
+        ?.filter((event) => {
+          if (event.name !== 'Annotation(address,bytes32,string)') {
+            return true;
+          }
+
+          if (
+            event.processedValues.txHash ===
+            '0x0000000000000000000000000000000000000000000000000000000000000001'
+          ) {
+            return true;
+          }
+
+          return false;
+        })
+        .reduce((acc, event) => {
+          if (
+            formatEventName(event.name) ===
+            ColonyAndExtensionsEvents.DomainMetadata
+          ) {
+            const linkedDomainAddedEvent = (
+              unformattedActions?.events || []
+            ).find(
+              (e) =>
+                formatEventName(e.name) ===
+                  ColonyAndExtensionsEvents.DomainAdded &&
+                e.transaction?.hash === event.transaction?.hash,
+            );
+            if (linkedDomainAddedEvent) return acc;
+          }
+          /* filtering out events that are already shown in `oneTxPayments` */
+          const isTransactionRepeated = unformattedActions?.oneTxPayments?.some(
+            (paymentAction) =>
+              paymentAction.transaction?.hash === event.transaction?.hash,
           );
-          if (linkedDomainAddedEvent) return acc;
-        }
-        /* filtering out events that are already shown in `oneTxPayments` */
-        const isTransactionRepeated = unformattedActions?.oneTxPayments?.some(
-          (paymentAction) =>
-            paymentAction.transaction?.hash === event.transaction?.hash,
-        );
-        if (isTransactionRepeated) return acc;
+          if (isTransactionRepeated) return acc;
 
-        /*
-         * Filter out events that have the recipient or initiator an extension's address
-         *
-         * This is used to filter out setting root roles to extensions after
-         * they have been installed. This also filter out duplicated events
-         * which occurs when motion is finalized.
-         */
-        if (
-          extensionAddresses?.find(
-            (extensionAddress) =>
-              extensionAddress === event?.processedValues?.user ||
-              extensionAddress === event?.processedValues?.agent,
-          )
-        ) {
-          return acc;
-        }
+          /*
+           * Filter out events that have the recipient or initiator an extension's address
+           *
+           * This is used to filter out setting root roles to extensions after
+           * they have been installed. This also filter out duplicated events
+           * which occurs when motion is finalized.
+           */
+          if (
+            extensionAddresses?.find(
+              (extensionAddress) =>
+                extensionAddress === event?.processedValues?.user ||
+                extensionAddress === event?.processedValues?.agent,
+            )
+          ) {
+            return acc;
+          }
 
-        return [...acc, event];
-      }, []) || [],
+          return [...acc, event];
+        }, []) || [],
     /*
      * Only display motions in the list if their stake reached 10% or
      * if they have been escalated

--- a/src/types/colonyActions.ts
+++ b/src/types/colonyActions.ts
@@ -3,9 +3,9 @@ import { ColonyRole } from '@colony/colony-js';
 import { ItemStatus } from '~core/ActionsList';
 import { MotionTimeoutPeriods } from '~data/generated';
 import { MotionState } from '~utils/colonyMotions';
+import { ExtendedActions } from '~utils/colonyActions';
 
 import { Address, ActionUserRoles } from './index';
-import { ColonyMotions } from './colonyMotions';
 
 export enum ColonyActions {
   Generic = 'Generic',
@@ -131,7 +131,7 @@ export enum ColonyAndExtensionsEvents {
 export interface FormattedAction {
   id: string;
   status?: ItemStatus;
-  actionType: ColonyActions | ColonyMotions;
+  actionType: ExtendedActions;
   initiator: Address;
   recipient: Address;
   amount: string;

--- a/src/utils/colonyActions.ts
+++ b/src/utils/colonyActions.ts
@@ -15,7 +15,7 @@ import {
   ColonyAction,
   ColonySafe,
   SafeTransaction,
-  SugraphEventProcessedValues,
+  SubgraphEventProcessedValues,
 } from '~data/index';
 
 import {
@@ -59,8 +59,8 @@ export const getDetailsForAction = (
  * Get values for action type based on action type
  */
 export const getValuesForActionType = (
-  values: SugraphEventProcessedValues,
-  actionType: ColonyActions,
+  values: SubgraphEventProcessedValues,
+  actionType: ColonyActions | AddedActions,
   colonyAddress: Address,
 ): ValuesForActionTypesMap => {
   if (Object.keys(values).length) {
@@ -130,6 +130,12 @@ export const getValuesForActionType = (
         return {
           recipient: values.user,
           reputationChange: values.amount,
+        };
+      }
+      case AddedActions.SafeTransactionInitiated: {
+        return {
+          initiator: values.agent,
+          metadata: values.metadata,
         };
       }
       default: {

--- a/src/utils/events/index.ts
+++ b/src/utils/events/index.ts
@@ -180,7 +180,7 @@ export const formatEventName = (
 ): ColonyAndExtensionsEvents =>
   rawEventName.split('(')[0] as ColonyAndExtensionsEvents;
 
-const getColonyMetadataIPFS = async (ipfsHash: string) => {
+export const getColonyMetadataIPFS = async (ipfsHash: string) => {
   /*
    * Fetch the colony's metadata
    */

--- a/src/utils/safes/index.ts
+++ b/src/utils/safes/index.ts
@@ -54,23 +54,24 @@ export const getColonySafe = (
   );
 };
 
-export const getSafeTransactionActionTypeMessageId = (
+export const getSafeTransactionActionMessageId = (
   actionType: AddedActions.SafeTransactionInitiated,
   safeTransaction: SafeTransaction[],
+  kind: 'type' | 'title',
 ) => {
   const type = getSafeTransactionActionType(actionType, safeTransaction);
   switch (type) {
     case TransactionTypes.RAW_TRANSACTION:
-      return `action.type.${ColonyExtendedActions.SafeTransactionInitiated}.rawTransaction`;
+      return `action.${kind}.${ColonyExtendedActions.SafeTransactionInitiated}.rawTransaction`;
     case TransactionTypes.TRANSFER_FUNDS:
-      return `action.type.${ColonyExtendedActions.SafeTransactionInitiated}.transferFunds`;
+      return `action.${kind}.${ColonyExtendedActions.SafeTransactionInitiated}.transferFunds`;
     case TransactionTypes.TRANSFER_NFT:
-      return `action.type.${ColonyExtendedActions.SafeTransactionInitiated}.transferNFT`;
+      return `action.${kind}.${ColonyExtendedActions.SafeTransactionInitiated}.transferNFT`;
     case TransactionTypes.CONTRACT_INTERACTION:
-      return `action.type.${ColonyExtendedActions.SafeTransactionInitiated}.contractInteraction`;
+      return `action.${kind}.${ColonyExtendedActions.SafeTransactionInitiated}.contractInteraction`;
     case TransactionTypes.MULTIPLE_TRANSACTIONS:
-      return `action.type.${ColonyExtendedActions.SafeTransactionInitiated}.multipleTransactions`;
+      return `action.${kind}.${ColonyExtendedActions.SafeTransactionInitiated}.multipleTransactions`;
     default:
-      return 'action.type';
+      return `action.${kind}`;
   }
 };


### PR DESCRIPTION
## Description

This PR connects Safe Transactions to the Actions List on the Colony Home page. 


To test, set up bridging environment (see pr for #3778) and make some txs. They should show up in the actions list. 

![ali](https://user-images.githubusercontent.com/64402732/197733452-e272b415-a769-400b-8953-4efdcd2ccfd0.png)

**Changes** 🏗

* Wire up the Actions List

Resolves #3974
