### PR TITLE
Bug fix of spawn truffle

### DIFF
--- a/scripts/deploy_contracts.js
+++ b/scripts/deploy_contracts.js
@@ -6,7 +6,7 @@ const { NETWORK_ROOT } = require('./paths');
 
 
 const deployContracts = () => {
-  return spawn('node_modules/.bin/truffle', ['migrate', '--reset', '--compile-all'], {
+  return spawn('npx', ['truffle', 'migrate', '--reset', '--compile-all'], {
     stdio: 'inherit',
     cwd: NETWORK_ROOT,
     env: {


### PR DESCRIPTION
## Description

Both
```
spawn('node_modules/.bin/truffle', ['migrate', '--reset', '--compile-all'], ...
```
and
```
spawn('./node_modules/.bin/truffle', ['migrate', '--reset', '--compile-all'], ...
```
fail on my Ubuntu Linux, even despite I create a symlink from `./node_modules/.bin/truffle` to truffle binary.

So, I fixed this bug.

**Changes** 🏗

* Add `npx` when spawning truffle.