### PR TITLE
Update staking tooltip message

### DIFF
--- a/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/GroupedTotalStake.tsx
+++ b/src/modules/dashboard/components/ActionsPage/TotalStakeWidget/GroupedTotalStake.tsx
@@ -54,7 +54,7 @@ const MSG = defineMessages({
   },
   totalStakeTooltip: {
     id: `dashboard.ActionsPage.TotalStakeWidget.GroupedTotalStake.totalStakeTooltip`,
-    defaultMessage: `[TO BE ADDED WHEN AVAILABLE]`,
+    defaultMessage: `The total staked amount and weight for each side of the Motion.`,
   },
   nextButton: {
     id: `dashboard.ActionsPage.TotalStakeWidget.GroupedTotalStake.nextButton`,


### PR DESCRIPTION
## Description

Noticed the staking tooltip message needed updating when reviewing the safe transaction motion page in Safe control. See issue for before.

![tt](https://user-images.githubusercontent.com/64402732/200024005-8d1689cd-2943-41ef-a205-d4edf300e033.png)

Resolves #4055
