### PR TITLE
Improve instructions in 2nd step of adding a safe

### DIFF
--- a/src/modules/dashboard/components/Dialogs/AddExistingSafeDialog/AddExistingSafeDialogForm.css
+++ b/src/modules/dashboard/components/Dialogs/AddExistingSafeDialog/AddExistingSafeDialogForm.css
@@ -53,6 +53,11 @@
   color: var(--temp-grey-blue-7);
 }
 
+.moduleLinkSection {
+  display: flex;
+  flex-direction: column;
+}
+
 .copyable {
   composes: colorSchemaGrey from '~core/Fields/Input/InputComponent.css';
   display: flex;

--- a/src/modules/dashboard/components/Dialogs/AddExistingSafeDialog/AddExistingSafeDialogForm.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/AddExistingSafeDialog/AddExistingSafeDialogForm.css.d.ts
@@ -5,6 +5,7 @@ export const step1Subtitle: string;
 export const chainSelect: string;
 export const headingContainer: string;
 export const instructions: string;
+export const moduleLinkSection: string;
 export const copyable: string;
 export const fat: string;
 export const copyableContainer: string;

--- a/src/modules/dashboard/components/Dialogs/AddExistingSafeDialog/AddExistingSafeDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/AddExistingSafeDialog/AddExistingSafeDialogForm.tsx
@@ -40,7 +40,7 @@ export interface AddExistingSafeProps {
 
 const AddExistingSafeDialogForm = ({
   networkOptions,
-  values: { chainId },
+  values: { chainId, contractAddress },
   values,
   loadingState,
   stepIndex,
@@ -74,7 +74,12 @@ const AddExistingSafeDialogForm = ({
         );
       case 2:
         return (
-          <ConnectSafe {...props} values={values} setStepIndex={setStepIndex} />
+          <ConnectSafe
+            {...props}
+            values={values}
+            setStepIndex={setStepIndex}
+            safeAddress={contractAddress}
+          />
         );
       case 3:
         return (

--- a/src/modules/dashboard/components/Dialogs/AddExistingSafeDialog/ConnectSafe.tsx
+++ b/src/modules/dashboard/components/Dialogs/AddExistingSafeDialog/ConnectSafe.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { FormikProps } from 'formik';
 import {
   defineMessages,
@@ -6,7 +6,6 @@ import {
   MessageDescriptor,
   useIntl,
 } from 'react-intl';
-import copyToClipboard from 'copy-to-clipboard';
 
 import Button from '~core/Button';
 import DialogSection from '~core/Dialog/DialogSection';
@@ -15,10 +14,13 @@ import Icon from '~core/Icon';
 import { Tooltip } from '~core/Popover';
 
 import {
+  ETHEREUM_NETWORK,
   GNOSIS_AMB_BRIDGES,
   GNOSIS_NETWORK,
   SUPPORTED_SAFE_NETWORKS,
 } from '~constants';
+import { CONNECT_SAFE_INSTRUCTIONS, getModuleLink } from '~externalUrls';
+import { useClipboardCopy } from '~modules/dashboard/hooks';
 
 import { FormValues, AddExistingSafeProps } from './index';
 
@@ -63,7 +65,7 @@ const MSG = defineMessages({
   },
   copyDataTooltip: {
     id: 'InvisibleCopyableAddress.copyAddressTooltip',
-    defaultMessage: `{copied, select,
+    defaultMessage: `{isCopied, select,
       true {Copied}
       false {{tooltipMessage}}
     }`,
@@ -73,8 +75,6 @@ const MSG = defineMessages({
     defaultMessage: 'Click to copy',
   },
 });
-
-const instructionsHref = `https://colony.gitbook.io/colony/advanced-features/safe-control-gnosis-safe/adding-a-safe#step-2-connect-the-safe`;
 
 interface ConnectSafeProps
   extends Pick<AddExistingSafeProps, 'colonyAddress' | 'setStepIndex'> {
@@ -97,25 +97,14 @@ const ConnectSafe = ({
     (network) => network.chainId === Number(chainId),
   );
   const { formatMessage } = useIntl();
-  const moduleHref = `https://app.safe.global/${selectedChain?.shortName.toLowerCase()}:${safeAddress}/apps?appUrl=https%3A%2F%2Fzodiac.gnosisguild.org%2F`;
+  const moduleHref = getModuleLink(
+    selectedChain?.shortName.toLowerCase() ||
+      ETHEREUM_NETWORK.shortName.toLowerCase(),
+    safeAddress,
+  );
   const CopyableData = ({ label, text }: CopyableProps) => {
-    const [copied, setCopied] = useState(false);
+    const { isCopied, handleClipboardCopy } = useClipboardCopy(text);
     const tooltipMessage = formatMessage(MSG.copyMessage);
-
-    const handleClipboardCopy = () => {
-      setCopied(true);
-      copyToClipboard(text);
-    };
-
-    useEffect(() => {
-      let timeout;
-      if (copied) {
-        timeout = setTimeout(() => setCopied(false), 2000);
-      }
-      return () => {
-        clearTimeout(timeout);
-      };
-    }, [copied]);
 
     return (
       <div className={styles.copyableContainer}>
@@ -129,7 +118,7 @@ const ConnectSafe = ({
             content={
               <FormattedMessage
                 {...MSG.copyDataTooltip}
-                values={{ copied, tooltipMessage }}
+                values={{ isCopied, tooltipMessage }}
               />
             }
           >
@@ -167,7 +156,7 @@ const ConnectSafe = ({
             {...MSG.instructions}
             values={{
               a: (chunks) => (
-                <ExternalLink text={chunks} href={instructionsHref} />
+                <ExternalLink text={chunks} href={CONNECT_SAFE_INSTRUCTIONS} />
               ),
             }}
           />

--- a/src/modules/dashboard/components/Dialogs/AddExistingSafeDialog/ConnectSafe.tsx
+++ b/src/modules/dashboard/components/Dialogs/AddExistingSafeDialog/ConnectSafe.tsx
@@ -1,18 +1,24 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { FormikProps } from 'formik';
 import {
   defineMessages,
   FormattedMessage,
   MessageDescriptor,
+  useIntl,
 } from 'react-intl';
-import classnames from 'classnames';
+import copyToClipboard from 'copy-to-clipboard';
 
 import Button from '~core/Button';
 import DialogSection from '~core/Dialog/DialogSection';
 import ExternalLink from '~core/ExternalLink';
 import Icon from '~core/Icon';
-import { GNOSIS_AMB_BRIDGES, GNOSIS_NETWORK } from '~constants';
-import { useClipboardCopy } from '~modules/dashboard/hooks';
+import { Tooltip } from '~core/Popover';
+
+import {
+  GNOSIS_AMB_BRIDGES,
+  GNOSIS_NETWORK,
+  SUPPORTED_SAFE_NETWORKS,
+} from '~constants';
 
 import { FormValues, AddExistingSafeProps } from './index';
 
@@ -25,11 +31,11 @@ const MSG = defineMessages({
   },
   warning: {
     id: 'dashboard.AddExistingSafeDialog.ConnectSafe.warning',
-    defaultMessage: `<span>Warning.</span> Bridging across chains can have an element of risk.`,
+    defaultMessage: `<span>Be aware.</span> Cross-chain bridging can have an element of risk.`,
   },
   instructions: {
     id: 'dashboard.AddExistingSafeDialog.ConnectSafe.instructions',
-    defaultMessage: `To give this colony permission to control the Safe, you need to provide the follow details in the Zodiac Bridge Module in your Safe. <a>Read the set up instructions here.</a>`,
+    defaultMessage: `To give this colony permission to control the Safe, you need to provide the following details in the Zodiac Bridge Module in your Safe. <a>Learn how to set up the Zodiac Bridge Module.</a>`,
   },
   amb: {
     id: 'dashboard.AddExistingSafeDialog.ConnectSafe.amb',
@@ -43,14 +49,37 @@ const MSG = defineMessages({
     id: 'dashboard.AddExistingSafeDialog.ConnectSafe.chain',
     defaultMessage: 'Chain ID',
   },
+  moduleLink: {
+    id: 'dashboard.AddExistingSafeDialog.ConnectSafe.moduleLink',
+    defaultMessage: `<a>Click to go to the Safe and add the Bridge Module</a>`,
+  },
+  moduleSubtitle: {
+    id: 'dashboard.AddExistingSafeDialog.ConnectSafe.moduleSubtitle',
+    defaultMessage: 'Add the module to the Safe',
+  },
+  moduleDetailsSubtitle: {
+    id: 'dashboard.AddExistingSafeDialog.ConnectSafe.moduleDetailsSubtitle',
+    defaultMessage: 'Bridge Module setup details',
+  },
+  copyDataTooltip: {
+    id: 'InvisibleCopyableAddress.copyAddressTooltip',
+    defaultMessage: `{copied, select,
+      true {Copied}
+      false {{tooltipMessage}}
+    }`,
+  },
+  copyMessage: {
+    id: 'InvisibleCopyableAddress.copyMessage',
+    defaultMessage: 'Click to copy',
+  },
 });
 
-const instructionsHref = `https://colony.gitbook.io/colony/advanced-features/safe-control-gnosis-safe`;
+const instructionsHref = `https://colony.gitbook.io/colony/advanced-features/safe-control-gnosis-safe/adding-a-safe#step-2-connect-the-safe`;
 
-type ConnectSafeProps = Pick<
-  AddExistingSafeProps,
-  'colonyAddress' | 'setStepIndex'
->;
+interface ConnectSafeProps
+  extends Pick<AddExistingSafeProps, 'colonyAddress' | 'setStepIndex'> {
+  safeAddress: string;
+}
 
 interface CopyableProps {
   label: MessageDescriptor;
@@ -62,25 +91,54 @@ const ConnectSafe = ({
   values: { chainId },
   setStepIndex,
   colonyAddress,
+  safeAddress,
 }: ConnectSafeProps & FormikProps<FormValues>) => {
+  const selectedChain = SUPPORTED_SAFE_NETWORKS.find(
+    (network) => network.chainId === Number(chainId),
+  );
+  const { formatMessage } = useIntl();
+  const moduleHref = `https://app.safe.global/${selectedChain?.shortName.toLowerCase()}:${safeAddress}/apps?appUrl=https%3A%2F%2Fzodiac.gnosisguild.org%2F`;
   const CopyableData = ({ label, text }: CopyableProps) => {
-    const { isCopied, handleClipboardCopy } = useClipboardCopy(text);
+    const [copied, setCopied] = useState(false);
+    const tooltipMessage = formatMessage(MSG.copyMessage);
+
+    const handleClipboardCopy = () => {
+      setCopied(true);
+      copyToClipboard(text);
+    };
+
+    useEffect(() => {
+      let timeout;
+      if (copied) {
+        timeout = setTimeout(() => setCopied(false), 2000);
+      }
+      return () => {
+        clearTimeout(timeout);
+      };
+    }, [copied]);
+
     return (
       <div className={styles.copyableContainer}>
         <span className={styles.subtitle}>
           <FormattedMessage {...label} />
         </span>
-        <div
-          className={classnames(styles.copyable, styles.fat, {
-            [styles.copied]: isCopied,
-          })}
-        >
+        <div className={`${styles.copyable} ${styles.fat}`}>
           <span>{text}</span>
-          <Icon
-            appearance={{ size: 'normal' }}
-            name="copy"
-            onClick={handleClipboardCopy}
-          />
+          <Tooltip
+            trigger="hover"
+            content={
+              <FormattedMessage
+                {...MSG.copyDataTooltip}
+                values={{ copied, tooltipMessage }}
+              />
+            }
+          >
+            <Icon
+              appearance={{ size: 'normal' }}
+              name="copy"
+              onClick={handleClipboardCopy}
+            />
+          </Tooltip>
         </div>
       </div>
     );
@@ -116,7 +174,23 @@ const ConnectSafe = ({
         </div>
       </DialogSection>
       <DialogSection appearance={{ theme: 'sidePadding' }}>
+        <div className={`${styles.instructions} ${styles.moduleLinkSection}`}>
+          <span className={styles.subtitle}>
+            <FormattedMessage {...MSG.moduleSubtitle} />
+          </span>
+          <FormattedMessage
+            {...MSG.moduleLink}
+            values={{
+              a: (chunks) => <ExternalLink text={chunks} href={moduleHref} />,
+            }}
+          />
+        </div>
+      </DialogSection>
+      <DialogSection appearance={{ theme: 'sidePadding' }}>
         <div className={styles.info}>
+          <span className={styles.subtitle}>
+            <FormattedMessage {...MSG.moduleDetailsSubtitle} />
+          </span>
           <CopyableData
             label={MSG.amb}
             text={GNOSIS_AMB_BRIDGES[chainId].foreignAMB}

--- a/src/modules/dashboard/components/Dialogs/AddExistingSafeDialog/ConnectSafe.tsx
+++ b/src/modules/dashboard/components/Dialogs/AddExistingSafeDialog/ConnectSafe.tsx
@@ -64,14 +64,14 @@ const MSG = defineMessages({
     defaultMessage: 'Bridge Module setup details',
   },
   copyDataTooltip: {
-    id: 'InvisibleCopyableAddress.copyAddressTooltip',
+    id: 'dashboard.AddExistingSafeDialog.ConnectSafe.copyAddressTooltip',
     defaultMessage: `{isCopied, select,
       true {Copied}
       false {{tooltipMessage}}
     }`,
   },
   copyMessage: {
-    id: 'InvisibleCopyableAddress.copyMessage',
+    id: 'dashboard.AddExistingSafeDialog.ConnectSafe.copyMessage',
     defaultMessage: 'Click to copy',
   },
 });

--- a/src/modules/externalUrls.ts
+++ b/src/modules/externalUrls.ts
@@ -52,3 +52,10 @@ export const METATRANSACTIONS_LEARN_MORE = `https://colony.gitbook.io/colony/ann
  * Safe control
  */
 export const SAFE_INTEGRATION_LEARN_MORE = `https://colony.gitbook.io/colony/manage-funds/safe-integration`;
+
+export const CONNECT_SAFE_INSTRUCTIONS = `https://colony.gitbook.io/colony/advanced-features/safe-control-gnosis-safe/adding-a-safe#step-2-connect-the-safe`;
+
+const SAFE_APP = `https://app.safe.global`;
+
+export const getModuleLink = (chainShortName: string, safeAddress: string) =>
+  `${SAFE_APP}/${chainShortName}:${safeAddress}/apps?appUrl=https%3A%2F%2Fzodiac.gnosisguild.org%2F`;


### PR DESCRIPTION
Improvements were made specifically to the 2nd step of the "Add Safe" process per our observations in the live QA session.

**Note**: In case you are in need of a safe to test the steps: `0x3F107AFF0342Cfb5519A68B3241565F6FC9BAC1e` (Ethereum).

**Changes** 🏗

* Changed copy of warning in 2nd step
* Added a new subsection with a link to easily get to the Safe App screen where the user is supposed to install the bridge module.
  * This link is generated by using the selected safe chain and address
* Updated copy and link of "Learn more" in the 2nd step so that the user gets to the relevant section in our docs faster/easier.
* Added a tooltip to the clipboard copy icon so that it's easier to tell that something was copied onto the clipboard.

(It would be a "good to have" if we can find a Binance safe also, just to test the link when the safe is on Binance)

![FireShot Capture 757 - Actions - Colony - wonker - localhost](https://user-images.githubusercontent.com/18473896/203871646-5515dd00-379c-47a2-b147-bdd97cd87e7f.png)

Resolves #4078 
