### PR TITLE
Fix validation edge cases

### DIFF
--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeDialog.tsx
@@ -35,8 +35,8 @@ export interface SafeTransaction {
   nft: SelectedNFT | null;
   nftData: NFT | null;
   tokenData: SafeBalanceToken | null;
-  amount: number | null;
-  rawAmount: number | null;
+  amount: string | null;
+  rawAmount: string | null;
   data: string;
   contract: AnyUser | null;
   abi: string;

--- a/src/modules/dashboard/sagas/utils/safeHelpers.ts
+++ b/src/modules/dashboard/sagas/utils/safeHelpers.ts
@@ -192,9 +192,13 @@ export const getRawTransactionData = (
     throw new Error('Transaction does not contain a recipient.');
   }
 
+  if (transaction.rawAmount === null) {
+    throw new Error('Transaction does not contain an amount');
+  }
+
   return zodiacBridgeModule.interface.functions.executeTransaction.encode([
     transaction.recipient.profile.walletAddress,
-    Number(transaction.rawAmount),
+    transaction.rawAmount,
     transaction.data,
     0,
   ]);
@@ -277,9 +281,9 @@ export const getTransferFundsData = async (
   const isSafeNativeToken = tokenAddress === AddressZero;
   const tokenDecimals = transaction.tokenData.decimals;
   const { recipient } = transaction;
-  const getAmount = (): number => {
+  const getAmount = (): number | string => {
     if (isSafeNativeToken) {
-      return moveDecimal(transaction.amount, tokenDecimals);
+      return moveDecimal(transaction.amount, tokenDecimals); // moveDecimal returns a string
     }
     return 0;
   };

--- a/src/utils/safes/contractParserValidation.ts
+++ b/src/utils/safes/contractParserValidation.ts
@@ -102,10 +102,10 @@ const isValueArray = (value: string) => {
   return value[0] === '[' && value[value.length - 1] === ']';
 };
 
-const getBytesArrayLength = (input: string) => {
-  let bytes = input.substring(5);
+const getBytesStringLength = (inputType: string) => {
+  let bytes = inputType.substring(5);
   /* "Prior to version 0.8.0, byte used to be an alias for bytes1." https://docs.soliditylang.org/en/v0.8.12/types.html */
-  if (bytes === '') {
+  if (inputType === 'byte') {
     bytes = '1';
   }
 
@@ -115,11 +115,21 @@ const getBytesArrayLength = (input: string) => {
   return prefix + length;
 };
 
-const isByteArrayValid = (value: string, inputType: string) => {
+const isByteStringValid = (value: string, inputType: string) => {
   if (!isHexString(value)) {
     return false;
   }
-  return value.length === getBytesArrayLength(inputType);
+
+  const isFixedLength = inputType !== 'bytes';
+
+  if (isFixedLength) {
+    return value.length === getBytesStringLength(inputType);
+  }
+
+  /*
+   * A dynamically sized byte array can be of arbitrary length. But it must have an even number of characters.
+   */
+  return value.length % 2 === 0;
 };
 
 const isValidBoolean = (value: string) => {
@@ -143,7 +153,7 @@ const typeFunctionMap: {
   uint: isUintSafe,
   int: isIntSafe,
   address: isAddressValid,
-  byte: isByteArrayValid,
+  byte: isByteStringValid,
   bool: isValidBoolean,
   string: isValidString,
 };


### PR DESCRIPTION
## Description

This PR fixes a couple of bugs in the Safe Control validation.

First, in the Contract Interaction section, dynamically-sized byte arrays were defaulting to bytes1 arrays, when actually, their size is arbitrary. 

Second, in the Raw Transaction section, inputting a wei amount over the max safe integer was causing ethers to error because the string was being coerced into a `number`. We can just pass it straight through as a string. 

**Changes** 🏗

* Add validation for dynamically sized byte arrays. 

Resolves #4042
