### PR TITLE
Update regex on getChainNameFromSafe

### DIFF
--- a/src/modules/dashboard/sagas/utils/safeHelpers.ts
+++ b/src/modules/dashboard/sagas/utils/safeHelpers.ts
@@ -393,5 +393,5 @@ export const getContractInteractionData = async (
 };
 
 export const getChainNameFromSafe = (safeDisplayName: string) => {
-  return safeDisplayName.match(/\((.*)\)/)?.pop() || '';
+  return safeDisplayName.match(/\(([^()]*)\)$/)?.pop() || '';
 };


### PR DESCRIPTION
Updated regex on `getChainNameFromSafe` so that it only matches the last parenthesis on the string, which should always be the chain name.

To quickly test the regex with string, we can use this: https://regex101.com/r/CMMXjQ/1

![FireShot Capture 816 - Actions - Colony - wonker - localhost](https://user-images.githubusercontent.com/18473896/223197677-477186d6-81f5-4a7f-8626-75d3cf9d292c.png)

Resolves #4208 
