### PR TITLE
Don't abbreviate numbers less than 7 digits

### DIFF
--- a/src/modules/core/components/Numeral/Numeral.tsx
+++ b/src/modules/core/components/Numeral/Numeral.tsx
@@ -27,9 +27,6 @@ export interface Props extends HTMLAttributes<HTMLSpanElement> {
   /** Number of mantissa digits to show */
   mantissa?: number;
 
-  /** Total length of number to show */
-  totalLength?: number;
-
   /** Number of decimals to format the number with, or unit from which to determine this (ether, gwei, etc.) */
   unit?: number | string;
 
@@ -43,7 +40,6 @@ const Numeral = ({
   prefix,
   suffix,
   mantissa,
-  totalLength,
   unit,
   value,
   ...props
@@ -55,7 +51,6 @@ const Numeral = ({
     unit,
     value,
     mantissa,
-    totalLength,
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Description

This PR prevents numbers with less than 7 digits from being abbreviated:
<img width="262" alt="Screenshot 2022-11-02 at 11 20 46" src="https://user-images.githubusercontent.com/112586815/199478439-3a3ea8f0-39d6-4ba3-8bbf-bcbeea7e9812.png">

**Changes** 🏗

* New format config for medium numbers (1,000-999,999)
* Removed `totalLength` prop from formatting function and `Numeral` component. It makes more sense to control the precision of a number by setting its mantissa length rather than to restrict it by total length.

Resolves #4051 