### PR TITLE
Fix `npm run provision` not building `colonyNetwork` successfully

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -25,7 +25,7 @@ jobs:
           ssh-private-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: npm
-        run: npm i -g npm@8 --registry=https://registry.npmjs.org
+        run: npm i -g npm@8.1.4 --registry=https://registry.npmjs.org
 
       - name: Install and Build 🔧
         run: |

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -40,7 +40,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
 
     - name: npm
-      run: npm i -g npm@8 --registry=https://registry.npmjs.org
+      run: npm i -g npm@8.1.4 --registry=https://registry.npmjs.org
 
     - run: npm install --legacy-peer-deps
     - run: npm run typecheck

--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 * `node` `v14.18.x` (Best use [nvm](https://github.com/nvm-sh/nvm))
-* `npm` `v8.x.x`
+* `npm` `v8.1.4`
 * `docker` (See [install instructions](https://docs.docker.com/engine/install/))
 * `docker-compose` (See [install instructions](https://docs.docker.com/compose/install/))
 * `jq` (See [install instructions](https://github.com/stedolan/jq/wiki/Installation))

--- a/package-lock.json
+++ b/package-lock.json
@@ -196,7 +196,7 @@
       },
       "engines": {
         "node": "14.18",
-        "npm": "^8"
+        "npm": "8.1.4"
       }
     },
     "../ColonyEventMetadataParser": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "engines": {
     "node": "14.18",
-    "npm": "^8"
+    "npm": "8.1.4"
   },
   "version": "4.6.2",
   "description": "",

--- a/scripts/provision_submodules.sh
+++ b/scripts/provision_submodules.sh
@@ -93,7 +93,7 @@ then
     # Build network
     log "Building '${NETWORK}' submodule"
     cd "${ROOT_PATH}/${LIB_PATH}/${NETWORK}"
-    $YARN --pure-lockfile
+    npm ci
     DISABLE_DOCKER=true $YARN provision:token:contracts
     cd ${ROOT_PATH}
 else


### PR DESCRIPTION
Self-explanatory title. Now in order to run the dev env of the Dapp we are going to require the npm version to specifically be `8.1.4` in order to avoid problems when installing packages inside `colonyNetwork`.

To test, make sure to delete the `colonyNetwork` lib folder if you already have it and go throught the normal dev process and see if everything works as expected. 

Example: `npm i` > `npm run provision` (check that `colonyNetwork` is built successfully with no leftover changes) > `npm run dev:heavy` > Create a user > Create a colony.
