### PR TITLE
Fix amount flashing in Safe Transaction Preview

### DIFF
--- a/src/modules/core/components/Numeral/Numeral.tsx
+++ b/src/modules/core/components/Numeral/Numeral.tsx
@@ -57,19 +57,30 @@ const Numeral = ({
     mantissa,
     totalLength,
   });
+  const prefixStr = prefix ? `${prefix} ` : '';
+  const suffixStr = suffix ? ` ${suffix}` : '';
+  const fullNumber = `${prefixStr}${formattedNumber}${suffixStr}`;
 
   useEffect(() => {
     if (outputRef.current) {
-      const prefixStr = prefix ? `${prefix} ` : '';
-      const suffixStr = suffix ? ` ${suffix}` : '';
-      outputRef.current.innerHTML = `${prefixStr}${formattedNumber}${suffixStr}`;
+      outputRef.current.innerHTML = fullNumber;
     }
-  }, [outputRef, formattedNumber, prefix, suffix]);
+  }, [outputRef, fullNumber]);
 
   const classNames = className
     ? `${styles.numeral} ${className}`
     : `${styles.numeral} ${getMainClasses(appearance, styles)}`;
-  return <span className={classNames} {...props} ref={outputRef} />;
+
+  // if display formatter returns engineering notation
+  if (formattedNumber.includes('<sup>')) {
+    return <span className={classNames} {...props} ref={outputRef} />;
+  }
+
+  return (
+    <span className={classNames} {...props}>
+      {fullNumber}
+    </span>
+  );
 };
 
 export default Numeral;


### PR DESCRIPTION
## Description

This PR implements a fix for the amount flashing in the Safe Transaction Preview. See the issue for an example of the problem.

It's an intentionally "quick and easy" fix. I envisioned the problem being fixed by https://github.com/JoinColony/colonyDapp/pull/3922, however, since it's been closed in favour of focusing on the CDapp, I've implemented something simple that solves the problem without impeding the display of engineering notation in other parts of the Dapp.

## To test

Go to safe control.
Select transfer funds and go to preview. 
No amount of moving to / from preview or inputting into the preview's inputs should cause any flashing in the amount line.

Numeral component should not be broken in any other part of the dapp.

**Changes** 🏗

* Only run the effect if we need to render the `<sup>` tags (as is the case only when displaying engineering notation). This is the only example I could see of the number formatter returning an html string.

Resolves #4049
