### PR TITLE
Add prefix to Safe transaction titles

### DIFF
--- a/src/i18n/en-actions.ts
+++ b/src/i18n/en-actions.ts
@@ -33,8 +33,8 @@ const actionsMessageDescriptors = {
       ${ColonyMotions.EmitDomainReputationRewardMotion} {Award {recipient} with a {reputationChangeNumeral} {reputationChange, plural, one {pt} other {pts}} reputation reward}
       ${ColonyExtendedActions.SafeRemoved} {Remove Safe}
       ${ColonyExtendedActions.SafeAdded} {Add Safe from {chainName}}
-      ${ColonyExtendedActions.SafeTransactionInitiated} {{safeTransactionTitle}}
-      ${ColonyExtendedMotions.SafeTransactionInitiatedMotion} {{safeTransactionTitle}}
+      ${ColonyExtendedActions.SafeTransactionInitiated} {Safe transaction: {safeTransactionTitle}}
+      ${ColonyExtendedMotions.SafeTransactionInitiatedMotion} {Safe transaction: {safeTransactionTitle}}
       ${ColonyMotions.CreateDecisionMotion} {Create Decision}
       other {Generic action we don't have information about}
     }`,

--- a/src/i18n/en-motions.ts
+++ b/src/i18n/en-motions.ts
@@ -17,7 +17,7 @@ const motionsMessageDescriptors = {
       ${ColonyMotions.EmitDomainReputationRewardMotion}
         {Award {recipient} with a {reputationChangeNumeral} {reputationChange, plural, one {pt} other {pts}} reputation reward}
       ${ColonyMotions.UnlockTokenMotion} {Unlock native token {tokenSymbol}}
-      ${ColonyExtendedMotions.SafeTransactionInitiatedMotion} {{safeTransactionTitle}}
+      ${ColonyExtendedMotions.SafeTransactionInitiatedMotion} {Safe transaction: {safeTransactionTitle}}
       other {Generic motion we don't have information about}
     }`,
   [`motion.${ColonyMotions.SetUserRolesMotion}.assign`]: `Assign the {roles} in {fromDomainName} to {recipient}`,

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/validation.ts
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/validation.ts
@@ -163,6 +163,7 @@ export const getValidationSchema = (
       ? {
           transactionsTitle: yup
             .string()
+            .trim()
             .required(() => MSG.requiredFieldError),
         }
       : {}),


### PR DESCRIPTION
- Also updated the title input validation, before you could submit an empty space as a title for transactions.

Resolves #4089 
