### PR TITLE
Fix checkbox component

### DIFF
--- a/src/modules/core/components/Fields/Checkbox/Checkbox.tsx
+++ b/src/modules/core/components/Fields/Checkbox/Checkbox.tsx
@@ -8,7 +8,6 @@ import React, {
 } from 'react';
 import { MessageDescriptor } from 'react-intl';
 import { nanoid } from 'nanoid';
-import findIndex from 'lodash/findIndex';
 
 import { PopperOptions } from 'react-popper-tooltip';
 
@@ -17,6 +16,7 @@ import { Tooltip } from '~core/Popover';
 import asFieldArray from '~core/Fields/asFieldArray';
 import { SimpleMessageValues } from '~types/index';
 import { getMainClasses } from '~utils/css';
+import { isEqual, findIndex } from '~utils/lodash';
 
 import styles from './Checkbox.css';
 
@@ -91,10 +91,11 @@ const Checkbox = ({
   showTooltipText,
 }: Props) => {
   const [inputId] = useState<string>(nanoid());
+  const findIndexPredicate = (val: any) => isEqual(val, value);
 
   const handleOnChange = useCallback(
     (e: SyntheticEvent<HTMLInputElement>) => {
-      const idx = findIndex(values[name], value);
+      const idx = findIndex(values[name], findIndexPredicate);
       if (idx >= 0) {
         remove(idx.toString());
       } else {
@@ -104,10 +105,10 @@ const Checkbox = ({
         onChange({ ...e, isChecked: !(idx >= 0) });
       }
     },
-    [name, onChange, push, remove, value, values],
+    [name, onChange, push, remove, value, values, findIndexPredicate],
   );
 
-  const isChecked = findIndex(values[name], value) >= 0;
+  const isChecked = findIndex(values[name], findIndexPredicate) >= 0;
   const mainClasses = getMainClasses(appearance, styles, {
     isChecked,
     disabled,

--- a/src/modules/core/components/Fields/Checkbox/Checkbox.tsx
+++ b/src/modules/core/components/Fields/Checkbox/Checkbox.tsx
@@ -5,6 +5,7 @@ import React, {
   useCallback,
   useMemo,
   useEffect,
+  ComponentType,
 } from 'react';
 import { MessageDescriptor } from 'react-intl';
 import { nanoid } from 'nanoid';
@@ -13,7 +14,9 @@ import { PopperOptions } from 'react-popper-tooltip';
 
 import InputLabel from '~core/Fields/InputLabel';
 import { Tooltip } from '~core/Popover';
-import asFieldArray from '~core/Fields/asFieldArray';
+import asFieldArray, {
+  AsFieldArrayEnhancedProps,
+} from '~core/Fields/asFieldArray';
 import { SimpleMessageValues } from '~types/index';
 import { getMainClasses } from '~utils/css';
 import { isEqual, findIndex } from '~utils/lodash';
@@ -33,7 +36,7 @@ interface Props {
   /** Additional className for customizing styles */
   className?: string;
   /** Disable the input */
-  disabled: boolean;
+  disabled?: boolean;
   /** Display the element without label */
   elementOnly?: boolean;
   /** Help text (will appear next to label text) */
@@ -41,7 +44,7 @@ interface Props {
   /** Values for help text (react-intl interpolation) */
   helpValues?: SimpleMessageValues;
   /** Label text */
-  label: string | MessageDescriptor;
+  label?: string | MessageDescriptor;
   /** Values for label text (react-intl interpolation) */
   labelValues?: SimpleMessageValues;
   /** Input field name (form variable) */
@@ -50,19 +53,14 @@ interface Props {
   onChange?: Function;
   /** Just to check what is a default value of checkbox */
   getDefaultValue?: Function;
-  /** Input field value */
-  value: string;
-  showTooltipText: boolean;
+  /** Value to be added/removed from fieldArray */
+  value: any;
+  /** Tooltip text visibility */
+  showTooltipText?: boolean;
   /**  Text for the checkbox tooltip */
   tooltipText?: string;
   /** Options to pass to the underlying PopperJS element. See here for more: https://popper.js.org/docs/v2/constructors/#options. */
   tooltipPopperOptions?: PopperOptions;
-  /** @ignore injected by `asFieldArray` */
-  form: { [s: string]: any };
-  /** @ignore injected by `asFieldArray` */
-  push: (value: string) => void;
-  /** @ignore injected by `asFieldArray` */
-  remove: (value: string) => void;
   dataTest?: string;
 }
 
@@ -72,32 +70,33 @@ const Checkbox = ({
   appearance,
   children,
   className,
-  disabled,
-  elementOnly,
-  form: { values },
+  disabled = false,
+  elementOnly = false,
   help,
   helpValues,
   label,
   labelValues,
   name,
   onChange,
-  push,
-  remove,
   value,
   tooltipText,
   tooltipPopperOptions,
   dataTest,
   getDefaultValue,
   showTooltipText,
-}: Props) => {
+  /* Injected by asFieldArray */
+  form: { values },
+  push,
+  remove,
+}: AsFieldArrayEnhancedProps<Props>) => {
   const [inputId] = useState<string>(nanoid());
-  const findIndexPredicate = (val: any) => isEqual(val, value);
+  const equalsValue = useCallback((val: any) => isEqual(val, value), [value]);
 
   const handleOnChange = useCallback(
     (e: SyntheticEvent<HTMLInputElement>) => {
-      const idx = findIndex(values[name], findIndexPredicate);
+      const idx = findIndex(values[name], equalsValue);
       if (idx >= 0) {
-        remove(idx.toString());
+        remove(idx);
       } else {
         push(value);
       }
@@ -105,10 +104,10 @@ const Checkbox = ({
         onChange({ ...e, isChecked: !(idx >= 0) });
       }
     },
-    [name, onChange, push, remove, value, values, findIndexPredicate],
+    [name, onChange, push, remove, value, values, equalsValue],
   );
 
-  const isChecked = findIndex(values[name], findIndexPredicate) >= 0;
+  const isChecked = findIndex(values[name], equalsValue) >= 0;
   const mainClasses = getMainClasses(appearance, styles, {
     isChecked,
     disabled,
@@ -185,4 +184,4 @@ Checkbox.defaultProps = {
   showTooltipText: false,
 };
 
-export default asFieldArray()(Checkbox);
+export default asFieldArray()(Checkbox) as ComponentType<Props>;

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/SafeListItem.tsx
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/SafeListItem.tsx
@@ -38,7 +38,7 @@ const SafeListItem = ({ safe, isChecked }: Props) => {
     >
       <Checkbox
         name="safeList"
-        appearance={{ theme: 'pink' }}
+        appearance={{ theme: 'pink', direction: 'vertical' }}
         value={safe}
         className={styles.checkbox}
       />

--- a/src/utils/lodash/index.ts
+++ b/src/utils/lodash/index.ts
@@ -3,5 +3,6 @@ import omit from 'lodash/omit';
 import isEqual from 'lodash/isEqual';
 import isNil from 'lodash/isNil';
 import isEmpty from 'lodash/isEmpty';
+import findIndex from 'lodash/findIndex';
 
-export { debounce, omit, isEqual, isNil, isEmpty };
+export { debounce, omit, isEqual, isNil, isEmpty, findIndex };


### PR DESCRIPTION
## Description

This PR fixes a regression introduced into the Checkbox component. Checkmarks were not displaying correctly (see issue).

It also fixes the typings in the Checkbox component, as previously its props were losing their types after it was returned from the `asFieldArray` hoc.

**Changes** 🏗

* Use `isEqual` in the `findIndex` predicate to ensure that `findIndex` handles both object and non-object value types predictably.

Resolves #4053

## To test

You can check the following places where the Checkbox component is used:
- RemoveSafe dialog (safe control)
- Manage user permissions (members section)
- Manage whitelisted addreses (members section)
- Manage tokens (funds section)

Checkmark should toggle when checkbox is clicked.

## GIF
![checkbox](https://user-images.githubusercontent.com/64402732/199724349-07486adc-9668-4a8d-a703-553ed447ca59.gif)
