### PR TITLE
Hide loading spinner in contract interaction when returning from preview

### DIFF
--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
@@ -328,6 +328,7 @@ const ControlSafeForm = ({
             handleValidation={handleValidation}
             handleInputChange={handleInputChange}
             removeSelectedContractMethod={removeSelectedContractMethod}
+            isValid={isValid}
           />
         );
       case TransactionTypes.TRANSFER_NFT:

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/ContractInteractionSection.tsx
@@ -83,7 +83,7 @@ interface Props
       FormProps,
       'safes' | 'selectedContractMethods' | 'handleSelectedContractMethods'
     >,
-    Pick<FormikProps<FormValues>, 'setFieldValue' | 'values'>,
+    Pick<FormikProps<FormValues>, 'setFieldValue' | 'values' | 'isValid'>,
     Omit<TransactionSectionProps, 'colony'> {
   removeSelectedContractMethod: (index: number) => void;
 }
@@ -105,6 +105,7 @@ const ContractInteractionSection = ({
   handleValidation,
   handleInputChange,
   removeSelectedContractMethod,
+  isValid,
 }: Props) => {
   const { formatMessage } = useIntl();
 
@@ -292,7 +293,8 @@ const ContractInteractionSection = ({
     handleValidation,
   ]);
 
-  if (isLoadingABI) {
+  // Ensures spinner doesn't show up when returning back from Preview
+  if (isLoadingABI && !isValid) {
     return <Loading message={MSG.loadingContract} />;
   }
 

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransferNFTSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransferNFTSection.tsx
@@ -115,7 +115,7 @@ const TransferNFTSection = ({
   );
 
   /*
-   * So the form shows loading spinner when entering from main menu
+   * So the form shows loading spinner immediately when entering from main menu
    * but not when clicking "back" from preview
    */
   const isFirstFetch = safe && !availableNFTs && !nftError && !selectedNFTData;


### PR DESCRIPTION
## Description

This small fix ensures the loading spinner does not show up when returning back from the Preview to the Contract Interaction section.

**Changes** 🏗

* Don't show spinner if form is valid.

Resolves #4029 
