### PR TITLE
Fix New Decision dialog scrolling up on state change

### DIFF
--- a/src/modules/core/components/RichTextEditor/RichTextEditor.tsx
+++ b/src/modules/core/components/RichTextEditor/RichTextEditor.tsx
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 import { useField } from 'formik';
 
 import { InputStatus } from '~core/Fields';
+
 import Toolbar from './Toolbar';
 
 import styles from './RichTextEditor.css';
@@ -39,12 +40,17 @@ const RichTextEditor = ({
       setContentValue(editorContent.getHTML());
 
     editor.on('update', handleUpdate);
-    editor.setEditable(!disabled);
 
     return () => {
       editor.off('update', handleUpdate);
     };
-  }, [disabled, editor, setContentValue]);
+  });
+
+  useEffect(() => {
+    if (editor.isEditable !== !disabled) {
+      editor.setEditable(!disabled);
+    }
+  }, [editor, disabled]);
 
   return (
     <div

--- a/src/modules/dashboard/components/DecisionPreview/DecisionPreview.tsx
+++ b/src/modules/dashboard/components/DecisionPreview/DecisionPreview.tsx
@@ -28,7 +28,7 @@ import { ColonyMotions, DecisionDetails } from '~types/index';
 import { NOT_FOUND_ROUTE } from '~routes/index';
 import LoadingTemplate from '~pages/LoadingTemplate';
 
-import DetailsWidget from '../ActionsPage/DetailsWidget';
+import DetailsWidget from '../ActionsPage/DetailsWidget/DetailsWidget';
 
 import styles from './DecisionPreview.css';
 
@@ -245,9 +245,7 @@ const DecisionPreview = () => {
               actionType={ColonyMotions.CreateDecisionMotion}
               recipient={userProfile}
               colony={colony}
-              values={{
-                ...actionAndEventValues,
-              }}
+              values={actionAndEventValues}
             />
           </div>
         </div>


### PR DESCRIPTION
`editor.setEditable(!disabled)` was triggered every time the `editor` prop changed and that made the state of the scroll reset. The solution was just to move the culprit to their own `useEffect` function where we don't call it unnecessarily like before.

Resolves #4118 
