### PR TITLE
Fix getAnnotationFromSubgraph crashing the ActionsPage

### DIFF
--- a/src/utils/events/getAnnotationFromSubgraph.ts
+++ b/src/utils/events/getAnnotationFromSubgraph.ts
@@ -35,12 +35,12 @@ export const getAnnotationFromSubgraph = async (
        * be filtering these out, and show the most recent annotation, no matter
        * who sent it
        */
-      .filter(({ address, values: { agent }, values }) => {
+      .filter(({ address, values: { agent, address: valuesAddress } }) => {
         const userAddressLowered = userAddress.toLowerCase();
         return (
-          agent.toLowerCase() === userAddressLowered ||
+          agent?.toLowerCase() === userAddressLowered ||
           address?.toLowerCase() === userAddressLowered ||
-          values.address?.toLowerCase() === userAddressLowered
+          valuesAddress?.toLowerCase() === userAddressLowered
         );
       }) || [];
   return mostRecentAnnotation;

--- a/src/utils/events/getAnnotationFromSubgraph.ts
+++ b/src/utils/events/getAnnotationFromSubgraph.ts
@@ -35,11 +35,13 @@ export const getAnnotationFromSubgraph = async (
        * be filtering these out, and show the most recent annotation, no matter
        * who sent it
        */
-      .filter(
-        ({ values: { agent, address } }) =>
-          agent.toLowerCase() === userAddress.toLowerCase() ||
-          address.toLowerCase() === userAddress.toLowerCase(),
-      ) || [];
-
+      .filter(({ address, values: { agent }, values }) => {
+        const userAddressLowered = userAddress.toLowerCase();
+        return (
+          agent.toLowerCase() === userAddressLowered ||
+          address?.toLowerCase() === userAddressLowered ||
+          values.address?.toLowerCase() === userAddressLowered
+        );
+      }) || [];
   return mostRecentAnnotation;
 };


### PR DESCRIPTION
Added conditional to check if the `address` prop is 1 level above on the event object or in the `values` prop. Previously this would crash the ActionsPage due to `values.address` being undefined ever since Metatransactions.

