### PR TITLE
Update permissions for Safe Control actions

### DIFF
--- a/src/i18n/en-events.ts
+++ b/src/i18n/en-events.ts
@@ -29,8 +29,8 @@ const eventsMessageDescriptors = {
   [`event.${ColonyAndExtensionsEvents.ColonyMetadata}.logo`]: `{initiator} changed this colony's logo`,
   [`event.${ColonyAndExtensionsEvents.ColonyMetadata}.tokens`]: `{initiator} changed this colony's tokens`,
   [`event.${ColonyAndExtensionsEvents.ColonyMetadata}.verifiedAddresses`]: `{initiator} updated this colony's address book`,
-  [`event.${ColonyAndExtensionsEvents.ColonyMetadata}.safeRemoved`]: `{initiator} removed {removedSafesString} using the Administration permission`,
-  [`event.${ColonyAndExtensionsEvents.ColonyMetadata}.safeAdded`]: `{initiator} added the Safe {addedSafeAddress} from {chainName} using the Administration permission`,
+  [`event.${ColonyAndExtensionsEvents.ColonyMetadata}.safeRemoved`]: `{initiator} removed {removedSafesString} using the Root permission`,
+  [`event.${ColonyAndExtensionsEvents.ColonyMetadata}.safeAdded`]: `{initiator} added the Safe {addedSafeAddress} from {chainName} using the Root permission`,
   [`event.${ColonyAndExtensionsEvents.ColonyMetadata}.fallback`]: `{initiator} changed this colony's metadata, but the values are the same`,
   [`event.${ColonyAndExtensionsEvents.DomainMetadata}.all`]: `{initiator} changed teams's name, description, color from {oldName}, {oldDescription}, {oldColor} to {domainName}, {domainPurpose}, {domainColor}`,
   [`event.${ColonyAndExtensionsEvents.DomainMetadata}.nameDescription`]: `{initiator} changed teams's name and description from {oldName}, {oldDescription} to {domainName}, {domainPurpose}`,
@@ -44,11 +44,11 @@ const eventsMessageDescriptors = {
     true {{safeTransactionRecipient}}
     other {{safeTransactionRawTransactionAddress}}
   }`,
-  [`event.${ColonyAndExtensionsEvents.ArbitraryTransaction}.transferFunds`]: `{safeName} made a payment using the Administration and Funding permissions to pay {safeTransactionAmount} from {fromDomain} to {isSafeTransactionRecipientUser, select, 
+  [`event.${ColonyAndExtensionsEvents.ArbitraryTransaction}.transferFunds`]: `{safeName} made a payment using the Root permission to pay {safeTransactionAmount} to {isSafeTransactionRecipientUser, select, 
     true {{safeTransactionRecipient}}
     other {{safeTransactionAddress}}
   }`,
-  [`event.${ColonyAndExtensionsEvents.ArbitraryTransaction}.transferNFT`]: `{safeName} made a payment using the Administration and Funding permissions to pay with NFT token called {safeTransactionNftToken} from {fromDomain} to {isSafeTransactionRecipientUser, select, 
+  [`event.${ColonyAndExtensionsEvents.ArbitraryTransaction}.transferNFT`]: `{safeName} made a payment using the Root permission to pay with NFT token called {safeTransactionNftToken} to {isSafeTransactionRecipientUser, select, 
     true {{safeTransactionRecipient}}
     other {{safeTransactionAddress}}
   }`,

--- a/src/modules/dashboard/components/ActionsPage/staticMaps.ts
+++ b/src/modules/dashboard/components/ActionsPage/staticMaps.ts
@@ -83,10 +83,7 @@ export const EVENT_ROLES_MAP: EventRolesMap = {
     ColonyRole.Root,
     ColonyRole.Arbitration,
   ],
-  [ColonyAndExtensionsEvents.ArbitraryTransaction]: [
-    ColonyRole.Root,
-    ColonyRole.Administration,
-  ],
+  [ColonyAndExtensionsEvents.ArbitraryTransaction]: [ColonyRole.Root],
   [ColonyAndExtensionsEvents.Generic]: [],
 };
 

--- a/src/modules/dashboard/components/Dialogs/AdvancedDialog/AdvancedDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/AdvancedDialog/AdvancedDialog.tsx
@@ -13,8 +13,6 @@ import {
   canEnterRecoveryMode,
   hasRoot,
   canArchitect,
-  canFund,
-  canAdminister,
 } from '~modules/users/checks';
 
 const MSG = defineMessages({
@@ -24,7 +22,7 @@ const MSG = defineMessages({
   },
   permissionsText: {
     id: 'dashboard.AdvancedDialog.permissionsText',
-    defaultMessage: `You must have the {permissionsList} permissions in the
+    defaultMessage: `You must have the {permission} permission in the
       relevant teams, in order to take this action`,
   },
   managePermissionsTitle: {
@@ -65,8 +63,8 @@ const MSG = defineMessages({
     defaultMessage:
       'New colony network version available? Get your colony’s swole on here.',
   },
-  upgradePermissionsList: {
-    id: 'dashboard.AdvancedDialog.upgradePermissionsList',
+  rootActionsPermission: {
+    id: 'dashboard.AdvancedDialog.rootActionsPermission',
     defaultMessage: 'root',
   },
   editColonyDetailsTitle: {
@@ -94,10 +92,6 @@ const MSG = defineMessages({
     id: 'dashboard.AdvancedDialog.manageSafeDescription',
     defaultMessage:
       'Control a Safe (multi-sig) on another chain with your colony',
-  },
-  adminFundingPermissions: {
-    id: 'dashboard.AdvancedDialog.adminFundingPermissions',
-    defaultMessage: 'funding and administration or root',
   },
 });
 
@@ -146,10 +140,7 @@ const AdvancedDialog = ({
   const { isVotingExtensionEnabled } = useEnabledExtensions({
     colonyAddress: colony.colonyAddress,
   });
-  const canManageSafes =
-    hasRegisteredProfile &&
-    canFund(allUserRoles) &&
-    (canAdminister(allUserRoles) || hasRoot(allUserRoles));
+  const canManageSafes = hasRegisteredProfile && hasRoot(allUserRoles);
 
   const items = [
     {
@@ -162,7 +153,7 @@ const AdvancedDialog = ({
       ),
       permissionInfoText: MSG.permissionsText,
       permissionInfoTextValues: {
-        permissionsList: (
+        permission: (
           <FormattedMessage {...MSG.managePermissionsPermissionList} />
         ),
       },
@@ -178,7 +169,7 @@ const AdvancedDialog = ({
       permissionRequired: !canEnterRecovery,
       permissionInfoText: MSG.permissionsText,
       permissionInfoTextValues: {
-        permissionsList: <FormattedMessage {...MSG.recoveryPermissionsList} />,
+        permission: <FormattedMessage {...MSG.recoveryPermissionsList} />,
       },
       disabled: !isSupportedColonyVersion,
       dataTest: 'recoveryDialogIndexItem',
@@ -190,7 +181,7 @@ const AdvancedDialog = ({
       permissionRequired: !(hasRootPermission || isVotingExtensionEnabled),
       permissionInfoText: MSG.permissionsText,
       permissionInfoTextValues: {
-        permissionsList: <FormattedMessage {...MSG.upgradePermissionsList} />,
+        permission: <FormattedMessage {...MSG.rootActionsPermission} />,
       },
       onClick: () => callStep(nextStepVersionUpgrade),
     },
@@ -201,7 +192,7 @@ const AdvancedDialog = ({
       permissionRequired: !(hasRootPermission || isVotingExtensionEnabled),
       permissionInfoText: MSG.permissionsText,
       permissionInfoTextValues: {
-        permissionsList: <FormattedMessage {...MSG.upgradePermissionsList} />,
+        permission: <FormattedMessage {...MSG.rootActionsPermission} />,
       },
       onClick: () => callStep(nextStepEditDetails),
       dataTest: 'updateColonyDialogIndexItem',
@@ -215,7 +206,7 @@ const AdvancedDialog = ({
       permissionRequired: !canManageSafes,
       permissionInfoText: MSG.permissionsText,
       permissionInfoTextValues: {
-        permissionsList: <FormattedMessage {...MSG.adminFundingPermissions} />,
+        permission: <FormattedMessage {...MSG.rootActionsPermission} />,
       },
     },
     {

--- a/src/modules/dashboard/components/Dialogs/ManageSafeDialog/ManageSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/ManageSafeDialog/ManageSafeDialog.tsx
@@ -1,4 +1,3 @@
-import { ColonyRole } from '@colony/colony-js';
 import React from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 
@@ -6,7 +5,7 @@ import { DialogProps, ActionDialogProps } from '~core/Dialog';
 import IndexModal from '~core/IndexModal';
 import { useLoggedInUser } from '~data/index';
 import { getAllUserRoles } from '~modules/transformers';
-import { userHasRole } from '~modules/users/checks';
+import { hasRoot } from '~modules/users/checks';
 import { useTransformer, WizardDialogType } from '~utils/hooks';
 
 const MSG = defineMessages({
@@ -79,15 +78,8 @@ const ManageSafeDialog = ({
   const allUserRoles = useTransformer(getAllUserRoles, [colony, walletAddress]);
 
   const hasRegisteredProfile = !!username && !ethereal;
-  const canAddRemoveSafes =
-    hasRegisteredProfile &&
-    userHasRole(allUserRoles, ColonyRole.Administration) &&
-    userHasRole(allUserRoles, ColonyRole.Funding);
-
-  const canControlSafes =
-    hasRegisteredProfile &&
-    userHasRole(allUserRoles, ColonyRole.Root) &&
-    userHasRole(allUserRoles, ColonyRole.Funding);
+  const canManageAndControlSafes =
+    hasRegisteredProfile && hasRoot(allUserRoles);
 
   const items = [
     {
@@ -96,7 +88,7 @@ const ManageSafeDialog = ({
       icon: 'plus-heavy',
       dataTest: 'addExistingSafeItem',
       onClick: () => callStep(nextStepAddExistingSafe),
-      permissionRequired: !canAddRemoveSafes,
+      permissionRequired: !canManageAndControlSafes,
       permissionInfoText: MSG.permissionText,
       permissionInfoTextValues: {
         permissionsList: <FormattedMessage {...MSG.adminFundingPermissions} />,
@@ -108,7 +100,7 @@ const ManageSafeDialog = ({
       icon: 'trash-can',
       dataTest: 'removeSafeItem',
       onClick: () => callStep(nextStepRemoveSafe),
-      permissionRequired: !canAddRemoveSafes,
+      permissionRequired: !canManageAndControlSafes,
       permissionInfoText: MSG.permissionText,
       permissionInfoTextValues: {
         permissionsList: <FormattedMessage {...MSG.adminFundingPermissions} />,
@@ -120,7 +112,7 @@ const ManageSafeDialog = ({
       icon: 'joystick',
       dataTest: 'controlSafeItem',
       onClick: () => callStep(nextStepControlSafe),
-      permissionRequired: !canControlSafes,
+      permissionRequired: !canManageAndControlSafes,
       permissionInfoText: MSG.permissionText,
       permissionInfoTextValues: {
         permissionsList: <FormattedMessage {...MSG.rootFundingPermissions} />,

--- a/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialogForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/RemoveSafeDialog/RemoveSafeDialogForm.tsx
@@ -10,7 +10,7 @@ import { ActionDialogProps } from '~core/Dialog';
 import { ColonySafe, useLoggedInUser } from '~data/index';
 import { useTransformer } from '~utils/hooks';
 import { getAllUserRoles } from '~modules/transformers';
-import { canEnterRecoveryMode } from '~modules/users/checks';
+import { hasRoot } from '~modules/users/checks';
 
 import SafeListItem from './SafeListItem';
 import { FormValues } from './RemoveSafeDialog';
@@ -47,8 +47,7 @@ const RemoveSafeDialogForm = ({
   const { walletAddress, username, ethereal } = useLoggedInUser();
   const allUserRoles = useTransformer(getAllUserRoles, [colony, walletAddress]);
   const hasRegisteredProfile = !!username && !ethereal;
-  const userHasPermission =
-    hasRegisteredProfile && canEnterRecoveryMode(allUserRoles);
+  const userHasPermission = hasRegisteredProfile && hasRoot(allUserRoles);
 
   return (
     <>


### PR DESCRIPTION
Updated conditionals, events, and messages to reflect that the user would need only the root permission to make safe control related actions.

![FireShot Capture 810 - Safe transaction_ asdasda - Action - Colony - wonker - localhost](https://user-images.githubusercontent.com/18473896/217829134-9caaf734-ad85-4cf4-bed0-36302c2f683f.png)
![FireShot Capture 811 - Safe transaction_ asdasda - Action - Colony - wonker - localhost](https://user-images.githubusercontent.com/18473896/217829149-e7984b4a-b0d3-4f53-836e-1bd83b55efae.png)
![FireShot Capture 812 - Add Safe from Ethereum - Action - Colony - wonker - localhost](https://user-images.githubusercontent.com/18473896/217829162-f0ffb44d-da0c-4af2-a43c-18142249e8d4.png)
![FireShot Capture 813 - Remove Safe - Action - Colony - wonker - localhost](https://user-images.githubusercontent.com/18473896/217829175-e21ca6d2-85f0-484d-abf2-bdef9017a562.png)

User with no root permission:
![FireShot Capture 814 - Actions - Colony - wonker - localhost](https://user-images.githubusercontent.com/18473896/217829193-11cb5c54-e21c-476b-82d8-c260c0e2b20c.png)

Resolves #4192 
