### PR TITLE
Handle long strings in `Select` component

### DIFF
--- a/src/modules/core/components/Fields/Select/Select.css
+++ b/src/modules/core/components/Fields/Select/Select.css
@@ -1,6 +1,5 @@
 .baseSelect {
   padding: 5px 10px;
-  width: auto;
   width: 100%;
   position: relative;
   border: 0;

--- a/src/modules/core/components/Fields/Select/SelectListBox.css
+++ b/src/modules/core/components/Fields/Select/SelectListBox.css
@@ -2,8 +2,7 @@
 .baseTheme {
   height: auto;
   max-height: 170px;
-  width: auto;
-  min-width: 100%;
+  width: 100%;
   position: absolute;
   top: calc(100% + 5px);
   z-index: var(--z-index-nav);
@@ -74,12 +73,6 @@
   transform: translate(-50%);
 }
 
-.widthFluid {
-  width: auto;
-  min-width: 100%;
-}
-
 .widthStrict {
   width: 300px;
-  min-width: auto;
 }

--- a/src/modules/core/components/Fields/Select/SelectListBox.css
+++ b/src/modules/core/components/Fields/Select/SelectListBox.css
@@ -76,3 +76,8 @@
 .widthStrict {
   width: 300px;
 }
+
+.stateUnrestrictedWidth {
+  width: auto;
+  min-width: 100%;
+}

--- a/src/modules/core/components/Fields/Select/SelectListBox.css.d.ts
+++ b/src/modules/core/components/Fields/Select/SelectListBox.css.d.ts
@@ -6,5 +6,4 @@ export const themeGrid: string;
 export const alignOptionsLeft: string;
 export const alignOptionsRight: string;
 export const alignOptionsCenter: string;
-export const widthFluid: string;
 export const widthStrict: string;

--- a/src/modules/core/components/Fields/Select/SelectListBox.css.d.ts
+++ b/src/modules/core/components/Fields/Select/SelectListBox.css.d.ts
@@ -7,3 +7,4 @@ export const alignOptionsLeft: string;
 export const alignOptionsRight: string;
 export const alignOptionsCenter: string;
 export const widthStrict: string;
+export const stateUnrestrictedWidth: string;

--- a/src/modules/core/components/Fields/Select/SelectListBox.tsx
+++ b/src/modules/core/components/Fields/Select/SelectListBox.tsx
@@ -50,14 +50,16 @@ const SelectListBox = ({
     // eslint-disable-next-line jsx-a11y/aria-activedescendant-has-tabindex
     <ul
       tabIndex={-1}
-      className={getMainClasses(appearance, styles)}
+      className={getMainClasses(appearance, styles, {
+        unrestrictedWidth: appearance?.unrestrictedOptionsWidth === 'true',
+      })}
       role="listbox"
       aria-activedescendant={getOptionId(name, activeDescendantIdx)}
       id={listboxId}
     >
       {options.map((option, idx) => (
         <SelectOption
-          bordered={appearance ? appearance.borderedOptions === 'true' : false}
+          bordered={appearance?.borderedOptions === 'true'}
           id={getOptionId(name, idx)}
           idx={idx}
           key={getOptionId(name, idx)}

--- a/src/modules/core/components/Fields/Select/types.ts
+++ b/src/modules/core/components/Fields/Select/types.ts
@@ -13,6 +13,7 @@ export interface Appearance {
   size?: DropdownSize;
   theme?: 'default' | 'alt' | 'grey' | 'grid';
   width?: 'content' | 'fluid' | 'strict';
+  unrestrictedOptionsWidth?: 'true' | 'false';
 }
 
 export interface SelectOption {

--- a/src/modules/core/components/Fields/SelectOption/SelectOption.css
+++ b/src/modules/core/components/Fields/SelectOption/SelectOption.css
@@ -50,9 +50,14 @@
   line-height: 32px;
 }
 
-.value {
+.labelContainer {
+  display: flex;
+  align-items: baseline;
+}
+
+.label {
   composes: inlineEllipsis from '~styles/text.css';
-  display: block;
+  flex-shrink: 1;
 }
 
 @media screen and query700 {

--- a/src/modules/core/components/Fields/SelectOption/SelectOption.css.d.ts
+++ b/src/modules/core/components/Fields/SelectOption/SelectOption.css.d.ts
@@ -4,4 +4,5 @@ export const checkedMsg: string;
 export const selectedHelpText: string;
 export const stateBordered: string;
 export const stateIsBasicLabel: string;
-export const value: string;
+export const labelContainer: string;
+export const label: string;

--- a/src/modules/core/components/Fields/SelectOption/SelectOption.tsx
+++ b/src/modules/core/components/Fields/SelectOption/SelectOption.tsx
@@ -105,19 +105,18 @@ const SelectOption = ({
       onMouseEnter={handleItemSelect}
       data-checked={checked}
       data-test={dataTest}
+      title={label}
     >
-      <span title={label} className={styles.value}>
-        {option.children || (
-          <>
-            {label}
-            {checked && (
-              <small className={styles.selectedHelpText}>
-                ({formatMessage(MSG.selectedLabelHelp)})
-              </small>
-            )}
-          </>
-        )}
-      </span>
+      {option.children || (
+        <div className={styles.labelContainer}>
+          <span className={styles.label}>{label}</span>
+          {checked && (
+            <small className={styles.selectedHelpText}>
+              ({formatMessage(MSG.selectedLabelHelp)})
+            </small>
+          )}
+        </div>
+      )}
     </li>
   );
 };

--- a/src/modules/dashboard/components/ColonyActions/ColonyActions.tsx
+++ b/src/modules/dashboard/components/ColonyActions/ColonyActions.tsx
@@ -287,7 +287,11 @@ const ColonyActions = ({
             >
               <div className={styles.filter}>
                 <Select
-                  appearance={{ alignOptions: 'left', theme: 'alt' }}
+                  appearance={{
+                    alignOptions: 'left',
+                    theme: 'alt',
+                    unrestrictedOptionsWidth: 'true',
+                  }}
                   elementOnly
                   label={MSG.labelFilter}
                   name="filter"

--- a/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
+++ b/src/modules/dashboard/components/ColonyDecisions/ColonyDecisions.tsx
@@ -180,7 +180,11 @@ const ColonyDecisions = ({
             >
               <div className={styles.filter}>
                 <Select
-                  appearance={{ alignOptions: 'left', theme: 'alt' }}
+                  appearance={{
+                    alignOptions: 'left',
+                    theme: 'alt',
+                    unrestrictedOptionsWidth: 'true',
+                  }}
                   elementOnly
                   label={MSG.labelFilter}
                   name="filter"

--- a/src/modules/dashboard/components/ColonyEvents/ColonyEvents.tsx
+++ b/src/modules/dashboard/components/ColonyEvents/ColonyEvents.tsx
@@ -138,7 +138,11 @@ const ColonyEvents = ({
         >
           <div className={styles.filter}>
             <Select
-              appearance={{ alignOptions: 'left', theme: 'alt' }}
+              appearance={{
+                alignOptions: 'left',
+                theme: 'alt',
+                unrestrictedOptionsWidth: 'true',
+              }}
               elementOnly
               label={MSG.labelFilter}
               name="filter"

--- a/src/modules/dashboard/components/ColonyFunding/ColonyFunding.tsx
+++ b/src/modules/dashboard/components/ColonyFunding/ColonyFunding.tsx
@@ -149,6 +149,7 @@ const ColonyFunding = ({ match }: Props) => {
                     alignOptions: 'right',
                     width: 'content',
                     theme: 'alt',
+                    unrestrictedOptionsWidth: 'true',
                   }}
                   elementOnly
                   label={MSG.labelSelectDomain}

--- a/src/modules/dashboard/components/Members/MembersTitle.tsx
+++ b/src/modules/dashboard/components/Members/MembersTitle.tsx
@@ -114,6 +114,7 @@ const MembersTitle = ({
                   alignOptions: 'right',
                   size: 'mediumLarge',
                   theme: 'alt',
+                  unrestrictedOptionsWidth: 'true',
                 }}
                 elementOnly
                 label={MSG.labelFilter}


### PR DESCRIPTION
## Description

This PR adds a little fix to correctly apply ellipsis overflow to Select options:
<img width="485" alt="Screenshot 2022-10-25 at 19 46 57" src="https://user-images.githubusercontent.com/112586815/197857646-90d38116-e8d7-4a2b-8c26-58dc73ec5b9c.png">

I have checked that it doesn't impact any Select that it shouldn't but would appreciate if you double check that.

Resolves #3991 