### PR TITLE
Implement placeholder as fallback in avatar component

### DIFF
--- a/src/modules/core/components/Avatar/Avatar.tsx
+++ b/src/modules/core/components/Avatar/Avatar.tsx
@@ -42,7 +42,8 @@ const Avatar = ({
   size,
   title,
 }: Props) => {
-  const avatar = notSet ? null : avatarURL || getIcon(seed || title);
+  const fallback = getIcon(seed || title);
+  const avatar = notSet ? null : avatarURL || fallback;
   const mainClass = size ? styles[size] : styles.main;
   if (children) {
     return (
@@ -57,7 +58,7 @@ const Avatar = ({
 
   const imageStyle: CSSProperties = avatar
     ? {
-        backgroundImage: `url(${avatar})`,
+        backgroundImage: `url(${avatar}), url(${fallback})`,
         // if using a blockie, do pixelated image scaling
         imageRendering: avatarURL ? undefined : 'pixelated',
       }


### PR DESCRIPTION
## Description

This PR implements a fallback in the Avatar component in the event that the specified url cannot be accessed. 

**Changes** 🏗

* Set blockie data url as fallback in case resource fetching fails. 

## Screenshot

See the final line. The blockie next to the NFT name is the fallback that is being rendered because the main resource fetch is failing. Previously, nothing was being displayed.

![blockiefallback](https://user-images.githubusercontent.com/64402732/198275618-b9775d1c-40ec-4ab7-af45-b50c773b04fb.png)

## Testing
1. set up bridging environment (see #3778)
2. Add this safe: 
address: 0x3F107AFF0342Cfb5519A68B3241565F6FC9BAC1e
module: 0xe7918E26db8eD038dF7a1933312872718DaBdD9C
3. Transfer NFT

Currently, the resource fetch is failing (captured here https://github.com/JoinColony/colonyDapp/issues/4038). This, however, is a positive coincidence for the purpose of this issue, as we can see the fallback working correctly. 

Resolves #3973
