### PR TITLE
Add view for unverified protector

### DIFF
--- a/src/modules/dashboard/components/Incorporation/IncorporationForm/LockedProtectors/LockedProtectors.tsx
+++ b/src/modules/dashboard/components/Incorporation/IncorporationForm/LockedProtectors/LockedProtectors.tsx
@@ -86,16 +86,17 @@ const LockedProtectors = ({ formValues }: Props) => {
           const { profile } = user || {};
           const { walletAddress, username, displayName: userDispalyName } =
             profile || {};
+          const isVerified = VerificationStatus.Unverified; // mockData
 
           return (
             <div className={styles.row}>
               <Tag
                 appearance={{
                   colorSchema: 'fullColor',
-                  theme: protector.verified ? 'primary' : 'danger',
+                  theme: isVerified ? 'primary' : 'danger',
                 }}
               >
-                {protector.verified
+                {isVerified
                   ? VerificationStatus.Verified
                   : VerificationStatus.Unverified}
               </Tag>

--- a/src/modules/dashboard/components/Incorporation/IncorporationForm/Protectors/Protectors.tsx
+++ b/src/modules/dashboard/components/Incorporation/IncorporationForm/Protectors/Protectors.tsx
@@ -14,9 +14,10 @@ import { filterUserSelection } from '~core/SingleUserPicker';
 import { supRenderAvatar } from '~dashboard/ExpenditurePage/Recipient/Recipient';
 import { Protector } from '~pages/IncorporationPage/types';
 import Button from '~core/Button';
+import { SignOption } from '~dashboard/Incorporation/IncorporationForm/constants';
 
 import Radio from '../Radio';
-import { SignOption } from '../types';
+
 import SingleUserPicker from '../SingleUserPicker';
 
 import styles from './Protectors.css';
@@ -69,7 +70,7 @@ export interface Props {
 
 const Protectors = ({ colony, sidebarRef }: Props) => {
   const [, { value: protectors }] = useField<Protector[]>('protectors');
-  const [, { value: signOption }] = useField('signOption');
+  const [, { value: signOption }] = useField<SignOption>('signOption');
   const [, { value: mainContact }, { setValue: setMainContact }] = useField(
     'mainContact',
   );

--- a/src/modules/dashboard/components/Incorporation/IncorporationForm/constants.ts
+++ b/src/modules/dashboard/components/Incorporation/IncorporationForm/constants.ts
@@ -6,4 +6,5 @@ export enum SignOption {
 export enum VerificationStatus {
   Verified = 'Verified',
   Unverified = 'Unverified',
+  Submitted = 'Submitted',
 }

--- a/src/modules/dashboard/components/Incorporation/IncorporationForm/types.ts
+++ b/src/modules/dashboard/components/Incorporation/IncorporationForm/types.ts
@@ -1,4 +1,0 @@
-export enum SignOption {
-  Individual = 'individual',
-  Multiple = 'multiple',
-}

--- a/src/modules/dashboard/components/Incorporation/VerificationBanner/VerificationBanner.tsx
+++ b/src/modules/dashboard/components/Incorporation/VerificationBanner/VerificationBanner.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
 import Button from '~core/Button';
+import UserMention from '~core/UserMention';
+import { LoggedInUser } from '~data/index';
 
 import styles from './VerificationBanner.css';
-import UserMention from '~core/UserMention';
-import { AnyUser } from '~data/index';
 
 const MSG = defineMessages({
   title: {
@@ -29,7 +29,10 @@ const MSG = defineMessages({
 const displayName = 'dashboard.Incorporation.VerificationBanner';
 
 export interface Props {
-  user: AnyUser;
+  user: Pick<
+    LoggedInUser,
+    'walletAddress' | 'balance' | 'username' | 'ethereal' | 'networkId'
+  >;
 }
 
 const VerificationBanner = ({ user }: Props) => {
@@ -40,13 +43,7 @@ const VerificationBanner = ({ user }: Props) => {
           <FormattedMessage
             {...MSG.title}
             values={{
-              user: (
-                <UserMention
-                  username={
-                    user.profile.username || user.profile.displayName || ''
-                  }
-                />
-              ),
+              user: <UserMention username={user.username || ''} />,
             }}
           />
         </div>

--- a/src/modules/pages/components/IncorporationPage/IncorporationPage.css
+++ b/src/modules/pages/components/IncorporationPage/IncorporationPage.css
@@ -36,6 +36,7 @@
 }
 
 .mainContainer {
+  padding: 76px 100px 70px 25px;
   padding-bottom: 50px;
   height: 600px;
   min-height: 100%;

--- a/src/modules/pages/components/IncorporationPage/IncorporationPage.tsx
+++ b/src/modules/pages/components/IncorporationPage/IncorporationPage.tsx
@@ -20,6 +20,7 @@ import {
 } from './constants';
 import { ValuesType } from './types';
 import styles from './IncorporationPage.css';
+import { VerificationStatus } from '~dashboard/Incorporation/IncorporationForm/constants';
 
 const displayName = 'pages.IncorporationPage';
 
@@ -37,20 +38,17 @@ const IncorporationPage = () => {
 
   const user = useLoggedInUser();
 
-  const currentUser = useMemo(() => {
-    const isNominated =
+  const isNominated = useMemo(
+    () =>
       user.walletAddress &&
       formValues?.protectors?.find(
         (protector) =>
           user.walletAddress === protector?.user?.profile?.walletAddress,
-      );
-    return {
-      isNominated,
-      isVerified: isNominated && isNominated.verified,
-    };
-  }, [formValues, user]);
+      ),
+    [formValues, user],
+  );
 
-  const { isNominated, isVerified } = currentUser;
+  const isVerified = VerificationStatus.Unverified; // mock value
 
   const handleSubmit = useCallback((values) => {
     setFormValues(values);

--- a/src/modules/pages/components/IncorporationPage/constants.ts
+++ b/src/modules/pages/components/IncorporationPage/constants.ts
@@ -4,7 +4,7 @@ import * as yup from 'yup';
 
 import { SignOption } from '~dashboard/Incorporation/IncorporationForm/constants';
 
-import { StageObject, ValuesType } from './types';
+import { StageObject } from './types';
 
 const MSG = defineMessages({
   create: {
@@ -167,51 +167,3 @@ export const stages: StageObject[] = [
   },
   { id: Stages.Complete, title: MSG.complete, description: MSG.completeDesc },
 ];
-
-export const formValuesMock: ValuesType = {
-  alternativeName1: 'WallStreetBets Foundation',
-  alternativeName2: 'WallStreet Corp',
-  mainContact: {
-    id: '0xb77D57F4959eAfA0339424b83FcFaf9c15407461',
-    profile: {
-      avatarHash: null,
-      displayName: null,
-      username: 'Storm',
-      walletAddress: '0xb77D57F4959eAfA0339424b83FcFaf9c15407461',
-    },
-  },
-  name: 'WallStreetBets',
-  protectors: [
-    {
-      user: {
-        id: '0xb77D57F4959eAfA0339424b83FcFaf9c15407461',
-        profile: {
-          avatarHash: null,
-          displayName: null,
-          username: 'Storm',
-          walletAddress: '0xb77D57F4959eAfA0339424b83FcFaf9c15407461',
-        },
-      },
-      key: nanoid(),
-    },
-    {
-      user: {
-        id: 'filterValue',
-        profile: { displayName: 'Ragnar', walletAddress: 'Ragnar' },
-      },
-      key: nanoid(),
-    },
-  ],
-  purpose: `WallStreetBets is on a mission to deploy decentralized satellites in our skies.`,
-  signOption: SignOption.Individual,
-};
-
-export const userMock = {
-  id: '0xb77D57F4959eAfA0339424b83FcFaf9c15407461',
-  profile: {
-    avatarHash: null,
-    displayName: null,
-    username: 'Storm',
-    walletAddress: '0xb77D57F4959eAfA0339424b83FcFaf9c15407461',
-  },
-};

--- a/src/modules/pages/components/IncorporationPage/types.ts
+++ b/src/modules/pages/components/IncorporationPage/types.ts
@@ -1,9 +1,6 @@
 import { MessageDescriptor } from 'react-intl';
 
-import {
-  SignOption,
-  VerificationStatus,
-} from '~dashboard/Incorporation/IncorporationForm/constants';
+import { SignOption } from '~dashboard/Incorporation/IncorporationForm/constants';
 import { AnyUser } from '~data/index';
 
 import { Stages } from './constants';
@@ -13,7 +10,6 @@ export interface Protector {
   key: string;
   removed?: boolean;
   created?: boolean;
-  verified?: VerificationStatus;
 }
 export interface ValuesType {
   name: string;


### PR DESCRIPTION
## Description

This PR adds view for user who is nominated as a protector and has not been verified yet. 

To test this view go to  **/incorporation/create** route and fill in the form. **Nominate yourself as protector**.
When you confirm the form you should see a banner with verify and remove buttons. You will also see the status (unverified, unverified) next to your name in the list of protectors. Status is a mock.

[Figma link](https://www.figma.com/file/fmnKIUY0LGfEnsOOQloVVX/Korporatio?node-id=976%3A114261&t=aUSDX6nimqEdLmSl-0)

<img width="1311" alt="Screenshot 2023-01-26 at 12 07 46" src="https://user-images.githubusercontent.com/91876137/214821308-db6fc2c9-dcb3-4c98-aa43-91676fb0d4e6.png">


Resolves #4131
