### PR TITLE
Fix Motions Query/Subscription `args` local resolver

### DIFF
--- a/src/data/generated.ts
+++ b/src/data/generated.ts
@@ -1354,6 +1354,7 @@ export type ActionsFilter = {
 export type MotionsFilter = {
   associatedColony?: Maybe<Scalars['String']>;
   extensionAddress?: Maybe<Scalars['String']>;
+  action_not?: Maybe<Scalars['String']>;
 };
 
 export type OneTxPayment = {

--- a/src/data/graphql/typeDefsSubscriptions.ts
+++ b/src/data/graphql/typeDefsSubscriptions.ts
@@ -8,6 +8,7 @@ export default gql`
   input MotionsFilter {
     associatedColony: String
     extensionAddress: String
+    action_not: String
   }
 
   type OneTxPayment {

--- a/src/data/resolvers/motions.ts
+++ b/src/data/resolvers/motions.ts
@@ -1198,10 +1198,17 @@ export const motionsResolvers = ({
           actionValues.args[6],
         );
 
-        const tokenClient = await colonyManager.getTokenClient(
-          actionValues.args[8],
-        );
-        const tokenInfo = await tokenClient.getTokenInfo();
+        let tokenSymbol = DEFAULT_NETWORK_TOKEN.symbol;
+        let tokenDecimals = DEFAULT_NETWORK_TOKEN.decimals;
+
+        if (actionValues.args[8] !== AddressZero) {
+          const tokenClient = await colonyManager.getTokenClient(
+            actionValues.args[8],
+          );
+          const tokenInfo = await tokenClient.getTokenInfo();
+          tokenSymbol = tokenInfo.symbol;
+          tokenDecimals = tokenInfo.decimals;
+        }
 
         return {
           amount: actionValues.args[7].toString(),
@@ -1209,8 +1216,8 @@ export const motionsResolvers = ({
           toDomain: toDomain.toNumber(),
           token: {
             id: actionValues.args[8],
-            symbol: tokenInfo.symbol,
-            decimals: tokenInfo.decimals,
+            symbol: tokenSymbol,
+            decimals: tokenDecimals,
           },
         };
       }
@@ -1239,7 +1246,7 @@ export const motionsResolvers = ({
       }
 
       if (actionValues.name === ColonyMotionActionName.CreateDecision) {
-        return actionValues.args[0];
+        return defaultValues;
       }
 
       if (
@@ -1270,6 +1277,7 @@ export const motionsResolvers = ({
         'emitDomainReputationPenalty(uint256,uint256,uint256,address,int256)'
       ) {
         return {
+          ...defaultValues,
           reputationChange: actionValues?.args[4].toString(),
           recipient: actionValues?.args[3],
         };
@@ -1280,6 +1288,7 @@ export const motionsResolvers = ({
         'emitDomainReputationReward(uint256,address,int256)'
       ) {
         return {
+          ...defaultValues,
           reputationChange: actionValues?.args[2].toString(),
           recipient: actionValues?.args[1],
         };

--- a/src/modules/dashboard/components/ColonyHome/ColonyNavigation/ColonyNavigation.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonyNavigation/ColonyNavigation.tsx
@@ -1,7 +1,9 @@
 import React, { ComponentProps, useMemo } from 'react';
 import { defineMessages } from 'react-intl';
+import { VotingReputationExtensionVersion } from '@colony/colony-js';
 
 import { Colony } from '~data/index';
+import { useEnabledExtensions } from '~utils/hooks/useEnabledExtensions';
 
 import NavItem from './NavItem';
 
@@ -44,7 +46,7 @@ type Props = {
 
 const displayName = 'dashboard.ColonyHome.ColonyNavigation';
 
-const ColonyNavigation = ({ colony: { colonyName } }: Props) => {
+const ColonyNavigation = ({ colony: { colonyName, colonyAddress } }: Props) => {
   /*
    * @TODO actually determine these
    * This can be easily inferred from the subgraph queries
@@ -58,19 +60,23 @@ const ColonyNavigation = ({ colony: { colonyName } }: Props) => {
   const hasNewDecisions = false;
   const hasNewExtensions = false;
 
+  const {
+    isVotingExtensionEnabled,
+    votingExtensionVersion,
+  } = useEnabledExtensions({ colonyAddress });
+
+  const decisionsSupported =
+    isVotingExtensionEnabled &&
+    votingExtensionVersion &&
+    votingExtensionVersion >=
+      VotingReputationExtensionVersion.GreenLightweightSpaceship;
+
   const items = useMemo<ComponentProps<typeof NavItem>[]>(() => {
     const navigationItems: ComponentProps<typeof NavItem>[] = [
       {
         linkTo: `/colony/${colonyName}`,
         showDot: hasNewActions,
         text: MSG.linkTextActions,
-      },
-      {
-        exact: false,
-        linkTo: `/colony/${colonyName}/decisions`,
-        showDot: hasNewDecisions,
-        text: MSG.linkTextDecisions,
-        dataTest: 'decisionsNavigationButton',
       },
       {
         exact: false,
@@ -81,8 +87,24 @@ const ColonyNavigation = ({ colony: { colonyName } }: Props) => {
       },
     ];
 
+    if (decisionsSupported) {
+      navigationItems.splice(1, 0, {
+        exact: false,
+        linkTo: `/colony/${colonyName}/decisions`,
+        showDot: hasNewDecisions,
+        text: MSG.linkTextDecisions,
+        dataTest: 'decisionsNavigationButton',
+      });
+    }
+
     return navigationItems;
-  }, [colonyName, hasNewActions, hasNewExtensions, hasNewDecisions]);
+  }, [
+    colonyName,
+    hasNewActions,
+    hasNewExtensions,
+    decisionsSupported,
+    hasNewDecisions,
+  ]);
 
   return (
     <nav role="navigation" className={styles.main}>

--- a/src/modules/dashboard/transformers/transformers.ts
+++ b/src/modules/dashboard/transformers/transformers.ts
@@ -72,7 +72,8 @@ export const getActionsListData = (
       unformattedActions?.oneTxPayments?.reduce((acc, action) => {
         if (
           installedExtensionsAddresses?.find(
-            (extensionAddress) => extensionAddress === action?.agent,
+            (extensionAddress) =>
+              extensionAddress.toLowerCase() === action?.agent?.toLowerCase(),
           )
         ) {
           return acc;

--- a/src/utils/events/index.ts
+++ b/src/utils/events/index.ts
@@ -1516,10 +1516,10 @@ export const getMotionActionType = async (
   const motion = await votingClient.getMotion(motionId);
 
   if (motion.action === '0x') {
-    return motionNameMapping[ColonyMotions.NullMotion];
+    return motionNameMapping.nullMotion;
   }
 
-  if (motion?.action === ACTION_DECISION_MOTION_CODE) {
+  if (motion.action === ACTION_DECISION_MOTION_CODE) {
     return motionNameMapping.createDecision;
   }
 


### PR DESCRIPTION
This PR fixes a issue reported in the internal `#tech-support` channel, where all motions on the `metacolony` would show up as _"forced"_ actions.

Turns out that while initially that looked so, in reality, the actions list would only show the actions triggered internally by the successful motions _(the initiator was actually the `VotingReputation` extension contract address)_

This was because the `motions` subgraph subscription (query) would fail, so the query would return an empty array. This also ties in with an implementation detail that we have, were we bring all the actions, but filter them out with the correct motions, if they were internal actions created by the extension contract. But since the dapp didn't know about any motions anymore, it would just show the actions.

Now, the `motions` query is "augmented" with a few local resolvers: `status`, `type`, `args`, etc. The `args` local resolver would fail in two places: first, if a _address null_ token was being used for a payment, second, if the return value for a simple decision was not the correct format.

Once the above two were fixed, everything started working correctly.

Besides the above, I've also put in a fix, that will prevent showing the _Simple Decisions_ Colony Home navigation entry, if the `VotingReputation` extension is not upgraded to version `7`, meaning the colony does not support them.

_Note: that this fix is already deployed into production_ 