### PR TITLE
Update version warning on Control Safe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@apollo/client": "^3.0.2",
         "@colony/colony-event-metadata-parser": "^1.1.5",
-        "@colony/colony-js": "^4.2.2-rc.1",
+        "@colony/colony-js": "^4.2.2-rc.3",
         "@colony/redux-promise-listener": "^1.2.0",
         "@colony/unicode-confusables-noascii": "^0.1.2",
         "@formatjs/intl": "^2.5.1",
@@ -4891,9 +4891,9 @@
       }
     },
     "node_modules/@colony/colony-js": {
-      "version": "4.2.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-4.2.2-rc.1.tgz",
-      "integrity": "sha512-aFjiq3kuJYvpTA+WeQYnCKX+pgFsQSJ7k6oQanEIgZp/1glaHWb7BpaCHGunKe05irzkIuoMalUoaTkvTVbkqw==",
+      "version": "4.2.2-rc.3",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-4.2.2-rc.3.tgz",
+      "integrity": "sha512-8nBlc9s+7o06Q8dOvSj/tEgt3520K5PZq8u8jf4TEVxj8++FFyfXJpNJ+PULNRuu8k3FS3cGLHev7bXK69yPEQ==",
       "dependencies": {
         "isomorphic-fetch": "^2.2.1",
         "lodash.isequal": "^4.5.0"
@@ -61103,9 +61103,9 @@
       }
     },
     "@colony/colony-js": {
-      "version": "4.2.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-4.2.2-rc.1.tgz",
-      "integrity": "sha512-aFjiq3kuJYvpTA+WeQYnCKX+pgFsQSJ7k6oQanEIgZp/1glaHWb7BpaCHGunKe05irzkIuoMalUoaTkvTVbkqw==",
+      "version": "4.2.2-rc.3",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-4.2.2-rc.3.tgz",
+      "integrity": "sha512-8nBlc9s+7o06Q8dOvSj/tEgt3520K5PZq8u8jf4TEVxj8++FFyfXJpNJ+PULNRuu8k3FS3cGLHev7bXK69yPEQ==",
       "requires": {
         "isomorphic-fetch": "^2.2.1",
         "lodash.isequal": "^4.5.0"

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
   "dependencies": {
     "@apollo/client": "^3.0.2",
     "@colony/colony-event-metadata-parser": "^1.1.5",
-    "@colony/colony-js": "^4.2.2-rc.1",
+    "@colony/colony-js": "^4.2.2-rc.3",
     "@colony/redux-promise-listener": "^1.2.0",
     "@colony/unicode-confusables-noascii": "^0.1.2",
     "@formatjs/intl": "^2.5.1",

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
@@ -105,7 +105,7 @@ const MSG = defineMessages({
   },
   upgradeWarning: {
     id: 'dashboard.ControlSafeDialog.ControlSafeForm.upgradeWarning',
-    defaultMessage: `Controlling a Safe is not supported on your current Colony version. Please upgrade Colony to at least version 11.{break}You can do this via <span>New Action > Advanced > Upgrade</span>`,
+    defaultMessage: `Controlling a Safe is not supported on your current Colony version. Please upgrade Colony to at least version 12.{break}You can do this via <span>New Action > Advanced > Upgrade</span>`,
   },
 });
 
@@ -368,7 +368,7 @@ const ControlSafeForm = ({
   const savedNFTState = useState({});
   const savedTokenState = useState({});
   const isSupportedColonyVersion =
-    parseInt(version, 10) >= ColonyVersion.GreenLightweightSpaceshipTwo;
+    parseInt(version, 10) >= ColonyVersion.GreenLightweightSpaceshipThree;
   const disabledInputs =
     !userHasPermission || isSubmitting || !isSupportedColonyVersion;
 


### PR DESCRIPTION
Update colonyJS version on warning of Control Safe dialog

The latest colony network version shouldn't be included in this feature yet, so this should be easy to test (Just go to Control Safe)