### PR TITLE
Add warning to TransferFunds section on Control Safe

### DIFF
--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css
@@ -56,3 +56,25 @@
 .noUsefulMethods > section {
   padding: 1px 20px 20px;
 }
+
+.warningContainer {
+  display: flex;
+  align-items: center;
+  padding: 14px;
+  border-radius: 5px;
+  background-color: color-mod(var(--golden) alpha(15%));
+  font-size: var(--size-normal);
+  line-height: 18px;
+  color: var(--dark);
+  column-gap: 10px;
+}
+
+.warningSafeChainName {
+  font-weight: var(--weight-bold);
+}
+
+.warningIcon {
+  height: 18px;
+  min-width: 18px;
+  fill: var(--golden);
+}

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css.d.ts
@@ -5,3 +5,6 @@ export const inputParamContainer: string;
 export const spinner: string;
 export const error: string;
 export const noUsefulMethods: string;
+export const warningContainer: string;
+export const warningSafeChainName: string;
+export const warningIcon: string;

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransferFundsSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransferFundsSection.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { FormikProps, useField } from 'formik';
-import { defineMessages } from 'react-intl';
+import { defineMessages, FormattedMessage } from 'react-intl';
 import moveDecimal from 'move-decimal-point';
 
 import { DEFAULT_TOKEN_DECIMALS } from '~constants';
@@ -20,6 +20,7 @@ import { FormValues, TransactionSectionProps } from '..';
 import { ErrorMessage as Error, Loading, AvatarXS } from './shared';
 
 import styles from './TransactionTypesSection.css';
+import Icon from '~core/Icon';
 
 export const MSG = defineMessages({
   amount: {
@@ -42,6 +43,14 @@ export const MSG = defineMessages({
     id: `dashboard.ControlSafeDialog.TransferFundsSection.balancesError`,
     defaultMessage:
       'Unable to fetch Safe balances. Please check your connection',
+  },
+  warning: {
+    id: `dashboard.ControlSafeDialog.TransferFundsSection.warning`,
+    defaultMessage: `Please confirm that the recipient’s address exists on the same chain as the selected Safe: <span>{safeChainName}</span>`,
+  },
+  warningIconTitle: {
+    id: `dashboard.ControlSafeDialog.TransferFundsSection.warningIconTitle`,
+    defaultMessage: 'Warning!',
   },
 });
 
@@ -171,6 +180,27 @@ const TransferFundsSection = ({
           transactionFormIndex={transactionFormIndex}
           handleValidation={handleValidation}
         />
+      </DialogSection>
+      <DialogSection appearance={{ theme: 'sidePadding' }}>
+        <div className={styles.warningContainer}>
+          <Icon
+            name="triangle-warning"
+            className={styles.warningIcon}
+            title={MSG.warningIconTitle}
+          />
+          <p>
+            <FormattedMessage
+              {...MSG.warning}
+              values={{
+                span: (chunks) => (
+                  <span className={styles.warningSafeChainName}>{chunks}</span>
+                ),
+                safeChainName:
+                  safe && getChainNameFromSafe(safe.profile.displayName),
+              }}
+            />
+          </p>
+        </div>
       </DialogSection>
       <DialogSection>
         <div className={styles.singleUserPickerContainer}>

--- a/src/modules/dashboard/sagas/utils/safeHelpers.ts
+++ b/src/modules/dashboard/sagas/utils/safeHelpers.ts
@@ -431,7 +431,5 @@ export const getContractInteractionData = async (
 };
 
 export const getChainNameFromSafe = (safeDisplayName: string) => {
-  const splitDisplayName = safeDisplayName.split(' ');
-  const chainNameInBrackets = splitDisplayName[splitDisplayName.length - 1];
-  return chainNameInBrackets.substring(1, chainNameInBrackets.length - 1);
+  return safeDisplayName.match(/\((.*)\)/)?.pop() || '';
 };


### PR DESCRIPTION
Safe I used to test:
`0x3F107AFF0342Cfb5519A68B3241565F6FC9BAC1e` (Ethereum)
`0x8dfABd117Db8BC64829Ce7C595F20998b054cDC2` (Module address)

`0xe759f388c97674D5B8a60406b254aB59f194163d` (Binance Smart Chain)
`0xCC199aCAb2B38C6DC5f7304B29BDEb3a83E7d212` (Module address)

![FireShot Capture 766 - Actions - Colony - wonker - localhost](https://user-images.githubusercontent.com/18473896/207620807-5fd0caf1-72a5-44db-80e2-3300a77377fd.png)

Resolves #4086 
