### PR TITLE
Remove reload after chain change

### DIFF
--- a/src/modules/core/components/Dialog/DialogProvider.tsx
+++ b/src/modules/core/components/Dialog/DialogProvider.tsx
@@ -61,7 +61,18 @@ const DialogProvider = ({ children }: Props) => {
             rejectPromise = reject;
           }),
       };
-      setOpenDialogs((prevOpenDialogs) => [...prevOpenDialogs, dialog]);
+
+      setOpenDialogs((prevOpenDialogs) => {
+        if (
+          !prevOpenDialogs.find(
+            (prevOpenDialog) =>
+              prevOpenDialog.Dialog.displayName === dialog.Dialog.displayName,
+          )
+        ) {
+          return [...prevOpenDialogs, dialog];
+        }
+        return prevOpenDialogs;
+      });
       return dialog;
     },
     [closeDialog],

--- a/src/modules/dashboard/components/Dialogs/WrongNetworkDialog/WrongNetworkDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/WrongNetworkDialog/WrongNetworkDialog.tsx
@@ -1,13 +1,15 @@
 import { Network } from '@colony/colony-js';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { FormattedMessage, defineMessages } from 'react-intl';
 import { DEFAULT_NETWORK, NETWORK_DATA } from '~constants';
 
 import Dialog, { DialogProps, DialogSection } from '~core/Dialog';
 import ExternalLink from '~core/ExternalLink';
 import Heading from '~core/Heading';
+import { useLoggedInUser } from '~data/helpers';
 
 import { WALLET_CONNECT_XDAI } from '~externalUrls';
+import { checkIfNetworkIsAllowed } from '~utils/networks';
 
 import styles from './WrongNetworkDialog.css';
 
@@ -25,7 +27,16 @@ const MSG = defineMessages({
 const displayName = 'dashboard.ColonyHome.WrongNetworkDialog';
 
 const WrongNetworkDialog = ({ cancel }: DialogProps) => {
+  const { networkId, ethereal } = useLoggedInUser();
+  const isNetworkAllowed = checkIfNetworkIsAllowed(networkId);
+
   const networkName = NETWORK_DATA[process.env.NETWORK || DEFAULT_NETWORK].name;
+
+  useEffect(() => {
+    if (ethereal || isNetworkAllowed) {
+      cancel();
+    }
+  }, [ethereal, isNetworkAllowed, cancel]);
 
   return (
     <Dialog cancel={cancel}>

--- a/src/modules/pages/components/RouteLayouts/UserNavigation.tsx
+++ b/src/modules/pages/components/RouteLayouts/UserNavigation.tsx
@@ -21,7 +21,8 @@ import { useSelector } from '~utils/hooks';
 import { useAutoLogin, getLastWallet } from '~utils/autoLogin';
 import { checkIfNetworkIsAllowed } from '~utils/networks';
 import { getUserTokenBalanceData } from '~utils/tokens';
-
+import { WalletMethod } from '~immutable/Wallet';
+import { ActionTypes } from '~redux/actionTypes';
 import {
   useUserNotificationsQuery,
   useLoggedInUser,
@@ -117,6 +118,17 @@ const UserNavigation = () => {
 
   const { formatMessage } = useIntl();
   const isMobile = useMediaQuery({ query });
+
+  useEffect(() => {
+    // @NOTE: .ethereum exists in window unlike what TS believes.
+    // @ts-ignore
+    window.ethereum.on('chainChanged', () => {
+      dispatch({
+        type: ActionTypes.WALLET_CREATE,
+        payload: { method: WalletMethod.MetaMask },
+      });
+    });
+  }, [dispatch]);
 
   useEffect(() => {
     if (!userDataLoading && !ethereal) {

--- a/src/modules/pages/components/RouteLayouts/UserNavigation.tsx
+++ b/src/modules/pages/components/RouteLayouts/UserNavigation.tsx
@@ -120,14 +120,17 @@ const UserNavigation = () => {
   const isMobile = useMediaQuery({ query });
 
   useEffect(() => {
-    // @NOTE: .ethereum exists in window unlike what TS believes.
+    // @NOTE: .ethereum can exist in window unlike what TS believes.
     // @ts-ignore
-    window.ethereum.on('chainChanged', () => {
-      dispatch({
-        type: ActionTypes.WALLET_CREATE,
-        payload: { method: WalletMethod.MetaMask },
+    if (window.ethereum) {
+      // @ts-ignore
+      window.ethereum.on('chainChanged', () => {
+        dispatch({
+          type: ActionTypes.WALLET_CREATE,
+          payload: { method: WalletMethod.MetaMask },
+        });
       });
-    });
+    }
   }, [dispatch]);
 
   useEffect(() => {

--- a/src/modules/users/sagas/wallet.ts
+++ b/src/modules/users/sagas/wallet.ts
@@ -10,7 +10,6 @@ import {
 import {
   open as purserOpenMetaMaskWallet,
   accountChangeHook,
-  chainChangeHook,
 } from '@purser/metamask';
 import { addChain } from '@purser/metamask/lib-esm/helpers';
 
@@ -36,13 +35,7 @@ function* metaMaskWatch(walletAddress: Address) {
     });
     return () => null;
   });
-  /*
-   * @TODO Make this smart at some point by allowing the chain to change
-   * w/o needing to refresh the page
-   */
-  chainChangeHook((): void => {
-    return window.location.reload();
-  });
+
   let previousAddress = walletAddress;
   while (true) {
     const selectedAddress: Address = yield take(channel);


### PR DESCRIPTION
Removed reload of the dapp after the chain changes in metamask.

- The Dapp should not be reloaded when you change chains through metamask, this is quite useful for Safe related processes.
- The Dapp should be updating the user when the chain changes.
- The WrongNetworkDialog should close automatically when an allowed network is chosen, unlike before when you had to close it manually. 

Resolves #4081 
