### PR TITLE
Add view after verification submission

### DIFF
--- a/src/modules/pages/components/IncorporationPage/IncorporationPage.tsx
+++ b/src/modules/pages/components/IncorporationPage/IncorporationPage.tsx
@@ -55,7 +55,7 @@ const IncorporationPage = () => {
         return {
           id: protector.user?.id,
           walletAddress: protector.user?.profile?.walletAddress,
-          verified: VerificationStatus.Unverified,
+          verified: VerificationStatus.Submitted,
         };
       }),
     [formValues],

--- a/src/modules/pages/components/IncorporationPage/IncorporationPage.tsx
+++ b/src/modules/pages/components/IncorporationPage/IncorporationPage.tsx
@@ -18,6 +18,7 @@ import {
   stages,
   validationSchema,
   Stages as StagesEnum,
+  formValuesMock,
 } from './constants';
 import { ValuesType } from './types';
 import styles from './IncorporationPage.css';
@@ -30,8 +31,8 @@ const IncorporationPage = () => {
   const { colonyName } = useParams<{
     colonyName: string;
   }>();
-  const [isFormEditable, setFormEditable] = useState(true);
-  const [formValues, setFormValues] = useState<ValuesType>();
+  const [isFormEditable, setFormEditable] = useState(false);
+  const [formValues, setFormValues] = useState<ValuesType>(formValuesMock);
   const [shouldValidate, setShouldValidate] = useState(false);
   const [activeStageId, setActiveStageId] = useState(StagesEnum.Draft);
   const sidebarRef = useRef<HTMLElement>(null);

--- a/src/modules/pages/components/IncorporationPage/constants.ts
+++ b/src/modules/pages/components/IncorporationPage/constants.ts
@@ -4,7 +4,7 @@ import * as yup from 'yup';
 
 import { SignOption } from '~dashboard/Incorporation/IncorporationForm/constants';
 
-import { StageObject } from './types';
+import { StageObject, ValuesType } from './types';
 
 const MSG = defineMessages({
   create: {
@@ -167,3 +167,41 @@ export const stages: StageObject[] = [
   },
   { id: Stages.Complete, title: MSG.complete, description: MSG.completeDesc },
 ];
+
+export const formValuesMock: ValuesType = {
+  alternativeName1: 'WallStreetBets Foundation',
+  alternativeName2: 'WallStreet Corp',
+  mainContact: {
+    id: '0xb77D57F4959eAfA0339424b83FcFaf9c15407461',
+    profile: {
+      avatarHash: null,
+      displayName: null,
+      username: 'Storm',
+      walletAddress: '0xb77D57F4959eAfA0339424b83FcFaf9c15407461',
+    },
+  },
+  name: 'WallStreetBets',
+  protectors: [
+    {
+      user: {
+        id: '0xb77D57F4959eAfA0339424b83FcFaf9c15407461',
+        profile: {
+          avatarHash: null,
+          displayName: null,
+          username: 'Storm',
+          walletAddress: '0xb77D57F4959eAfA0339424b83FcFaf9c15407461',
+        },
+      },
+      key: nanoid(),
+    },
+    {
+      user: {
+        id: 'filterValue',
+        profile: { displayName: 'Ragnar', walletAddress: 'Ragnar' },
+      },
+      key: nanoid(),
+    },
+  ],
+  purpose: `WallStreetBets is on a mission to deploy decentralized satellites in our skies.`,
+  signOption: SignOption.Individual,
+};


### PR DESCRIPTION
## Description

This PR adds view when  protectors  have completed their verification forms. 
To test it go to **/incorporation/create** route. 
Form is in a locked state, filled with mock values. Form edition was added in a separate [PR](https://github.com/JoinColony/colonyDapp/pull/4164).

[Figma Link - Protector verification confirmation](https://www.figma.com/file/fmnKIUY0LGfEnsOOQloVVX/Korporatio?node-id=976%3A113166&t=b6WlfQw1DuZsWM6p-0)

<img width="412" alt="Screenshot 2023-01-31 at 11 46 26" src="https://user-images.githubusercontent.com/91876137/215739459-f47dea0b-891b-447d-a0ab-22a5d48cea48.png">


Resolves #4153 
