### PR TITLE
Fix users without permissions not being able to create Safe motions

### DIFF
--- a/src/modules/dashboard/components/Dialogs/AdvancedDialog/AdvancedDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/AdvancedDialog/AdvancedDialog.tsx
@@ -140,7 +140,8 @@ const AdvancedDialog = ({
   const { isVotingExtensionEnabled } = useEnabledExtensions({
     colonyAddress: colony.colonyAddress,
   });
-  const canManageSafes = hasRegisteredProfile && hasRoot(allUserRoles);
+  const canManageOrControlSafes =
+    (hasRegisteredProfile && hasRoot(allUserRoles)) || isVotingExtensionEnabled;
 
   const items = [
     {
@@ -203,7 +204,7 @@ const AdvancedDialog = ({
       icon: 'safe-logo',
       dataTest: 'manageSafeItem',
       onClick: () => callStep(nextStepManageSafe),
-      permissionRequired: !canManageSafes,
+      permissionRequired: !canManageOrControlSafes,
       permissionInfoText: MSG.permissionsText,
       permissionInfoTextValues: {
         permission: <FormattedMessage {...MSG.rootActionsPermission} />,

--- a/src/modules/dashboard/components/Dialogs/AdvancedDialog/AdvancedDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/AdvancedDialog/AdvancedDialog.tsx
@@ -122,26 +122,23 @@ const AdvancedDialog = ({
   colony,
   colony: { version: colonyVersion },
 }: Props) => {
-  const { walletAddress, username, ethereal } = useLoggedInUser();
-
-  const hasRegisteredProfile = !!username && !ethereal;
+  const { walletAddress } = useLoggedInUser();
 
   const allUserRoles = useTransformer(getAllUserRoles, [colony, walletAddress]);
-  const hasRootPermission = hasRegisteredProfile && hasRoot(allUserRoles);
+  const hasRootPermission = hasRoot(allUserRoles);
 
-  const canEnterRecovery =
-    hasRegisteredProfile && canEnterRecoveryMode(allUserRoles);
+  const canEnterRecovery = canEnterRecoveryMode(allUserRoles);
   const isSupportedColonyVersion =
     parseInt(colonyVersion, 10) > ColonyVersion.LightweightSpaceship;
 
   const canEnterPermissionManagement =
-    (hasRegisteredProfile && canArchitect(allUserRoles)) || hasRootPermission;
+    canArchitect(allUserRoles) || hasRootPermission;
 
   const { isVotingExtensionEnabled } = useEnabledExtensions({
     colonyAddress: colony.colonyAddress,
   });
   const canManageOrControlSafes =
-    (hasRegisteredProfile && hasRoot(allUserRoles)) || isVotingExtensionEnabled;
+    hasRoot(allUserRoles) || isVotingExtensionEnabled;
 
   const items = [
     {

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/ControlSafeForm.tsx
@@ -32,6 +32,7 @@ import { debounce, isEmpty, isEqual, omit } from '~utils/lodash';
 import { hasRoot } from '~modules/users/checks';
 import { getAllUserRoles } from '~modules/transformers';
 import { useTransformer } from '~utils/hooks';
+import NotEnoughReputation from '~dashboard/NotEnoughReputation';
 
 import SafeTransactionPreview from './SafeTransactionPreview';
 import {
@@ -615,10 +616,16 @@ const ControlSafeForm = ({
           values={values}
           selectedContractMethods={selectedContractMethods}
           isVotingExtensionEnabled={isVotingExtensionEnabled}
-          userHasPermission={userHasPermission}
+          canManageAndControlSafes={canManageAndControlSafes}
           onlyForceAction={onlyForceAction}
           handleValidation={handleValidation}
           setFieldValue={setFieldValue}
+        />
+      )}
+      {onlyForceAction && (!canManageAndControlSafes || showPreview) && (
+        <NotEnoughReputation
+          appearance={{ marginTop: 'negative' }}
+          includeForceCopy={showPreview}
         />
       )}
       <DialogSection appearance={{ align: 'right', theme: 'footer' }}>

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/SafeTransactionPreview.tsx
@@ -10,7 +10,6 @@ import Heading from '~core/Heading';
 import Numeral from '~core/Numeral';
 import TokenIcon from '~dashboard/HookedTokenIcon';
 import MotionDomainSelect from '~dashboard/MotionDomainSelect';
-import NotEnoughReputation from '~dashboard/NotEnoughReputation';
 import Button from '~core/Button';
 import Icon from '~core/Icon';
 import Avatar from '~core/Avatar';
@@ -210,7 +209,7 @@ interface Props
   extends Pick<FormProps, 'colony' | 'selectedContractMethods'>,
     Pick<TransactionSectionProps, 'handleValidation'> {
   isVotingExtensionEnabled: boolean;
-  userHasPermission: boolean;
+  canManageAndControlSafes: boolean;
   onlyForceAction: boolean;
 }
 
@@ -219,7 +218,7 @@ const SafeTransactionPreview = ({
   values,
   selectedContractMethods,
   isVotingExtensionEnabled,
-  userHasPermission,
+  canManageAndControlSafes,
   isSubmitting,
   onlyForceAction,
   handleValidation,
@@ -299,7 +298,7 @@ const SafeTransactionPreview = ({
               disabled
             />
           )}
-          {userHasPermission && isVotingExtensionEnabled && (
+          {canManageAndControlSafes && isVotingExtensionEnabled && (
             <ForceToggle disabled={isSubmitting} />
           )}
         </div>
@@ -453,9 +452,6 @@ const SafeTransactionPreview = ({
             disabled={onlyForceAction}
           />
         </DialogSection>
-        {onlyForceAction && (
-          <NotEnoughReputation appearance={{ marginTop: 'negative' }} />
-        )}
       </div>
     </>
   );

--- a/src/modules/dashboard/components/Dialogs/ManageSafeDialog/ManageSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/ManageSafeDialog/ManageSafeDialog.tsx
@@ -7,6 +7,7 @@ import { useLoggedInUser } from '~data/index';
 import { getAllUserRoles } from '~modules/transformers';
 import { hasRoot } from '~modules/users/checks';
 import { useTransformer, WizardDialogType } from '~utils/hooks';
+import { useEnabledExtensions } from '~utils/hooks/useEnabledExtensions';
 
 const MSG = defineMessages({
   dialogHeader: {
@@ -73,10 +74,13 @@ const ManageSafeDialog = ({
   const { walletAddress, username, ethereal } = useLoggedInUser();
   const allUserRoles = useTransformer(getAllUserRoles, [colony, walletAddress]);
 
-  const hasRegisteredProfile = !!username && !ethereal;
-  const canManageAndControlSafes =
-    hasRegisteredProfile && hasRoot(allUserRoles);
+  const { isVotingExtensionEnabled } = useEnabledExtensions({
+    colonyAddress: colony.colonyAddress,
+  });
 
+  const hasRegisteredProfile = !!username && !ethereal;
+  const canManageSafes = hasRegisteredProfile && hasRoot(allUserRoles);
+  const canControlSafes = canManageSafes || isVotingExtensionEnabled;
   const items = [
     {
       title: MSG.addExistingSafeTitle,
@@ -84,7 +88,7 @@ const ManageSafeDialog = ({
       icon: 'plus-heavy',
       dataTest: 'addExistingSafeItem',
       onClick: () => callStep(nextStepAddExistingSafe),
-      permissionRequired: !canManageAndControlSafes,
+      permissionRequired: !canManageSafes,
       permissionInfoText: MSG.permissionText,
       permissionInfoTextValues: {
         permission: <FormattedMessage {...MSG.manageSafePermission} />,
@@ -96,7 +100,7 @@ const ManageSafeDialog = ({
       icon: 'trash-can',
       dataTest: 'removeSafeItem',
       onClick: () => callStep(nextStepRemoveSafe),
-      permissionRequired: !canManageAndControlSafes,
+      permissionRequired: !canManageSafes,
       permissionInfoText: MSG.permissionText,
       permissionInfoTextValues: {
         permission: <FormattedMessage {...MSG.manageSafePermission} />,
@@ -108,7 +112,7 @@ const ManageSafeDialog = ({
       icon: 'joystick',
       dataTest: 'controlSafeItem',
       onClick: () => callStep(nextStepControlSafe),
-      permissionRequired: !canManageAndControlSafes,
+      permissionRequired: !canControlSafes,
       permissionInfoText: MSG.permissionText,
       permissionInfoTextValues: {
         permission: <FormattedMessage {...MSG.manageSafePermission} />,

--- a/src/modules/dashboard/components/Dialogs/ManageSafeDialog/ManageSafeDialog.tsx
+++ b/src/modules/dashboard/components/Dialogs/ManageSafeDialog/ManageSafeDialog.tsx
@@ -71,15 +71,14 @@ const ManageSafeDialog = ({
   nextStepRemoveSafe,
   nextStepControlSafe,
 }: Props) => {
-  const { walletAddress, username, ethereal } = useLoggedInUser();
+  const { walletAddress } = useLoggedInUser();
   const allUserRoles = useTransformer(getAllUserRoles, [colony, walletAddress]);
 
   const { isVotingExtensionEnabled } = useEnabledExtensions({
     colonyAddress: colony.colonyAddress,
   });
 
-  const hasRegisteredProfile = !!username && !ethereal;
-  const canManageSafes = hasRegisteredProfile && hasRoot(allUserRoles);
+  const canManageSafes = hasRoot(allUserRoles);
   const canControlSafes = canManageSafes || isVotingExtensionEnabled;
   const items = [
     {


### PR DESCRIPTION
- Also, I've removed the `hasRegisteredProfile` conditional from the `AdvancedDialog` and `ManageSafeDialog` as it seems kind of redundant to have it there... If the user can access the UAC, it means that they have a registered profile already as the `New Action` button is disabled otherwise, and there's no other way for users to get to this flow.

### User with no permission in a colony without reputation:
![FireShot Capture 819 - Actions - Colony - wonker - localhost](https://user-images.githubusercontent.com/18473896/227075871-7f8efb8f-5d2f-4b7c-a88b-72c54cd48d8a.png)

### User with permission in a colony without reputation:
![FireShot Capture 820 - Actions - Colony - wonker - localhost](https://user-images.githubusercontent.com/18473896/227075878-8bfdf0a6-ea8a-496d-8550-af213ae2cea6.png)

### User with permission in a colony with reputation:
![FireShot Capture 821 - Actions - Colony - wonker - localhost](https://user-images.githubusercontent.com/18473896/227075884-a9bc7f0f-d7ae-4ac7-89cb-f2e073b39a27.png)

### User with no permission in a colony with reputation:
![FireShot Capture 822 - Actions - Colony - wonker - localhost](https://user-images.githubusercontent.com/18473896/227076145-c9d2b16b-bae0-4cf5-9c49-6c1a2b597454.png)
