### PR TITLE
Rename expenditure option to "Multiple"

### DIFF
--- a/src/modules/dashboard/components/ExpenditurePage/ExpenditureSettings/ExpenditureSettings.tsx
+++ b/src/modules/dashboard/components/ExpenditurePage/ExpenditureSettings/ExpenditureSettings.tsx
@@ -28,9 +28,9 @@ export const MSG = defineMessages({
     id: 'dashboard.ExpenditurePage.ExpenditureSettings.owner',
     defaultMessage: 'Owner',
   },
-  advancedPayment: {
-    id: 'dashboard.ExpenditurePage.ExpenditureSettings.advancedPayment',
-    defaultMessage: 'Advanced payment',
+  multiple: {
+    id: 'dashboard.ExpenditurePage.ExpenditureSettings.multiple',
+    defaultMessage: 'Multiple',
   },
   staged: {
     id: 'dashboard.ExpenditurePage.ExpenditureSettings.staged',
@@ -52,7 +52,7 @@ export const MSG = defineMessages({
 
 const expenditureTypes = [
   {
-    label: MSG.advancedPayment,
+    label: MSG.multiple,
     value: ExpenditureTypes.Advanced,
   },
   {

--- a/src/modules/pages/components/ExpenditurePage/types.ts
+++ b/src/modules/pages/components/ExpenditurePage/types.ts
@@ -12,7 +12,7 @@ import { Batch as BatchType } from '~dashboard/ExpenditurePage/Batch/types';
 import { Streaming as StreamingType } from '~dashboard/ExpenditurePage/Streaming/types';
 
 export enum ExpenditureTypes {
-  Advanced = 'advanced',
+  Advanced = 'multiple',
   Split = 'split',
   Staged = 'staged',
   Batch = 'batch',


### PR DESCRIPTION
## Description

In this PR the "Advanced" payment option has been renamed to "Multiple".


<img width="629" alt="Screenshot 2022-11-14 at 23 49 11" src="https://user-images.githubusercontent.com/91876137/201784361-048145e0-4b01-4557-a941-03c225d0fd32.png">


Resolves  #4047
