### PR TITLE
change location of the "Another token" button

### DIFF
--- a/src/modules/dashboard/components/ExpenditurePage/Recipient/Recipient.css
+++ b/src/modules/dashboard/components/ExpenditurePage/Recipient/Recipient.css
@@ -1,5 +1,3 @@
-@value buttonMargin: 7px 0 0 0;
-
 .singleUserContainer {
   padding: 6px 0;
 }
@@ -148,4 +146,19 @@
 .inputContainer input {
   padding: 20px 0 4px;
   height: 42px;
+}
+
+.labelWrapper {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.labelWrapper button {
+  bottom: 0;
+}
+
+.labelWrapper label {
+  margin-right: 14px;
+  width: auto;
 }

--- a/src/modules/dashboard/components/ExpenditurePage/Recipient/Recipient.css.d.ts
+++ b/src/modules/dashboard/components/ExpenditurePage/Recipient/Recipient.css.d.ts
@@ -1,4 +1,3 @@
-export const buttonMargin: string;
 export const singleUserContainer: string;
 export const formContainer: string;
 export const marginBottom: string;
@@ -14,3 +13,4 @@ export const questionIcon: string;
 export const tooltip: string;
 export const tooltipDescription: string;
 export const error: string;
+export const labelWrapper: string;

--- a/src/modules/dashboard/components/ExpenditurePage/Recipient/Recipient.tsx
+++ b/src/modules/dashboard/components/ExpenditurePage/Recipient/Recipient.tsx
@@ -5,7 +5,13 @@ import { defineMessages, FormattedMessage } from 'react-intl';
 import classNames from 'classnames';
 
 import Button from '~core/Button';
-import { FormSection, Input, Select, TokenSymbolSelector } from '~core/Fields';
+import {
+  FormSection,
+  Input,
+  InputLabel,
+  Select,
+  TokenSymbolSelector,
+} from '~core/Fields';
 import Icon from '~core/Icon';
 import { ItemDataType } from '~core/OmniPicker';
 import { Tooltip } from '~core/Popover';
@@ -133,13 +139,33 @@ const Recipient = ({
                 {tokens?.map((token, idx) => (
                   <div className={styles.valueContainer} key={token.id}>
                     <div className={styles.inputContainer}>
+                      <div className={styles.labelWrapper}>
+                        <InputLabel label={MSG.valueLabel} />
+                        {idx === 0 && (
+                          <Button
+                            type="button"
+                            onClick={() => {
+                              arrayHelpers.push({
+                                ...newTokenData,
+                                id: nanoid(),
+                              });
+                              setFieldTouched(
+                                `recipients[${index}].value[${idx + 1}].amount`,
+                              );
+                            }}
+                            appearance={{ theme: 'blue' }}
+                          >
+                            <FormattedMessage {...MSG.addTokenText} />
+                          </Button>
+                        )}
+                      </div>
                       <Input
                         name={`recipients[${index}].value[${idx}].amount`}
                         appearance={{
                           theme: 'underlined',
                           size: 'small',
                         }}
-                        label={MSG.valueLabel}
+                        label=""
                         placeholder="Not set"
                         formattingOptions={{
                           numeral: true,
@@ -175,25 +201,6 @@ const Recipient = ({
                           elementOnly
                         />
                       </div>
-                      {/* if last */}
-                      {tokens.length === idx + 1 && (
-                        <Button
-                          type="button"
-                          onClick={() => {
-                            arrayHelpers.push({
-                              ...newTokenData,
-                              id: nanoid(),
-                            });
-                            setFieldTouched(
-                              `recipients[${index}].value[${idx + 1}].amount`,
-                            );
-                          }}
-                          appearance={{ theme: 'blue' }}
-                          style={{ margin: styles.buttonMargin }}
-                        >
-                          <FormattedMessage {...MSG.addTokenText} />
-                        </Button>
-                      )}
                     </div>
                   </div>
                 ))}


### PR DESCRIPTION
## Description

In this PR changed location of the Another token button. For "Advanced" and "Streaming" payment types, the placement is now the same - in the upper part, next to the label.


<img width="411" alt="Screenshot 2022-11-14 at 22 49 52" src="https://user-images.githubusercontent.com/91876137/201775282-128124cf-bab9-4b71-a5e0-d85bf7cd67ec.png">
<img width="418" alt="Screenshot 2022-11-14 at 22 50 20" src="https://user-images.githubusercontent.com/91876137/201775338-d63af80f-db3d-42df-9078-a23bf898e715.png">

[Figma link](https://www.figma.com/file/dCtvv76S8mk5HNApjwmBto/Expenditures?node-id=5740%3A333993&t=ibuKvrXgtHC1QGSt-0)


Resolves  #4046
