### PR TITLE
Fix Transfer NFT section on Control Safe

### DIFF
--- a/src/modules/dashboard/components/ColonyHome/ColonySafes/ColonySafes.tsx
+++ b/src/modules/dashboard/components/ColonyHome/ColonySafes/ColonySafes.tsx
@@ -40,7 +40,10 @@ const ColonySafes = ({ colony: { safes }, colony }: Props) => {
       </Heading>
       <ul>
         {safes.map((safe) => (
-          <li className={styles.safeItem}>
+          <li
+            className={styles.safeItem}
+            key={`${safe.chainId}-${safe.contractAddress}`}
+          >
             <InfoPopover
               key={`${safe.chainId}-${safe.contractAddress}`}
               safe={safe}

--- a/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransferNFTSection.tsx
+++ b/src/modules/dashboard/components/Dialogs/ControlSafeDialog/TransactionTypesSection/TransferNFTSection.tsx
@@ -117,15 +117,15 @@ const TransferNFTSection = ({
       const address = chosenSafe.profile.walletAddress;
       try {
         const response = await fetch(
-          `${baseUrl}/v1/safes/${address}/collectibles/`,
+          `${baseUrl}/v2/safes/${address}/collectibles/`,
         );
         if (response.status === 200) {
           const data = await response.json();
           setSavedNFTs((nfts) => ({
             ...nfts,
-            [address]: data,
+            [address]: data.results,
           }));
-          setAvailableNFTs(data);
+          setAvailableNFTs(data.results);
         }
       } catch (e) {
         log.error(e);


### PR DESCRIPTION
The API endpoint we used to get NFTs was updated (Both the URL and the data structure of the response.), therefore it wasn't working before. This should fix it and make the section available once more.
