### PR TITLE
Update monitor links and add warning for older colony versions

### DIFF
--- a/src/modules/constants.ts
+++ b/src/modules/constants.ts
@@ -296,7 +296,7 @@ export const GNOSIS_AMB_BRIDGES: { [x: number]: AmbBridge } = {
   [ETHEREUM_NETWORK.chainId]: {
     homeAMB: '0x75Df5AF045d91108662D8080fD1FEFAd6aA0bb59',
     foreignAMB: '0x4C36d2919e407f0Cc2Ee3c993ccF8ac26d9CE64e',
-    monitor: 'http://13.40.211.40/',
+    monitor: 'https://alm-gnosis-eth.colony.io/',
     referenceUrl:
       'https://docs.tokenbridge.net/eth-xdai-amb-bridge/about-the-eth-xdai-amb',
     homeGasLimit: 2000000,
@@ -307,7 +307,7 @@ export const GNOSIS_AMB_BRIDGES: { [x: number]: AmbBridge } = {
   [BINANCE_NETWORK.chainId]: {
     homeAMB: '0x162E898bD0aacB578C8D5F8d6ca588c13d2A383F',
     foreignAMB: '0x05185872898b6f94AA600177EF41B9334B1FA48B',
-    monitor: 'https://alm-bsc-xdai.herokuapp.com/',
+    monitor: 'https://alm-gnosis-bsc.colony.io/',
     referenceUrl:
       'https://docs.tokenbridge.net/bsc-xdai-amb/about-the-bsc-xdai-amb',
     homeGasLimit: 2000000,

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.css
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.css
@@ -163,3 +163,28 @@
   text-align: right;
   overflow-wrap: anywhere;
 }
+
+.warningIcon {
+  margin-top: 3px;
+  margin-right: 12px;
+}
+
+.warningIcon svg {
+  height: 18px;
+  width: 18px;
+  fill: var(--golden);
+}
+
+.upgradeWarning {
+  display: flex;
+  margin-top: 20px;
+  padding: 15px 12px 15px 18px;
+  border-radius: 5px;
+  background-color: color-mod(var(--golden) alpha(15%));
+  line-height: 18px;
+  color: var(--dark);
+}
+
+.upgradePath {
+  font-weight: var(--weight-bold);
+}

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.css.d.ts
@@ -17,3 +17,6 @@ export const nftValue: string;
 export const tokenAmount: string;
 export const transactionDetailsSection: string;
 export const rawTransactionValues: string;
+export const warningIcon: string;
+export const upgradeWarning: string;
+export const upgradePath: string;

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
@@ -4,6 +4,7 @@ import { FieldArray, FieldArrayRenderProps, FormikProps } from 'formik';
 import {
   ColonyRole,
   VotingReputationExtensionVersion,
+  ColonyVersion,
 } from '@colony/colony-js';
 import classnames from 'classnames';
 import { nanoid } from 'nanoid';
@@ -98,6 +99,14 @@ const MSG = defineMessages({
     defaultMessage:
       'Select a safe from the menu or add a new one via Safe Control',
   },
+  warningIconTitle: {
+    id: 'dashboard.ControlSafeDialog.ControlSafeForm.warningIconTitle',
+    defaultMessage: `Warning!`,
+  },
+  upgradeWarning: {
+    id: 'dashboard.ControlSafeDialog.ControlSafeForm.upgradeWarning',
+    defaultMessage: `Controlling a Safe is not supported on your current Colony version. Please upgrade Colony to at least version 11.{break}You can do this via <span>New Action > Advanced > Upgrade</span>`,
+  },
 });
 
 export const { invalidSafeError } = MSG;
@@ -141,7 +150,7 @@ const renderAvatar = (address: string, item) => (
 
 const ControlSafeForm = ({
   colony,
-  colony: { colonyAddress },
+  colony: { colonyAddress, version },
   back,
   handleSubmit,
   safes,
@@ -358,6 +367,10 @@ const ControlSafeForm = ({
 
   const savedNFTState = useState({});
   const savedTokenState = useState({});
+  const isSupportedColonyVersion =
+    parseInt(version, 10) >= ColonyVersion.GreenLightweightSpaceshipTwo;
+  const disabledInputs =
+    !userHasPermission || isSubmitting || !isSupportedColonyVersion;
 
   const renderTransactionSection = (
     transaction: SafeTransaction,
@@ -369,7 +382,7 @@ const ControlSafeForm = ({
         return (
           <TransferFundsSection
             colony={colony}
-            disabledInput={!userHasPermission || isSubmitting}
+            disabledInput={disabledInputs}
             values={values}
             transactionFormIndex={index}
             setFieldValue={setFieldValue}
@@ -383,7 +396,7 @@ const ControlSafeForm = ({
         return (
           <RawTransactionSection
             colony={colony}
-            disabledInput={!userHasPermission || isSubmitting}
+            disabledInput={disabledInputs}
             transactionFormIndex={index}
             handleInputChange={handleInputChange}
             handleValidation={handleValidation}
@@ -392,7 +405,7 @@ const ControlSafeForm = ({
       case TransactionTypes.CONTRACT_INTERACTION:
         return (
           <ContractInteractionSection
-            disabledInput={!userHasPermission || isSubmitting}
+            disabledInput={disabledInputs}
             transactionFormIndex={index}
             values={values}
             safes={safes}
@@ -411,7 +424,7 @@ const ControlSafeForm = ({
             colonyAddress={colonyAddress}
             transactionFormIndex={index}
             values={values}
-            disabledInput={!userHasPermission || isSubmitting}
+            disabledInput={disabledInputs}
             savedNFTState={savedNFTState}
             handleValidation={handleValidation}
           />
@@ -445,6 +458,28 @@ const ControlSafeForm = ({
               }}
             />
           </DialogSection>
+          {!isSupportedColonyVersion && (
+            <DialogSection appearance={{ theme: 'sidePadding' }}>
+              <div className={styles.upgradeWarning}>
+                <Icon
+                  name="triangle-warning"
+                  className={styles.warningIcon}
+                  title={MSG.warningIconTitle}
+                />
+                <div>
+                  <FormattedMessage
+                    {...MSG.upgradeWarning}
+                    values={{
+                      span: (chunks) => (
+                        <span className={styles.upgradePath}>{chunks}</span>
+                      ),
+                      break: <br />,
+                    }}
+                  />
+                </div>
+              </div>
+            </DialogSection>
+          )}
           <DialogSection>
             <div className={styles.safePicker}>
               <SingleSafePicker
@@ -454,7 +489,7 @@ const ControlSafeForm = ({
                 renderAvatar={renderAvatar}
                 data={safes}
                 showMaskedAddress
-                disabled={!userHasPermission || isSubmitting}
+                disabled={disabledInputs}
                 placeholder={MSG.safePickerPlaceholder}
                 onSelected={handleSafeChange}
                 validateOnChange
@@ -542,7 +577,7 @@ const ControlSafeForm = ({
                             }}
                             appearance={{ theme: 'grey', width: 'fluid' }}
                             placeholder={MSG.transactionPlaceholder}
-                            disabled={!userHasPermission || isSubmitting}
+                            disabled={disabledInputs}
                             validateOnChange
                           />
                         </div>

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css
@@ -78,3 +78,20 @@
   min-width: 18px;
   fill: var(--golden);
 }
+
+.abiContainer {
+  position: relative;
+}
+
+.attributionMessage {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  font-size: var(--size-tiny);
+  line-height: 18px;
+  color: var(--dark);
+}
+
+.fetchFailedErrorContainer {
+  margin-top: 19px;
+}

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css.d.ts
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransactionTypesSection.css.d.ts
@@ -8,3 +8,6 @@ export const noUsefulMethods: string;
 export const warningContainer: string;
 export const warningSafeChainName: string;
 export const warningIcon: string;
+export const abiContainer: string;
+export const attributionMessage: string;
+export const fetchFailedErrorContainer: string;


### PR DESCRIPTION
- Updated bridge monitor links with the ones we are hosting.
- Added warning for old colony version (older than 11). To see how it should look, change both `!isSupportedColonyVersion` in `ControlSafeForm` to `isSupportedColonyVersion`.
- Added Etherscan and BscScan attributions to ABI textarea. The attribution should change depending on the chain of the safe.

Safes to test:
`0x3F107AFF0342Cfb5519A68B3241565F6FC9BAC1e` (Ethereum)
`0x8dfABd117Db8BC64829Ce7C595F20998b054cDC2` (Module)

`0xe759f388c97674D5B8a60406b254aB59f194163d` (Binance Smart Chain)
`0xCC199aCAb2B38C6DC5f7304B29BDEb3a83E7d212` (Module)

Resolves #4173 
