### PR TITLE
Remove scrollbar from expenditure dropdown

### DIFF
--- a/src/modules/core/components/Fields/Select/Select.tsx
+++ b/src/modules/core/components/Fields/Select/Select.tsx
@@ -13,6 +13,7 @@ import { nanoid } from 'nanoid';
 
 import { getMainClasses } from '~utils/css';
 import { DOWN, ENTER, ESC, SimpleMessageValues, SPACE, UP } from '~types/index';
+import Dropdown from '~core/UserPickerWithSearch/Dropdown';
 
 import SelectListBox from './SelectListBox';
 import { Appearance, SelectOption } from './types';
@@ -21,7 +22,6 @@ import InputStatus from '../InputStatus';
 import Icon from '../../Icon';
 
 import styles from './Select.css';
-import Dropdown from '~core/UserPickerWithSearch/Dropdown';
 
 const MSG = defineMessages({
   expandIconHTMLTitle: {
@@ -94,6 +94,7 @@ export interface Props {
   optionSizeLarge?: boolean;
   hasBlueActiveState?: boolean;
   dropdownHeight?: number;
+  autoHeight?: boolean;
 }
 
 const displayName = 'Select';
@@ -123,6 +124,7 @@ const Select = ({
   optionSizeLarge,
   hasBlueActiveState,
   dropdownHeight,
+  autoHeight = false,
 }: Props) => {
   const [id] = useState<string>(idProp || nanoid());
   const [, { error, value }, { setValue }] = useField(name);
@@ -354,6 +356,7 @@ const Select = ({
                 optionSizeLarge={optionSizeLarge}
                 hasBlueActiveState={hasBlueActiveState}
                 dropdownHeight={dropdownHeight}
+                autoHeight={autoHeight}
               >
                 <SelectListBox
                   checkedOption={checkedOption}

--- a/src/modules/core/components/Fields/Select/SelectHorizontal.tsx
+++ b/src/modules/core/components/Fields/Select/SelectHorizontal.tsx
@@ -18,6 +18,7 @@ interface Props extends SelectProps {
   scrollContainer?: HTMLElement | null;
   placement?: 'bottom' | 'right';
   hasBlueActiveState?: boolean;
+  autoHeight?: boolean;
 }
 
 const SelectHorizontal = ({
@@ -26,6 +27,7 @@ const SelectHorizontal = ({
   withDropdownElement,
   scrollContainer,
   placement,
+  autoHeight,
   ...selectProps
 }: Props) => {
   const {
@@ -72,6 +74,7 @@ const SelectHorizontal = ({
             placement,
             hasBlueActiveState,
             dropdownHeight,
+            autoHeight,
             ...selectProps,
           }}
           elementOnly

--- a/src/modules/core/components/UserPickerWithSearch/Dropdown.css
+++ b/src/modules/core/components/UserPickerWithSearch/Dropdown.css
@@ -3,6 +3,10 @@
   position: absolute;
 }
 
+.autoHeight ul {
+  max-height: unset;
+}
+
 .optionSizeLarge li {
   min-height: 40px;
   line-height: 40px;

--- a/src/modules/core/components/UserPickerWithSearch/Dropdown.css.d.ts
+++ b/src/modules/core/components/UserPickerWithSearch/Dropdown.css.d.ts
@@ -1,3 +1,4 @@
 export const dropdown: string;
+export const autoHeight: string;
 export const optionSizeLarge: string;
 export const hasBlueActiveState: string;

--- a/src/modules/core/components/UserPickerWithSearch/Dropdown.tsx
+++ b/src/modules/core/components/UserPickerWithSearch/Dropdown.tsx
@@ -19,6 +19,7 @@ interface Props {
   optionSizeLarge?: boolean;
   hasBlueActiveState?: boolean;
   dropdownHeight?: number;
+  autoHeight?: boolean;
   children: React.ReactNode;
 }
 
@@ -32,6 +33,7 @@ const Dropdown = React.forwardRef(
       optionSizeLarge,
       dropdownHeight,
       hasBlueActiveState,
+      autoHeight,
       children,
     }: Props,
     ref: RefObject<HTMLDivElement>,
@@ -114,6 +116,7 @@ const Dropdown = React.forwardRef(
             className={classNames(styles.dropdown, {
               [styles.optionSizeLarge]: optionSizeLarge,
               [styles.hasBlueActiveState]: hasBlueActiveState,
+              [styles.autoHeight]: autoHeight,
             })}
             style={{
               top: posTop,

--- a/src/modules/dashboard/components/ExpenditurePage/ExpenditureSettings/ExpenditureSettings.tsx
+++ b/src/modules/dashboard/components/ExpenditurePage/ExpenditureSettings/ExpenditureSettings.tsx
@@ -111,6 +111,7 @@ const ExpenditureSettings = ({ colony, sidebarRef, inEditMode }: Props) => {
             placement="bottom"
             withDropdownElement
             optionSizeLarge
+            autoHeight
           />
         </div>
       </FormSection>


### PR DESCRIPTION
## Description

This PR removes the scroll bar from the list of payment types.

<img width="414" alt="Screenshot 2022-11-21 at 13 19 06" src="https://user-images.githubusercontent.com/91876137/203053154-c93044de-842b-4416-afe5-413a12dcebd5.png">

Resolves #4071
